### PR TITLE
Mock query for completed works for ingest sheet

### DIFF
--- a/lib/meadow_web/schema/schema.ex
+++ b/lib/meadow_web/schema/schema.ex
@@ -14,12 +14,14 @@ defmodule MeadowWeb.Schema do
   import_types(__MODULE__.IngestTypes)
   import_types(__MODULE__.Data.WorkTypes)
   import_types(__MODULE__.Data.FileSetTypes)
+  import_types(__MODULE__.MockTypes)
 
   query do
     import_fields(:account_queries)
     import_fields(:ingest_queries)
     import_fields(:work_queries)
     import_fields(:file_set_queries)
+    import_fields(:mock_queries)
   end
 
   mutation do

--- a/lib/meadow_web/schema/types/mock_types.ex
+++ b/lib/meadow_web/schema/types/mock_types.ex
@@ -1,0 +1,132 @@
+defmodule MeadowWeb.Schema.MockTypes do
+  @moduledoc """
+  Absinthe Schema for WorkTypes
+
+  """
+  use Absinthe.Schema.Notation
+
+  alias MeadowWeb.Schema.Middleware
+
+  @fake_db %{
+    "foo" => %{
+      id: "01DP6073MBNW6K85GS9J805DCE",
+      name: "Sample Ingest Sheet",
+      filename: "something.csv",
+      status: "completed",
+      works: [
+        %{
+          id: "01DP6073MBNW6K85GS9J805DJJ",
+          accession_number: "Something_001",
+          visibility: "open",
+          work_type: "image",
+          file_sets: [
+            %{
+              id: "01DP6073MBNW6K85GS9J805D66",
+              accession_number: "Something_001_01",
+              role: "am",
+              metadata: %{
+                description: "Mauris pellentesque sodales"
+              }
+            },
+            %{
+              id: "01DP6073MBNW6K85GS9J805DLL",
+              accession_number: "Something_001_02",
+              role: "am",
+              metadata: %{
+                description: "Mauris pellentesque sodales"
+              }
+            },
+            %{
+              id: "01DP6073MBNW6K85GS9J805DLL",
+              accession_number: "Something_001_03",
+              role: "am",
+              metadata: %{
+                description: "Mauris pellentesque sodales"
+              }
+            }
+          ]
+        },
+        %{
+          id: "01DP6073MBNW6K85GS9J805DDJJ",
+          accession_number: "Something_Else_002",
+          visibility: "open",
+          work_type: "image",
+          file_sets: [
+            %{
+              id: "01DP6073MBNW6K85GS9J805D66",
+              accession_number: "Something_Else_002_01",
+              role: "am",
+              metadata: %{
+                description: "Mauris pellentesque sodales"
+              }
+            },
+            %{
+              id: "01DP6073MBNW6K85GS9J805DLL",
+              accession_number: "Something_Else_002_02",
+              role: "am",
+              metadata: %{
+                description: "Mauris pellentesque sodales"
+              }
+            },
+            %{
+              id: "01DP6073MBNW6K85GS9J805DLL",
+              accession_number: "Something_Else_002_03",
+              role: "am",
+              metadata: %{
+                description: "Mauris pellentesque sodales"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+
+  object :mock_queries do
+    @desc "`MOCK` for getting completed works along with an IngestSheet"
+    field :mock_ingest_sheet, list_of(:mock_ingest_sheet) do
+      @desc "The ID of `IngestSheet`"
+      arg(:id, type: non_null(:id))
+      middleware(Middleware.Authenticate)
+
+      resolve(fn %{id: _id}, _ ->
+        {:ok, Map.get(@fake_db, "foo")}
+      end)
+    end
+  end
+
+  @desc "MOCK IngestSheet object"
+  object :mock_ingest_sheet do
+    field :id, non_null(:id)
+    field :name, non_null(:string)
+    @desc "Overall Status of the Ingest Sheet"
+    field :status, :ingest_sheet_status
+    field :filename, non_null(:string)
+    field :works, list_of(:mock_work)
+  end
+
+  @desc "MOCK work object"
+  object :mock_work do
+    field :id, non_null(:id)
+    field :accession_number, non_null(:string)
+    field :work_type, non_null(:work_type)
+    field :visibility, non_null(:visibility)
+
+    field :file_sets, list_of(:mock_file_set)
+  end
+
+  @desc "MOCK `file_set` object represents one file (repository object in S3)"
+  object :mock_file_set do
+    field :id, non_null(:id)
+    field :accession_number, non_null(:string)
+    field :role, non_null(:file_set_role)
+    field :metadata, :mock_file_set_metadata
+  end
+
+  @desc "MOCK `file_set_metadata` represents all metadata associated with a file set object. It is stored in a single json field."
+  object :mock_file_set_metadata do
+    field :location, :string
+    field :original_filename, :string
+    field :description, :string
+  end
+end


### PR DESCRIPTION
Provides `mockIngestSheet` query to populate this screen with mock data during development: 
https://sketch.cloud/s/w8YwA/a/08ELVG



![Screen Shot 2019-10-02 at 1 37 59 PM](https://user-images.githubusercontent.com/6372022/66072356-81235e80-e51a-11e9-821c-1cd7785c203d.png)
