### PR TITLE
Prevent embedded nils

### DIFF
--- a/lib/meadow/data/schemas/file_set.ex
+++ b/lib/meadow/data/schemas/file_set.ex
@@ -9,6 +9,7 @@ defmodule Meadow.Data.Schemas.FileSet do
 
   import Ecto.Changeset
   import EctoRanked
+  import Meadow.Data.Schemas.Validations
 
   use Meadow.Constants
 
@@ -35,6 +36,7 @@ defmodule Meadow.Data.Schemas.FileSet do
   def changeset(file_set, params) do
     file_set
     |> cast(params, [:accession_number, :work_id, :role, :rank, :position])
+    |> prepare_embed(:metadata)
     |> cast_embed(:metadata)
     |> validate_required([:accession_number, :role, :metadata])
     |> assoc_constraint(:work)

--- a/lib/meadow/data/schemas/validations.ex
+++ b/lib/meadow/data/schemas/validations.ex
@@ -8,7 +8,7 @@ defmodule Meadow.Data.Schemas.Validations do
   If a `cast_embed()` will result in a `nil` value (either on create or
   update), set it to an empty embedded struct instead
   """
-  def prepare_embed(%Ecto.Changeset{data: data, params: params} = change, field) do
+  def prepare_embed(%Ecto.Changeset{data: data, params: params} = change, field) when is_atom(field) do
     with f <- to_string(field) do
       case {Map.get(params, f), Map.get(data, f)} do
         {nil, nil} ->

--- a/lib/meadow/data/schemas/validations.ex
+++ b/lib/meadow/data/schemas/validations.ex
@@ -1,0 +1,24 @@
+defmodule Meadow.Data.Schemas.Validations do
+  @moduledoc """
+  This module provides custom changeset functions and
+  validations
+  """
+
+  @doc """
+  If a `cast_embed()` will result in a `nil` value (either on create or
+  update), set it to an empty embedded struct instead
+  """
+  def prepare_embed(%Ecto.Changeset{data: data, params: params} = change, field) do
+    with f <- to_string(field) do
+      case {Map.get(params, f), Map.get(data, f)} do
+        {nil, nil} ->
+          {:embed, field_spec} = change.data.__struct__.__schema__(:type, field)
+          params = Map.put(params, f, field_spec.related.__struct__ |> Map.from_struct())
+          Map.put(change, :params, params)
+
+        _ ->
+          change
+      end
+    end
+  end
+end

--- a/lib/meadow/data/schemas/work.ex
+++ b/lib/meadow/data/schemas/work.ex
@@ -11,6 +11,7 @@ defmodule Meadow.Data.Schemas.Work do
   alias Meadow.Data.Schemas.WorkDescriptiveMetadata
 
   import Ecto.Changeset
+  import Meadow.Data.Schemas.Validations
 
   use Meadow.Constants
 
@@ -43,6 +44,8 @@ defmodule Meadow.Data.Schemas.Work do
 
     work
     |> cast(attrs, required_params ++ optional_params)
+    |> prepare_embed(:administrative_metadata)
+    |> prepare_embed(:descriptive_metadata)
     |> cast_embed(:administrative_metadata)
     |> cast_embed(:descriptive_metadata)
     |> cast_assoc(:file_sets)

--- a/test/meadow/data/works_test.exs
+++ b/test/meadow/data/works_test.exs
@@ -86,10 +86,8 @@ defmodule Meadow.Data.WorksTest do
       {:ok, work} =
         Works.create_work(%{accession_number: "abc", visibility: "open", work_type: "image"})
 
-      with work <- Works.get_work!(work.id) do
-        assert work.descriptive_metadata.title == nil
-        assert work.administrative_metadata.preservation_level == nil
-      end
+      assert work.descriptive_metadata.title == nil
+      assert work.administrative_metadata.preservation_level == nil
     end
   end
 end


### PR DESCRIPTION
Make sure embedded nils are always converted to an empty map of the right type by the changeset