### PR TITLE
290 ingest sheet refactor based on status

### DIFF
--- a/assets/js/components/IngestSheet/ActionRow.jsx
+++ b/assets/js/components/IngestSheet/ActionRow.jsx
@@ -1,0 +1,77 @@
+import React, { useState } from "react";
+import ButtonGroup from "../UI/ButtonGroup";
+import UIButton from "../UI/Button";
+import CheckMarkIcon from "../../../css/fonts/zondicons/checkmark.svg";
+import UIModalDelete from "../UI/Modal/Delete";
+import { DELETE_INGEST_SHEET } from "./ingestSheet.query";
+import { useMutation } from "@apollo/react-hooks";
+import { toast } from "react-toastify";
+import PropTypes from "prop-types";
+import ReactRouterPropTypes from "react-router-prop-types";
+import { withRouter } from "react-router-dom";
+
+const IngestSheetActionRow = ({
+  projectId,
+  ingestSheetId,
+  status,
+  history
+}) => {
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [deleteIngestSheet, { data: deleteIngestSheetData }] = useMutation(
+    DELETE_INGEST_SHEET,
+    {
+      onCompleted({ deleteIngestSheet }) {
+        toast(`Ingest sheet deleted successfully`);
+        history.push(`/project/${projectId}`);
+      }
+    }
+  );
+  const showApproveButton = status === "VALID";
+
+  const handleDeleteClick = () => {
+    deleteIngestSheet({ variables: { ingestSheetId: ingestSheetId } });
+  };
+
+  const onOpenModal = () => {
+    setDeleteModalOpen(true);
+  };
+
+  const onCloseModal = () => {
+    setDeleteModalOpen(false);
+  };
+
+  return (
+    <div className="my-12">
+      <ButtonGroup>
+        {showApproveButton && (
+          <UIButton>
+            <CheckMarkIcon className="icon" />
+            Approve ingest sheet
+          </UIButton>
+        )}
+        <UIButton
+          classes={showApproveButton ? `btn-clear` : ``}
+          onClick={onOpenModal}
+        >
+          Delete ingest sheet / job and start over
+        </UIButton>
+      </ButtonGroup>
+
+      <UIModalDelete
+        isOpen={deleteModalOpen}
+        handleClose={onCloseModal}
+        handleConfirm={handleDeleteClick}
+        thingToDeleteLabel={`Ingest Sheet`}
+      />
+    </div>
+  );
+};
+
+IngestSheetActionRow.propTypes = {
+  projectId: PropTypes.string,
+  ingestSheetId: PropTypes.string,
+  status: PropTypes.string,
+  history: ReactRouterPropTypes.history
+};
+
+export default withRouter(IngestSheetActionRow);

--- a/assets/js/components/IngestSheet/Alert.jsx
+++ b/assets/js/components/IngestSheet/Alert.jsx
@@ -1,0 +1,75 @@
+import React from "react";
+import UIAlert from "../UI/Alert";
+import PropTypes from "prop-types";
+
+const IngestSheetAlert = ({ ingestSheet }) => {
+  if (!ingestSheet) return null;
+
+  const { status, fileErrors } = ingestSheet;
+  let alertObj = {};
+
+  switch (status) {
+    case "APPROVED":
+      alertObj = {
+        type: "info",
+        title: "Approved",
+        body: "The Ingest Sheet has been approved and the ingest is in progress"
+      };
+      break;
+    case "COMPLETED":
+      alertObj = {
+        type: "success",
+        title: "Ingestion Complete",
+        body: "All files have been processed"
+      };
+      break;
+    case "DELETED":
+      // Not sure if someone could actually end up here
+      alertObj = {
+        type: "danger",
+        title: "Deleted",
+        body: "Ingest sheet no longer exists"
+      };
+      break;
+    case "FILE_FAIL":
+      alertObj = {
+        type: "danger",
+        title: "File errors",
+        body: fileErrors.length > 0 ? fileErrors.map(error => `${error}`) : ""
+      };
+      break;
+    case "ROW_FAIL":
+      // Peel off ingestSheet.ingestSheetRows and inspect the "errors" array for each row to
+      // give additional user feedback.  Put that data in "body"s value below.
+      alertObj = {
+        type: "danger",
+        title: "File has failing rows",
+        body: ""
+      };
+      break;
+    case "UPLOADED":
+      alertObj = {
+        type: "info",
+        title: "File uploaded",
+        body: "Ingest sheet validation is in progress"
+      };
+      break;
+    case "VALID":
+      alertObj = {
+        type: "success",
+        title: "File is valid",
+        body: "All checks have passed and the ingest sheet is valid."
+      };
+      break;
+    default:
+      break;
+  }
+
+  return <UIAlert {...alertObj} />;
+};
+
+IngestSheetAlert.propTypes = {
+  ingestSheet: PropTypes.object
+};
+
+export default IngestSheetAlert;

