### PR TITLE
Fix the name of the ActionStates migration module

### DIFF
--- a/priv/repo/migrations/20191008151402_create_action_states.exs
+++ b/priv/repo/migrations/20191008151402_create_action_states.exs
@@ -1,4 +1,4 @@
-defmodule Meadow.Repo.Migrations.CreateAuditEntries do
+defmodule Meadow.Repo.Migrations.CreateActionStates do
   use Ecto.Migration
 
   def change do


### PR DESCRIPTION
The module name of the `Meadow.Repo.Migrations.CreateActionStates` migration was accidentally left as `Meadow.Repo.Migrations.CreateAuditEntries` in #488. This is a quick cosmetic fix.