### PR TITLE
LDAP lookup/group management functions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,12 @@ jobs:
           POSTGRES_USER: docker
           POSTGRES_PASSWORD: d0ck3r
       - image: nulib/goaws
+      - image: nulib/ldap-test
+        environment:
+          DOMAIN: library.northwestern.edu
+          DOMAINPASS: d0ck3rAdm1n!
+          INSECURELDAP: "true"
+          NOCOMPLEXITY: "true"
     steps:
       - checkout
       - restore_cache:

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -70,7 +70,8 @@ config :meadow,
   ingest_bucket: "dev-ingest",
   upload_bucket: "dev-uploads",
   preservation_bucket: "dev-preservation",
-  pyramid_bucket: "dev-pyramids"
+  pyramid_bucket: "dev-pyramids",
+  ldap_nested_groups: false
 
 config :ex_aws,
   access_key_id: "fake",
@@ -95,6 +96,13 @@ config :ex_aws, :sns,
   port: 4101,
   scheme: "http://",
   region: "us-east-1"
+
+config :exldap, :settings,
+  server: "localhost",
+  base: "DC=library,DC=northwestern,DC=edu",
+  port: 390,
+  user_dn: "cn=Administrator,cn=Users,dc=library,dc=northwestern,dc=edu",
+  password: "d0ck3rAdm1n!"
 
 # Do not include metadata nor timestamps in development logs
 config :logger, :console,

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -9,6 +9,13 @@ get_required_var = fn var ->
   System.get_env(var) || raise "environment variable #{var} is missing."
 end
 
+config :exldap, :settings,
+  server: get_required_var.("LDAP_SERVER"),
+  base: System.get_env("LDAP_BASE_DN", "DC=library,DC=northwestern,DC=edu"),
+  port: String.to_integer(System.get_env("LDAP_PORT", "389")),
+  user_dn: get_required_var.("LDAP_BIND_DN"),
+  password: get_required_var.("LDAP_BIND_PASSWORD")
+
 config :meadow, Meadow.Repo,
   # ssl: true,
   url: get_required_var.("DATABASE_URL"),

--- a/config/test.exs
+++ b/config/test.exs
@@ -19,7 +19,8 @@ config :meadow,
   ingest_bucket: "test-ingest",
   upload_bucket: "test-uploads",
   preservation_bucket: "test-preservation",
-  pyramid_bucket: "test-pyramids"
+  pyramid_bucket: "test-pyramids",
+  ldap_nested_groups: false
 
 config :meadow,
   start_pipeline: false
@@ -48,6 +49,13 @@ config :ex_aws, :sns,
   port: if(System.get_env("CI"), do: 4100, else: 4102),
   scheme: "http://",
   region: "us-east-1"
+
+config :exldap, :settings,
+  server: "localhost",
+  base: "DC=library,DC=northwestern,DC=edu",
+  port: if(System.get_env("CI"), do: 389, else: 391),
+  user_dn: "cn=Administrator,cn=Users,dc=library,dc=northwestern,dc=edu",
+  password: "d0ck3rAdm1n!"
 
 # Print only warnings and errors during test
 config :logger, level: :info

