### PR TITLE
Create bare bones initial views/pages for Ingest Project listing, and…

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -3,7 +3,52 @@
 /* @import "./phoenix.css"; */
 
 @tailwind base;
+
+@font-face {
+  font-family: 'AkkuratPro-Regular';
+  src: url('fonts/AkkuratPro-Regular.otf') format('otf');
+}
+
+body {
+  font-family: 'AkkuratPro-Regular';
+  @apply bg-gray-100;
+}
+
+h1 {
+  @apply text-2xl my-6;
+}
+
+h2 {
+  @apply text-xl;
+}
+
+h3 {
+  @apply text-lg;
+}
+
+a {
+  @apply text-gray-700;
+}
+
+a:hover {
+  @apply underline;
+}
+
+.btn {
+  @apply bg-gray-300 text-gray-800 font-bold py-2 px-4 rounded;
+}
+
+.btn:hover {
+  @apply bg-gray-400 no-underline;
+}
+
+.btn:focus {
+  @apply outline-none shadow-outline;
+}
+
+.content-block {
+  @apply bg-white p-6 shadow-md;
+}
+
 @tailwind components;
 @tailwind utilities;
-
-@import './meadow.css';

--- a/assets/css/meadow.css
+++ b/assets/css/meadow.css
@@ -1,8 +1,0 @@
-@font-face {
-  font-family: "AkkuratPro-Regular";
-  src: url("fonts/AkkuratPro-Regular.otf") format("otf");
-}
-
-body {
-  font-family: "AkkuratPro-Regular";
-}

--- a/assets/js/Root.jsx
+++ b/assets/js/Root.jsx
@@ -1,21 +1,28 @@
-import React from "react";
-import { BrowserRouter, Route, Switch } from "react-router-dom";
+import React from 'react';
+import { BrowserRouter, Route, Switch } from 'react-router-dom';
 
