### PR TITLE
Tell coveralls what the real project root is for the JS coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           command: |
             export COVERALLS_SERVICE_NAME=circle-ci 
             export COVERALLS_SERVICE_JOB_ID=$CIRCLE_WORKFLOW_WORKSPACE_ID 
-            yarn ci --coverageReporters=text-lcov | yarn run coveralls
+            yarn ci --coverageReporters=text-lcov | yarn run coveralls ~/meadow
           working_directory: ~/meadow/assets
       - run:
           name: Merge coverage output


### PR DESCRIPTION
The node `coveralls` command takes a file path argument to override where the script calculates relative paths from. This PR lets coveralls display JavaScript assets in `assets/js` instead of `js`