### PR TITLE
Simple csv file extension validation for IngestJob

### DIFF
--- a/lib/meadow/ingest/ingest_job.ex
+++ b/lib/meadow/ingest/ingest_job.ex
@@ -21,7 +21,18 @@ defmodule Meadow.Ingest.IngestJob do
   def changeset(ingest_job, attrs) do
     ingest_job
     |> cast(attrs, [:name, :filename, :presigned_url, :project_id])
-    |> validate_required([:name, :presigned_url, :project_id])
+    |> validate_required([:name, :presigned_url, :filename, :project_id])
+    |> validate_csv_format()
     |> unique_constraint(:name)
+  end
+
+  def validate_csv_format(changeset) do
+    name = get_field(changeset, :filename)
+
+    if name && Path.extname(name) == ".csv" do
+      changeset
+    else
+      add_error(changeset, :filename, "is not a csv")
+    end
   end
 end

--- a/test/meadow/ingest/ingest_job_test.exs
+++ b/test/meadow/ingest/ingest_job_test.exs
@@ -1,0 +1,20 @@
+defmodule Meadow.Ingest.IngestJobTest do
+  use Meadow.DataCase
+  alias Meadow.Ingest.IngestJob
+  doctest Meadow.Ingest.IngestJob
+
+  describe "ingest_jobs" do
+    @valid_attrs %{
+      name: "some name",
+      presigned_url: "some presigned url",
+      project_id: "01DFC45C20ZMBD1R57HWTSKJ1N",
+      filename: "test.csv"
+    }
+
+    test "validates csv format" do
+      attrs = %{@valid_attrs | filename: "test.jpg"}
+      changeset = IngestJob.changeset(%IngestJob{}, attrs)
+      assert %{filename: ["is not a csv"]} = errors_on(changeset)
+    end
+  end
+end

--- a/test/meadow/ingest_test.exs
+++ b/test/meadow/ingest_test.exs
@@ -81,14 +81,16 @@ defmodule Meadow.IngestTest do
     @valid_attrs %{
       name: "some name",
       presigned_url: "some presigned_url",
+      filename: "some_name.csv",
       project_id: "01DFC45C20ZMBD1R57HWTSKJ1N"
     }
     @update_attrs %{
       name: "some updated name",
       presigned_url: "some updated presigned_url",
+      filename: "some_name.csv",
       project_id: "01DFC45C20ZMBD1R57HWTSKJ1N"
     }
-    @invalid_attrs %{name: nil, presigned_url: nil}
+    @invalid_attrs %{name: nil, presigned_url: nil, filename: nil}
 
     def ingest_job_fixture(attrs \\ %{}) do
       {:ok, ingest_job} =

--- a/test/meadow_web/controllers/api/v1/ingest_job_controller_test.exs
+++ b/test/meadow_web/controllers/api/v1/ingest_job_controller_test.exs
@@ -16,7 +16,7 @@ defmodule MeadowWeb.IngestJobControllerTest do
     presigned_url: "some updated presigned_url",
     filename: "some-updated-filename.csv"
   }
-  @invalid_attrs %{name: nil, presigned_url: nil}
+  @invalid_attrs %{name: nil, presigned_url: nil, filename: nil}
 
   setup do
     %{spec: MeadowWeb.ApiSpec.spec()}


### PR DESCRIPTION
Custom schema validation for verification of IngestJob filename `.csv` format. Adds `Meadow.Ingest.IngestJobTest`.