### PR TITLE
Mock out pyramid creation action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN mix phx.digest \
   && mix release --overwrite
 
 # Create runtime image
-FROM alpine:3.9
+FROM node-11:alpine
 LABEL edu.northwestern.library.app=meadow \
   edu.northwestern.library.stage=runtime
 RUN apk update && apk --no-cache --update add ncurses-libs openssl-dev

--- a/bin/fake_pyramid.js
+++ b/bin/fake_pyramid.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+process.stdin.resume();
+
+process.stdin.on("data", data => {
+  sleep(5000).then(() => {
+    var r = Math.floor(Math.random() * 5);
+    switch (r) {
+      case 1:
+        const parsedJSON = JSON.parse(data);
+        const target = parsedJSON.target;
+        process.stdout.write(`${target} not found`);
+        break;
+      case 2:
+        process.exit(1);
+        break;
+      case 3:
+        break;
+      default:
+        process.stdout.write("complete");
+        break;
+    }
+  });
+});
+process.stdin.on("end", () => {
+  process.exit;
+});
+
+process.stdin.on("exit", () => {
+  process.exit;
+});
+
+const sleep = milliseconds => {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+};

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -69,7 +69,8 @@ config :meadow, MeadowWeb.Endpoint,
 config :meadow,
   ingest_bucket: "dev-ingest",
   upload_bucket: "dev-uploads",
-  preservation_bucket: "dev-preservation"
+  preservation_bucket: "dev-preservation",
+  pyramid_bucket: "dev-pyramids"
 
 config :ex_aws,
   access_key_id: "fake",

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -25,6 +25,7 @@ config :meadow, MeadowWeb.Endpoint,
 config :meadow, ingest_bucket: get_required_var.("INGEST_BUCKET")
 config :meadow, preservation_bucket: get_required_var.("PRESERVATION_BUCKET")
 config :meadow, upload_bucket: get_required_var.("UPLOAD_BUCKET")
+config :meadow, pyramid_bucket: get_required_var.("PYRAMID_BUCKET")
 
 config :honeybadger,
   api_key: get_required_var.("HONEYBADGER_API_KEY"),

--- a/config/test.exs
+++ b/config/test.exs
@@ -34,7 +34,8 @@ config :meadow, MeadowWeb.Endpoint,
 config :meadow,
   ingest_bucket: "test-ingest",
   upload_bucket: "test-uploads",
-  preservation_bucket: "test-preservation"
+  preservation_bucket: "test-preservation",
+  pyramid_bucket: "test-pyramids"
 
 config :meadow,
   start_pipeline: false

--- a/lib/meadow/config.ex
+++ b/lib/meadow/config.ex
@@ -18,12 +18,18 @@ defmodule Meadow.Config do
     Application.get_env(:meadow, :upload_bucket)
   end
 
+  @doc "Retrieve the configured pyramid bucket"
+  def pyramid_bucket do
+    Application.get_env(:meadow, :pyramid_bucket)
+  end
+
   @doc "Retrieve a list of configured buckets"
   def buckets do
     [
       ingest_bucket(),
       preservation_bucket(),
-      upload_bucket()
+      upload_bucket(),
+      pyramid_bucket()
     ]
   end
 

--- a/lib/meadow/ingest/actions/create_pyramid_tiff.ex
+++ b/lib/meadow/ingest/actions/create_pyramid_tiff.ex
@@ -1,0 +1,76 @@
+defmodule Meadow.Ingest.Actions.CreatePyramidTiff do
+  @moduledoc "Create the pyramid tiff derivative for Image objects"
+
+  alias Meadow.Config
+  alias Meadow.Data.{AuditEntries, FileSets}
+  alias Meadow.Utils.Pairtree
+  alias Sequins.Pipeline.Action
+  use Action
+
+  @pyramid_bucket Config.pyramid_bucket()
+  @command "bin/fake_pyramid.js"
+  @timeout 7_000
+
+  def process(data, attrs),
+    do: process(data, attrs, AuditEntries.ok?(data.file_set_id, __MODULE__))
+
+  defp process(%{file_set_id: file_set_id}, _, true) do
+    Logger.warn("Skipping #{__MODULE__} for #{file_set_id} – already complete")
+    :ok
+  end
+
+  defp process(%{file_set_id: file_set_id}, _, _) do
+    Logger.info("Beginning #{__MODULE__} for FileSet #{file_set_id}")
+    file_set = FileSets.get_file_set!(file_set_id)
+
+    Process.flag(:trap_exit, true)
+    port = Port.open({:spawn, @command}, [:binary, :exit_status])
+    Port.monitor(port)
+
+    case create_pyramid_tiff(file_set, port) do
+      {:ok, _} ->
+        AuditEntries.add_entry!(file_set.id, __MODULE__, "ok")
+        :ok
+
+      {:error, error} ->
+        AuditEntries.add_entry!(file_set.id, __MODULE__, "error", error)
+        {:error, error}
+    end
+  rescue
+    err in RuntimeError -> {:error, err}
+  end
+
+  defp create_pyramid_tiff(file_set, port) do
+    source = file_set.metadata.location
+    target = pyramid_uri_for(file_set.id)
+    input = Poison.encode!(%{source: source, target: target})
+
+    send(port, {self(), {:command, input}})
+
+    receive do
+      {_port, {:data, "complete"}} ->
+        Logger.info("complete")
+        {:ok, "complete"}
+
+      {_port, {:data, message}} ->
+        Logger.error(message)
+        {:error, message}
+
+      {_port, {:exit_status, status}} ->
+        Logger.error("exit_status: #{status}")
+        {:error, "exit_status: #{status}"}
+    after
+      @timeout ->
+        Logger.error("No response after 7s")
+        {:error, "Timeout"}
+    end
+  end
+
+  defp pyramid_uri_for(file_set_id) do
+    dest_bucket = Config.pyramid_bucket()
+
+    dest_key = Path.join(["/", Pairtree.generate_pyramid_path(file_set_id)])
+
+    %URI{scheme: "s3", host: dest_bucket, path: dest_key} |> URI.to_string()
+  end
+end

