### PR TITLE
Queries, mutations for Works and FileSets

### DIFF
--- a/lib/meadow/constants.ex
+++ b/lib/meadow/constants.ex
@@ -3,8 +3,9 @@ defmodule Meadow.Constants do
 
   defmacro __using__(_) do
     quote do
-      @work_types ~w[Image Video Audio Document]
-      @visibility ~w[public private registered]
+      @work_types ~w[image audio video document]
+      @visibility ~w[open authenticated restricted]
+      @file_set_roles ~w[am pm]
     end
   end
 end

--- a/lib/meadow/data.ex
+++ b/lib/meadow/data.ex
@@ -26,4 +26,14 @@ defmodule Meadow.Data do
     |> Ecto.assoc(:work)
     |> Repo.one()
   end
+
+  # Dataloader
+
+  def datasource do
+    Dataloader.Ecto.new(Repo, query: &query/2)
+  end
+
+  def query(queryable, _) do
+    queryable
+  end
 end

--- a/lib/meadow/data/file_sets.ex
+++ b/lib/meadow/data/file_sets.ex
@@ -37,6 +37,15 @@ defmodule Meadow.Data.FileSets do
   def get_file_set!(id), do: Repo.get!(FileSet, id)
 
   @doc """
+  Gets a file_set by accession_number
+
+  Raises `Ecto.NoResultsError` if the Work does not exist
+  """
+  def get_file_set_by_accession_number!(accession_number) do
+    Repo.get_by!(FileSet, accession_number: accession_number)
+  end
+
+  @doc """
   Creates a file set.
 
   ## Examples
@@ -52,5 +61,12 @@ defmodule Meadow.Data.FileSets do
     %FileSet{}
     |> FileSet.changeset(attrs)
     |> Repo.insert()
+  end
+
+  @doc """
+  Deletes a FileSet.
+  """
+  def delete_file_set(%FileSet{} = file_set) do
+    Repo.delete(file_set)
   end
 end

--- a/lib/meadow/data/file_sets/file_set.ex
+++ b/lib/meadow/data/file_sets/file_set.ex
@@ -8,10 +8,13 @@ defmodule Meadow.Data.FileSets.FileSet do
 
   import Ecto.Changeset
 
+  use Meadow.Constants
+
   @primary_key {:id, Ecto.ULID, autogenerate: true}
   @foreign_key_type Ecto.ULID
   schema "file_sets" do
     field :accession_number
+    field :role, :string
     embeds_one :metadata, FileSetMetadata
     timestamps()
 
@@ -20,9 +23,11 @@ defmodule Meadow.Data.FileSets.FileSet do
 
   def changeset(file_set, params) do
     file_set
-    |> cast(params, [:accession_number])
+    |> cast(params, [:accession_number, :work_id, :role])
     |> cast_embed(:metadata)
-    |> validate_required([:accession_number])
+    |> validate_required([:accession_number, :role])
+    |> assoc_constraint(:work)
     |> unique_constraint(:accession_number)
+    |> validate_inclusion(:role, @file_set_roles)
   end
 end

--- a/lib/meadow/data/file_sets/file_set_metadata.ex
+++ b/lib/meadow/data/file_sets/file_set_metadata.ex
@@ -9,12 +9,16 @@ defmodule Meadow.Data.FileSets.FileSetMetadata do
   embedded_schema do
     field :location
     field :original_filename
+    field :description
 
     timestamps()
   end
 
   def changeset(metadata, params) do
+    required_params = [:location, :original_filename, :description]
+
     metadata
-    |> cast(params, [:location, :original_filename])
+    |> cast(params, required_params)
+    |> validate_required(required_params)
   end
 end

--- a/lib/meadow/data/works/work.ex
+++ b/lib/meadow/data/works/work.ex
@@ -9,6 +9,8 @@ defmodule Meadow.Data.Works.Work do
 
   import Ecto.Changeset
 
+  use Meadow.Constants
+
   @primary_key {:id, Ecto.ULID, autogenerate: true}
   @foreign_key_type Ecto.ULID
   schema "works" do
@@ -23,11 +25,16 @@ defmodule Meadow.Data.Works.Work do
   end
 
   def changeset(work, attrs) do
+    required_params = [:accession_number, :visibility, :work_type]
+    optional_params = []
+
     work
-    |> cast(attrs, [:accession_number, :visibility, :work_type])
+    |> cast(attrs, required_params ++ optional_params)
     |> cast_embed(:metadata)
     |> cast_assoc(:file_sets)
-    |> validate_required([:accession_number, :metadata, :visibility, :work_type])
+    |> validate_required(required_params)
+    |> validate_inclusion(:visibility, @visibility)
+    |> validate_inclusion(:work_type, @work_types)
     |> unique_constraint(:accession_number)
   end
 end

--- a/lib/meadow_web/resolvers/data.ex
+++ b/lib/meadow_web/resolvers/data.ex
@@ -1,0 +1,85 @@
+defmodule MeadowWeb.Resolvers.Data do
+  @moduledoc """
+  Absinthe GraphQL query resolver for Data Context
+
+  """
+  alias Meadow.Data.FileSets
+  alias Meadow.Data.Works
+  alias MeadowWeb.Schema.ChangesetErrors
+
+  def works(_, args, _) do
+    {:ok, Works.list_works(args)}
+  end
+
+  def work(_, %{id: id}, _) do
+    {:ok, Works.get_work!(id)}
+  end
+
+  def work(_, %{accession_number: accession_number}, _) do
+    {:ok, Works.get_work_by_accession_number!(accession_number)}
+  end
+
+  def create_work(_, args, _) do
+    case Works.create_work(args) do
+      {:error, changeset} ->
+        {:error,
+         message: "Could not create work", details: ChangesetErrors.error_details(changeset)}
+
+      {:ok, work} ->
+        {:ok, work}
+    end
+  end
+
+  def create_file_set(_, args, _) do
+    case FileSets.create_file_set(args) do
+      {:error, changeset} ->
+        {:error,
+         message: "Could not create file set", details: ChangesetErrors.error_details(changeset)}
+
+      {:ok, file_set} ->
+        {:ok, file_set}
+    end
+  end
+
+  def delete_work(_, args, _) do
+    work = Works.get_work!(args[:work_id])
+
+    case Works.delete_work(work) do
+      {:error, changeset} ->
+        {
+          :error,
+          message: "Could not delete work", details: ChangesetErrors.error_details(changeset)
+        }
+
+      {:ok, work} ->
+        {:ok, work}
+    end
+  end
+
+  def file_sets(_, _args, _) do
+    {:ok, FileSets.list_file_sets()}
+  end
+
+  def file_set(_, %{id: id}, _) do
+    {:ok, FileSets.get_file_set!(id)}
+  end
+
+  def file_set(_, %{accession_number: accession_number}, _) do
+    {:ok, FileSets.get_file_set_by_accession_number!(accession_number)}
+  end
+
+  def delete_file_set(_, args, _) do
+    file_set = FileSets.get_file_set!(args[:file_set_id])
+
+    case FileSets.delete_file_set(file_set) do
+      {:error, changeset} ->
+        {
+          :error,
+          message: "Could not delete file_set", details: ChangesetErrors.error_details(changeset)
+        }
+
+      {:ok, file_set} ->
+        {:ok, file_set}
+    end
+  end
+end

--- a/lib/meadow_web/schema/schema.ex
+++ b/lib/meadow_web/schema/schema.ex
@@ -7,18 +7,25 @@ defmodule MeadowWeb.Schema do
   import_types(Absinthe.Type.Custom)
   import_types(MeadowWeb.Schema.Types.Json)
 
+  alias Meadow.Data
   alias Meadow.Ingest
 
   import_types(__MODULE__.AccountTypes)
   import_types(__MODULE__.IngestTypes)
+  import_types(__MODULE__.Data.WorkTypes)
+  import_types(__MODULE__.Data.FileSetTypes)
 
   query do
     import_fields(:account_queries)
     import_fields(:ingest_queries)
+    import_fields(:work_queries)
+    import_fields(:file_set_queries)
   end
 
   mutation do
     import_fields(:ingest_mutations)
+    import_fields(:work_mutations)
+    import_fields(:file_set_mutations)
   end
 
   subscription do
@@ -52,6 +59,7 @@ defmodule MeadowWeb.Schema do
     loader =
       Dataloader.new()
       |> Dataloader.add_source(Ingest, Ingest.datasource())
+      |> Dataloader.add_source(Data, Data.datasource())
 
     Map.put(ctx, :loader, loader)
   end

--- a/lib/meadow_web/schema/types/data/file_set_types.ex
+++ b/lib/meadow_web/schema/types/data/file_set_types.ex
@@ -1,0 +1,86 @@
+defmodule MeadowWeb.Schema.Data.FileSetTypes do
+  @moduledoc """
+  Absinthe Schema for FileSetTypes
+
+  """
+  use Absinthe.Schema.Notation
+
+  import Absinthe.Resolution.Helpers, only: [dataloader: 1]
+
+  alias Meadow.Data
+  alias MeadowWeb.Resolvers
+  alias MeadowWeb.Schema.Middleware
+
+  object :file_set_queries do
+    @desc "Get a list of file sets"
+    field :file_sets, list_of(:file_set) do
+      middleware(Middleware.Authenticate)
+      resolve(&MeadowWeb.Resolvers.Data.file_sets/3)
+    end
+  end
+
+  object :file_set_mutations do
+    @desc "Create a new FileSet for a work"
+    field :create_file_set, :file_set do
+      arg(:accession_number, non_null(:string))
+      arg(:role, non_null(:file_set_role))
+      arg(:work_id, non_null(:id))
+      arg(:metadata, non_null(:file_set_metadata_input))
+      middleware(Middleware.Authenticate)
+      resolve(&Resolvers.Data.create_file_set/3)
+    end
+
+    @desc "Delete a FileSet"
+    field :delete_file_set, :file_set do
+      arg(:file_set_id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      resolve(&Resolvers.Data.delete_file_set/3)
+    end
+  end
+
+  #
+  # Input Object Types
+  #
+
+  @desc "Same as `file_set_metadata`. This represents all metadata associated with a file_set. It is stored in a single json field."
+  input_object :file_set_metadata_input do
+    field :location, :string
+    field :original_filename, :string
+    field :description, :string
+  end
+
+  @desc "Input fields for a `file_set` object "
+  input_object :file_set_input do
+    field :accession_number, non_null(:string)
+    field :role, non_null(:file_set_role)
+    field :metadata, :file_set_metadata_input
+  end
+
+  #
+  # Object Types
+  #
+
+  @desc "A `file_set` object represents one file (repository object in S3)"
+  object :file_set do
+    field :id, non_null(:id)
+    field :accession_number, non_null(:string)
+    field :role, non_null(:file_set_role)
+    field :work, :work, resolve: dataloader(Data)
+    field :metadata, :file_set_metadata
+    field :inserted_at, non_null(:naive_datetime)
+    field :updated_at, non_null(:naive_datetime)
+  end
+
+  @desc "`file_set_metadata` represents all metadata associated with a file set object. It is stored in a single json field."
+  object :file_set_metadata do
+    field :location, :string
+    field :original_filename, :string
+    field :description, :string
+  end
+
+  @desc "A `file_set_role` designates whether the file is an access or preservation master and will determine how the file is processed and stored."
+  enum :file_set_role do
+    value(:am, as: "am", description: "Access Master")
+    value(:pm, as: "pm", description: "Preservaton Master")
+  end
+end

--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -1,0 +1,114 @@
+defmodule MeadowWeb.Schema.Data.WorkTypes do
+  @moduledoc """
+  Absinthe Schema for WorkTypes
+
+  """
+  use Absinthe.Schema.Notation
+
+  import Absinthe.Resolution.Helpers, only: [dataloader: 1]
+  alias Meadow.Data
+  alias MeadowWeb.Resolvers
+  alias MeadowWeb.Schema.Middleware
+
+  object :work_queries do
+    @desc "Get a list of works"
+    field :works, list_of(:work) do
+      arg(:limit, :integer, default_value: 100)
+      arg(:filter, :work_filter)
+      arg(:order, type: :sort_order, default_value: :asc)
+      middleware(Middleware.Authenticate)
+      resolve(&MeadowWeb.Resolvers.Data.works/3)
+    end
+
+    @desc "Get a work by id"
+    field :work, :work do
+      arg(:id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      resolve(&MeadowWeb.Resolvers.Data.work/3)
+    end
+
+    @desc "Get a work by accession_number"
+    field :work_by_accession, :work do
+      arg(:accession_number, non_null(:string))
+      middleware(Middleware.Authenticate)
+      resolve(&MeadowWeb.Resolvers.Data.work/3)
+    end
+  end
+
+  object :work_mutations do
+    @desc "Create a new Work"
+    field :create_work, :work do
+      arg(:metadata, non_null(:work_metadata_input))
+      arg(:accession_number, non_null(:string))
+      arg(:work_type, non_null(:work_type))
+      arg(:visibility, non_null(:visibility))
+      arg(:file_sets, list_of(:file_set_input))
+      middleware(Middleware.Authenticate)
+      resolve(&Resolvers.Data.create_work/3)
+    end
+
+    @desc "Delete a Work"
+    field :delete_work, :work do
+      arg(:work_id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      resolve(&Resolvers.Data.delete_work/3)
+    end
+  end
+
+  @desc "A work object"
+  object :work do
+    field :id, non_null(:id)
+    field :accession_number, non_null(:string)
+    field :metadata, :work_metadata
+    field :work_type, non_null(:work_type)
+    field :visibility, non_null(:visibility)
+    field :inserted_at, non_null(:naive_datetime)
+    field :updated_at, non_null(:naive_datetime)
+
+    field :file_sets, list_of(:file_set), resolve: dataloader(Data)
+  end
+
+  #
+  # Input Object Types
+  #
+
+  @desc "Filters for the list of works"
+  input_object :work_filter do
+    @desc "Matching a title"
+    field :matching, :string
+
+    @desc "By visibility"
+    field :visibility, :visibility
+
+    @desc "By work_type"
+    field :work_type, :work_type
+  end
+
+  @desc "Same as `work_metadata`. This represents all metadata associated with a work object. It is stored in a single json field."
+  input_object :work_metadata_input do
+    field :title, :string
+  end
+
+  #
+  # Object Types
+  #
+
+  @desc "`work_metadata` represents all metadata associated with a work object. It is stored in a single json field."
+  object :work_metadata do
+    field :title, :string
+  end
+
+  @desc "visibility setting for the object"
+  enum :visibility do
+    value(:open, as: "open", description: "Public")
+    value(:authenticated, as: "authenticated", description: "Institution")
+    value(:restricted, as: "restricted", description: "Private")
+  end
+
+  @desc "work types"
+  enum :work_type do
+    value(:image, as: "image", description: "Image")
+    value(:video, as: "video", description: "Video")
+    value(:document, as: "document", description: "Document")
+  end
+end

--- a/lib/meadow_web/schema/types/ingest_types.ex
+++ b/lib/meadow_web/schema/types/ingest_types.ex
@@ -140,6 +140,16 @@ defmodule MeadowWeb.Schema.IngestTypes do
     end
   end
 
+  object :project do
+    field :id, non_null(:id)
+    field :title, non_null(:string)
+    field :folder, non_null(:string)
+    field :inserted_at, non_null(:naive_datetime)
+    field :updated_at, non_null(:naive_datetime)
+
+    field :ingest_sheets, list_of(:ingest_sheet), resolve: dataloader(Ingest)
+  end
+
   @desc "IngestSheet object"
   object :ingest_sheet do
     field :id, non_null(:id)
@@ -193,10 +203,12 @@ defmodule MeadowWeb.Schema.IngestTypes do
     field :ingest_sheets, list_of(:ingest_sheet), resolve: dataloader(Ingest)
   end
 
-  object :sheet_progress do
-    field :states, list_of(:state_count)
-    field :total, non_null(:integer)
-    field :percent_complete, non_null(:float)
+  object :ingest_sheet_row do
+    field :ingest_sheet, :ingest_sheet, resolve: dataloader(Ingest)
+    field :row, non_null(:integer)
+    field :fields, list_of(:field)
+    field :errors, list_of(:error)
+    field :state, :state
   end
 
   @desc "Object that tracks IngestSheet state"
@@ -206,16 +218,21 @@ defmodule MeadowWeb.Schema.IngestTypes do
     field :state, non_null(:state)
   end
 
+  @desc "states: PENDING, PASS or FAIL"
+  enum :state do
+    value(:pending, as: "pending")
+    value(:pass, as: "pass")
+    value(:fail, as: "fail")
+  end
+
+  object :sheet_progress do
+    field :states, list_of(:state_count)
+    field :total, non_null(:integer)
+    field :percent_complete, non_null(:float)
+  end
+
   object :state_count do
     field :state, non_null(:state)
     field :count, non_null(:integer)
-  end
-
-  object :ingest_sheet_row do
-    field :ingest_sheet, :ingest_sheet, resolve: dataloader(Ingest)
-    field :row, non_null(:integer)
-    field :fields, list_of(:field)
-    field :errors, list_of(:error)
-    field :state, :state
   end
 end

--- a/priv/repo/migrations/20191001152143_change_file_sets_add_role_cascade_delete.exs
+++ b/priv/repo/migrations/20191001152143_change_file_sets_add_role_cascade_delete.exs
@@ -1,0 +1,12 @@
+defmodule Meadow.Repo.Migrations.ChangeFileSetsAddRoleCascadeDelete do
+  use Ecto.Migration
+
+  def change do
+    drop(constraint(:file_sets, "file_sets_work_id_fkey"))
+
+    alter table(:file_sets) do
+      add :role, :string
+      modify :work_id, references(:works, null: false, on_delete: :delete_all)
+    end
+  end
+end

--- a/test/meadow/data/file_sets/file_set_test.exs
+++ b/test/meadow/data/file_sets/file_set_test.exs
@@ -6,7 +6,12 @@ defmodule Meadow.Data.FileSets.FileSetTest do
   describe "file_sets" do
     @valid_attrs %{
       accession_number: "12345",
-      metadata: %{location: "https://example.com", original_filename: "test.tiff"}
+      role: "am",
+      metadata: %{
+        description: "yes",
+        location: "https://example.com",
+        original_filename: "test.tiff"
+      }
     }
 
     test "created file_set has a ULID identifier" do

--- a/test/meadow/data/file_sets_test.exs
+++ b/test/meadow/data/file_sets_test.exs
@@ -7,8 +7,14 @@ defmodule Meadow.Data.FileSetsTest do
   describe "queries" do
     @valid_attrs %{
       accession_number: "12345",
-      metadata: %{location: "https://example.com", original_filename: "test.tiff"}
+      role: "am",
+      metadata: %{
+        description: "yes",
+        location: "https://example.com",
+        original_filename: "test.tiff"
+      }
     }
+
     @invalid_attrs %{accession_number: nil}
 
     test "list_file_sets/0 returns all file_sets" do
@@ -17,11 +23,27 @@ defmodule Meadow.Data.FileSetsTest do
     end
 
     test "create_file_set/1 with valid data creates a file_set" do
-      assert {:ok, %FileSet{} = work} = FileSets.create_file_set(@valid_attrs)
+      assert {:ok, %FileSet{} = file_set} = FileSets.create_file_set(@valid_attrs)
     end
 
     test "create_file_set/1 with invalid data does not create a file_set" do
       assert {:error, %Ecto.Changeset{}} = FileSets.create_file_set(@invalid_attrs)
+    end
+
+    test "delete_file_set/1 deletes a file_set" do
+      file_set = file_set_fixture()
+      assert {:ok, %FileSet{} = file_set} = FileSets.delete_file_set(file_set)
+      assert Enum.empty?(FileSets.list_file_sets())
+    end
+
+    test "get_file_set!/1 returns a file set by id" do
+      file_set = file_set_fixture()
+      assert FileSets.get_file_set!(file_set.id) == file_set
+    end
+
+    test "get_file_set_by_accessionb_number!/1 returns a file set by accession_number" do
+      file_set = file_set_fixture()
+      assert FileSets.get_file_set_by_accession_number!(file_set.accession_number) == file_set
     end
   end
 end

--- a/test/meadow/data/works/work_test.exs
+++ b/test/meadow/data/works/work_test.exs
@@ -7,7 +7,7 @@ defmodule Meadow.Data.Works.WorkTest do
     @valid_attrs %{
       accession_number: "12345",
       visibility: "open",
-      work_type: "Image",
+      work_type: "image",
       metadata: %{title: "Test"}
     }
 

--- a/test/meadow/data/works_test.exs
+++ b/test/meadow/data/works_test.exs
@@ -8,7 +8,7 @@ defmodule Meadow.Data.WorksTest do
     @valid_attrs %{
       accession_number: "12345",
       visibility: "open",
-      work_type: "Image",
+      work_type: "image",
       metadata: %{title: "Test"}
     }
     @invalid_attrs %{accession_number: nil}
@@ -30,6 +30,17 @@ defmodule Meadow.Data.WorksTest do
 
     test "create_work/1 with invalid data does not create a work" do
       assert {:error, %Ecto.Changeset{}} = Works.create_work(@invalid_attrs)
+    end
+
+    test "delete_work/1 deletes a work" do
+      work = work_fixture()
+      assert {:ok, %Work{} = work} = Works.delete_work(work)
+      assert Enum.empty?(Works.list_works())
+    end
+
+    test "get_work!/1 returns a work by id" do
+      work = work_fixture()
+      assert %Work{} = Works.get_work!(work.id)
     end
   end
 end

--- a/test/meadow/data_test.exs
+++ b/test/meadow/data_test.exs
@@ -9,7 +9,9 @@ defmodule Meadow.DataTest do
       file_sets: [
         %{
           accession_number: "1234",
+          role: "am",
           metadata: %{
+            description: "This is the description",
             location: "https://www.library.northwestern.edu",
             original_filename: "test.tiff"
           }
@@ -21,6 +23,10 @@ defmodule Meadow.DataTest do
       work = work_fixture(@file_set_attrs) |> Repo.preload(:file_sets)
       file_set_id = List.first(work.file_sets).id
       assert Data.get_work_by_file_set_id(file_set_id).id == work.id
+    end
+
+    test "query/2 returns its queryable" do
+      assert Data.query(:input, :ignored) == :input
     end
   end
 end

--- a/test/meadow_web/schema/mutation/create_file_set_test.exs
+++ b/test/meadow_web/schema/mutation/create_file_set_test.exs
@@ -1,0 +1,59 @@
+defmodule MeadowWeb.Schema.Mutation.CreateFileSetTest do
+  use MeadowWeb.ConnCase, async: true
+
+  import Mox
+
+  @query """
+    mutation (
+      $accession_number: String!
+      $role: FileSetRole!
+      $metadata: FileSetMetadataInput!
+      $work_id: ID!
+      ) {
+      createFileSet(
+        accessionNumber: $accession_number
+        role: $role
+        metadata: $metadata
+        workId: $work_id
+        )
+      {
+        id
+      }
+    }
+  """
+
+  test "createWork mutation creates a FileSet", _context do
+    work = work_fixture()
+
+    Meadow.ExAwsHttpMock
+    |> stub(:request, fn _method, _url, _body, _headers, _opts ->
+      {:ok, %{status_code: 200}}
+    end)
+
+    input = %{
+      "accession_number" => "99999",
+      "role" => "AM",
+      "work_id" => work.id,
+      "metadata" => %{
+        "description" => "Something",
+        "original_filename" => "file.tif",
+        "location" => "s3://path/to/file/on/s3"
+      }
+    }
+
+    conn = build_conn() |> auth_user(user_fixture())
+
+    conn =
+      post conn, "/api/graphql",
+        query: @query,
+        variables: input
+
+    assert %{
+             "data" => %{
+               "createFileSet" => %{
+                 "id" => _
+               }
+             }
+           } = json_response(conn, 200)
+  end
+end

--- a/test/meadow_web/schema/mutation/create_work_test.exs
+++ b/test/meadow_web/schema/mutation/create_work_test.exs
@@ -1,0 +1,53 @@
+defmodule MeadowWeb.Schema.Mutation.CreateWorkTest do
+  use MeadowWeb.ConnCase, async: true
+
+  import Mox
+
+  @query """
+    mutation (
+      $accession_number: String!
+      $work_type: WorkType!
+      $visibility: Visibility!
+      $metadata: WorkMetadataInput!
+      ) {
+      createWork(
+        accessionNumber: $accession_number
+        workType: $work_type
+        visibility: $visibility
+        metadata: $metadata
+        )
+      {
+        id
+      }
+    }
+  """
+
+  test "createWork mutation creates a work", _context do
+    Meadow.ExAwsHttpMock
+    |> stub(:request, fn _method, _url, _body, _headers, _opts ->
+      {:ok, %{status_code: 200}}
+    end)
+
+    input = %{
+      "accession_number" => "99999",
+      "visibility" => "OPEN",
+      "work_type" => "IMAGE",
+      "metadata" => %{"title" => "Something"}
+    }
+
+    conn = build_conn() |> auth_user(user_fixture())
+
+    conn =
+      post conn, "/api/graphql",
+        query: @query,
+        variables: input
+
+    assert %{
+             "data" => %{
+               "createWork" => %{
+                 "id" => _
+               }
+             }
+           } = json_response(conn, 200)
+  end
+end

--- a/test/meadow_web/schema/query/file_sets_test.exs
+++ b/test/meadow_web/schema/query/file_sets_test.exs
@@ -1,0 +1,57 @@
+defmodule MeadowWeb.Schema.Query.FileSetsTest do
+  use MeadowWeb.ConnCase, async: true
+
+  @query """
+  query {
+    fileSets{
+      id
+    }
+  }
+  """
+
+  test "fileSets query returns all file_sets" do
+    file_set_fixture()
+    file_set_fixture()
+    file_set_fixture()
+
+    conn = build_conn() |> auth_user(user_fixture())
+
+    response = get(conn, "/api/graphql", query: @query)
+
+    assert %{
+             "data" => %{
+               "fileSets" => [
+                 %{"id" => _},
+                 %{"id" => _},
+                 %{"id" => _}
+               ]
+             }
+           } = json_response(response, 200)
+  end
+
+  @delete_query """
+  mutation ($file_set_id: ID!) {
+    deleteFileSet(fileSetId: $file_set_id){
+      id
+    }
+  }
+  """
+
+  test "delete file_set mutation deletes a file set" do
+    file_set = file_set_fixture()
+
+    input = %{
+      "file_set_id" => file_set.id
+    }
+
+    conn = build_conn() |> auth_user(user_fixture())
+
+    response = post(conn, "/api/graphql", query: @delete_query, variables: input)
+
+    assert %{
+             "data" => %{
+               "deleteFileSet" => %{"id" => file_set.id}
+             }
+           } == json_response(response, 200)
+  end
+end

--- a/test/meadow_web/schema/query/work_test.exs
+++ b/test/meadow_web/schema/query/work_test.exs
@@ -1,0 +1,47 @@
+defmodule MeadowWeb.Schema.Query.WorkTest do
+  use MeadowWeb.ConnCase, async: true
+
+  @query """
+  query($id: String!) {
+    work(id: $id) {
+      id
+    }
+  }
+  """
+
+  test "work query returns the work with a given id" do
+    work = work_fixture()
+    variables = %{"id" => work.id}
+
+    conn = build_conn() |> auth_user(user_fixture())
+    conn = get conn, "/api/graphql", query: @query, variables: variables
+
+    assert %{
+             "data" => %{
+               "work" => %{"id" => work.id}
+             }
+           } == json_response(conn, 200)
+  end
+
+  @accession_query """
+  query($accession_number: String!) {
+    workByAccession(accessionNumber: $accession_number) {
+      id
+    }
+  }
+  """
+
+  test "workByAccession query returns the work with a given accession_number" do
+    work = work_fixture()
+    variables = %{"accession_number" => work.accession_number}
+
+    conn = build_conn() |> auth_user(user_fixture())
+    conn = get conn, "/api/graphql", query: @accession_query, variables: variables
+
+    assert %{
+             "data" => %{
+               "workByAccession" => %{"id" => work.id}
+             }
+           } == json_response(conn, 200)
+  end
+end

--- a/test/meadow_web/schema/query/works_test.exs
+++ b/test/meadow_web/schema/query/works_test.exs
@@ -1,0 +1,134 @@
+defmodule MeadowWeb.Schema.Query.WorksTest do
+  use MeadowWeb.ConnCase, async: true
+
+  @query """
+  query {
+    works{
+      id
+    }
+  }
+  """
+
+  test "works query returns all works" do
+    work_fixture()
+    work_fixture()
+    work_fixture()
+
+    conn = build_conn() |> auth_user(user_fixture())
+
+    response = get(conn, "/api/graphql", query: @query)
+
+    assert %{
+             "data" => %{
+               "works" => [
+                 %{"id" => _},
+                 %{"id" => _},
+                 %{"id" => _}
+               ]
+             }
+           } = json_response(response, 200)
+  end
+
+  @query """
+  query($limit: Int!) {
+    works(limit: $limit){
+      id
+    }
+  }
+  """
+  @variables %{"limit" => 2}
+  test "works query limits the number of works returned" do
+    work_fixture()
+    work_fixture()
+    work_fixture()
+
+    conn = build_conn() |> auth_user(user_fixture())
+
+    response = get(conn, "/api/graphql", query: @query, variables: @variables)
+
+    assert %{
+             "data" => %{
+               "works" => [
+                 %{"id" => _},
+                 %{"id" => _}
+               ]
+             }
+           } = json_response(response, 200)
+  end
+
+  @match_attrs %{
+    accession_number: "12345",
+    visibility: "open",
+    work_type: "image",
+    metadata: %{title: "This Title"}
+  }
+  @no_match_attrs %{
+    accession_number: "123456",
+    visibility: "restricted",
+    work_type: "video",
+    metadata: %{title: "Other One"}
+  }
+
+  @query """
+  query ($filter: WorkFilter!) {
+    works(filter: $filter) {
+      metadata{
+        title
+      }
+    }
+  }
+  """
+  @variables %{"filter" => %{"matching" => "This Title"}}
+  test "works query returns works filtered by title" do
+    work_fixture(@match_attrs)
+    work_fixture(@no_match_attrs)
+
+    conn = build_conn() |> auth_user(user_fixture())
+
+    response = get(conn, "/api/graphql", query: @query, variables: @variables)
+
+    assert %{
+             "data" => %{
+               "works" => [
+                 %{"metadata" => %{"title" => "This Title"}}
+               ]
+             }
+           } == json_response(response, 200)
+  end
+
+  @variables %{"filter" => %{"workType" => "IMAGE"}}
+  test "works query returns works filtered by workType" do
+    work_fixture(@match_attrs)
+    work_fixture(@no_match_attrs)
+
+    conn = build_conn() |> auth_user(user_fixture())
+
+    response = get(conn, "/api/graphql", query: @query, variables: @variables)
+
+    assert %{
+             "data" => %{
+               "works" => [
+                 %{"metadata" => %{"title" => "This Title"}}
+               ]
+             }
+           } == json_response(response, 200)
+  end
+
+  @variables %{"filter" => %{"visibility" => "OPEN"}}
+  test "works query returns works filtered by visibility" do
+    work_fixture(@match_attrs)
+    work_fixture(@no_match_attrs)
+
+    conn = build_conn() |> auth_user(user_fixture())
+
+    response = get(conn, "/api/graphql", query: @query, variables: @variables)
+
+    assert %{
+             "data" => %{
+               "works" => [
+                 %{"metadata" => %{"title" => "This Title"}}
+               ]
+             }
+           } == json_response(response, 200)
+  end
+end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -121,19 +121,21 @@ defmodule Meadow.TestHelpers do
     attrs =
       Enum.into(attrs, %{
         accession_number: attrs[:accession_number] || Faker.String.base64(),
+        role: attrs[:role] || Faker.Util.pick(@file_set_roles),
         metadata:
           attrs[:metadata] ||
             %{
+              description: attrs[:description] || Faker.String.base64(),
               location: "https://fake-s3-bucket/" <> Faker.String.base64(),
               original_filename: Faker.File.file_name()
             }
       })
 
-    {:ok, work} =
+    {:ok, file_set} =
       %FileSet{}
       |> FileSet.changeset(attrs)
       |> Repo.insert()
 
-    work
+    file_set
   end
 end


### PR DESCRIPTION
- adds `description` to `FileSetMetadata` schema
- adds `role` to `FileSet` schema
- adds cascading delete to file_sets table

- adds validation for required fields in Works and FileSets changesets

- adds GraphQL queries:
  - works
  - work
  - worksByAccession

- provides very basic ability to order, limit and filter (title match) in the works query

- adds GraphQL mutations:
  - createWork
  - createFileSet
  - deleteWork
  - deleteFileSet

- tests for new GraphQL queries/mutations