### PR TITLE
Join ingest_sheet_rows to ingest_sheet_works instead of to itself

### DIFF
--- a/lib/meadow/ingest/sheets.ex
+++ b/lib/meadow/ingest/sheets.ex
@@ -609,7 +609,7 @@ defmodule Meadow.Ingest.Sheets do
       join: r in Row,
       as: :row,
       on:
-        r.sheet_id == r.sheet_id and
+        r.sheet_id == iw.sheet_id and
           r.file_set_accession_number == f.accession_number,
       where: iw.sheet_id == ^sheet_id
     )


### PR DESCRIPTION
Fix Ecto join in order to retrieve the right number of ingest errors.