### PR TITLE
Update ingest job filename key

### DIFF
--- a/assets/js/components/InventorySheet/Form.jsx
+++ b/assets/js/components/InventorySheet/Form.jsx
@@ -35,16 +35,12 @@ const InventorySheetForm = ({ history, projectId }) => {
     try {
       const response = await axios.get("/api/v1/ingest_jobs/presigned_url");
       const presignedUrl = response.data.data.presigned_url;
-      const filename = presignedUrl
-        .split("?")[0]
-        .split("/")
-        .pop();
+      const filename = `s3://${presignedUrl.split("?")[0].split("/").slice(-3).join("/")}`
 
       await axios.put(presignedUrl, file, options);
       const ingestJobResponse = await axios.post(`/api/v1/projects/${projectId}/ingest_jobs`, {
         ingest_job: {
           name: ingest_job_name,
-          presigned_url: presignedUrl,
           project_id: projectId,
           filename: filename
         }

--- a/assets/js/components/InventorySheet/List.jsx
+++ b/assets/js/components/InventorySheet/List.jsx
@@ -5,7 +5,7 @@ import axios from "axios";
 
 const InventorySheetList = ({ projectId }) => {
   const [inventorySheets, setInventorySheets] = useState([]);
-  const url = "/api/v1/ingest_jobs";
+  const url = `/api/v1/projects/${projectId}/ingest_jobs`;
 
   useEffect(() => {
     // Start it off by assuming the component is still mounted
@@ -43,7 +43,6 @@ const InventorySheetList = ({ projectId }) => {
                   {sheet.name}
                 </Link>
               </p>
-              <p>Filename: ${sheet.filename}</p>
               <p>Total Works: xxx</p>
               <p>Ingested: 2019-05-12</p>
               <p>Creator: Some person</p>

--- a/lib/meadow/ingest/ingest_job.ex
+++ b/lib/meadow/ingest/ingest_job.ex
@@ -9,7 +9,6 @@ defmodule Meadow.Ingest.IngestJob do
   @foreign_key_type Ecto.ULID
   schema "ingest_jobs" do
     field :name, :string
-    field :presigned_url, :string
     field :filename, :string
 
     belongs_to :project, Meadow.Ingest.Project
@@ -20,8 +19,8 @@ defmodule Meadow.Ingest.IngestJob do
   @doc false
   def changeset(ingest_job, attrs) do
     ingest_job
-    |> cast(attrs, [:name, :filename, :presigned_url, :project_id])
-    |> validate_required([:name, :presigned_url, :filename, :project_id])
+    |> cast(attrs, [:name, :filename, :project_id])
+    |> validate_required([:name, :filename, :project_id])
     |> validate_csv_format()
     |> unique_constraint(:name)
   end

--- a/lib/meadow_web/controllers/api/v1/ingest_job_controller.ex
+++ b/lib/meadow_web/controllers/api/v1/ingest_job_controller.ex
@@ -2,22 +2,13 @@ defmodule MeadowWeb.Api.V1.IngestJobController do
   use MeadowWeb, :controller
 
   alias Meadow.Ingest
-  alias Meadow.Ingest.{Bucket, IngestJob, Project}
+  alias Meadow.Ingest.{Bucket, IngestJob}
   alias MeadowWeb.Schemas
   alias OpenApiSpex.Operation
 
   import OpenApiSpex.Operation
 
   action_fallback MeadowWeb.FallbackController
-
-  # def extract_project(%{params: %{"project_id" => project_id}} = conn, _) do
-  #   case Ingest.get_project!(project_id) do
-  #     %Project{} = project -> assign(conn, :project, project)
-  #     _ -> render(conn, "error.json")
-  #   end
-  # end
-
-  # plug :extract_project when action in [:create, :show, :index, :update, :delete]
 
   def action(%{params: %{"project_id" => project_id}} = conn, _) do
     project = Ingest.get_project!(project_id)

--- a/lib/meadow_web/schemas.ex
+++ b/lib/meadow_web/schemas.ex
@@ -123,7 +123,6 @@ defmodule MeadowWeb.Schemas do
         id: %Schema{type: :string, description: "Ingest Job ID", format: "ulid", readOnly: "true"},
         name: %Schema{type: :string, description: "Ingest Job Name", minLength: 4, maxLength: 140},
         filename: %Schema{type: :string, description: "Inventory Sheet Filename in S3 bucket"},
-        presigned_url: %Schema{type: :string, description: "S3 csv upload url", format: :uri},
         project_id: %Schema{
           type: :string,
           description: "ID of the parent project",
@@ -136,14 +135,12 @@ defmodule MeadowWeb.Schemas do
         },
         updated_at: %Schema{type: :string, description: "Update timestamp", format: :datetime}
       },
-      required: [:name, :presigned_url, :project_id, :filename],
+      required: [:name, :project_id, :filename],
       example: %{
         "id" => "01DEMM44VWN8M3PJFY4J5JJJMF",
         "name" => "Name of the Ingest Job",
         "project_id" => "01DFBXCA303G43Y3695NMQDH8F",
-        "filename" => "01DFBXCA303G43Y3695NMQ1111.csv",
-        "presigned_url" =>
-          "http://localhost:9001/dev-uploads/inventory_sheets/01DFENBFNJAMYKR3C9YT3NRVWZ.csv?contentType=binary%2Foctet-stream&x-amz-acl=public-read&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minio%2F20190710%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190710T192152Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=a215cd85011af1cd54bxxxxx8ad67a1de83bf5b0f005b504294c1bec6727a789"
+        "filename" => "s3://bucket-name/project-folder/filename.csv"
       },
       "x-struct": __MODULE__
     })
@@ -165,9 +162,7 @@ defmodule MeadowWeb.Schemas do
         "id" => "01DEMM44VWN8M3PJFY4J5JJJMF",
         "name" => "Name of the Ingest Job",
         "project_id" => "01DFBXCA303G43Y3695NMQDH8F",
-        "filename" => "01DFBXCA303G43Y3695NMQ1111.csv",
-        "presigned_url" =>
-          "http://localhost:9001/dev-uploads/inventory_sheets/01DFENBFNJAMYKR3C9YT3NRVWZ.csv?contentType=binary%2Foctet-stream&x-amz-acl=public-read&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minio%2F20190710%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190710T192152Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=a215cd85011af1cd54bxxxxx8ad67a1de83bf5b0f005b504294c1bec6727a789"
+        "filename" => "s3://bucket-name/project-folder/filename.csv"
       },
       "x-struct": __MODULE__
     })
@@ -191,17 +186,13 @@ defmodule MeadowWeb.Schemas do
             "id" => "01DEMM44VWN8M3PJFY4J5JJJMF",
             "name" => "Name of the Ingest Job",
             "project_id" => "01DFBXCA303G43Y3695NMQDH8F",
-            "filename" => "01DFBXCA303G43Y3695NMQ1111.csv",
-            "presigned_url" =>
-              "http://localhost:9001/dev-uploads/inventory_sheets/01DFENBFNJAMYKR3C9YT3NRVWZ.csv?contentType=binary%2Foctet-stream&x-amz-acl=public-read&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minio%2F20190710%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190710T192152Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=a215cd85011af1cd54bxxxxx8ad67a1de83bf5b0f005b504294c1bec6727a789"
+            "filename" => "s3://bucket-name/project-folder/filename.csv"
           },
           %{
             "id" => "01DFBXN0BNB8YEPXCMCNGAWV2J",
             "name" => "Another Name of the Ingest Job",
             "project_id" => "01DFBXPN3EEZSWC6QTCFYQHTBB",
-            "filename" => "01DFBXCA303G43Y3695NMQ1111.csv",
-            "presigned_url" =>
-              "http://localhost:9001/dev-uploads/inventory_sheets/01DFENBFNJAMYKR3C9YT3NRVWZ.csv?contentType=binary%2Foctet-stream&x-amz-acl=public-read&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minio%2F20190710%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190710T192152Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=a215cd85011af1cd54bxxxxx8ad67a1de83bf5b0f0yyyy4294c1bec6727a789"
+            "filename" => "s3://bucket-name/project-folder/filename.csv"
           }
         ]
       }
