### PR TITLE
Reconfigure Terraform to put Meadow in a VPC with a NAT gateway

### DIFF
--- a/terraform/task-definitions/meadow_app.json
+++ b/terraform/task-definitions/meadow_app.json
@@ -23,6 +23,26 @@
         "value": "${ingest_bucket}"
       },
       {
+        "name": "LDAP_BASE_DN",
+        "value": "${ldap_base_dn}"
+      },
+      {
+        "name": "LDAP_BIND_DN",
+        "value": "${ldap_bind_dn}"
+      },
+      {
+        "name": "LDAP_BIND_PASSWORD",
+        "value": "${ldap_bind_password}"
+      },
+      {
+        "name": "LDAP_PORT",
+        "value": "${ldap_port}"
+      },
+      {
+        "name": "LDAP_SERVER",
+        "value": "${ldap_server}"
+      },
+      {
         "name": "MEADOW_HOSTNAME",
         "value": "${host_name}"
       },

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,47 +1,72 @@
 variable "aws_region" {
-  type    = "string"
+  type    = string
   default = "us-east-1"
 }
 
 variable "availability_zones" {
-  type    = "list"
+  type    = list
   default = ["us-east-1a", "us-east-1b", "us-east-1c"]
 }
 
 variable "honeybadger_api_key" {
-  type    = "string"
+  type    = string
   default = ""
 }
 
 variable "ingest_bucket" {
-  type    = "string"
+  type    = string
   default = ""
 }
 
 variable "stack_name" {
-  type = "string"
+  type = string
 }
 
 variable "environment" {
-  type = "string"
+  type = string
 }
 
 variable "dns_zone" {
-  type = "string"
+  type = string
 }
 
 variable "tags" {
-  type    = "map"
+  type    = map
   default = {}
 }
 
 variable "upload_bucket" {
-  type    = "string"
+  type    = string
   default = ""
 }
 
 variable "pyramid_bucket" {
-  type    = "string"
+  type    = string
   default = ""
 }
 
+variable "vpc_id" {
+  type    = string
+}
+
+variable "ldap_base_dn" {
+  type    = string
+  default = "DC=library,DC=northwestern,DC=edu"
+}
+
+variable "ldap_bind_dn" {
+  type    = string
+}
+
+variable "ldap_bind_password" {
+  type    = string
+}
+
+variable "ldap_port" {
+  type    = string
+  default = 389
+}
+
+variable "ldap_server" {
+  type    = string
+}


### PR DESCRIPTION
Addresses https://github.com/nulib/repodev_planning_and_docs/issues/428

Change terraform templates so that Meadow and its database are in a user-specified VPC instead of always using the default VPC