### PR TITLE
Add role to ingest job headers

### DIFF
--- a/lib/meadow/ingest/ingest_jobs/inventory_validator.ex
+++ b/lib/meadow/ingest/ingest_jobs/inventory_validator.ex
@@ -7,6 +7,8 @@ defmodule Meadow.Ingest.IngestJobs.InventoryValidator do
   alias NimbleCSV.RFC4180, as: CSV
   import Ecto.Query
 
+  @headers ~w(accession_number description filename role work_accession_number)
+
   def async(job_id) do
     case Meadow.TaskRegistry |> Registry.lookup(job_id) do
       [{pid, _}] ->
@@ -127,7 +129,7 @@ defmodule Meadow.Ingest.IngestJobs.InventoryValidator do
     headers = for(field <- first_row.fields, into: [], do: field.header) |> Enum.sort()
 
     case headers do
-      ~w(accession_number description filename work_accession_number) -> {:ok, job}
+      @headers -> {:ok, job}
       _ -> {:error, job}
     end
   end

--- a/test/fixtures/inventory_sheet.csv
+++ b/test/fixtures/inventory_sheet.csv
@@ -1,8 +1,8 @@
-work_accession_number,accession_number,filename,description
-Donohue_001,Donohue_001_01,Donohue_001_01.tif,"Letter, page 1, Dear Sir, recto"
-Donohue_001,Donohue_001_02,Donohue_001_02.tif,"Letter, page 1, Dear Sir, verso, blank"
-Donohue_001,Donohue_001_03,Donohue_001_03.tif,"Letter, page 2, If these papers, recto"
-Donohue_001,Donohue_001_04,Donohue_001_04.tif,"Letter, page 2, If these papers, verso, blank"
-Donohue_002,Donohue_002_01,Donohue_002_01.tif,"Photo, man with two children"
-Donohue_002,Donohue_002_02,Donohue_002_02.tif,Verso
-Donohue_002,Donohue_002_03,Donohue_002_03.tif,"Photo, two children praying"
+work_accession_number,accession_number,filename,description,role
+Donohue_001,Donohue_001_01,Donohue_001_01.tif,"Letter, page 1, Dear Sir, recto",am
+Donohue_001,Donohue_001_02,Donohue_001_02.tif,"Letter, page 1, Dear Sir, verso, blank",pm
+Donohue_001,Donohue_001_03,Donohue_001_03.tif,"Letter, page 2, If these papers, recto",am
+Donohue_001,Donohue_001_04,Donohue_001_04.tif,"Letter, page 2, If these papers, verso, blank",am
+Donohue_002,Donohue_002_01,Donohue_002_01.tif,"Photo, man with two children",am
+Donohue_002,Donohue_002_02,Donohue_002_02.tif,Verso,am
+Donohue_002,Donohue_002_03,Donohue_002_03.tif,"Photo, two children praying",am

--- a/test/fixtures/inventory_sheet_missing_field.csv
+++ b/test/fixtures/inventory_sheet_missing_field.csv
@@ -1,8 +1,8 @@
-work_accession_number,accession_number,filename,description
-Donohue_001,Donohue_001_01,Donohue_001_01.tif,"Letter, page 1, Dear Sir, recto"
-Donohue_001,Donohue_001_02,Donohue_001_02.tif,"Letter, page 1, Dear Sir, verso, blank"
-Donohue_001,,Donohue_001_03.tif,"Letter, page 2, If these papers, recto"
-Donohue_001,Donohue_001_04,Donohue_001_04.tif,"Letter, page 2, If these papers, verso, blank"
-Donohue_002,Donohue_002_01,Donohue_002_01.tif,"Photo, man with two children"
-Donohue_002,Donohue_002_02,Donohue_002_02.tif,Verso
-Donohue_002,Donohue_002_03,Donohue_002_03.tif,"Photo, two children praying"
+work_accession_number,accession_number,filename,description,role
+Donohue_001,Donohue_001_01,Donohue_001_01.tif,"Letter, page 1, Dear Sir, recto",am
+Donohue_001,Donohue_001_02,Donohue_001_02.tif,"Letter, page 1, Dear Sir, verso, blank",am
+Donohue_001,,Donohue_001_03.tif,"Letter, page 2, If these papers, recto",am
+Donohue_001,Donohue_001_04,Donohue_001_04.tif,"Letter, page 2, If these papers, verso, blank",am
+Donohue_002,Donohue_002_01,Donohue_002_01.tif,"Photo, man with two children",am
+Donohue_002,Donohue_002_02,Donohue_002_02.tif,Verso,am
+Donohue_002,Donohue_002_03,Donohue_002_03.tif,"Photo, two children praying",am

