### PR TITLE
Remove '.keep' file from S3 folders

### DIFF
--- a/lib/meadow/ingest/bucket.ex
+++ b/lib/meadow/ingest/bucket.ex
@@ -5,7 +5,7 @@ defmodule Meadow.Ingest.Bucket do
 
   def create_project_folder(bucket, name) do
     ensure_bucket_exists(bucket)
-    ExAws.S3.put_object(bucket, "#{name}/.keep", "") |> ExAws.request()
+    ExAws.S3.put_object(bucket, "#{name}/", "") |> ExAws.request()
   end
 
   def presigned_s3_url(bucket) do


### PR DESCRIPTION
I did a little poking around on how the AWS S3 console UI creates folders without content in them, and it turns out that if you just create an empty object that ends with a `/`, S3 (and other S3 clients) will treat it as a folder.