@@ -224,10 +215,8 @@ defmodule MeadowWeb.Schemas do
       example: %{
         "ingest_job" => %{
           "name" => "The Name of the Ingest Job",
-          "filename" => "01DFBXCA303G43Y3695NMQ1111.csv",
-          "project_id" => "01DFBXPN3EEZSWC6QTCFYQHTBB",
-          "presigned_url" =>
-            "http://localhost:9001/dev-uploads/inventory_sheets/01DFENBFNJAMYKR3C9YT3NRVWZ.csv?contentType=binary%2Foctet-stream&x-amz-acl=public-read&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minio%2F20190710%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190710T192152Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=a215cd85011af1cd54bxxxxx8ad67a1de83bf5b0f0yyyy4294c1bec6727a789"
+          "filename" => "s3://bucket-name/project-folder/filename.csv",
+          "project_id" => "01DFBXPN3EEZSWC6QTCFYQHTBB"
         }
       },
       "x-struct": __MODULE__

--- a/lib/meadow_web/views/api/v1/ingest_job_view.ex
+++ b/lib/meadow_web/views/api/v1/ingest_job_view.ex
@@ -15,7 +15,6 @@ defmodule MeadowWeb.Api.V1.IngestJobView do
       id: ingest_job.id,
       name: ingest_job.name,
       filename: ingest_job.filename,