--- a/lib/meadow/accounts/ldap.ex
+++ b/lib/meadow/accounts/ldap.ex
@@ -1,0 +1,188 @@
+defmodule Meadow.Accounts.Ldap do
+  @moduledoc """
+  This module defines functions for creating and managing LDAP/Active Directory
+  groups and group membership.
+  """
+
+  alias Meadow.Accounts.Users.User
+  alias Meadow.Config
+
+  @ldap_matching_rule_in_chain "1.2.840.113556.1.4.1941"
+  @meadow_base "OU=Meadow,DC=library,DC=northwestern,DC=edu"
+
+  defmodule Entry do
+    @moduledoc """
+    Simple id/name struct for LDAP entries
+    """
+    defstruct id: nil, name: nil
+
+    def new(%Exldap.Entry{} = entry) do
+      %__MODULE__{
+        id: entry.object_name |> to_string(),
+        name: entry |> Exldap.get_attribute!("cn")
+      }
+    end
+
+    def new(connection, dn) do
+      case Exldap.search(connection, base: dn, filter: Exldap.equalityMatch("objectClass", "top")) do
+        {:ok, [entry]} -> %__MODULE__{id: dn, name: entry |> Exldap.get_attribute!("cn")}
+        _ -> %__MODULE__{id: dn, name: nil}
+      end
+    end
+  end
+
+  def connection do
+    case Exldap.connect() do
+      {:ok, result} -> result
+      other -> other
+    end
+  end
+
+  @doc "Fetch the display name (LDAP commonName) for an entry"
+  def display_name(%Entry{} = entry), do: entry.name
+
+  @doc "Fetch the display names (LDAP commonName) for a list of entries"
+  def display_names([]), do: []
+  def display_names([entry | entries]), do: [display_name(entry) | display_names(entries)]
+
+  @doc "Fetch the unique identifier (LDAP distinguishedName) for a user"
+  def user_dn(%Entry{} = user), do: user.id
+  def user_dn(%User{username: username}), do: user_dn(username)
+
+  def user_dn(username) do
+    with {:ok, results} <- connection() |> Exldap.search_field("cn", username) do
+      case results do
+        [] ->
+          nil
+
+        _ ->
+          results
+          |> List.first()
+          |> Map.get(:object_name)
+          |> to_string()
+      end
+    end
+  end
+
+  @doc "List all group names and DNs under the @meadow_base DN"
+  def list_groups do
+    {:ok, meadow_groups} =
+      connection()
+      |> Exldap.search_with_filter(
+        @meadow_base,
+        Exldap.equalityMatch("objectClass", "group")
+      )
+
+    meadow_groups
+    |> Enum.map(&Entry.new/1)
+  end
+
+  @doc "List the members of a given group"
+  def list_group_members(group) do
+    with conn <- connection() do
+      case Exldap.search(conn, base: @meadow_base, filter: Exldap.equalityMatch("cn", group)) do
+        {:ok, [entry]} -> extract_members(conn, entry)
+        other -> other
+      end
+    end
+  end
+
+  @doc "List the groups a given user belongs to"
+  def list_user_groups(user) do
+    user_dn = user_dn(user)
+
+    list_groups()
+    |> Enum.map(fn %Entry{id: group_dn} = entry ->
+      {:ok, results} =
+        connection()
+        |> Exldap.search_with_filter(user_dn, filter_for(group_dn))
+
+      case length(results) do
+        0 -> nil
+        1 -> entry
+      end
+    end)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  @doc "Create a group under the @meadow_base DN"
+  def create_group(group) do
+    with {:ok, connection} <- Exldap.connect(),
+         group_dn <- "CN=#{group},#{@meadow_base}" |> to_charlist() do
+      attributes = [
+        {'objectClass', ['group']},
+        {'objectClass', ['top']},
+        {'groupType', ['4']},
+        {'cn', [group]},
+        {'description', [group]}
+      ]
+
+      case :eldap.add(connection, group_dn, attributes) do
+        :ok ->
+          {:ok, Entry.new(connection, group_dn)}
+
+        {:error, :entryAlreadyExists} ->
+          {:exists, Entry.new(connection, group_dn)}
+
+        other ->
+          other
+      end
+    end
+  end
+
+  @doc "Add a user to a group"
+  def add_user(user, group) do
+    with user_dn <- user_dn(user),
+         group_dn <- "CN=#{group},#{@meadow_base}" |> to_charlist(),
+         operation <- :eldap.mod_add('member', [to_charlist(user_dn)]) do
+      case modify_entry(group_dn, operation) do
+        {:ok, _} -> :ok
+        {:exists, _} -> :exists
+        other -> other
+      end
+    end
+  end
+
+  @doc "Remove a user from a group"
+  def remove_user(user, group) do
+    with user_dn <- user_dn(user),
+         group_dn <- "CN=#{group},#{@meadow_base}" |> to_charlist(),
+         operation <- :eldap.mod_delete('member', [to_charlist(user_dn)]) do
+      case modify_entry(group_dn, operation) do
+        {:ok, _} -> :ok
+        other -> other
+      end
+    end
+  end
+
+  defp extract_members(connection, %Exldap.Entry{} = group) do
+    group
+    |> Exldap.get_attribute!("member")
+    |> ensure_list()
+    |> Enum.map(fn dn -> Entry.new(connection, dn) end)
+  end
+
+  defp ensure_list(x) when is_list(x), do: x
+  defp ensure_list(x), do: [x]
+
+  defp modify_entry(dn, operation) do
+    case :eldap.modify(connection(), dn, [operation]) do
+      :ok -> {:ok, to_string(dn)}
+      {:error, :entryAlreadyExists} -> {:exists, to_string(dn)}
+      other -> other
+    end
+  end
+
+  defp filter_for(dn) do
+    case Config.ldap_nested_groups?() do
+      true ->
+        Exldap.extensibleMatch(dn,
+          type: "memberOf",
+          matchingRule: @ldap_matching_rule_in_chain
+        )
+
+      _ ->
+        Exldap.equalityMatch("memberOf", dn)
+    end
+  end
+end

