### PR TITLE
Add FileSet update API

### DIFF
--- a/lib/meadow/data/file_sets.ex
+++ b/lib/meadow/data/file_sets.ex
@@ -81,6 +81,15 @@ defmodule Meadow.Data.FileSets do
   end
 
   @doc """
+  Updates a FileSet.
+  """
+  def update_file_set(%FileSet{} = file_set, attrs) do
+    file_set
+    |> FileSet.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
   Dynamically compute the position for each item in a list of maps
   that include the key `:position`.
 

--- a/lib/meadow/pipeline/actions/copy_file_to_preservation.ex
+++ b/lib/meadow/pipeline/actions/copy_file_to_preservation.ex
@@ -9,8 +9,6 @@ defmodule Meadow.Pipeline.Actions.CopyFileToPreservation do
   """
   alias Meadow.Config
   alias Meadow.Data.{ActionStates, FileSets}
-  alias Meadow.Data.Schemas.FileSet
-  alias Meadow.Repo
   alias Meadow.Utils.Pairtree
   alias Sequins.Pipeline.Action
   use Action
@@ -34,8 +32,7 @@ defmodule Meadow.Pipeline.Actions.CopyFileToPreservation do
     case copy_file_to_preservation(file_set) do
       {:ok, new_location} ->
         file_set
-        |> FileSet.changeset(%{metadata: %{location: new_location}})
-        |> Repo.update!()
+        |> FileSets.update_file_set(%{metadata: %{location: new_location}})
 
         ActionStates.set_state!(file_set, __MODULE__, "ok")
         :ok

--- a/lib/meadow/pipeline/actions/generate_file_set_digests.ex
+++ b/lib/meadow/pipeline/actions/generate_file_set_digests.ex
@@ -7,8 +7,6 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigests do
 
   """
   alias Meadow.Data.{ActionStates, FileSets}
-  alias Meadow.Data.Schemas.FileSet
-  alias Meadow.Repo
   alias Meadow.Utils
   alias Sequins.Pipeline.Action
   use Action
@@ -38,9 +36,9 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigests do
         |> Enum.reduce(init_hashes(), &update_hashes(&2, &1))
         |> finalize_hashes()
 
-      file_set
-      |> FileSet.changeset(%{metadata: %{digests: hashes}})
-      |> Repo.update!()
+      {:ok, _} =
+        file_set
+        |> FileSets.update_file_set(%{metadata: %{digests: hashes}})
 
       ActionStates.set_state!(file_set, __MODULE__, "ok")
       :ok

--- a/test/meadow/data/file_sets_test.exs
+++ b/test/meadow/data/file_sets_test.exs
@@ -36,6 +36,22 @@ defmodule Meadow.Data.FileSetsTest do
       assert Enum.empty?(FileSets.list_file_sets())
     end
 
+    test "update_file_set/2 updates a file_set" do
+      file_set = file_set_fixture()
+
+      assert {:ok, %FileSet{} = file_set} =
+               FileSets.update_file_set(file_set, %{metadata: %{description: "New description"}})
+
+      assert file_set.metadata.description == "New description"
+    end
+
+    test "update_file_set/2 with invalid attributes returns an error" do
+      file_set = file_set_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               FileSets.update_file_set(file_set, %{role: "Unsupported"})
+    end
+
     test "get_file_set!/1 returns a file set by id" do
       file_set = file_set_fixture()
       assert FileSets.get_file_set!(file_set.id) == file_set


### PR DESCRIPTION
- Add `Meadow.Data.FileSets.update_file_set/2`
- change two `Meadow.Pipeline.Actions` (`CopyFileToPreservation` and `GenerateFileSetDigests`) to call `FileSets.update_file_set` instead of using the `FileSet` schema directly