-      presigned_url: ingest_job.presigned_url,
       project_id: ingest_job.project_id,
       inserted_at: ingest_job.inserted_at,
       updated_at: ingest_job.updated_at

--- a/priv/repo/migrations/20190722195515_remove_presigned_url_ingest_jobs.exs
+++ b/priv/repo/migrations/20190722195515_remove_presigned_url_ingest_jobs.exs
@@ -1,0 +1,9 @@
+defmodule Meadow.Repo.Migrations.RemovePresignedUrlIngestJobs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:ingest_jobs) do
+      remove :presigned_url
+    end
+  end
+end

--- a/spec.json
+++ b/spec.json
@@ -4,10 +4,9 @@
       "IngestJob": {
         "description": "An ingest job that kicks off an inventory sheet upload",
         "example": {
-          "filename": "01DFBXCA303G43Y3695NMQ1111.csv",
+          "filename": "s3://bucket-name/project-folder/filename.csv",
           "id": "01DEMM44VWN8M3PJFY4J5JJJMF",
           "name": "Name of the Ingest Job",
-          "presigned_url": "http://localhost:9001/dev-uploads/inventory_sheets/01DFENBFNJAMYKR3C9YT3NRVWZ.csv?contentType=binary%2Foctet-stream&x-amz-acl=public-read&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minio%2F20190710%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190710T192152Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=a215cd85011af1cd54bxxxxx8ad67a1de83bf5b0f005b504294c1bec6727a789",
           "project_id": "01DFBXCA303G43Y3695NMQDH8F"
         },
         "properties": {
@@ -32,11 +31,6 @@
             "minLength": 4,
             "type": "string"
           },
-          "presigned_url": {
-            "description": "S3 csv upload url",
-            "format": "uri",
-            "type": "string"
-          },
           "project_id": {
             "description": "ID of the parent project",
             "format": "ulid",
@@ -50,7 +44,6 @@
         },
         "required": [
           "name",
-          "presigned_url",
           "project_id",
           "filename"
         ],
@@ -62,9 +55,9 @@
         "description": "POST body for creating an ingest job",
         "example": {
           "ingest_job": {
-            "filename": "01DFBXCA303G43Y3695NMQ1111.csv",
+            "filename": "s3://bucket-name/project-folder/filename.csv",
             "name": "The Name of the Ingest Job",
-            "presigned_url": "http://localhost:9001/dev-uploads/inventory_sheets/01DFENBFNJAMYKR3C9YT3NRVWZ.csv?contentType=binary%2Foctet-stream&x-amz-acl=public-read&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minio%2F20190710%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190710T192152Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=a215cd85011af1cd54bxxxxx8ad67a1de83bf5b0f0yyyy4294c1bec6727a789"
+            "project_id": "01DFBXPN3EEZSWC6QTCFYQHTBB"
           }
         },
         "properties": {
@@ -82,10 +75,9 @@
       "IngestJobResponse": {
         "description": "Response schema for single ingest job",
         "example": {
-          "filename": "01DFBXCA303G43Y3695NMQ1111.csv",
+          "filename": "s3://bucket-name/project-folder/filename.csv",
           "id": "01DEMM44VWN8M3PJFY4J5JJJMF",
           "name": "Name of the Ingest Job",
-          "presigned_url": "http://localhost:9001/dev-uploads/inventory_sheets/01DFENBFNJAMYKR3C9YT3NRVWZ.csv?contentType=binary%2Foctet-stream&x-amz-acl=public-read&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minio%2F20190710%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190710T192152Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=a215cd85011af1cd54bxxxxx8ad67a1de83bf5b0f005b504294c1bec6727a789",
           "project_id": "01DFBXCA303G43Y3695NMQDH8F"
         },
         "properties": {
@@ -102,17 +94,15 @@
         "example": {
           "data": [
             {
-              "filename": "01DFBXCA303G43Y3695NMQ1111.csv",
+              "filename": "s3://bucket-name/project-folder/filename.csv",
               "id": "01DEMM44VWN8M3PJFY4J5JJJMF",
               "name": "Name of the Ingest Job",
-              "presigned_url": "http://localhost:9001/dev-uploads/inventory_sheets/01DFENBFNJAMYKR3C9YT3NRVWZ.csv?contentType=binary%2Foctet-stream&x-amz-acl=public-read&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minio%2F20190710%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190710T192152Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=a215cd85011af1cd54bxxxxx8ad67a1de83bf5b0f005b504294c1bec6727a789",
               "project_id": "01DFBXCA303G43Y3695NMQDH8F"
             },
             {
-              "filename": "01DFBXCA303G43Y3695NMQ1111.csv",
+              "filename": "s3://bucket-name/project-folder/filename.csv",
               "id": "01DFBXN0BNB8YEPXCMCNGAWV2J",
               "name": "Another Name of the Ingest Job",
-              "presigned_url": "http://localhost:9001/dev-uploads/inventory_sheets/01DFENBFNJAMYKR3C9YT3NRVWZ.csv?contentType=binary%2Foctet-stream&x-amz-acl=public-read&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minio%2F20190710%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20190710T192152Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=a215cd85011af1cd54bxxxxx8ad67a1de83bf5b0f0yyyy4294c1bec6727a789",
               "project_id": "01DFBXPN3EEZSWC6QTCFYQHTBB"
             }
           ]
@@ -280,6 +270,31 @@
   },
   "openapi": "3.0.0",
   "paths": {
+    "/api/v1/ingest_jobs": {
+      "get": {
+        "callbacks": {},
+        "deprecated": false,
+        "description": "List all ingest jobs",
+        "operationId": "IngestJobController.list_all_ingest_jobs",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngestJobsResponse"
+                }
+              }
+            },
+            "description": "Project List Response"
+          }
+        },
+        "summary": "List All Ingest Jobs",
+        "tags": [
+          "ingest_jobs"
+        ]
+      }
+    },
     "/api/v1/ingest_jobs/presigned_url": {
       "get": {
         "callbacks": {},
@@ -528,7 +543,7 @@
       "get": {
         "callbacks": {},
         "deprecated": false,
-        "description": "List all ingest jobs",
+        "description": "List all ingest jobs in a project",
         "operationId": "IngestJobController.index",
         "parameters": [
           {
@@ -554,7 +569,7 @@
             "description": "Project List Response"
           }
         },
-        "summary": "List Ingest Jobs",
+        "summary": "List Ingest Jobs in a project",
         "tags": [
           "ingest_jobs"
         ]

--- a/test/meadow/ingest/ingest_job_test.exs
+++ b/test/meadow/ingest/ingest_job_test.exs
@@ -6,7 +6,6 @@ defmodule Meadow.Ingest.IngestJobTest do
   describe "ingest_jobs" do
     @valid_attrs %{
       name: "some name",
-      presigned_url: "some presigned url",
       project_id: "01DFC45C20ZMBD1R57HWTSKJ1N",
       filename: "test.csv"
     }

--- a/test/meadow/ingest_test.exs
+++ b/test/meadow/ingest_test.exs
@@ -80,17 +80,15 @@ defmodule Meadow.IngestTest do
 
     @valid_attrs %{
       name: "some name",
-      presigned_url: "some presigned_url",
       filename: "some_name.csv",
       project_id: "01DFC45C20ZMBD1R57HWTSKJ1N"
     }
     @update_attrs %{
       name: "some updated name",
-      presigned_url: "some updated presigned_url",
       filename: "some_name.csv",
       project_id: "01DFC45C20ZMBD1R57HWTSKJ1N"
     }
-    @invalid_attrs %{name: nil, presigned_url: nil, filename: nil}
+    @invalid_attrs %{name: nil, filename: nil}
 
     def ingest_job_fixture(attrs \\ %{}) do
       {:ok, ingest_job} =
@@ -120,7 +118,6 @@ defmodule Meadow.IngestTest do
                Ingest.create_ingest_job(Map.put(@valid_attrs, :project_id, project.id))
 
       assert ingest_job.name == "some name"
-      assert ingest_job.presigned_url == "some presigned_url"
     end
 
     test "create_ingest_job/1 with invalid data returns error changeset" do
@@ -138,7 +135,6 @@ defmodule Meadow.IngestTest do
                )
 
       assert ingest_job.name == "some updated name"
-      assert ingest_job.presigned_url == "some updated presigned_url"
     end
 
     test "update_ingest_job/2 with invalid data returns error changeset" do

--- a/test/meadow_web/controllers/api/v1/ingest_job_controller_test.exs
+++ b/test/meadow_web/controllers/api/v1/ingest_job_controller_test.exs
@@ -8,15 +8,13 @@ defmodule MeadowWeb.IngestJobControllerTest do
 
   @create_attrs %{
     name: "some name",
-    presigned_url: "some presigned_url",
     filename: "some-filename.csv"
   }
   @update_attrs %{
     name: "some updated name",
-    presigned_url: "some updated presigned_url",
     filename: "some-updated-filename.csv"
   }
-  @invalid_attrs %{name: nil, presigned_url: nil, filename: nil}
+  @invalid_attrs %{name: nil, filename: nil}
 
   setup do
     %{spec: MeadowWeb.ApiSpec.spec()}
@@ -56,7 +54,6 @@ defmodule MeadowWeb.IngestJobControllerTest do
       {:ok, _job} =
         Ingest.create_ingest_job(%{
           name: "Job 1",
-          presigned_url: "http://example.com",
           project_id: project.id,
           filename: "test.csv"
         })
@@ -64,7 +61,6 @@ defmodule MeadowWeb.IngestJobControllerTest do
       {:ok, _job} =
         Ingest.create_ingest_job(%{
           name: "Job 2",
-          presigned_url: "http://example.com",
           project_id: project.id,
           filename: "test.csv"
         })
@@ -94,7 +90,6 @@ defmodule MeadowWeb.IngestJobControllerTest do
       assert %{
                "id" => id,
                "name" => "some name",
-               "presigned_url" => "some presigned_url",
                "filename" => "some-filename.csv"
              } = json_response(conn, 200)["data"]
     end
@@ -150,7 +145,6 @@ defmodule MeadowWeb.IngestJobControllerTest do
       assert %{
                "id" => id,
                "name" => "some updated name",
-               "presigned_url" => "some updated presigned_url",
                "filename" => "some-updated-filename.csv"
              } = json_response(conn, 200)["data"]
     end


### PR DESCRIPTION
- change ingest job to store filename in this format: `s3://bucket-name/project-folder/filename.csv`
- remove `presigned_url` column from `ingest_jobs` table
- Update api call to only display ingest jobs for a particular project on Project screen 