--- a/lib/meadow/ingest/pipeline.ex
+++ b/lib/meadow/ingest/pipeline.ex
@@ -28,6 +28,7 @@ defmodule Meadow.Ingest.Pipeline do
       {Actions.CopyFileToPreservation, max_number_of_messages: 3, visibility_timeout: 180},
       {Actions.GenerateFileSetDigests, max_number_of_messages: 3, visibility_timeout: 180},
       {Actions.IngestFileSet, processor_stages: 1},
+      {Actions.CreatePyramidTiff, processor_stages: 1},
       {Actions.UpdateSheetStatus, processor_stages: 1},
       {Actions.FileSetComplete, processor_stages: 1}
     ]
@@ -43,11 +44,13 @@ defmodule Meadow.Ingest.Pipeline do
       IngestFileSet: [],
       GenerateFileSetDigests: [IngestFileSet: [status: :ok]],
       CopyFileToPreservation: [GenerateFileSetDigests: [status: :ok]],
-      FileSetComplete: [CopyFileToPreservation: [status: :ok]],
+      CreatePyramidTiff: [CopyFileToPreservation: [status: :ok]],
+      FileSetComplete: [CreatePyramidTiff: [status: :ok]],
       UpdateSheetStatus: [
         IngestFileSet: [context: :Sheet, status: :error],
         GenerateFileSetDigests: [context: :Sheet, status: :error],
         CopyFileToPreservation: [context: :Sheet, status: :error],
+        CreatePyramidTiff: [context: :Sheet, status: :error],
         FileSetComplete: [context: :Sheet, status: [:ok, :error]]
       ]
     ]

--- a/lib/meadow/utils/pairtree.ex
+++ b/lib/meadow/utils/pairtree.ex
@@ -36,4 +36,22 @@ defmodule Meadow.Utils.Pairtree do
       {:error, message} -> raise ArgumentError, message
     end
   end
+
+  @doc """
+  Generate a pairtree for a pyramid key
+
+  Example:
+    Meadow.Utils.Pairtree.generate_pyramid_path("01DT5BNAR8XB6YFWB9V1VQQKDN")
+    => "01/dt/5b/na/r8/xb/6y/fw/b9/v1/vq/qk/dn-pyramid.tif"
+  """
+  def generate_pyramid_path(id) do
+    transform = fn str ->
+      (Regex.scan(~r/../, String.slice(str, 0, 24)) ++
+         ["#{String.slice(str, 24, 2)}-pyramid.tif"])
+      |> Enum.join("/")
+      |> String.downcase()
+    end
+
+    id |> String.slice(0, 26 * 2) |> transform.()
+  end
 end

--- a/terraform/task-definitions/meadow_app.json
+++ b/terraform/task-definitions/meadow_app.json
@@ -30,15 +30,19 @@
         "name": "PRESERVATION_BUCKET",
         "value": "${preservation_bucket}"
       },
-      { 
+      {
+        "name": "PYRAMID_BUCKET",
+        "value": "${pyramid_bucket}"
+      },
+      {
         "name": "RELEASE_COOKIE",
         "value": "${secret_key_base}"
       },
-      { 
+      {
         "name": "RELEASE_DISTRIBUTION",
         "value": "name"
       },
-      { 
+      {
         "name": "RELEASE_NODE",
         "value": "meadow@${host_name}"
       },

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -40,3 +40,8 @@ variable "upload_bucket" {
   default = ""
 }
 
+variable "pyramid_bucket" {
+  type    = "string"
+  default = ""
+}
+

--- a/test/meadow/utils/pairtree_test.exs
+++ b/test/meadow/utils/pairtree_test.exs
@@ -47,4 +47,9 @@ defmodule Meadow.Utils.PairtreeTest do
       end
     end
   end
+
+  describe "generate_pyramid_path/1" do
+    assert Pairtree.generate_pyramid_path("01DT5BNAR8XB6YFWB9V1VQQKDN") ==
+             "01/dt/5b/na/r8/xb/6y/fw/b9/v1/vq/qk/dn-pyramid.tif"
+  end
 end


### PR DESCRIPTION
- Creates shell of action for pyramid tiff generation
- Generates pyramid path pairtree using same format as donut
- Spawns mock node.js process passing source and destination
- Waits for response, mocks a completed status and a couple possible failures including a timeout if there is no response
- Adds pyramid bucket environment variable to config
- adds a node runtime image to dockerfile

