### PR TITLE
Support iex remote shell connections to running Meadow app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ LABEL edu.northwestern.library.app=meadow \
   edu.northwestern.library.stage=runtime
 RUN apk update && apk --no-cache --update add ncurses-libs openssl-dev
 ENV LANG=en_US.UTF-8
-EXPOSE 4000 4369
+EXPOSE 4000 4369 24601
 COPY --from=release /app/_build/prod/rel/meadow /app
 WORKDIR /app
 ENTRYPOINT ["./bin/meadow"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '3.2'
+version: "3.7"
 networks:
   default:
     external:
@@ -10,7 +10,22 @@ services:
     build:
       context: .
     environment:
+      AWS_ACCESS_KEY_ID: minio
+      AWS_SECRET_ACCESS_KEY: minio123
       SECRET_KEY_BASE: c/HprlqRq6CxhIysNuGFKvuIJ9LJ73TFzOIhYM3uW2/y3M2EKriDyjDzrbSlnBM0
       DATABASE_URL: ecto://docker:d0ck3r@db/docker
+      HONEYBADGER_ENV: development
+      HONEYBADGER_API_KEY: n0th1ng
+      INGEST_BUCKET: dev-ingest
+      UPLOAD_BUCKET: dev-uploads
+      RELEASE_COOKIE: HprlqRq6CxhIysNuGFKvuIJ9LJ73TFzOIhYM3uW2
+      RELEASE_NAME: meadow
+      RELEASE_DISTRIBUTION: sname
+    networks:
+      default:
+        aliases:
+          - meadow.internal
     ports:
       - 4000:4000
+      - 4369:4369
+      - 24601:24601

--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -1,0 +1,2 @@
+-kernel inet_dist_listen_min 24601 inet_dist_listen_max 24601
+-start_epmd true

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -69,6 +69,11 @@ data "template_file" "container_definitions" {
   }
 }
 
+locals {
+  container_ports = "${list(4000, 4369, 24601)}"
+  listener_ports = "${list(80, 4369, 24601)}"
+}
+
 resource "aws_ecs_service" "meadow" {
   name            = "meadow"
   cluster         = "${aws_ecs_cluster.meadow.id}"
@@ -78,9 +83,21 @@ resource "aws_ecs_service" "meadow" {
   depends_on      = ["aws_alb.meadow_load_balancer"]
 
   load_balancer {
-    target_group_arn = "${aws_alb_target_group.meadow_targets.arn}"
+    target_group_arn = "${aws_alb_target_group.meadow_targets.0.arn}"
     container_name   = "meadow-app"
-    container_port   = 4000
+    container_port   = "${element(local.container_ports, 0)}"
+  }
+
+  load_balancer {
+    target_group_arn = "${aws_alb_target_group.meadow_targets.1.arn}"
+    container_name   = "meadow-app"
+    container_port   = "${element(local.container_ports, 1)}"
+  }
+
+  load_balancer {
+    target_group_arn = "${aws_alb_target_group.meadow_targets.2.arn}"
+    container_name   = "meadow-app"
+    container_port   = "${element(local.container_ports, 2)}"
   }
 
   network_configuration {
@@ -93,7 +110,8 @@ resource "aws_ecs_service" "meadow" {
 }
 
 resource "aws_alb_target_group" "meadow_targets" {
-  port        = 4000
+  count       = "${length(local.container_ports)}"
+  port        = "${element(local.container_ports, count.index)}"
   target_type = "ip"
   protocol    = "TCP"
   vpc_id      = "${data.aws_vpc.default_vpc.id}"
@@ -115,13 +133,14 @@ resource "aws_alb" "meadow_load_balancer" {
 }
 
 resource "aws_lb_listener" "meadow_alb_listener" {
+  count             = "${length(local.listener_ports)}"
   load_balancer_arn = "${aws_alb.meadow_load_balancer.arn}"
-  port              = "80"
+  port              = "${element(local.listener_ports, count.index)}"
   protocol          = "TCP"
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_alb_target_group.meadow_targets.arn}"
+    target_group_arn = "${element(aws_alb_target_group.meadow_targets.*.arn, count.index)}"
   }
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -136,18 +136,10 @@ resource "aws_security_group_rule" "allow_meadow_db_access" {
 }
 
 resource "aws_security_group_rule" "allow_alb_access" {
+  count             = "${length(local.listener_ports)}"
   type              = "ingress"
-  from_port         = 4000
-  to_port           = 4000
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.meadow.id}"
-}
-
-resource "aws_security_group_rule" "allow_alb_remsh_access" {
-  type              = "ingress"
-  from_port         = 4369
-  to_port           = 4369
+  from_port         = "${element(local.listener_ports, count.index)}"
+  to_port           = "${element(local.listener_ports, count.index)}"
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = "${aws_security_group.meadow.id}"

--- a/terraform/task-definitions/meadow_app.json
+++ b/terraform/task-definitions/meadow_app.json
@@ -31,8 +31,12 @@
         "value": "${secret_key_base}"
       },
       { 
+        "name": "RELEASE_DISTRIBUTION",
+        "value": "name"
+      },
+      { 
         "name": "RELEASE_NODE",
-        "value": "meadow"
+        "value": "meadow@${host_name}"
       },
       {
         "name": "UPLOAD_BUCKET",
@@ -47,6 +51,10 @@
       {
         "containerPort": 4369,
         "hostPort": 4369
+      },
+      {
+        "containerPort": 24601,
+        "hostPort": 24601
       }
     ],
     "logConfiguration": {


### PR DESCRIPTION
This PR contains the build/deploy-time changes and terraform code to allow IEx to attach directly to the running remote Meadow instance on staging for real-time introspection and debugging.