### PR TITLE
Wire up mock errors on work creation to ingest sheet completed status

### DIFF
--- a/assets/css/meadow.css
+++ b/assets/css/meadow.css
@@ -69,6 +69,10 @@ td {
   @apply p-2 border-t border-gray-300 text-sm;
 }
 
+table.clear th {
+  @apply bg-transparent text-red-900;
+}
+
 .alert {
   @apply border-t-4 rounded-b px-4 py-3 shadow-md;
 }

--- a/assets/js/components/IngestSheet/Completed.jsx
+++ b/assets/js/components/IngestSheet/Completed.jsx
@@ -1,15 +1,16 @@
-import React from "react";
-import { withRouter } from "react-router-dom";
+import React, { useState } from "react";
 import WorkRow from "./WorkRow";
 import { useQuery } from "@apollo/react-hooks";
 import PropTypes from "prop-types";
 import { MOCK_INGEST_SHEET_COMPLETED } from "./ingestSheet.query";
 import Error from "../UI/Error";
+import IngestSheetCompletedErrors from "./Completed/Errors";
 
-const IngestSheetStatusCompleted = ({ ingestSheetId }) => {
+const IngestSheetCompleted = ({ ingestSheetId }) => {
   const { loading, error, data } = useQuery(MOCK_INGEST_SHEET_COMPLETED, {
     variables: { id: ingestSheetId }
   });
+  const [showErrors, setShowErrors] = useState(false);
 
   if (loading) return "Loading...";
   if (error) return <Error error={error} />;
@@ -17,15 +18,29 @@ const IngestSheetStatusCompleted = ({ ingestSheetId }) => {
   const { works = [] } = data.mockIngestSheet;
 
   return (
-    <section>
-      {works.length > 0 &&
-        works.map(work => <WorkRow key={work.id} work={work} />)}
-    </section>
+    <>
+      <div className="my-8">
+        <input
+          type="checkbox"
+          className="mr-2"
+          onChange={() => setShowErrors(!showErrors)}
+        />
+        Show mock errors
+      </div>
+
+      {showErrors && (
+        <IngestSheetCompletedErrors ingestSheetId={ingestSheetId} />
+      )}
+      <section>
+        {works.length > 0 &&
+          works.map(work => <WorkRow key={work.id} work={work} />)}
+      </section>
+    </>
   );
 };
 
-IngestSheetStatusCompleted.propTypes = {
+IngestSheetCompleted.propTypes = {
   ingestSheetId: PropTypes.string
 };
 
-export default IngestSheetStatusCompleted;
+export default IngestSheetCompleted;

--- a/assets/js/components/IngestSheet/Completed/Errors.jsx
+++ b/assets/js/components/IngestSheet/Completed/Errors.jsx
@@ -1,0 +1,63 @@
+import React from "react";
+import PropTypes from "prop-types";
+import UIAlert from "../../UI/Alert";
+import { MOCK_INGEST_SHEET_COMPLETED_ERRORS } from "../ingestSheet.query";
+import { useQuery } from "@apollo/react-hooks";
+import Error from "../../UI/Error";
+
+const IngestSheetCompletedErrors = ({ ingestSheetId }) => {
+  const { loading, error, data } = useQuery(
+    MOCK_INGEST_SHEET_COMPLETED_ERRORS,
+    {
+      variables: { id: ingestSheetId }
+    }
+  );
+
+  if (loading) return "Loading...";
+  if (error) return <Error error={error} />;
+
+  const { fileSets } = data.mockIngestSheetErrors;
+  const errorBody = (
+    <table className="w-full clear">
+      <thead>
+        <tr>
+          <th>Row</th>
+          <th>Work Accession Number</th>
+          <th>Accession Number</th>
+          <th>Filename</th>
+          <th>Errors</th>
+        </tr>
+      </thead>
+      <tbody>
+        {fileSets.map(row => (
+          <tr key={row.rowNumber}>
+            <td>{row.rowNumber}</td>
+            <td>{row.workAccessionNumber}</td>
+            <td>{row.accessionNumber}</td>
+            <td>{row.filename}</td>
+            <td>
+              {row.errors.map(error => (
+                <p key={error}>{error}</p>
+              ))}
+            </td>
+            <td></td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+
+  return (
+    <UIAlert
+      title="Errors creating works from filesets"
+      type="danger"
+      body={errorBody}
+    />
+  );
+};
+
+IngestSheetCompletedErrors.propTypes = {
+  ingestSheetId: PropTypes.string
+};
+
+export default IngestSheetCompletedErrors;

--- a/assets/js/components/IngestSheet/ingestSheet.query.js
+++ b/assets/js/components/IngestSheet/ingestSheet.query.js
@@ -256,3 +256,19 @@ export const MOCK_INGEST_SHEET_COMPLETED = gql`
     }
   }
 `;
+
+export const MOCK_INGEST_SHEET_COMPLETED_ERRORS = gql`
+  query MockIngestSheetCompletedErrors($id: ID!) {
+    mockIngestSheetErrors(id: $id) {
+      fileSets {
+        accessionNumber
+        description
+        errors
+        filename
+        role
+        rowNumber
+        workAccessionNumber
+      }
+    }
+  }
+`;


### PR DESCRIPTION
To mock his out for the demo, I put in a little check box to toggle what errors could look like:

![image](https://user-images.githubusercontent.com/3020266/66516214-2c499000-eaa6-11e9-9d91-8e4499459158.png)
