### PR TITLE
297 more mocked data for front end to develop against

### DIFF
--- a/lib/meadow_web/resolvers/mock.ex
+++ b/lib/meadow_web/resolvers/mock.ex
@@ -1,0 +1,24 @@
+defmodule MeadowWeb.Resolvers.Mock do
+  @moduledoc """
+  Absinthe GraphQL query resolver for Ingest Context
+
+  """
+  alias Meadow.Ingest.{IngestSheets, MockSubscription}
+  alias MeadowWeb.Schema.ChangesetErrors
+
+  def mock_approve_ingest_sheet(_, %{id: id}, _) do
+    ingest_sheet = IngestSheets.get_ingest_sheet!(id)
+
+    case IngestSheets.update_ingest_sheet_status(ingest_sheet, "approved") do
+      {:error, changeset} ->
+        {
+          :error,
+          message: "Could not approve sheet", details: ChangesetErrors.error_details(changeset)
+        }
+
+      {:ok, ingest_sheet} ->
+        MockSubscription.async(ingest_sheet.id)
+        {:ok, ingest_sheet}
+    end
+  end
+end

--- a/lib/meadow_web/schema/mock_subscription.ex
+++ b/lib/meadow_web/schema/mock_subscription.ex
@@ -1,0 +1,30 @@
+defmodule Meadow.Ingest.MockSubscription do
+  @moduledoc """
+  Fake Subscription - will count to 100- Delete
+  """
+
+  def async(id) do
+    case Meadow.TaskRegistry |> Registry.lookup("mock" <> id) do
+      [{pid, _}] ->
+        {:running, pid}
+
+      _ ->
+        Task.start(fn ->
+          Meadow.TaskRegistry |> Registry.register("mock" <> id, nil)
+          count(id)
+        end)
+    end
+  end
+
+  defp count(id) do
+    Enum.each(0..100, fn x ->
+      :timer.sleep(1000)
+
+      Absinthe.Subscription.publish(
+        MeadowWeb.Endpoint,
+        %{count: x},
+        mock_works_created_count: Enum.join(["mock_subscription", id], ":")
+      )
+    end)
+  end
+end

--- a/lib/meadow_web/schema/schema.ex
+++ b/lib/meadow_web/schema/schema.ex
@@ -28,10 +28,12 @@ defmodule MeadowWeb.Schema do
     import_fields(:ingest_mutations)
     import_fields(:work_mutations)
     import_fields(:file_set_mutations)
+    import_fields(:mock_mutations)
   end
 
   subscription do
     import_fields(:ingest_subscriptions)
+    import_fields(:mock_subscriptions)
   end
 
   enum :sort_order do


### PR DESCRIPTION
Mock data help UI buildout during development of the Ingest Error report (https://sketch.cloud/s/w8YwA/a/jWnR2D) and the ingest progress (https://sketch.cloud/s/w8YwA/a/AE7maR)

- `mockIngestSheetErrors` - query for ingest errors
- `mockApproveIngestSheet` - mutation to use which will approve the sheet and also kick off a fake "ingest" - will increment a counter slowly to 100.
- `mockWorksCreatedCount` - subscription to the counter. 

** These are meant to be deleted once real schema implemented.

Examples:

```
  query{
  mockIngestSheetErrors(id: "asdfkl"){
    works{
      workAccessionNumber
      errors
      fileSets{
        rowNumber
        accessionNumber
        role
        description
        filename
        errors
      }
    }
  }
}

mutation{
  mockApproveIngestSheet(id: "01DP60WHM99N1QHMZ4SKMG09PZ") {
    id
    status
  }
}

subscription{
  mockWorksCreatedCount(sheetId: "01DP60WHM99N1QHMZ4SKMG09PZ"){
    count 
  }
}