### PR TITLE
Fix garbage can and ingest sheet order

### DIFF
--- a/assets/js/components/IngestSheet/List.jsx
+++ b/assets/js/components/IngestSheet/List.jsx
@@ -108,9 +108,13 @@ const IngestSheetList = ({ project, subscribeToIngestSheetStatusChanges }) => {
                   <td>{updatedAt}</td>
                   <td>{TEMP_USER_FRIENDLY_STATUS[status]}</td>
                   <td className="text-right">
-                    <button onClick={e => onOpenModal(e, id)}>
-                      <TrashIcon className="icon cursor-pointer" />
-                    </button>
+                    {["VALID", "ROW_FAIL", "FILE_FAIL", "UPLOADED"].indexOf(
+                      status
+                    ) > -1 && (
+                      <button onClick={e => onOpenModal(e, id)}>
+                        <TrashIcon className="icon cursor-pointer" />
+                      </button>
+                    )}
                   </td>
                 </tr>
               ))}

--- a/lib/meadow/ingest/projects.ex
+++ b/lib/meadow/ingest/projects.ex
@@ -5,6 +5,7 @@ defmodule Meadow.Ingest.Projects do
 
   import Ecto.Query, warn: false
 
+  alias Meadow.Ingest.IngestSheets.IngestSheet
   alias Meadow.{Ingest.Projects.Project, Repo}
 
   @doc """
@@ -39,7 +40,11 @@ defmodule Meadow.Ingest.Projects do
 
   Raises `Ecto.NoResultsError` if the Project does not exist.
   """
-  def get_project!(id), do: Repo.get!(Project, id)
+  def get_project!(id) do
+    Project
+    |> Repo.get(id)
+    |> Repo.preload(ingest_sheets: from(i in IngestSheet, order_by: [desc: i.inserted_at]))
+  end
 
   @doc """
   Creates a project.


### PR DESCRIPTION
* Only show garbage can in ingest sheet list if the ingest sheet is deletable (hasn't been ingested)
* Sort the ingest sheet list by creation time descending