--- a/assets/js/components/IngestSheet/Alert.test.jsx
+++ b/assets/js/components/IngestSheet/Alert.test.jsx
@@ -1,0 +1,250 @@
+import React from "react";
+import IngestSheetAlert from "./Alert";
+import { render } from "@testing-library/react";
+
+const fileFail = {
+  fileErrors: ["Invalid csv file: unexpected escape character..."],
+  filename: "s3://dev-uploads/ingest_sheets/01DP6H30V4XV3Z5W4H782N2BXM.csv",
+  id: "01DP6H3JWC6VGE7EH5KW1GHNQZ",
+  ingestSheetRows: [],
+  name: "Illegal file",
+  state: [
+    {
+      name: "file",
+      state: "FAIL"
+    },
+    {
+      name: "rows",
+      state: "PENDING"
+    },
+    {
+      name: "overall",
+      state: "FAIL"
+    }
+  ],
+  status: "FILE_FAIL"
+};
+
+it("renders without crashing", () => {
+  const { debug } = render(<IngestSheetAlert />);
+});
+
+it("displays danger alert with file fail message when the Ingest Sheet status is FILE_FAIL", () => {
+  const { debug, getByTestId, getByText } = render(
+    <IngestSheetAlert ingestSheet={fileFail} />
+  );
+
+  const alertElement = getByTestId("ui-alert");
+
+  expect(alertElement).toBeInTheDocument();
+  expect(alertElement).toHaveClass("danger");
+  expect(getByText("File errors")).toBeInTheDocument();
+  expect(
+    getByText("Invalid csv file: unexpected escape character...")
+  ).toBeInTheDocument();
+});
+
+const rowFail = {
+  fileErrors: ["Invalid header: something"],
+  filename: "s3://dev-uploads/ingest_sheets/01DP6H30V4XV3Z5W4H782N2BXM.csv",
+  id: "01DP6H3JWC6VGE7EH5KW1GHNQZ",
+  ingestSheetRows: [],
+  name: "Illegal header",
+  state: [
+    {
+      name: "file",
+      state: "PASS"
+    },
+    {
+      name: "rows",
+      state: "FAIL"
+    },
+    {
+      name: "overall",
+      state: "FAIL"
+    }
+  ],
+  status: "ROW_FAIL"
+};
+
+it("renders without crashing", () => {
+  const { debug } = render(<IngestSheetAlert />);
+});
+
+it("displays danger alert with row fail message when the Ingest Sheet status is ROW_FAIL", () => {
+  const { debug, getByTestId, getByText } = render(
+    <IngestSheetAlert ingestSheet={rowFail} />
+  );
+
+  const alertElement = getByTestId("ui-alert");
+
+  expect(alertElement).toBeInTheDocument();
+  expect(alertElement).toHaveClass("danger");
+  expect(getByText("File has failing rows")).toBeInTheDocument();
+});
+
+const valid = {
+  fileErrors: [],
+  filename: "s3://dev-uploads/ingest_sheets/01DP6H30V4XV3Z5W4H782N2BXM.csv",
+  id: "01DP6H3JWC6VGE7EH5KW1GHNQZ",
+  ingestSheetRows: [],
+  name: "Valid File",
+  state: [
+    {
+      name: "file",
+      state: "PASS"
+    },
+    {
+      name: "rows",
+      state: "PASS"
+    },
+    {
+      name: "overall",
+      state: "PASS"
+    }
+  ],
+  status: "VALID"
+};
+
+it("renders without crashing", () => {
+  const { debug } = render(<IngestSheetAlert />);
+});
+
+it("displays success alert with valid file message when the Ingest Sheet status is VALID", () => {
+  const { debug, getByTestId, getByText } = render(
+    <IngestSheetAlert ingestSheet={valid} />
+  );
+
+  const alertElement = getByTestId("ui-alert");
+
+  expect(alertElement).toBeInTheDocument();
+  expect(alertElement).toHaveClass("success");
+  expect(getByText("File is valid")).toBeInTheDocument();
+  expect(
+    getByText("All checks have passed and the ingest sheet is valid.")
+  ).toBeInTheDocument();
+});
+
+const approved = {
+  fileErrors: [],
+  filename: "s3://dev-uploads/ingest_sheets/01DP6H30V4XV3Z5W4H782N2BXM.csv",
+  id: "01DP6H3JWC6VGE7EH5KW1GHNQZ",
+  ingestSheetRows: [],
+  name: "Approved File",
+  state: [
+    {
+      name: "file",
+      state: "PASS"
+    },
+    {
+      name: "rows",
+      state: "PASS"
+    },
+    {
+      name: "overall",
+      state: "PASS"
+    }
+  ],
+  status: "APPROVED"
+};
+
+it("renders without crashing", () => {
+  const { debug } = render(<IngestSheetAlert />);
+});
+
+it("displays info alert with approved message when the Ingest Sheet status is APPROVED", () => {
+  const { debug, getByTestId, getByText } = render(
+    <IngestSheetAlert ingestSheet={approved} />
+  );
+
+  const alertElement = getByTestId("ui-alert");
+
+  expect(alertElement).toBeInTheDocument();
+  expect(alertElement).toHaveClass("info");
+  expect(getByText("Approved")).toBeInTheDocument();
+  expect(
+    getByText(
+      "The Ingest Sheet has been approved and the ingest is in progress"
+    )
+  ).toBeInTheDocument();
+});
+
+const completed = {
+  fileErrors: [],
+  filename: "s3://dev-uploads/ingest_sheets/01DP6H30V4XV3Z5W4H782N2BXM.csv",
+  id: "01DP6H3JWC6VGE7EH5KW1GHNQZ",
+  ingestSheetRows: [],
+  name: "Completed File",
+  state: [
+    {
+      name: "file",
+      state: "PASS"
+    },
+    {
+      name: "rows",
+      state: "PASS"
+    },
+    {
+      name: "overall",
+      state: "PASS"
+    }
+  ],
+  status: "COMPLETED"
+};
+
+it("renders without crashing", () => {
+  const { debug } = render(<IngestSheetAlert />);
+});
+
+it("displays success alert with completed message when the Ingest Sheet status is COMPLETED", () => {
+  const { debug, getByTestId, getByText } = render(
+    <IngestSheetAlert ingestSheet={completed} />
+  );
+
+  const alertElement = getByTestId("ui-alert");
+
+  expect(alertElement).toBeInTheDocument();
+  expect(alertElement).toHaveClass("success");
+  expect(getByText("Ingestion Complete")).toBeInTheDocument();
+  expect(getByText("All files have been processed")).toBeInTheDocument();
+});
+
+const deleted = {
+  fileErrors: [],
+  filename: "s3://dev-uploads/ingest_sheets/01DP6H30V4XV3Z5W4H782N2BXM.csv",
+  id: "01DP6H3JWC6VGE7EH5KW1GHNQZ",
+  ingestSheetRows: [],
+  name: "Deleted File",
+  state: [
+    {
+      name: "file",
+      state: "PASS"
+    },
+    {
+      name: "rows",
+      state: "PASS"
+    },
+    {
+      name: "overall",
+      state: "PASS"
+    }
+  ],
+  status: "DELETED"
+};
+
+it("renders without crashing", () => {
+  const { debug } = render(<IngestSheetAlert />);
+});
+
+it("displays success alert with completed message when the Ingest Sheet status is COMPLETED", () => {
+  const { debug, getByTestId, getByText } = render(
+    <IngestSheetAlert ingestSheet={deleted} />
+  );
+
+  const alertElement = getByTestId("ui-alert");
+
+  expect(alertElement).toBeInTheDocument();
+  expect(alertElement).toHaveClass("danger");
+  expect(getByText("Deleted")).toBeInTheDocument();
+  expect(getByText("Ingest sheet no longer exists")).toBeInTheDocument();
+});

