### PR TITLE
Two Small Fixes

### DIFF
--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -125,7 +125,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
   @desc "work types"
   enum :work_type do
     value(:image, as: "image", description: "Image")
-    value(:image, as: "audio", description: "Audio")
+    value(:audio, as: "audio", description: "Audio")
     value(:video, as: "video", description: "Video")
     value(:document, as: "document", description: "Document")
   end

--- a/test/meadow/ingest/sheets_to_works_test.exs
+++ b/test/meadow/ingest/sheets_to_works_test.exs
@@ -1,7 +1,7 @@
 defmodule Meadow.Ingest.SheetsToWorksTest do
   use Meadow.DataCase
-  alias Meadow.Ingest.{Sheets, SheetWorks, SheetsToWorks}
   alias Meadow.Data.{FileSets, Works}
+  alias Meadow.Ingest.{Sheets, SheetsToWorks, SheetWorks}
   alias Meadow.Repo
 
   @fixture "test/fixtures/ingest_sheet.csv"


### PR DESCRIPTION
* Fix a credo warning about out-of-order aliases
* Fix a typo that resulted in a duplicate `work_type` key