-import Header from "./components/Header";
-import CounterPage from "./pages/counter";
-import FetchDataPage from "./pages/fetch-data";
-import HomePage from "./pages";
+import Header from './components/Header';
+import CounterPage from './pages/counter';
+import FetchDataPage from './pages/fetch-data';
+import HomePage from './pages';
+import IngestPage from './pages/ingest';
+import CreateIngestProjectPage from './pages/create-ingest-project';
 
 export default class Root extends React.Component {
   render() {
     return (
       <>
-        <Header />
         <BrowserRouter>
+          <Header />
           <Switch>
             <Route exact path="/" component={HomePage} />
             <Route path="/counter" component={CounterPage} />
             <Route path="/fetch-data" component={FetchDataPage} />
+            <Route path="/ingest" component={IngestPage} />
+            <Route
+              path="/create-ingest-project"
+              component={CreateIngestProjectPage}
+            />
           </Switch>
         </BrowserRouter>
       </>

--- a/assets/js/components/Header.jsx
+++ b/assets/js/components/Header.jsx
@@ -1,16 +1,53 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+
+const navLinks = [
+  {
+    url: '/',
+    title: 'User Management'
+  },
+  {
+    url: '/ingest',
+    title: 'Ingest'
+  },
+  {
+    url: '/',
+    title: 'Works'
+  },
+  {
+    url: '/',
+    title: 'Collections'
+  },
+  {
+    url: '/',
+    title: 'Dashboards'
+  },
+  {
+    url: '/',
+    title: 'Admin Sets'
+  }
+];
+
+const NavLink = ({ url, title }) => (
+  <Link
+    to={url}
+    className="block mt-4 lg:inline-block lg:mt-0 hover:text-white mr-4"
+  >
+    {title}
+  </Link>
+);
 
 const Header = () => (
   <header>
     <section className="container mx-auto uppercase">
-      <nav className="flex items-center justify-between flex-wrap bg-gray-500 p-6">
+      <nav className="flex items-center justify-between flex-wrap bg-gray-300 p-6">
         <div className="flex items-center flex-shrink-0 text-white mr-6">
-          <span className="font-semibold text-xl tracking-tight">
-            Ingestion Engine
-          </span>
+          <Link to="/" className="font-semibold text-xl tracking-tight">
+            Meadow
+          </Link>
         </div>
         <div className="block lg:hidden">
-          <button className="flex items-center px-3 py-2 border rounded border-teal-400 hover:text-white hover:border-white">
+          <button className="flex items-center px-3 py-2 border rounded border-black hover:text-white hover:border-white">
             <svg
               className="fill-current h-3 w-3"
               viewBox="0 0 20 20"
@@ -23,31 +60,16 @@ const Header = () => (
         </div>
         <div className="w-full block flex-grow lg:flex lg:items-center lg:w-auto">
           <div className="text-sm lg:flex-grow">
-            <a
-              href="#responsive-header"
-              className="block mt-4 lg:inline-block lg:mt-0 hover:text-white mr-4"
-            >
-              Collections
-            </a>
-            <a
-              href="#responsive-header"
-              className="block mt-4 lg:inline-block lg:mt-0 hover:text-white mr-4"
-            >
-              Works
-            </a>
-            <a
-              href="#responsive-header"
-              className="block mt-4 lg:inline-block lg:mt-0 hover:text-white"
-            >
-              Dashboards
-            </a>
+            {navLinks.map(item => (
+              <NavLink key={item.title} url={item.url} title={item.title} />
+            ))}
           </div>
           <div>
             <a
               href="#"
               className="inline-block text-sm px-4 py-2 leading-none border rounded text-white border-white hover:border-transparent hover:text-gray-500 hover:bg-white mt-4 lg:mt-0"
             >
-              Something?
+              Login
             </a>
           </div>
         </div>

--- a/assets/js/mock-data/projects.js
+++ b/assets/js/mock-data/projects.js
@@ -1,0 +1,29 @@
+export const projects = [
+  {
+    id: 'asd9608asdf',
+    title: 'Berkeley Folk Music Festival',
+    dateLastModified: '2019-02-11',
+    numFilesets: 228,
+    numWorks: 79,
+    numInventorySheets: 3,
+    s3Folder: '/s3bucket-location-here'
+  },
+  {
+    id: 'oiuy2435345',
+    title: 'Cathorin Wolf Donohue',
+    dateLastModified: '2018-10-28',
+    numFilesets: 1788,
+    numWorks: 311,
+    numInventorySheets: 12,
+    s3Folder: '/donohue-2384'
+  },
+  {
+    id: 'mnjjdh778833',
+    title: 'Africa Embraces Obama 3-D',
+    dateLastModified: '2019-08-02',
+    numFilesets: 86,
+    numWorks: 15,
+    numInventorySheets: 8,
+    s3Folder: '/obama-3d-7883asdf'
+  }
+];

--- a/assets/js/pages/create-ingest-project.jsx
+++ b/assets/js/pages/create-ingest-project.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import Main from '../components/Main';
+
+export default class CreateIngestProjectPage extends React.Component {
+  state = {
+    projectTitle: ''
+  };
+
+  handleSubmit = e => {
+    e.preventDefault();
+    // POST the data somewhere here
+  };
+
+  handleTitleChange = e => {
+    this.setState({ projectTitle: e.target.value });
+  };
+
+  render() {
+    const { projectTitle } = this.state;
+    return (
+      <Main>
+        <h1>Create Ingest Project</h1>
+        <form className="content-block" onSubmit={this.handleSubmit}>
+          <div className="mb-4">
+            <label
+              className="block text-gray-700 text-sm font-bold mb-2"
+              htmlFor="username"
+            >
+              Project Title
+            </label>
+            <input
+              className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+              id="project-title"
+              type="text"
+              placeholder="Project Title"
+              value={projectTitle}
+              onChange={this.handleTitleChange}
+            />
+          </div>
+
+          <button className="btn mt-6" type="submit">
+            Submit
+          </button>
+        </form>
+      </Main>
+    );
+  }
+}

--- a/assets/js/pages/index.jsx
+++ b/assets/js/pages/index.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import { RouteComponentProps } from 'react-router-dom';
 import Main from '../components/Main';
-import Tester from '../components/Tester';
 
 const HomePage = () => (
   <Main>

--- a/assets/js/pages/ingest.jsx
+++ b/assets/js/pages/ingest.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import Main from '../components/Main';
+import { projects } from '../mock-data/projects';
+import { Link } from 'react-router-dom';
+
+export default class IngestPage extends React.Component {
+  render() {
+    return (
+      <Main>
+        <h1>Ingestion Projects</h1>
+        <Link to="/create-ingest-project" className="btn">
+          Create Project
+        </Link>
+        <section className="my-6 content-block">
+          {projects.map(
+            ({
+              id,
+              title,
+              numWorks,
+              numFilesets,
+              numInventorySheets,
+              dateLastModified,
+              s3Folder
+            }) => (
+              <article key={id} className="pb-6">
+                <h3>
+                  <a href="#">{title}</a>
+                </h3>
+                <p>
+                  {numWorks} Works | {numFilesets} Filesets |{' '}
+                  {numInventorySheets} Inventory Sheets
+                </p>
+                <p>
+                  <span className="font-bold">s3 Bucket Folder: </span>{' '}
+                  <a href="#">{s3Folder}</a>
+                </p>
+                <p>
+                  <span className="font-bold">Date Last Modified: </span>
+                  {dateLastModified}
+                </p>
+              </article>
+            )
+          )}
+        </section>
+      </Main>
+    );
+  }
+}


### PR DESCRIPTION
… Create new project

Just something quick to get UI items on the page in case we want to wire up any `POST` or `GET`s.  

Some initial `react-router` routes are set up (still not sure if this is how we want to handle in the Phoenix environment?), so clicking "Ingest" from main navigation will take you to the pages.