### PR TITLE
Remove collection types

### DIFF
--- a/assets/js/components/Collection/Form.jsx
+++ b/assets/js/components/Collection/Form.jsx
@@ -19,7 +19,6 @@ import { useToasts } from "react-toast-notifications";
 function setInitialFormValues(obj = {}) {
   const initialFormValues = {
     collectionName: obj.name || "",
-    collectionType: "",
     isFeatured: false,
     description: "",
     findingAidUrl: "",
@@ -47,9 +46,7 @@ const CollectionForm = ({ collection }) => {
   const [submitDisabled, setSubmitDisabled] = useState(true);
 
   useEffect(() => {
-    setSubmitDisabled(
-      formValues.collectionName === "" || formValues.collectionType === ""
-    );
+    setSubmitDisabled(formValues.collectionName === "");
   }, [formValues]);
 
   useEffect(() => {
@@ -159,28 +156,6 @@ const CollectionForm = ({ collection }) => {
           </div>
         </section>
         <section className="sm:w-full md:w-2/3">
-          <div className="form-group">
-            <UISelect
-              options={[
-                {
-                  label: "Collection type...",
-                  value: ""
-                },
-                {
-                  label: "NUL Collection",
-                  value: "NUL Collection"
-                },
-                {
-                  label: "NUL Theme",
-                  value: "NUL Theme"
-                }
-              ]}
-              value={formValues.collectionType}
-              name="collectionType"
-              onChange={handleInputChange}
-              className="shadow"
-            ></UISelect>
-          </div>
           <div className="form-group">
             <p>[Select thumbnail]</p>
           </div>

--- a/assets/js/components/Collection/ListRow.jsx
+++ b/assets/js/components/Collection/ListRow.jsx
@@ -28,8 +28,6 @@ const CollectionListRow = ({ collection }) => {
             <dd>{description}</dd>
             <dt>Keywords</dt>
             <dd>{keywords.join(", ")}</dd>
-            <dt>Type [not yet supported]</dt>
-            <dd>NUL Collection</dd>
             <dt>Works [not yet supported]</dt>
             <dd>3810 works, 2010 public, 700 netid, 100 private</dd>
             <dt>Assets [not yet supported]</dt>

--- a/assets/js/components/UI/Sidebar.jsx
+++ b/assets/js/components/UI/Sidebar.jsx
@@ -53,7 +53,7 @@ const Sidebar = () => {
               >
                 <Link to="/collection/list" className="nav-link">
                   <BookReferenceIcon className="icon" />
-                  Collections
+                  Themes & Collections
                 </Link>
               </li>
               <li


### PR DESCRIPTION
We decided that instead of Collection Types we will have two different types of objects: "Collections" and "Thematic Groups".  

Changes the navigation from "Collections" to "Themes and Collections" 