### PR TITLE
Hardcode LDAP base, port, ssl values in release

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -11,8 +11,9 @@ end
 
 config :exldap, :settings,
   server: get_required_var.("LDAP_SERVER"),
-  base: System.get_env("LDAP_BASE_DN", "DC=library,DC=northwestern,DC=edu"),
-  port: String.to_integer(System.get_env("LDAP_PORT", "389")),
+  base: "DC=library,DC=northwestern,DC=edu",
+  port: 636,
+  ssl: true,
   user_dn: get_required_var.("LDAP_BIND_DN"),
   password: get_required_var.("LDAP_BIND_PASSWORD")
 


### PR DESCRIPTION
Always build release using LDAPS on port 636 with the library's Base DN