--- a/assets/js/components/IngestSheet/IngestSheet.jsx
+++ b/assets/js/components/IngestSheet/IngestSheet.jsx
@@ -1,24 +1,35 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useQuery } from "@apollo/react-hooks";
 import Error from "../UI/Error";
 import Loading from "../UI/Loading";
 import IngestSheetValidations from "./Validations";
 import {
-  GET_INGEST_SHEET_STATUS,
+  GET_INGEST_SHEET_STATE,
   GET_INGEST_SHEET_PROGRESS
 } from "./ingestSheet.query";
+import IngestSheetAlert from "./Alert";
 import PropTypes from "prop-types";
+import IngestSheetActionRow from "./ActionRow";
 
-const IngestSheet = ({ ingestSheetId }) => {
-  const {
-    data: statusData,
-    loading: statusLoading,
-    error: statusError,
-    subscribeToMore: statusSubscribeToMore
-  } = useQuery(GET_INGEST_SHEET_STATUS, {
-    variables: { ingestSheetId },
-    fetchPolicy: "network-only"
-  });
+/**
+ * The following are possible status values for an Ingest Sheet)
+ *
+
+APPROVED: Approved, ingest in progress
+COMPLETED: Ingest Completed
+DELETED: Ingest Sheet deleted
+FILE_FAIL: Errors validating csv file
+ROW_FAIL: Errors in content rows
+UPLOADED: Uploaded, validation in progress
+VALID: Passes validation
+*/
+
+const IngestSheet = ({
+  ingestSheetData,
+  projectId,
+  subscribeToIngestSheetUpdates
+}) => {
+  const { id, status } = ingestSheetData;
 
   const {
     data: progressData,
@@ -26,29 +37,41 @@ const IngestSheet = ({ ingestSheetId }) => {
     error: progressError,
     subscribeToMore: progressSubscribeToMore
   } = useQuery(GET_INGEST_SHEET_PROGRESS, {
-    variables: { ingestSheetId },
+    variables: { ingestSheetId: id },
     fetchPolicy: "network-only"
   });
 
-  if (statusLoading || progressLoading) return <Loading />;
-  if (statusError || progressError)
-    return <Error error={statusError || progressError} />;
+  useEffect(() => {
+    subscribeToIngestSheetUpdates();
+  }, []);
+
+  if (progressLoading) return <Loading />;
+  if (progressError) return <Error error={progressError} />;
 
   return (
     <>
+      <IngestSheetAlert ingestSheet={ingestSheetData} />
+
+      <IngestSheetActionRow
+        ingestSheetId={id}
+        projectId={projectId}
+        status={status}
+      />
+
       <IngestSheetValidations
-        ingestSheetId={ingestSheetId}
+        ingestSheetId={id}
+        status={status}
         initialProgress={progressData.ingestSheetProgress}
-        initialStatus={statusData.ingestSheet.state}
         subscribeToIngestSheetProgress={progressSubscribeToMore}
-        subscribeToIngestSheetStatus={statusSubscribeToMore}
       />
     </>
   );
 };
 
 IngestSheet.propTypes = {
-  ingestSheetId: PropTypes.string.isRequired
+  ingestSheetData: PropTypes.object,
+  projectId: PropTypes.string,
+  subscribeToIngestSheetUpdates: PropTypes.func
 };
 
 export default IngestSheet;

--- a/assets/js/components/IngestSheet/Report.jsx
+++ b/assets/js/components/IngestSheet/Report.jsx
@@ -10,13 +10,9 @@ import {
   GET_INGEST_SHEET_VALIDATIONS
 } from "./ingestSheet.query";
 
-function IngestSheetReport({ ingestSheetId, progress, sheetState }) {
+function IngestSheetReport({ ingestSheetId, progress, status }) {
   const sheetHasErrors = () => {
-    if (sheetState.find(({ state }) => state == "FAIL")) {
-      return true;
-    }
-    const fails = progress.states.find(({ state }) => state == "FAIL");
-    return fails && fails.count > 0;
+    return ["FILE_FAIL", "ROW_FAIL"].indexOf(status) > -1;
   };
 
   const { loading, error, data } = useQuery(
@@ -53,7 +49,7 @@ function IngestSheetReport({ ingestSheetId, progress, sheetState }) {
 IngestSheetReport.propTypes = {
   ingestSheetId: PropTypes.string.isRequired,
   progress: PropTypes.object.isRequired,
-  sheetState: PropTypes.arrayOf(PropTypes.object).isRequired
+  status: PropTypes.string
 };
 
 export default IngestSheetReport;

--- a/assets/js/components/IngestSheet/Upload.jsx
+++ b/assets/js/components/IngestSheet/Upload.jsx
@@ -25,7 +25,7 @@ const IngestSheetUpload = ({ projectId, presignedUrl, history }) => {
         return [
           {
             query: GET_PROJECT,
-            variables: { projectId: projectId }
+            variables: { projectId }
           }
         ];
       }
@@ -42,7 +42,26 @@ const IngestSheetUpload = ({ projectId, presignedUrl, history }) => {
     history.push(`/project/${projectId}`);
   };
 
-  const uploadToS3 = () => {
+  const handleSubmit = async e => {
+    console.log("enters handleSubmit");
+    e.preventDefault();
+    await uploadToS3();
+    console.log("upload to s3 done");
+    await createIngestSheet({
+      variables: {
+        name: ingest_sheet_name,
+        projectId: projectId,
+        filename: `s3://${presignedUrl
+          .split("?")[0]
+          .split("/")
+          .slice(-3)
+          .join("/")}`
+      }
+    });
+    console.log("done creating IngestSheet");
+  };
+
+  const uploadToS3 = async () => {
     try {
       const submitFile = async (data, headers) => {
         await axios.put(presignedUrl, data, { headers: headers });
@@ -56,6 +75,7 @@ const IngestSheetUpload = ({ projectId, presignedUrl, history }) => {
       };
       reader.readAsText(file);
     } catch (error) {
+      Promise.resolve(null);
       console.log(error);
       toast(`Error uploading file to S3: ${error}`, { type: "error" });
     }
@@ -67,23 +87,7 @@ const IngestSheetUpload = ({ projectId, presignedUrl, history }) => {
   if (error) return <Error error={error} />;
 
   return (
-    <form
-      onSubmit={e => {
-        e.preventDefault();
-        uploadToS3();
-        createIngestSheet({
-          variables: {
-            name: ingest_sheet_name,
-            projectId: projectId,
-            filename: `s3://${presignedUrl
-              .split("?")[0]
-              .split("/")
-              .slice(-3)
-              .join("/")}`
-          }
-        });
-      }}
-    >
+    <form onSubmit={handleSubmit}>
       <Error error={error} />
       <div className="mb-4">
         <label htmlFor="ingest_sheet_name">Ingest Sheet Name</label>

--- a/assets/js/components/IngestSheet/Validations.jsx
+++ b/assets/js/components/IngestSheet/Validations.jsx
@@ -1,45 +1,23 @@
 import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
-import ReactRouterPropTypes from "react-router-prop-types";
-import { useMutation } from "@apollo/react-hooks";
 import UIProgressBar from "../UI/UIProgressBar";
 import debounce from "lodash.debounce";
 import IngestSheetReport from "./Report";
 import {
-  DELETE_INGEST_SHEET,
-  SUBSCRIBE_TO_INGEST_SHEET_STATUS,
-  SUBSCRIBE_TO_INGEST_SHEET_PROGRESS
+  SUBSCRIBE_TO_INGEST_SHEET_PROGRESS,
+  START_VALIDATION
 } from "./ingestSheet.query";
-import UIAlert from "../UI/Alert";
-import ButtonGroup from "../UI/ButtonGroup";
-import UIButton from "../UI/Button";
-import CheckMarkIcon from "../../../css/fonts/zondicons/checkmark.svg";
-import UIModalDelete from "../UI/Modal/Delete";
 import { withRouter } from "react-router-dom";
-import { toast } from "react-toastify";
+import { useMutation } from "@apollo/react-hooks";
 
 function IngestSheetValidations({
   ingestSheetId,
   initialProgress,
-  initialStatus,
-  match,
-  history,
   subscribeToIngestSheetProgress,
-  subscribeToIngestSheetStatus
+  status
 }) {
   const [progress, setProgress] = useState({ states: [] });
-  const [status, setStatus] = useState([]);
-  const [displayRowChecks, setDisplayRowChecks] = useState(false);
-  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
-  const [deleteIngestSheet, { data: deleteIngestSheetData }] = useMutation(
-    DELETE_INGEST_SHEET,
-    {
-      onCompleted({ deleteIngestSheet }) {
-        toast(`Ingest sheet deleted successfully`);
-        history.push(`/project/${match.params.id}`);
-      }
-    }
-  );
+  const [startValidation, { validationData }] = useMutation(START_VALIDATION);
 
   useEffect(() => {
     setProgress(initialProgress);
@@ -49,25 +27,8 @@ function IngestSheetValidations({
       updateQuery: debounce(handleProgressUpdate, 250, { maxWait: 250 })
     });
 
-    setStatus(initialStatus);
-    subscribeToIngestSheetStatus({
-      document: SUBSCRIBE_TO_INGEST_SHEET_STATUS,
-      variables: { ingestSheetId },
-      updateQuery: handleStatusUpdate
-    });
+    startValidation({ variables: { id: ingestSheetId } });
   }, []);
-
-  const handleDeleteClick = () => {
-    deleteIngestSheet({ variables: { ingestSheetId: ingestSheetId } });
-  };
-
-  const onOpenModal = () => {
-    setDeleteModalOpen(true);
-  };
-
-  const onCloseModal = () => {
-    setDeleteModalOpen(false);
-  };
 
   const handleProgressUpdate = (prev, { subscriptionData }) => {
     if (!subscriptionData.data) return prev;
@@ -77,25 +38,8 @@ function IngestSheetValidations({
     return { ingestSheetProgress: progress };
   };
 
-  const handleStatusUpdate = (prev, { subscriptionData }) => {
-    if (!subscriptionData.data) return prev;
-
-    const status = subscriptionData.data.ingestSheetUpdate.state;
-    setStatus(status);
-    return { ingestSheet: subscriptionData.data.ingestSheetUpdate };
-  };
-
   const isFinished = () => {
-    return status.find(
-      ({ name, state }) => name == "overall" && state != "PENDING"
-    );
-  };
-
-  const isFinishedAndErrors = () => {
-    return (
-      isFinished() &&
-      status.find(({ name, state }) => name === "overall" && state === "FAIL")
-    );
+    return status !== "UPLOADED";
   };
 
   const showProgressBar = () => {
@@ -110,97 +54,13 @@ function IngestSheetValidations({
     );
   };
 
-  const showAlert = () => {
-    if (isFinished()) {
-      const failedChecks = status.filter(
-        statusObj => statusObj.state === "FAIL"
-      );
-
-      if (failedChecks.length > 0) {
-        const AlertBody = (
-          <>
-            {failedChecks.map(obj => (
-              <p key={obj.name}>
-                {obj.name}: {obj.state}
-              </p>
-            ))}
-          </>
-        );
-
-        return (
-          <UIAlert
-            type="danger"
-            title="The following Ingest Sheet validations failed:"
-            body={AlertBody}
-          />
-        );
-      }
-      return (
-        <UIAlert
-          type="success"
-          title="Validation success"
-          body="All checks on the ingest sheet were successful"
-        />
-      );
-    }
-    return null;
-  };
-
-  const showChecksTable = () => (
-    <div className="mb-12 pt-8">
-      <button
-        className="btn btn-clear"
-        onClick={() => setDisplayRowChecks(!displayRowChecks)}
-      >
-        {displayRowChecks ? "Hide" : "Show"} row check details
-      </button>
-
-      {displayRowChecks && (
-        <>
-          <table className="mt-4">
-            <thead>
-              <tr>
-                {status.map(({ name }) => (
-                  <th key={name}>{name}</th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                {status.map(({ state, name }) => {
-                  let colorClass = "";
-
-                  if (state === "PASS") {
-                    colorClass = "bg-green-400";
-                  } else if (state === "FAIL") {
-                    colorClass = "bg-red-400";
-                  }
-
-                  return (
-                    <td key={name} className={`${colorClass} text-white`}>
-                      {name !== "rows"
-                        ? state
-                        : progress.states.map(
-                            ({ state, count }) => `${state} (${count}) `
-                          )}
-                    </td>
-                  );
-                })}
-              </tr>
-            </tbody>
-          </table>
-        </>
-      )}
-    </div>
-  );
-
   const showReport = () => {
     if (isFinished()) {
       return (
         <>
           <IngestSheetReport
             progress={progress}
-            sheetState={status}
+            status={status}
             ingestSheetId={ingestSheetId}
           />
         </>
@@ -210,58 +70,28 @@ function IngestSheetValidations({
     }
   };
 
-  const showUserButtons = () => {
-    if (isFinishedAndErrors()) {
-      return (
-        <ButtonGroup>
-          <UIButton classes="btn-danger" onClick={onOpenModal}>
-            Delete sheet and re-upload ingest sheet
-          </UIButton>
-        </ButtonGroup>
-      );
-    }
-    if (isFinished()) {
-      return (
-        <ButtonGroup>
-          <UIButton>
-            <CheckMarkIcon className="icon" />
-            Approve ingest sheet
-          </UIButton>
-          <UIButton classes="btn-clear" onClick={onOpenModal}>
-            Delete sheet and re-upload ingest sheet
-          </UIButton>
-        </ButtonGroup>
-      );
-    }
-  };
-
   return (
     <>
       <section>
-        <h2>Unapproved State UI</h2>
         {showProgressBar()}
-        {showAlert()}
-        {showChecksTable()}
         {showReport()}
-        {showUserButtons()}
       </section>
-
-      <UIModalDelete
-        isOpen={deleteModalOpen}
-        handleClose={onCloseModal}
-        handleConfirm={handleDeleteClick}
-        thingToDeleteLabel={`Ingest Sheet`}
-      />
     </>
   );
 }
 
 IngestSheetValidations.propTypes = {
   ingestSheetId: PropTypes.string.isRequired,
-  initialProgress: PropTypes.object.isRequired,
-  initialStatus: PropTypes.arrayOf(PropTypes.object).isRequired,
-  match: ReactRouterPropTypes.match,
-  history: ReactRouterPropTypes.history
+  status: PropTypes.oneOf([
+    "APPROVED",
+    "COMPLETED",
+    "DELETED",
+    "FILE_FAIL",
+    "ROW_FAIL",
+    "UPLOADED",
+    "VALID"
+  ]),
+  initialProgress: PropTypes.object.isRequired
 };
 
 export default withRouter(IngestSheetValidations);

--- a/assets/js/components/IngestSheet/ingestSheet.query.js
+++ b/assets/js/components/IngestSheet/ingestSheet.query.js
@@ -1,4 +1,33 @@
 import gql from "graphql-tag";
+import IngestSheet from "./IngestSheet";
+
+IngestSheet.fragments = {
+  parts: gql`
+    fragment IngestSheetParts on IngestSheet {
+      fileErrors
+      ingestSheetRows {
+        errors {
+          field
+          message
+        }
+        fields {
+          header
+          value
+        }
+        row
+        state
+      }
+      id
+      name
+      filename
+      state {
+        name
+        state
+      }
+      status
+    }
+  `
+};
 
 export const CREATE_INGEST_SHEET = gql`
   mutation CreateIngestSheet(
@@ -47,9 +76,10 @@ export const GET_INGEST_SHEETS = gql`
   }
 `;
 
-export const GET_INGEST_SHEET_STATUS = gql`
-  query IngestSheetStatus($ingestSheetId: String!) {
+export const GET_INGEST_SHEET_STATE = gql`
+  query IngestSheetState($ingestSheetId: String!) {
     ingestSheet(id: $ingestSheetId) {
+      id
       state {
         name
         state
@@ -112,17 +142,33 @@ export const GET_PRESIGNED_URL = gql`
   }
 `;
 
-export const SUBSCRIBE_TO_INGEST_SHEET_STATUS = gql`
-  subscription IngestSheetStatusUpdate($ingestSheetId: String!) {
-    ingestSheetUpdate(sheetId: $ingestSheetId) {
-      state {
-        name
-        state
-      }
+export const START_VALIDATION = gql`
+  mutation ValidateIngestSheet($id: String!) {
+    validateIngestSheet(ingestSheetId: $id) {
+      message
     }
   }
 `;
 
+export const INGEST_SHEET_QUERY = gql`
+  query IngestSheetQuery($ingestSheetId: ID!) {
+    ingestSheet(id: $ingestSheetId) {
+      ...IngestSheetParts
+    }
+  }
+  ${IngestSheet.fragments.parts}
+`;
+
+export const INGEST_SHEET_SUBSCRIPTION = gql`
+  subscription SubscribeToIngestSheet($ingestSheetId: ID!) {
+    ingestSheetUpdate(sheetId: $ingestSheetId) {
+      ...IngestSheetParts
+    }
+  }
+  ${IngestSheet.fragments.parts}
+`;
+
+//TODO: Delete this?
 export const SUBSCRIBE_TO_INGEST_SHEET_VALIDATIONS = gql`
   subscription IngestSheetRowUpdate($ingestSheetId: String!) {
     ingestSheetRowUpdate(sheetId: $ingestSheetId) {
@@ -140,6 +186,7 @@ export const SUBSCRIBE_TO_INGEST_SHEET_VALIDATIONS = gql`
   }
 `;
 
+// TODO: Delete this?
 export const SUBSCRIBE_TO_INGEST_SHEET_ERRORS = gql`
   subscription IngestSheetRowErrors($ingestSheetId: String!) {
     ingestSheetRowStateUpdate(sheetId: $ingestSheetId, state: FAIL) {

--- a/assets/js/components/UI/Alert.jsx
+++ b/assets/js/components/UI/Alert.jsx
@@ -9,7 +9,7 @@ const UIAlert = ({
   type = "info"
 }) => {
   return (
-    <div className={`alert my-4 ${type}`} role="alert">
+    <div data-testid="ui-alert" className={`alert my-4 ${type}`} role="alert">
       <div className="flex">
         <div className="py-1">
           {type === "success" && <CheckmarkOutlineIcon className="icon" />}

--- a/assets/js/screens/IngestSheet/IngestSheet.jsx
+++ b/assets/js/screens/IngestSheet/IngestSheet.jsx
@@ -8,12 +8,18 @@ import IngestSheet from "../../components/IngestSheet/IngestSheet";
 import gql from "graphql-tag";
 import { useQuery } from "@apollo/react-hooks";
 import { Link } from "react-router-dom";
+import {
+  INGEST_SHEET_SUBSCRIPTION,
+  INGEST_SHEET_QUERY
+} from "../../components/IngestSheet/ingestSheet.query";
 
 const GET_CRUMB_DATA = gql`
   query GetCrumbData($ingestSheetId: String!) {
     ingestSheet(id: $ingestSheetId) {
+      id
       name
       project {
+        id
         title
       }
     }
@@ -22,14 +28,29 @@ const GET_CRUMB_DATA = gql`
 
 const ScreensIngestSheet = ({ match }) => {
   const { id, ingestSheetId } = match.params;
-  const { loading, error, data } = useQuery(GET_CRUMB_DATA, {
+  const {
+    loading: crumbsLoading,
+    error: crumbsError,
+    data: crumbsData
+  } = useQuery(GET_CRUMB_DATA, {
     variables: { ingestSheetId }
   });
 
-  if (error) return <Error error={error} />;
-  if (loading) return <Loading />;
+  const {
+    subscribeToMore,
+    data: sheetData,
+    loading: sheetLoading,
+    error: sheetError
+  } = useQuery(INGEST_SHEET_QUERY, {
+    variables: { ingestSheetId },
+    fetchPolicy: "network-only"
+  });
 
-  const { ingestSheet } = data;
+  if (crumbsLoading || sheetLoading) return <Loading />;
+  if (crumbsError || sheetError)
+    return <Error error={crumbsError || sheetError} />;
+
+  const { ingestSheet } = crumbsData;
 
   const createCrumbs = () => {
     return [
@@ -73,11 +94,24 @@ const ScreensIngestSheet = ({ match }) => {
           </Link>
         </div>
 
-        <IngestSheet ingestSheetId={ingestSheetId} />
+        <IngestSheet
+          ingestSheetData={sheetData.ingestSheet}
+          projectId={id}
+          subscribeToIngestSheetUpdates={() =>
+            subscribeToMore({
+              document: INGEST_SHEET_SUBSCRIPTION,
+              variables: { ingestSheetId },
+              updateQuery: (prev, { subscriptionData }) => {
+                if (!subscriptionData.data) return prev;
+                const updatedSheet = subscriptionData.data.ingestSheetUpdate;
+                return { ingestSheet: { ...updatedSheet } };
+              }
+            })
+          }
+        />
       </ScreenContent>
     </>
   );
 };
 
 export default withRouter(ScreensIngestSheet);
-export { GET_CRUMB_DATA };

--- a/assets/js/screens/IngestSheet/IngestSheet.test.jsx
+++ b/assets/js/screens/IngestSheet/IngestSheet.test.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, fireEvent } from "@testing-library/react";
-import ScreensIngestSheet from "./IngestSheet";
+//import ScreensIngestSheet from "./IngestSheet";
 import { renderWithRouter } from "../../testing-helpers";
 
 xtest("IngestSheet component loads", () => {

--- a/lib/meadow_web/resolvers/ingest.ex
+++ b/lib/meadow_web/resolvers/ingest.ex
@@ -84,6 +84,12 @@ defmodule MeadowWeb.Resolvers.Ingest do
     {:ok, %{validations: [%{id: "sheet", object: %{errors: [], status: "pending"}}]}}
   end
 
+  def validate_ingest_sheet(_, args, _) do
+    {response, pid} = args[:ingest_sheet_id] |> IngestSheetValidator.async()
+    pid_string = pid |> :erlang.pid_to_list() |> List.to_string()
+    {:ok, %{message: to_string(response) <> " : " <> pid_string}}
+  end
+
   def create_ingest_sheet(_, args, _) do
     case IngestSheets.create_ingest_sheet(args) do
       {:error, changeset} ->
@@ -92,7 +98,6 @@ defmodule MeadowWeb.Resolvers.Ingest do
          details: ChangesetErrors.error_details(changeset)}
 
       {:ok, ingest_sheet} ->
-        {_response, _pid} = ingest_sheet.id |> IngestSheetValidator.async()
         {:ok, ingest_sheet}
     end
   end

--- a/lib/meadow_web/schema/types/ingest_types.ex
+++ b/lib/meadow_web/schema/types/ingest_types.ex
@@ -92,6 +92,13 @@ defmodule MeadowWeb.Schema.IngestTypes do
       middleware(Middleware.Authenticate)
       resolve(&Resolvers.Ingest.approve_ingest_sheet/3)
     end
+
+    @desc "Kick off Validation of an Ingest Sheet"
+    field :validate_ingest_sheet, :status_message do
+      arg(:ingest_sheet_id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      resolve(&Resolvers.Ingest.validate_ingest_sheet/3)
+    end
   end
 
   object :ingest_subscriptions do

--- a/priv/repo/migrations/20191005132444_change_ingest_sheets_file_errors_to_text.exs
+++ b/priv/repo/migrations/20191005132444_change_ingest_sheets_file_errors_to_text.exs
@@ -1,0 +1,9 @@
+defmodule Meadow.Repo.Migrations.ChangeIngestSheetsFileErrorsToText do
+  use Ecto.Migration
+
+  def change do
+    alter table(:ingest_sheets) do
+      modify :file_errors, {:array, :text}, default: []
+    end
+  end
+end


### PR DESCRIPTION
- Remerging work from Friday plus:
  - Fixes Apollo "Store error: the application attempted to write an object with no provided id but the store already contains an id" with breadcrumbs query
  - changes file_errors to text so it doesn't fail with longer messages
  - Make the ingest job wait for upload to finish before creating ingest sheet in db.
  - move start validation trigger back to front end