--- a/test/fixtures/inventory_sheet_missing_file.csv
+++ b/test/fixtures/inventory_sheet_missing_file.csv
@@ -1,8 +1,8 @@
-work_accession_number,accession_number,filename,description
-Donohue_001,Donohue_001_01,Donohue_001_01.tif,"Letter, page 1, Dear Sir, recto"
-Donohue_001,Donohue_001_02,Donohue_001_02.tif,"Letter, page 1, Dear Sir, verso, blank"
-Donohue_001,Donohue_001_03,Donohue_001_03.tif,"Letter, page 2, If these papers, recto"
-Donohue_001,Donohue_001_04,Missing_001_04.tif,"Letter, page 2, If these papers, verso, blank"
-Donohue_002,Donohue_002_01,Donohue_002_01.tif,"Photo, man with two children"
-Donohue_002,Donohue_002_02,Donohue_002_02.tif,Verso
-Donohue_002,Donohue_002_03,Donohue_002_03.tif,"Photo, two children praying"
+work_accession_number,accession_number,filename,description,role
+Donohue_001,Donohue_001_01,Donohue_001_01.tif,"Letter, page 1, Dear Sir, recto",am
+Donohue_001,Donohue_001_02,Donohue_001_02.tif,"Letter, page 1, Dear Sir, verso, blank",am
+Donohue_001,Donohue_001_03,Donohue_001_03.tif,"Letter, page 2, If these papers, recto",am
+Donohue_001,Donohue_001_04,Missing_001_04.tif,"Letter, page 2, If these papers, verso, blank",am
+Donohue_002,Donohue_002_01,Donohue_002_01.tif,"Photo, man with two children",am
+Donohue_002,Donohue_002_02,Donohue_002_02.tif,Verso,am
+Donohue_002,Donohue_002_03,Donohue_002_03.tif,"Photo, two children praying",am

--- a/test/fixtures/inventory_sheet_wrong_headers.csv
+++ b/test/fixtures/inventory_sheet_wrong_headers.csv
@@ -1,8 +1,8 @@
-work_accession_number,not_the_accession_number,filename,description
-Donohue_001,Donohue_001_01,Donohue_001_01.tif,"Letter, page 1, Dear Sir, recto"
-Donohue_001,Donohue_001_02,Donohue_001_02.tif,"Letter, page 1, Dear Sir, verso, blank"
-Donohue_001,Donohue_001_03,Donohue_001_03.tif,"Letter, page 2, If these papers, recto"
-Donohue_001,Donohue_001_04,Donohue_001_04.tif,"Letter, page 2, If these papers, verso, blank"
-Donohue_002,Donohue_002_01,Donohue_002_01.tif,"Photo, man with two children"
-Donohue_002,Donohue_002_02,Donohue_002_02.tif,Verso
-Donohue_002,Donohue_002_03,Donohue_002_03.tif,"Photo, two children praying"
+work_accession_number,not_the_accession_number,filename,description,role
+Donohue_001,Donohue_001_01,Donohue_001_01.tif,"Letter, page 1, Dear Sir, recto",am
+Donohue_001,Donohue_001_02,Donohue_001_02.tif,"Letter, page 1, Dear Sir, verso, blank",am
+Donohue_001,Donohue_001_03,Donohue_001_03.tif,"Letter, page 2, If these papers, recto",am
+Donohue_001,Donohue_001_04,Donohue_001_04.tif,"Letter, page 2, If these papers, verso, blank",am
+Donohue_002,Donohue_002_01,Donohue_002_01.tif,"Photo, man with two children",am
+Donohue_002,Donohue_002_02,Donohue_002_02.tif,Verso,am
+Donohue_002,Donohue_002_03,Donohue_002_03.tif,"Photo, two children praying",am


### PR DESCRIPTION
– First iteration, no error reporting or validation of content, just adds 'role' to the list of required headers.
