### PR TITLE
1130 wire up current crud actions supported

### DIFF
--- a/assets/css/meadow.css
+++ b/assets/css/meadow.css
@@ -181,7 +181,7 @@ td {
 
 /** Overrides **/
 .Toastify__toast--default {
-  @apply bg-gray-500 text-white !important;
+  @apply bg-gray-600 text-white !important;
 }
 .Toastify__close-button--default {
   @apply text-white !important;

--- a/assets/css/meadow.css
+++ b/assets/css/meadow.css
@@ -42,11 +42,11 @@ nav a:hover {
 }
 
 table {
-  @apply text-left;
+  @apply text-left w-full;
 }
 
 caption {
-  @apply italic py-4;
+  @apply italic py-4 text-sm text-gray-600;
 }
 
 th {

--- a/assets/css/meadow.css
+++ b/assets/css/meadow.css
@@ -42,7 +42,11 @@ nav a:hover {
 }
 
 table {
-  @apply w-full text-left;
+  @apply text-left;
+}
+
+caption {
+  @apply italic py-4;
 }
 
 th {

--- a/assets/js/components/InventorySheet/List.jsx
+++ b/assets/js/components/InventorySheet/List.jsx
@@ -4,15 +4,53 @@ import { Link } from "react-router-dom";
 import { useQuery } from "@apollo/react-hooks";
 import Error from "../UI/Error";
 import Loading from "../UI/Loading";
-import { GET_INGEST_JOBS } from "./inventorySheet.query";
+import { GET_INGEST_JOBS, DELETE_INGEST_JOB } from "./inventorySheet.query";
+import { useApolloClient, useMutation } from "@apollo/react-hooks";
 
 const InventorySheetList = ({ projectId }) => {
   const { loading, error, data } = useQuery(GET_INGEST_JOBS, {
     variables: { projectId }
   });
+  const client = useApolloClient();
+  const [deleteIngestJob, { data: deleteIngestJobData }] = useMutation(
+    DELETE_INGEST_JOB,
+    {
+      update(
+        cache,
+        {
+          data: { deleteIngestJob }
+        }
+      ) {
+        try {
+          const { project } = client.readQuery({
+            query: GET_INGEST_JOBS,
+            variables: { projectId }
+          });
+
+          const index = project.ingestJobs.findIndex(
+            ingestJob => ingestJob.id === deleteIngestJob.id
+          );
+
+          project.ingestJobs.splice(index, 1);
+
+          client.writeQuery({
+            query: GET_INGEST_JOBS,
+            data: { project }
+          });
+        } catch (error) {
+          console.log("Error reading from cache", error);
+        }
+      }
+    }
+  );
 
   if (loading) return <Loading />;
   if (error) return <Error error={error} />;
+
+  const handleDeleteClick = ingestJobId => {
+    console.log("TCL: handleDeleteClick -> ingestJobId", ingestJobId);
+    deleteIngestJob({ variables: { ingestJobId } });
+  };
 
   return (
     <div>
@@ -24,11 +62,13 @@ const InventorySheetList = ({ projectId }) => {
 
       {data.project.ingestJobs.length > 0 && (
         <table>
+          <caption>All Project Ingest Jobs</caption>
           <thead>
             <tr>
               <th>Ingest job title</th>
               <th>Last updated</th>
               <th>Status</th>
+              <th></th>
             </tr>
           </thead>
           <tbody>
@@ -41,7 +81,12 @@ const InventorySheetList = ({ projectId }) => {
                     </Link>
                   </td>
                   <td>{updatedAt}</td>
-                  <td>...tbd</td>
+                  <td>[ supported? ]</td>
+                  <td>
+                    <button onClick={() => handleDeleteClick(id)}>
+                      Delete
+                    </button>
+                  </td>
                 </tr>
               )
             )}

--- a/assets/js/components/InventorySheet/Validations.jsx
+++ b/assets/js/components/InventorySheet/Validations.jsx
@@ -235,7 +235,7 @@ function InventorySheetValidations({
         <div className="pt-12">
           <UIProgressBar percentComplete={50} label="works being created" />
         </div>
-        <div class="text-center leading-loose text-gray-600">
+        <div className="text-center leading-loose text-gray-600">
           <p>48 works are being created</p>
           <p>370 file sets are being created</p>
           <p>What other info goes here?</p>

--- a/assets/js/components/InventorySheet/inventorySheet.query.js
+++ b/assets/js/components/InventorySheet/inventorySheet.query.js
@@ -18,6 +18,15 @@ export const CREATE_INGEST_JOB = gql`
   }
 `;
 
+export const DELETE_INGEST_JOB = gql`
+  mutation DeleteIngestJob($ingestJobId: ID!) {
+    deleteIngestJob(ingestJobId: $ingestJobId) {
+      id
+      name
+    }
+  }
+`;
+
 export const GET_INGEST_JOBS = gql`
   query GetIngestJobs($projectId: ID!) {
     project(id: $projectId) {

--- a/assets/js/components/UI/Modal/Delete.jsx
+++ b/assets/js/components/UI/Modal/Delete.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import ExclamationIcon from "../../../../css/fonts/zondicons/exclamation-solid.svg";
+import Modal from "react-responsive-modal";
+import PropTypes from "prop-types";
+
+const UIModalDelete = ({
+  isOpen,
+  handleClose,
+  handleConfirm,
+  thingToDeleteLabel
+}) => {
+  return (
+    <Modal center open={isOpen} onClose={handleClose}>
+      <div className="flex">
+        <ExclamationIcon className="icon w-16 h-16 text-danger-dark pr-4" />
+        <div className="mr-8">
+          <h4 className="uppercase text-sm font-bold leading-loose">
+            Delete {thingToDeleteLabel}
+          </h4>
+          <p className="text-gray-600">This action cannot be undone</p>
+          <div className="button-group mt-8 flex justify-end">
+            <button className="btn btn-clear" onClick={handleClose}>
+              Cancel
+            </button>
+            <button className="btn btn-danger" onClick={handleConfirm}>
+              Delete
+            </button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+UIModalDelete.propTypes = {
+  isOpen: PropTypes.bool,
+  handleClose: PropTypes.func,
+  handleConfirm: PropTypes.func,
+  thingToDeleteLabel: PropTypes.string
+};
+
+export default UIModalDelete;

--- a/assets/package.json
+++ b/assets/package.json
@@ -24,7 +24,8 @@
     "phoenix_html": "file:../deps/phoenix_html",
     "prop-types": "^15.7.2",
     "rc-progress": "^2.5.1",
-    "react-apollo": "^2.5.8"
+    "react-apollo": "^2.5.8",
+    "react-responsive-modal": "^4.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -2523,6 +2523,11 @@ cssstyle@^1.0.0:
   dependencies:
     cssom "0.3.x"
 
+csstype@^2.6.6:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.6.tgz#c34f8226a94bbb10c32cc0d714afdf942291fc41"
+  integrity sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==
+
 cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
@@ -2686,6 +2691,14 @@ dom-helpers@^3.4.0:
   integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
   dependencies:
     "@babel/runtime" "^7.1.2"
+
+dom-helpers@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.1.0.tgz#57a726de04abcc2a8bbfe664b3e21c584bde514e"
+  integrity sha512-zRRYDhpiKuAJHasOqCm7lBnsd22nrM4+OYI4ASWCxen+ocTMl7BIAKgGag97TlLiTl6rrau5aPe1VGUm9jQBng==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    csstype "^2.6.6"
 
 dom-serializer@0:
   version "0.2.1"
@@ -3098,6 +3111,21 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+focus-trap-react@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-4.0.1.tgz#3cffd39341df3b2f546a4a2fe94cfdea66154683"
+  integrity sha512-UUZKVEn5cFbF6yUnW7lbXNW0iqN617ShSqYKgxctUvWw1wuylLtyVmC0RmPQNnJ/U+zoKc/djb0tZMs0uN/0QQ==
+  dependencies:
+    focus-trap "^3.0.0"
+
+focus-trap@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-3.0.0.tgz#4d2ee044ae66bf7eb6ebc6c93bd7a1039481d7dc"
+  integrity sha512-jTFblf0tLWbleGjj2JZsAKbgtZTdL1uC48L8FcmSDl4c2vDoU4NycN1kgV5vJhuq1mxNFkw7uWZ1JAGlINWvyw==
+  dependencies:
+    tabbable "^3.1.0"
+    xtend "^4.0.1"
 
 follow-redirects@1.5.10:
   version "1.5.10"
@@ -4903,6 +4931,11 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+no-scroll@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/no-scroll/-/no-scroll-2.1.1.tgz#f37e08cb159b75a5bdbfc0a87cd9223e120e6e27"
+  integrity sha512-YTzGAJOo/B6hkodeT5SKKHpOhAzjMfkUCCXjLJwjWk2F4/InIg+HbdH9kmT7bKpleDuqLZDTRy2OdNtAj0IVyQ==
+
 node-emoji@^1.8.1:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.10.0.tgz#8886abd25d9c7bb61802a658523d1f8d2a89b2da"
@@ -6043,6 +6076,17 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-responsive-modal@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/react-responsive-modal/-/react-responsive-modal-4.0.1.tgz#f3de0fc2571be96ed8a013ee45d572f42ed1e7c5"
+  integrity sha512-R+exyFDILtWtggYfiwiQv4V0cGRplTNRnUGf2qSXDDD4L2HCia+LjpUCHnhb/7dAl10ASq9BwzAxSOJj0GHjCg==
+  dependencies:
+    classnames "^2.2.6"
+    focus-trap-react "^4.0.1"
+    no-scroll "^2.1.1"
+    prop-types "^15.6.2"
+    react-transition-group "^4.0.0"
+
 react-router-dom@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.0.1.tgz#ee66f4a5d18b6089c361958e443489d6bab714be"
@@ -6120,6 +6164,16 @@ react-transition-group@^2.6.1:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
+
+react-transition-group@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.3.0.tgz#fea832e386cf8796c58b61874a3319704f5ce683"
+  integrity sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@^16.7.0-alpha.0, react@^16.8.6:
   version "16.9.0"
@@ -6919,6 +6973,11 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+tabbable@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-3.1.2.tgz#f2d16cccd01f400e38635c7181adfe0ad965a4a2"
+  integrity sha512-wjB6puVXTYO0BSFtCmWQubA/KIn7Xvajw0x0l6eJUudMG/EAiJvIUnyNX6xO4NpGrJ16lbD0eUseB9WxW0vlpQ==
+
 tailwindcss-spinner@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tailwindcss-spinner/-/tailwindcss-spinner-1.0.0.tgz#5769793e6ce2bab2ce25ad3efeefb64e788bd255"
@@ -7568,7 +7627,7 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xtend@^4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
This supports the Delete GraphQL mutation for an Inventory Sheet / Ingestion Job.   Also implements modal validations on delete action.

![image](https://user-images.githubusercontent.com/3020266/65185039-5c17f180-da2c-11e9-838b-10915ddebd23.png)

![image](https://user-images.githubusercontent.com/3020266/65185076-6df99480-da2c-11e9-9c45-8cbed021d224.png)

![image](https://user-images.githubusercontent.com/3020266/65185118-823d9180-da2c-11e9-8954-29d8864b9b79.png)

![image](https://user-images.githubusercontent.com/3020266/65185168-997c7f00-da2c-11e9-871d-fbe4e40ad8fa.png)