--- a/lib/meadow/config.ex
+++ b/lib/meadow/config.ex
@@ -46,4 +46,9 @@ defmodule Meadow.Config do
   def start_pipeline? do
     Application.get_env(:meadow, :start_pipeline, true)
   end
+
+  @doc "Check whether LDAP server supports nested groups"
+  def ldap_nested_groups? do
+    Application.get_env(:meadow, :ldap_nested_groups, true)
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -64,6 +64,7 @@ defmodule Meadow.MixProject do
       {:ex_aws, "~> 2.1"},
       {:ex_aws_s3, "~> 2.0"},
       {:excoveralls, "~> 0.10", only: :test},
+      {:exldap, "~> 0.6.3"},
       {:faker, "~> 0.12", only: [:dev, :test]},
       {:gettext, "~> 0.11"},
       {:hackney, "~> 1.15"},

--- a/mix.lock
+++ b/mix.lock
@@ -28,6 +28,7 @@
   "ex_aws_sns": {:hex, :ex_aws_sns, "2.1.0", "912a2092c5a028646f04263b0a380e4da74670b77c0647bc68e8d9c282b8e954", [:mix], [{:ex_aws, "~> 2.0", [hex: :ex_aws, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_aws_sqs": {:hex, :ex_aws_sqs, "3.0.2", "90690946a1156f4408a981461eb9e0b35113be8d2c1a25afa87a0f465b72b42b", [:mix], [{:ex_aws, "~> 2.0", [hex: :ex_aws, repo: "hexpm", optional: false]}], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.12.1", "a553c59f6850d0aff3770e4729515762ba7c8e41eedde03208182a8dc9d0ce07", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
+  "exldap": {:hex, :exldap, "0.6.3", "98e8c4ad5e1773b921ba0a5f27c96a6d814a7dff1581e5648eaf7c4f594729e7", [:mix], [], "hexpm"},
   "faker": {:hex, :faker, "0.13.0", "8abcb996f010ccd6c85588c89fc047f11134e04da019b70252f95431d721a3dc", [:mix], [], "hexpm"},
   "file_system": {:hex, :file_system, "0.2.7", "e6f7f155970975789f26e77b8b8d8ab084c59844d8ecfaf58cbda31c494d14aa", [:mix], [], "hexpm"},
   "gen_stage": {:hex, :gen_stage, "0.14.3", "d0c66f1c87faa301c1a85a809a3ee9097a4264b2edf7644bf5c123237ef732bf", [:mix], [], "hexpm"},

--- a/test/meadow/accounts/ldap_test.exs
+++ b/test/meadow/accounts/ldap_test.exs
@@ -1,0 +1,91 @@
+defmodule Meadow.Accounts.LdapTest do
+  use Meadow.LdapCase
+  import Assertions
+
+  @groups ["Administrators", "Managers", "Editors", "Viewers", "Users"]
+
+  describe "create groups" do
+    test "create group" do
+      assert Ldap.list_groups() == []
+      Ldap.create_group("TestGroup")
+
+      with result <- Ldap.list_groups() |> Enum.map(fn %Ldap.Entry{name: name} -> name end) do
+        assert_lists_equal(result, ["TestGroup"])
+      end
+    end
+
+    test "create group that already exists" do
+      {result, entry} = Ldap.create_group("TestGroup")
+      assert result == :ok
+      assert entry.name == "TestGroup"
+
+      {result, entry} = Ldap.create_group("TestGroup")
+      assert result == :exists
+      assert entry.name == "TestGroup"
+    end
+  end
+
+  describe "group membership" do
+    setup do
+      Enum.each(@groups, fn group -> Ldap.create_group(group) end)
+      create_users(["testUser1", "testUser2", "testUser3"])
+      :ok
+    end
+
+    test "add user to group" do
+      assert Ldap.list_user_groups("testUser1") == []
+      assert Ldap.add_user("testUser1", "Users") == :ok
+      assert_lists_equal(Ldap.list_user_groups("testUser1") |> Ldap.display_names(), ["Users"])
+      assert Ldap.add_user("testUser1", "Editors") == :ok
+
+      assert_lists_equal(Ldap.list_user_groups("testUser1") |> Ldap.display_names(), [
+        "Editors",
+        "Users"
+      ])
+    end
+
+    test "add user to group user is already a member of" do
+      assert Ldap.add_user("testUser1", "Users") == :ok
+      assert Ldap.add_user("testUser1", "Users") == :exists
+    end
+
+    test "remove user from group" do
+      Ldap.add_user("testUser1", "Managers")
+      Ldap.add_user("testUser2", "Managers")
+
+      assert_lists_equal(Ldap.list_group_members("Managers") |> Ldap.display_names(), [
+        "testUser1",
+        "testUser2"
+      ])
+
+      Ldap.remove_user("testUser1", "Managers")
+
+      assert_lists_equal(Ldap.list_group_members("Managers") |> Ldap.display_names(), [
+        "testUser2"
+      ])
+    end
+  end
+
+  describe "fetch distinguished names for users" do
+    setup do
+      {:ok, conn: Ldap.connection(), dn: create_user("testUser1")}
+    end
+
+    test "from User model", %{dn: expected} do
+      assert Ldap.user_dn(%Meadow.Accounts.Users.User{username: "testUser1"}) == expected
+    end
+
+    test "from user's Ldap.Entry", %{conn: conn, dn: expected} do
+      assert Ldap.user_dn(Ldap.Entry.new(conn, expected)) == expected
+    end
+
+    test "from a username", %{dn: expected} do
+      assert Ldap.user_dn("testUser1") == expected
+    end
+  end
+
+  test "entry for nonexistent dn" do
+    bad_dn = "CN=blah,OU=nonexistent,DC=library,DC=northwestern,DC=edu"
+    assert Ldap.Entry.new(Ldap.connection(), bad_dn) == %Ldap.Entry{id: bad_dn, name: nil}
+  end
+end

--- a/test/support/ldap_case.ex
+++ b/test/support/ldap_case.ex
@@ -1,0 +1,82 @@
+defmodule Meadow.LdapCase do
+  @moduledoc """
+  This module defines the setup for tests requiring
+  access to LDAP services.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      alias Meadow.Accounts.Ldap
+      import Meadow.LdapCase
+    end
+  end
+
+  setup do
+    with {:ok, connection} <- Exldap.connect() do
+      ["Meadow", "TestUsers"]
+      |> Enum.each(fn ou ->
+        attributes = [
+          {'objectClass', ['organizationalUnit']},
+          {'objectClass', ['top']},
+          {'ou', [to_charlist(ou)]},
+          {'name', [to_charlist(ou)]}
+        ]
+
+        :eldap.add(
+          connection,
+          to_charlist("OU=#{ou},DC=library,DC=northwestern,DC=edu"),
+          attributes
+        )
+      end)
+    end
+
+    on_exit(fn ->
+      with {:ok, connection} <- Exldap.connect() do
+        ["Meadow", "TestUsers"]
+        |> Enum.each(fn ou ->
+          {:ok, children} =
+            Exldap.search(connection,
+              base: "OU=#{ou},DC=library,DC=northwestern,DC=edu",
+              scope: :eldap.wholeSubtree(),
+              filter: Exldap.equalityMatch("objectClass", "top")
+            )
+
+          Enum.reverse(children)
+          |> Enum.each(fn leaf ->
+            :eldap.delete(connection, leaf.object_name)
+          end)
+        end)
+      end
+    end)
+
+    :ok
+  end
+
+  def create_user(username) do
+    with {:ok, connection} <- Exldap.connect(),
+         user_dn <-
+           "CN=#{username},OU=TestUsers,DC=library,DC=northwestern,DC=edu" |> to_charlist() do
+      attributes = [
+        {'objectClass', ['user']},
+        {'objectClass', ['person']},
+        {'objectClass', ['organizationalPerson']},
+        {'objectClass', ['top']},
+        {'sn', [to_charlist(username)]}
+      ]
+
+      case :eldap.add(connection, user_dn, attributes) do
+        :ok -> to_string(user_dn)
+        {:error, :entryAlreadyExists} -> to_string(user_dn)
+        other -> other
+      end
+    end
+  end
+
+  def create_users([]), do: []
+
+  def create_users([user | users]) do
+    [create_user(user) | create_users(users)]
+  end
+end


### PR DESCRIPTION
This PR adds a `Meadow.Accounts.Ldap` module that can:

- List groups
- Create groups
- List members of groups
- List group membership for a user
- Add members to groups
- Remove members from groups
