### PR TITLE
Replace toast notifications package with a better one

### DIFF
--- a/assets/js/components/IngestSheet/ActionRow.jsx
+++ b/assets/js/components/IngestSheet/ActionRow.jsx
@@ -8,10 +8,10 @@ import {
   MOCK_APPROVE_INGEST_SHEET
 } from "./ingestSheet.query";
 import { useMutation } from "@apollo/react-hooks";
-import { toast } from "react-toastify";
 import PropTypes from "prop-types";
 import ReactRouterPropTypes from "react-router-prop-types";
 import { withRouter } from "react-router-dom";
+import { useToasts } from "react-toast-notifications";
 
 const IngestSheetActionRow = ({
   projectId,
@@ -19,12 +19,16 @@ const IngestSheetActionRow = ({
   status,
   history
 }) => {
+  const { addToast } = useToasts();
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [deleteIngestSheet, { data: deleteIngestSheetData }] = useMutation(
     DELETE_INGEST_SHEET,
     {
       onCompleted({ deleteIngestSheet }) {
-        toast(`Ingest sheet deleted successfully`);
+        addToast("Ingest sheet deleted successfully", {
+          appearance: "success",
+          autoDismiss: true
+        });
         history.push(`/project/${projectId}`);
       }
     }

--- a/assets/js/components/IngestSheet/List.jsx
+++ b/assets/js/components/IngestSheet/List.jsx
@@ -2,10 +2,10 @@ import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import { useApolloClient, useMutation } from "@apollo/react-hooks";
-import { toast } from "react-toastify";
 import { GET_INGEST_SHEETS, DELETE_INGEST_SHEET } from "./ingestSheet.query";
 import UIModalDelete from "../UI/Modal/Delete";
 import TrashIcon from "../../../css/fonts/zondicons/trash.svg";
+import { useToasts } from "react-toast-notifications";
 
 // delete/refine later
 export const TEMP_USER_FRIENDLY_STATUS = {
@@ -20,6 +20,7 @@ export const TEMP_USER_FRIENDLY_STATUS = {
 const IngestSheetList = ({ project, subscribeToIngestSheetStatusChanges }) => {
   const [modalOpen, setModalOpen] = useState(false);
   const [activeModal, setActiveModal] = useState();
+  const { addToast } = useToasts();
 
   useEffect(() => {
     subscribeToIngestSheetStatusChanges();
@@ -59,7 +60,10 @@ const IngestSheetList = ({ project, subscribeToIngestSheetStatusChanges }) => {
   });
 
   if (deleteIngestSheetError) {
-    toast(`Error: ${deleteIngestSheetError.message}`);
+    addToast(`Error: ${deleteIngestSheetError.message}`, {
+      appearance: "error",
+      autoDismiss: true
+    });
   }
 
   const handleDeleteClick = () => {

--- a/assets/js/components/IngestSheet/Upload.jsx
+++ b/assets/js/components/IngestSheet/Upload.jsx
@@ -5,13 +5,14 @@ import Error from "../UI/Error";
 import Loading from "../UI/Loading";
 import { withRouter } from "react-router-dom";
 import { GET_PROJECT } from "../Project/project.query";
-import { toast } from "react-toastify";
 import { useMutation } from "@apollo/react-hooks";
 import UIButton from "../UI/Button";
 import UIButtonGroup from "../UI/ButtonGroup";
 import { CREATE_INGEST_SHEET } from "./ingestSheet.query";
+import { useToasts } from "react-toast-notifications";
 
 const IngestSheetUpload = ({ projectId, presignedUrl, history }) => {
+  const { addToast } = useToasts();
   const [values, setValues] = useState({ ingest_sheet_name: "", file: "" });
   const [createIngestSheet, { data, loading, error }] = useMutation(
     CREATE_INGEST_SHEET,
@@ -77,7 +78,10 @@ const IngestSheetUpload = ({ projectId, presignedUrl, history }) => {
     } catch (error) {
       Promise.resolve(null);
       console.log(error);
-      toast(`Error uploading file to S3: ${error}`, { type: "error" });
+      addToast(`Error uploading file to S3: ${error}`, {
+        appearance: "error",
+        autoDismiss: true
+      });
     }
   };
 

--- a/assets/js/components/IngestSheet/Validations.jsx
+++ b/assets/js/components/IngestSheet/Validations.jsx
@@ -46,9 +46,12 @@ function IngestSheetValidations({
     if (isFinished()) {
       return null;
     }
+    const { percentComplete } = progress;
     return (
       <UIProgressBar
-        percentComplete={progress.percentComplete}
+        percentComplete={
+          percentComplete ? percentComplete.toFixed(2) : percentComplete
+        }
         label="Please wait for validation"
       />
     );

--- a/assets/js/components/Project/Form.jsx
+++ b/assets/js/components/Project/Form.jsx
@@ -1,21 +1,25 @@
 import React, { useState } from "react";
 import { withRouter } from "react-router-dom";
 import { useMutation } from "@apollo/react-hooks";
-import { toast } from "react-toastify";
 import UIButton from "../UI/Button";
 import UIButtonGroup from "../UI/ButtonGroup";
 import { CREATE_PROJECT, GET_PROJECTS } from "./project.query.js";
 import Error from "../UI/Error";
 import Loading from "../UI/Loading";
+import { useToasts } from "react-toast-notifications";
 
 const ProjectForm = ({ history }) => {
+  const { addToast } = useToasts();
   let inputTitle;
   const [submitDisabled, setSubmitDisabled] = useState(true);
   const [createProject, { loading, error, data }] = useMutation(
     CREATE_PROJECT,
     {
       onCompleted({ createProject }) {
-        toast(`Project ${createProject.title} created successfully`);
+        addToast(`Project ${createProject.title} created successfully`, {
+          appearance: "success",
+          autoDismiss: true
+        });
         history.push("/project/list");
       },
       refetchQueries(mutationResult) {

--- a/assets/js/components/Project/List.jsx
+++ b/assets/js/components/Project/List.jsx
@@ -4,12 +4,13 @@ import { useQuery } from "@apollo/react-hooks";
 import Error from "../UI/Error";
 import Loading from "../UI/Loading";
 import TrashIcon from "../../../css/fonts/zondicons/trash.svg";
-import { toast } from "react-toastify";
 import { useMutation, useApolloClient } from "@apollo/react-hooks";
 import { DELETE_PROJECT, GET_PROJECTS } from "./project.query.js";
 import UIModalDelete from "../UI/Modal/Delete";
+import { useToasts } from "react-toast-notifications";
 
 const ProjectList = () => {
+  const { addToast } = useToasts();
   const [modalOpen, setModalOpen] = useState(false);
   const [activeModal, setActiveModal] = useState();
   const { loading, error, data: projectsData } = useQuery(GET_PROJECTS);
@@ -50,9 +51,12 @@ const ProjectList = () => {
     setModalOpen(false);
 
     if (activeModal.ingestSheets.length > 0) {
-      toast(
+      addToast(
         `Project has existing ingest sheets.  You must delete these before deleting project: ${activeModal.title} `,
-        { type: "error" }
+        {
+          appearance: "error",
+          autoDismiss: true
+        }
       );
       return setActiveModal(null);
     }

--- a/assets/js/screens/Project/List.test.jsx
+++ b/assets/js/screens/Project/List.test.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ScreensProjectList from "./List";
 import { GET_PROJECTS } from "../../components/Project/project.query";
-import { renderWithRouterApollo } from "../../testing-helpers";
+import { renderWithRouterApollo, wrapWithToast } from "../../testing-helpers";
 import { waitForElement } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 
@@ -31,7 +31,9 @@ const mocks = [
 ];
 
 it("renders a create new project button", async () => {
-  const { getByTestId } = renderWithRouterApollo(<ScreensProjectList />);
+  const { getByTestId } = renderWithRouterApollo(
+    wrapWithToast(<ScreensProjectList />)
+  );
   const buttonElement = await waitForElement(() =>
     getByTestId("button-new-project")
   );
@@ -39,7 +41,9 @@ it("renders a create new project button", async () => {
 });
 
 it("renders screen header and screen content components", async () => {
-  const { getByTestId } = renderWithRouterApollo(<ScreensProjectList />);
+  const { getByTestId } = renderWithRouterApollo(
+    wrapWithToast(<ScreensProjectList />)
+  );
   const [screenHeaderElement, screenContentElement] = await waitForElement(
     () => [getByTestId("screen-header"), getByTestId("screen-content")]
   );
@@ -49,7 +53,7 @@ it("renders screen header and screen content components", async () => {
 
 it("renders the project list component", async () => {
   const { getByTestId, debug } = renderWithRouterApollo(
-    <ScreensProjectList />,
+    wrapWithToast(<ScreensProjectList />),
     {
       mocks
     }

--- a/assets/js/screens/Project/Project.test.jsx
+++ b/assets/js/screens/Project/Project.test.jsx
@@ -4,7 +4,7 @@ import {
   GET_PROJECT,
   INGEST_SHEET_STATUS_UPDATES_FOR_PROJECT_SUBSCRIPTION
 } from "../../components/Project/project.query";
-import { renderWithRouterApollo } from "../../testing-helpers";
+import { renderWithRouterApollo, wrapWithToast } from "../../testing-helpers";
 import "@testing-library/jest-dom/extend-expect";
 import { Route } from "react-router-dom";
 import { waitForElement } from "@testing-library/react";
@@ -63,7 +63,7 @@ const mocks = [
 
 function setupMatchTests() {
   return renderWithRouterApollo(
-    <Route path="/project/:id" component={ScreensProject} />,
+    wrapWithToast(<Route path="/project/:id" component={ScreensProject} />),
     {
       mocks,
       route: "/project/01DNFK4B8XASXNKBSAKQ6YVNF3"

--- a/assets/js/screens/Root.jsx
+++ b/assets/js/screens/Root.jsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { BrowserRouter, Route, Switch, Redirect } from "react-router-dom";
-import { ToastContainer } from "react-toastify";
-import "react-toastify/dist/ReactToastify.css";
-
+import { ToastProvider } from "react-toast-notifications";
 import { AuthProvider } from "../components/Auth/Auth";
 import Header from "../components/UI/Header/Header";
 import ScreensProjectList from "./Project/List";
@@ -19,45 +17,41 @@ export default class Root extends React.Component {
   render() {
     return (
       <AuthProvider>
-        <BrowserRouter>
-          <Header />
-          <ToastContainer
-            position="top-center"
-            hideProgressBar
-            autoClose={7000}
-          />
-
-          <Switch>
-            <Route exact path="/login" component={Login} />
-            <PrivateRoute
-              exact
-              path="/project/list"
-              component={ScreensProjectList}
-            />
-            <PrivateRoute
-              exact
-              path="/project/create"
-              component={ScreensProjectForm}
-            />
-            <PrivateRoute
-              exact
-              path="/project/:id/ingest-sheet/upload"
-              component={ScreensIngestSheetForm}
-            />
-            <PrivateRoute
-              exact
-              path="/project/:id/ingest-sheet/:ingestSheetId"
-              component={ScreensIngestSheet}
-            />
-            <PrivateRoute
-              exact
-              path="/project/:id"
-              component={ScreensProject}
-            />
-            <PrivateRoute exact path="/" component={Home} />
-            <PrivateRoute component={NotFoundPage} />
-          </Switch>
-        </BrowserRouter>
+        <ToastProvider>
+          <BrowserRouter>
+            <Header />
+            <Switch>
+              <Route exact path="/login" component={Login} />
+              <PrivateRoute
+                exact
+                path="/project/list"
+                component={ScreensProjectList}
+              />
+              <PrivateRoute
+                exact
+                path="/project/create"
+                component={ScreensProjectForm}
+              />
+              <PrivateRoute
+                exact
+                path="/project/:id/ingest-sheet/upload"
+                component={ScreensIngestSheetForm}
+              />
+              <PrivateRoute
+                exact
+                path="/project/:id/ingest-sheet/:ingestSheetId"
+                component={ScreensIngestSheet}
+              />
+              <PrivateRoute
+                exact
+                path="/project/:id"
+                component={ScreensProject}
+              />
+              <PrivateRoute exact path="/" component={Home} />
+              <PrivateRoute component={NotFoundPage} />
+            </Switch>
+          </BrowserRouter>
+        </ToastProvider>
       </AuthProvider>
     );
   }

--- a/assets/js/testing-helpers.js
+++ b/assets/js/testing-helpers.js
@@ -3,6 +3,7 @@ import { Router } from "react-router-dom";
 import { render } from "@testing-library/react";
 import { createMemoryHistory } from "history";
 import { MockedProvider } from "@apollo/react-testing";
+import { ToastProvider } from "react-toast-notifications";
 
 /**
  * Testing Library utility function to wrap tested component in React Router history
@@ -69,4 +70,8 @@ export function renderWithApollo(ui, { mocks = [] }) {
   return {
     ...render(ui, { wrapper: Wrapper })
   };
+}
+
+export function wrapWithToast(ui) {
+  return <ToastProvider addToast={() => {}}>{ui}</ToastProvider>;
 }

--- a/assets/package.json
+++ b/assets/package.json
@@ -26,7 +26,8 @@
     "prop-types": "^15.7.2",
     "rc-progress": "^2.5.1",
     "react-apollo": "^3.1.1",
-    "react-responsive-modal": "^4.0.1"
+    "react-responsive-modal": "^4.0.1",
+    "react-toast-notifications": "^2.2.5"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",
@@ -59,7 +60,6 @@
     "react-router-dom": "^5.0.1",
     "react-router-prop-types": "^1.0.4",
     "react-svg-loader": "^3.0.3",
-    "react-toastify": "^5.3.2",
     "tailwindcss": "^1.0.5",
     "tailwindcss-spinner": "^1.0.0",
     "terser-webpack-plugin": "^2.1.0",

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -820,6 +820,83 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@emotion/cache@^10.0.17":
+  version "10.0.19"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.19.tgz#d258d94d9c707dcadaf1558def968b86bb87ad71"
+  integrity sha512-BoiLlk4vEsGBg2dAqGSJu0vJl/PgVtCYLBFJaEO8RmQzPugXewQCXZJNXTDFaRlfCs0W+quesayav4fvaif5WQ==
+  dependencies:
+    "@emotion/sheet" "0.9.3"
+    "@emotion/stylis" "0.8.4"
+    "@emotion/utils" "0.11.2"
+    "@emotion/weak-memoize" "0.2.4"
+
+"@emotion/core@^10.0.14":
+  version "10.0.21"
+  resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.21.tgz#2e8398d2b92fd90d4ed6ac4d0b66214971de3458"
+  integrity sha512-U9zbc7ovZ2ceIwbLXYZPJy6wPgnOdTNT4jENZ31ee6v2lojetV5bTbCVk6ciT8G3wQRyVaTTfUCH9WCrMzpRIw==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/cache" "^10.0.17"
+    "@emotion/css" "^10.0.14"
+    "@emotion/serialize" "^0.11.10"
+    "@emotion/sheet" "0.9.3"
+    "@emotion/utils" "0.11.2"
+
+"@emotion/css@^10.0.14":
+  version "10.0.14"
+  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.14.tgz#95dacabdd0e22845d1a1b0b5968d9afa34011139"
+  integrity sha512-MozgPkBEWvorcdpqHZE5x1D/PLEHUitALQCQYt2wayf4UNhpgQs2tN0UwHYS4FMy5ROBH+0ALyCFVYJ/ywmwlg==
+  dependencies:
+    "@emotion/serialize" "^0.11.8"
+    "@emotion/utils" "0.11.2"
+    babel-plugin-emotion "^10.0.14"
+
+"@emotion/hash@0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.3.tgz#a166882c81c0c6040975dd30df24fae8549bd96f"
+  integrity sha512-14ZVlsB9akwvydAdaEnVnvqu6J2P6ySv39hYyl/aoB6w/V+bXX0tay8cF6paqbgZsN2n5Xh15uF4pE+GvE+itw==
+
+"@emotion/memoize@0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.3.tgz#5b6b1c11d6a6dddf1f2fc996f74cf3b219644d78"
+  integrity sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow==
+
+"@emotion/serialize@^0.11.10", "@emotion/serialize@^0.11.11", "@emotion/serialize@^0.11.8":
+  version "0.11.11"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.11.tgz#c92a5e5b358070a7242d10508143306524e842a4"
+  integrity sha512-YG8wdCqoWtuoMxhHZCTA+egL0RSGdHEc+YCsmiSBPBEDNuVeMWtjEWtGrhUterSChxzwnWBXvzSxIFQI/3sHLw==
+  dependencies:
+    "@emotion/hash" "0.7.3"
+    "@emotion/memoize" "0.7.3"
+    "@emotion/unitless" "0.7.4"
+    "@emotion/utils" "0.11.2"
+    csstype "^2.5.7"
+
+"@emotion/sheet@0.9.3":
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.3.tgz#689f135ecf87d3c650ed0c4f5ddcbe579883564a"
+  integrity sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A==
+
+"@emotion/stylis@0.8.4":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.4.tgz#6c51afdf1dd0d73666ba09d2eb6c25c220d6fe4c"
+  integrity sha512-TLmkCVm8f8gH0oLv+HWKiu7e8xmBIaokhxcEKPh1m8pXiV/akCiq50FvYgOwY42rjejck8nsdQxZlXZ7pmyBUQ==
+
+"@emotion/unitless@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.4.tgz#a87b4b04e5ae14a88d48ebef15015f6b7d1f5677"
+  integrity sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==
+
+"@emotion/utils@0.11.2":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.2.tgz#713056bfdffb396b0a14f1c8f18e7b4d0d200183"
+  integrity sha512-UHX2XklLl3sIaP6oiMmlVzT0J+2ATTVpf0dHQVyPJHTkOITvXfaSqnRk6mdDhV9pR8T/tHc3cex78IKXssmzrA==
+
+"@emotion/weak-memoize@0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz#622a72bebd1e3f48d921563b4b60a762295a81fc"
+  integrity sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA==
+
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.9.0.tgz#79b1bc06fb74a8cfb01cbdedf945584b1b9707f0"
@@ -1709,6 +1786,22 @@ babel-plugin-dynamic-import-node@^2.3.0:
   dependencies:
     object.assign "^4.1.0"
 
+babel-plugin-emotion@^10.0.14:
+  version "10.0.21"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.0.21.tgz#9ebeb12edeea3e60a5476b0e07c9868605e65968"
+  integrity sha512-03o+T6sfVAJhNDcSdLapgv4IeewcFPzxlvBUVdSf7o5PI57ZSxoDvmy+ZulVWSu+rOWAWkEejNcsb29TuzJHbg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/hash" "0.7.3"
+    "@emotion/memoize" "0.7.3"
+    "@emotion/serialize" "^0.11.11"
+    babel-plugin-macros "^2.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^1.0.5"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+
 babel-plugin-istanbul@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz#df4ade83d897a92df069c4d9a25cf2671293c854"
@@ -1726,10 +1819,24 @@ babel-plugin-jest-hoist@^24.9.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
+babel-plugin-macros@^2.0.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.6.1.tgz#41f7ead616fc36f6a93180e89697f69f51671181"
+  integrity sha512-6W2nwiXme6j1n2erPOnmRiWfObUhWH7Qw1LMi9XZy8cj+KtESu3T6asZvtk5bMQQjX8te35o7CFueiSdL/2NmQ==
+  dependencies:
+    "@babel/runtime" "^7.4.2"
+    cosmiconfig "^5.2.0"
+    resolve "^1.10.0"
+
 babel-plugin-react-svg@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-svg/-/babel-plugin-react-svg-3.0.3.tgz#7da46a0bd8319f49ac85523d259f145ce5d78321"
   integrity sha512-Pst1RWjUIiV0Ykv1ODSeceCBsFOP2Y4dusjq7/XkjuzJdvS9CjpkPMUIoO4MLlvp5PiLCeMlsOC7faEUA0gm3Q==
+
+babel-plugin-syntax-jsx@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
 babel-polyfill@6.26.0:
   version "6.26.0"
@@ -2264,7 +2371,7 @@ constants-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
-convert-source-map@^1.1.0, convert-source-map@^1.4.0:
+convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
   integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
@@ -2329,7 +2436,7 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-cosmiconfig@^5.0.0:
+cosmiconfig@^5.0.0, cosmiconfig@^5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
   integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
@@ -2598,6 +2705,11 @@ csstype@^2.2.0, csstype@^2.6.6:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.6.tgz#c34f8226a94bbb10c32cc0d714afdf942291fc41"
   integrity sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==
+
+csstype@^2.5.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.7.tgz#20b0024c20b6718f4eda3853a1f5a1cce7f5e4a5"
+  integrity sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ==
 
 cyclist@^1.0.1:
   version "1.0.1"
@@ -3153,6 +3265,11 @@ find-cache-dir@^3.0.0:
     commondir "^1.0.1"
     make-dir "^3.0.0"
     pkg-dir "^4.1.0"
+
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
 find-up@^3.0.0:
   version "3.0.0"
@@ -6268,17 +6385,15 @@ react-svg-loader@^3.0.3:
     loader-utils "^1.2.3"
     react-svg-core "^3.0.3"
 
-react-toastify@^5.3.2:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-5.4.0.tgz#29501618d02cc25329c32bfd7cfeed19b532b2ef"
-  integrity sha512-0cdPq1gyxAcYu0KiDPOYp9nNiqIFDWoi7nyoaSw496DElUnNlcjhc7Aduz8CXrGTRugvjuXd3eplUvFaCeQMNA==
+react-toast-notifications@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/react-toast-notifications/-/react-toast-notifications-2.2.5.tgz#2475b4a048f5f9d07fad2fd4ca0b28e72e317f96"
+  integrity sha512-Z2oZK2NUHZKaFI2fFTP5Byq3EFJ5Ufa0NHBISMr7l3zfAy4TCMwyTyxgE/PHnpYV204XPoi8s+/bSeHCP/atXA==
   dependencies:
-    "@babel/runtime" "^7.4.2"
-    classnames "^2.2.6"
-    prop-types "^15.7.2"
-    react-transition-group "^2.6.1"
+    "@emotion/core" "^10.0.14"
+    react-transition-group "^2.3.1"
 
-react-transition-group@^2.6.1:
+react-transition-group@^2.3.1:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
   integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
@@ -6823,7 +6938,7 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
-source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6:
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=


### PR DESCRIPTION
The previous Toast notification package was clunky and hard to easily customize for some reason.  Swapped it out for a newer one, which provides a custom React hook, `useToasts`.   Looks like:

![image](https://user-images.githubusercontent.com/3020266/66593168-14344800-eb5c-11e9-9ead-0140888a992c.png)
