### PR TITLE
Add UI components, routes and some initial views for Inventory Sheets

### DIFF
--- a/assets/css/meadow.css
+++ b/assets/css/meadow.css
@@ -14,7 +14,7 @@ h1 {
 }
 
 h2 {
-  @apply text-xl;
+  @apply text-xl my-6;
 }
 
 h3 {
@@ -29,17 +29,35 @@ a:hover {
   @apply underline;
 }
 
+input {
+  @apply shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight;
+}
+
+input:focus {
+  @apply outline-none shadow-outline;
+}
+
+label {
+  @apply block text-gray-700 text-sm font-bold mb-2;
+}
+
 .btn {
-  @apply bg-gray-300 font-bold tracking-wide text-sm uppercase py-2 px-4 rounded;
+  @apply bg-gray-300 font-bold tracking-wide text-sm uppercase py-2 px-4 rounded inline-block;
 }
 
 .btn:hover {
-  @apply bg-gray-400 no-underline;
+  @apply bg-gray-400 no-underline text-gray-600;
 }
 
 .btn:focus {
   @apply outline-none shadow-outline;
 }
+
+.btn-cancel,
+.btn-cancel:hover {
+  background: none;
+}
+
 
 .content-block {
   @apply bg-white p-6 shadow-md;

--- a/assets/jest.config.js
+++ b/assets/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  verbose: true
+};

--- a/assets/js/components/InventorySheet/Form.jsx
+++ b/assets/js/components/InventorySheet/Form.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import ButtonGroup from "../../components/UI/ButtonGroup";
+import PropTypes from "prop-types";
+
+const InventorySheetForm = ({ handleSubmit, handleCancel }) => {
+  return (
+    <form
+      data-testid="inventory-sheet-upload-form"
+      className="content-block"
+      onSubmit={handleSubmit}
+    >
+      <div className="mb-4">
+        <label htmlFor="inventory-sheet-file">Inventory sheet</label>
+        <input id="inventory-sheet-file" type="file" />
+      </div>
+      <ButtonGroup>
+        <button className="btn" type="submit">
+          Submit
+        </button>
+        <button className="btn btn-cancel" onClick={handleCancel}>
+          Cancel
+        </button>
+      </ButtonGroup>
+    </form>
+  );
+};
+
+InventorySheetForm.propTypes = {
+  handleSubmit: PropTypes.func.isRequired,
+  handleCancel: PropTypes.func.isRequired
+};
+
+export default InventorySheetForm;

--- a/assets/js/components/InventorySheet/Form.test.jsx
+++ b/assets/js/components/InventorySheet/Form.test.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { render, fireEvent, cleanup } from "@testing-library/react";
+import InventorySheetForm from "./Form";
+import "@testing-library/jest-dom/extend-expect";
+import { renderWithRouter } from "../../testing-helpers";
+
+afterEach(cleanup);
+
+const testFormId = "inventory-sheet-upload-form";
+
+const handleSubmit = jest.fn();
+const handleCancel = jest.fn();
+
+test("InventorySheet upload form component renders", () => {
+  const { container } = renderWithRouter(
+    <InventorySheetForm
+      handleSubmit={handleSubmit}
+      handleCancel={handleCancel}
+    />
+  );
+  expect(container).toBeTruthy();
+});
+
+test("Upload form is displayed", () => {
+  const { queryByTestId } = renderWithRouter(
+    <InventorySheetForm
+      handleSubmit={handleSubmit}
+      handleCancel={handleCancel}
+    />
+  );
+  expect(queryByTestId(testFormId)).toBeVisible();
+});
+
+test("Submitting the form calls the parent function", () => {
+  const { getByTestId } = renderWithRouter(
+    <InventorySheetForm
+      handleSubmit={handleSubmit}
+      handleCancel={handleCancel}
+    />,
+    { route: "/inventory-sheet/upload" }
+  );
+
+  fireEvent.submit(getByTestId("inventory-sheet-upload-form"));
+  expect(handleSubmit).toHaveBeenCalledTimes(1);
+});

--- a/assets/js/components/InventorySheet/List.jsx
+++ b/assets/js/components/InventorySheet/List.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import { mockInventorySheets } from "../../mock-data/inventorySheets";
+import { Link } from "react-router-dom";
+
+const InventorySheetList = ({ projectId }) => {
+  const [inventorySheets, setInventorySheets] = useState([]);
+
+  useEffect(() => {
+    // Get inventory sheets for project based on id
+    getInventorySheets();
+  });
+
+  function getInventorySheets() {
+    setInventorySheets(mockInventorySheets);
+  }
+
+  return (
+    <div>
+      {inventorySheets.length === 0 && (
+        <p data-testid="no-inventory-sheets-notification">
+          No inventory sheets are found.
+        </p>
+      )}
+
+      {inventorySheets.length > 0 && (
+        <ul data-testid="inventory-sheet-list">
+          {inventorySheets.map(sheet => (
+            <li key={sheet.id} className="pb-4">
+              <p>
+                <Link to={`/project/${projectId}/inventory-sheet/${sheet.id}`}>
+                  {sheet.title}
+                </Link>
+              </p>
+              <p>Total Works: {sheet.totalWorks}</p>
+              <p>Ingested: {sheet.dateCreated}</p>
+              <p>Creator: {sheet.creator}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+InventorySheetList.propTypes = {
+  projectId: PropTypes.string.isRequired
+};
+
+export default InventorySheetList;

--- a/assets/js/components/InventorySheet/List.test.jsx
+++ b/assets/js/components/InventorySheet/List.test.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { render, cleanup } from "@testing-library/react";
+import InventorySheetList from "./List";
+import "@testing-library/jest-dom/extend-expect";
+import { InventorySheets } from "../../mock-data/inventorySheets";
+import { renderWithRouter } from "../../testing-helpers";
+
+const projectId = "abcdefg123";
+
+afterEach(cleanup);
+
+test("InventorySheetList component renders", () => {
+  const { container } = renderWithRouter(
+    <InventorySheetList projectId={projectId} />
+  );
+  expect(container).toBeTruthy();
+});
+
+xtest("Displays a message that no sheets exist", () => {
+  const { queryByTestId } = render(
+    <InventorySheetList projectId={projectId} />
+  );
+  expect(queryByTestId("no-inventory-sheets-notification")).toBeVisible();
+});
+
+xtest("Displays a list of inventory sheets", () => {
+  const { queryByTestId } = render(
+    <InventorySheetList projectId={projectId} />
+  );
+  expect(queryByTestId("inventory-sheet-list")).toBeVisible();
+});

--- a/assets/js/components/UI/ButtonGroup.jsx
+++ b/assets/js/components/UI/ButtonGroup.jsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+const ButtonGroup = ({ children }) => <div className="my-6">{children}</div>;
+
+export default ButtonGroup;

--- a/assets/js/mock-data/inventorySheets.js
+++ b/assets/js/mock-data/inventorySheets.js
@@ -1,0 +1,16 @@
+export const mockInventorySheets = [
+  {
+    id: "kjhasoiuy",
+    title: "BFMF Inventory Sheet Boxes 21-30",
+    totalWorks: 526,
+    dateCreated: "2018-02-18",
+    creator: "Dan Zellner"
+  },
+  {
+    id: "zasdf7788",
+    title: "BFMF Inventory Sheet Boxes 31-40",
+    totalWorks: 52,
+    dateCreated: "2019-10-28",
+    creator: "Jen Young"
+  }
+];

--- a/assets/js/screens/Home/Home.test.jsx
+++ b/assets/js/screens/Home/Home.test.jsx
@@ -1,10 +1,5 @@
 import React from "react";
-import {
-  render,
-  fireEvent,
-  cleanup,
-  waitForElement
-} from "@testing-library/react";
+import { render, cleanup } from "@testing-library/react";
 // this adds custom jest matchers from jest-dom
 import "@testing-library/jest-dom/extend-expect";
 import HomePage from "./home";

--- a/assets/js/screens/InventorySheet/Form.jsx
+++ b/assets/js/screens/InventorySheet/Form.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import Main from "../../components/UI/Main";
+import { withRouter } from "react-router-dom";
+import InventorySheetForm from "../../components/InventorySheet/Form";
+
+const ScreensInventorySheetForm = ({ history, match, location }) => {
+  const { id } = match.params;
+
+  const handleCancel = () => {
+    history.push(`/project/${id}`);
+  };
+
+  const handleSubmit = e => {
+    e.preventDefault();
+  };
+
+  return (
+    <Main>
+      <h1>Upload Inventory Sheet</h1>
+      <InventorySheetForm
+        handleCancel={handleCancel}
+        handleSubmit={handleSubmit}
+      />
+    </Main>
+  );
+};
+
+export default withRouter(ScreensInventorySheetForm);

--- a/assets/js/screens/InventorySheet/Form.test.jsx
+++ b/assets/js/screens/InventorySheet/Form.test.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { render, fireEvent, cleanup } from "@testing-library/react";
+import ScreensInventorySheetForm from "./Form";
+import "@testing-library/jest-dom/extend-expect";
+import { renderWithRouter } from "../../testing-helpers";
+
+afterEach(cleanup);
+
+test("ScreensInventorySheet upload form component renders", () => {
+  const { container } = renderWithRouter(<ScreensInventorySheetForm />, {
+    route: "/project/01DESDW646M02M8S8R9B4Y98W9/inventory-sheet/upload"
+  });
+
+  expect(container).toBeTruthy();
+});

--- a/assets/js/screens/InventorySheet/InventorySheet.jsx
+++ b/assets/js/screens/InventorySheet/InventorySheet.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import Main from "../../components/UI/Main";
+import { withRouter } from "react-router-dom";
+
+const ScreensInventorySheet = ({ history, match, location }) => {
+  const { id, inventorySheetId } = match.params;
+
+  return (
+    <Main>
+      <h1>Inventory Sheet</h1>
+      <section className="content-block">
+        <p>Show inventory sheet stuff here</p>
+      </section>
+    </Main>
+  );
+};
+
+export default withRouter(ScreensInventorySheet);

--- a/assets/js/screens/Project/Form.jsx
+++ b/assets/js/screens/Project/Form.jsx
@@ -9,6 +9,10 @@ export default class ProjectForm extends React.Component {
     projectTitle: ""
   };
 
+  handleCancel = e => {
+    this.props.history.push("/project/list");
+  };
+
   handleSubmit = async e => {
     e.preventDefault();
     const { projectTitle } = this.state;
@@ -47,7 +51,6 @@ export default class ProjectForm extends React.Component {
               Project Title
             </label>
             <input
-              className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
               id="project-title"
               type="text"
               placeholder="Project Title"
@@ -56,8 +59,12 @@ export default class ProjectForm extends React.Component {
             />
           </div>
 
-          <button className="btn mt-6" type="submit">
+          <div className="mt-6"></div>
+          <button className="btn" type="submit">
             Submit
+          </button>
+          <button className="btn btn-cancel" onClick={this.handleCancel}>
+            Cancel
           </button>
         </form>
       </Main>

--- a/assets/js/screens/Project/List.jsx
+++ b/assets/js/screens/Project/List.jsx
@@ -31,7 +31,7 @@ export default class ProjectList extends React.Component {
         <Link to="/project/create" className="btn">
           Create Project
         </Link>
-        <h2 className="mt-12">Real system output</h2>
+
         <section className="my-6 content-block">
           {projects.map(({ id, folder, title }) => (
             <article key={id} className="pb-6">

--- a/assets/js/screens/Project/Project.jsx
+++ b/assets/js/screens/Project/Project.jsx
@@ -3,10 +3,12 @@ import Main from "../../components/UI/Main";
 import { withRouter } from "react-router";
 import axios from "axios";
 import { toast } from "react-toastify";
+import InventorySheetList from "../../components/InventorySheet/List";
+import { Link } from "react-router-dom";
 
 const Project = ({ match }) => {
   const { id } = match.params;
-  const [project, setProject] = useState({});
+  const [project, setProject] = useState(null);
 
   useEffect(() => {
     const getProject = async () => {
@@ -25,15 +27,19 @@ const Project = ({ match }) => {
       {project && (
         <div>
           <h1>{project.title}</h1>
+
+          <h2>Inventory Sheets</h2>
+          <Link
+            to={{
+              pathname: `/project/${id}/inventory-sheet/upload`,
+              state: { projectId: project.id }
+            }}
+            className="btn mb-4"
+          >
+            Add Inventory Sheet
+          </Link>
           <section className="content-block">
-            <p>
-              <span className="font-bold">Id: </span>
-              {project.id}
-            </p>
-            <p>
-              <span className="font-bold">s3 Bucket Folder: </span>
-              <a href="#">{project.folder}</a>
-            </p>
+            <InventorySheetList projectId={project.id} />
           </section>
         </div>
       )}

--- a/assets/js/screens/Root.jsx
+++ b/assets/js/screens/Root.jsx
@@ -10,6 +10,8 @@ import ProjectForm from "./Project/Form";
 import Project from "./Project/Project";
 import Home from "./Home/Home";
 import NotFoundPage from "./404";
+import ScreensInventorySheet from "./InventorySheet/InventorySheet";
+import ScreensInventorySheetForm from "./InventorySheet/Form";
 
 export default class Root extends React.Component {
   render() {
@@ -22,7 +24,16 @@ export default class Root extends React.Component {
             <Route path="/fetch-data" component={FetchDataPage} />
             <Route path="/project/list" component={ProjectList} />
             <Route path="/project/create" component={ProjectForm} />
+            <Route
+              path="/project/:id/inventory-sheet/upload"
+              component={ScreensInventorySheetForm}
+            />
+            <Route
+              path="/project/:id/inventory-sheet/:inventorySheetId"
+              component={ScreensInventorySheet}
+            />
             <Route path="/project/:id" component={Project} />
+
             <Route path="/" component={Home} />
             <Route component={NotFoundPage} />
           </Switch>

--- a/assets/js/testing-helpers.js
+++ b/assets/js/testing-helpers.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { MemoryRouter, Router } from "react-router-dom";
+import { render } from "@testing-library/react";
+import { createMemoryHistory } from "history";
+
+export function renderWithRouter(
+  ui,
+  {
+    route = "/",
+    history = createMemoryHistory({ initialEntries: [route] })
+  } = {}
+) {
+  return {
+    ...render(<Router history={history}>{ui}</Router>),
+    history
+  };
+}

--- a/assets/package.json
+++ b/assets/package.json
@@ -9,7 +9,8 @@
   "prettier": "@nulib/prettier-config",
   "dependencies": {
     "phoenix": "file:../deps/phoenix",
-    "phoenix_html": "file:../deps/phoenix_html"
+    "phoenix_html": "file:../deps/phoenix_html",
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",


### PR DESCRIPTION
Stubs out some initial screens, ui components, and some added testing helpers, though need to finish that up to figure out how to get `react-router` params in the testing helpers...that's next.  Along with adding some rudimentary breadcrumbs to help navigate these initial screens.