### PR TITLE
Add Work data to preservation tab

### DIFF
--- a/assets/js/components/Work/Tabs/Preservation.jsx
+++ b/assets/js/components/Work/Tabs/Preservation.jsx
@@ -6,9 +6,7 @@ const WorkTabsPreservation = ({ work }) => {
   return (
     <div className="columns is-centered" data-testid="tab-preservation-content">
       <div className="column">
-        <p className="notification is-warning">
-          TODO: wire this table up to GraphQL data
-        </p>
+
         <table className="table is-fullwidth is-striped is-hoverable">
           <thead>
             <tr>
@@ -21,20 +19,32 @@ const WorkTabsPreservation = ({ work }) => {
             </tr>
           </thead>
           <tbody>
-            <tr>
-              <td>AM</td>
-              <td>1234_12.tif</td>
-              <td>ASDF09860986AS0986ASDF</td>
-              <td>s3://asoyuoasd.com</td>
-              <td>
-                <FontAwesomeIcon icon="check" />
-              </td>
-              <td>
-                <button className="button">
-                  <FontAwesomeIcon icon="trash" />
-                </button>
-              </td>
-            </tr>
+
+            { work.fileSets &&
+              work.fileSets.map(fileset => {
+                const metadata = fileset.metadata;
+                return (
+                  <tr key={fileset.id}>
+                    <td>{fileset.role}</td>
+                    <td>{metadata ? metadata.originalFilename : " "}</td>
+                    <td className="notification is-warning">
+                      TODO: Need this exposed in GraphQL
+                    </td>
+                    <td className="notification is-warning">
+                      TODO: Need this exposed in GraphQL
+                    </td>
+                    <td className="notification is-warning">
+                      TODO: Need this exposed in GraphQL
+                    </td>
+                    <td>
+                      <button className="button">
+                        <FontAwesomeIcon icon="trash" />
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })
+            }
           </tbody>
         </table>
       </div>

--- a/assets/js/components/Work/work.query.js
+++ b/assets/js/components/Work/work.query.js
@@ -7,9 +7,11 @@ export const GET_WORK = gql`
       accessionNumber
       fileSets {
         id
+        role
         accessionNumber
         metadata {
           description
+          originalFilename
         }
         work {
           id
@@ -33,9 +35,11 @@ export const GET_WORKS = gql`
       accessionNumber
       fileSets {
         id
+        role
         accessionNumber
         metadata {
           description
+          originalFilename
         }
         work {
           id

--- a/assets/js/screens/Work/Work.test.jsx
+++ b/assets/js/screens/Work/Work.test.jsx
@@ -25,8 +25,11 @@ const mocks = [
             {
               accessionNumber: "Donohue_001_04",
               id: "01E08T3EXBJX3PWDG22NSRE0BS",
+              role: "AM",
               metadata: {
-                description: "Letter, page 2, If these papers, verso, blank"
+                description: "Letter, page 2, If these papers, verso, blank",
+                originalFilename: "coffee.jpg"
+
               },
               work: {
                 id: "01E08T3ETNGSNJ3T13JZK0ET29"
@@ -35,8 +38,10 @@ const mocks = [
             {
               accessionNumber: "Donohue_001_01",
               id: "01E08T3EW3TQ9T0AXCR6X9QDJW",
+              role: "AM",
               metadata: {
-                description: "Letter, page 1, Dear Sir, recto"
+                description: "Letter, page 1, Dear Sir, recto",
+                originalFilename: "coffee.jpg"
               },
               work: {
                 id: "01E08T3ETNGSNJ3T13JZK0ET29"
@@ -45,8 +50,10 @@ const mocks = [
             {
               accessionNumber: "Donohue_001_03",
               id: "01E08T3EWRPXMWW0B1NHZ56AW6",
+              role: "AM",
               metadata: {
-                description: "Letter, page 2, If these papers, recto"
+                description: "Letter, page 2, If these papers, recto",
+                originalFilename: "coffee.jpg"
               },
               work: {
                 id: "01E08T3ETNGSNJ3T13JZK0ET29"
@@ -55,8 +62,10 @@ const mocks = [
             {
               accessionNumber: "Donohue_001_02",
               id: "01E08T3EWFJB35RY3RVR65AXMK",
+              role: "AM",
               metadata: {
-                description: "Letter, page 1, Dear Sir, verso, blank"
+                description: "Letter, page 1, Dear Sir, verso, blank",
+                originalFilename: "coffee.jpg"
               },
               work: {
                 id: "01E08T3ETNGSNJ3T13JZK0ET29"


### PR DESCRIPTION
Added work data for preservation tab, modified Work query to extract fileset data for works.

This issue will be 100% complete when graphQL exposes Checksum, s3 key and verified values for the filesets.