### PR TITLE
Remove reference to Mix.env() from Meadow.Application

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -39,7 +39,7 @@ config :meadow,
   pyramid_bucket: "test-pyramids"
 
 config :meadow,
-  start_pipeline: false
+  test_mode: true
 
 config :ex_aws,
   access_key_id: "minio",

--- a/lib/meadow/application.ex
+++ b/lib/meadow/application.ex
@@ -25,12 +25,12 @@ defmodule Meadow.Application do
     ]
 
     children =
-      case Mix.env() do
-        :test -> base_children
+      case Config.test_mode? do
+        true -> base_children
         _ -> base_children ++ [{Meadow.Data.IndexWorker, interval: Config.index_interval()}]
       end
 
-    if Meadow.Config.start_pipeline?(), do: Pipeline.start()
+    unless Meadow.Config.test_mode?(), do: Pipeline.start()
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options

--- a/lib/meadow/config.ex
+++ b/lib/meadow/config.ex
@@ -47,9 +47,9 @@ defmodule Meadow.Config do
     ]
   end
 
-  @doc "Check whether the ingest pipeline should be started"
-  def start_pipeline? do
-    Application.get_env(:meadow, :start_pipeline, true)
+  @doc "Check whether Meadow is running in test mode"
+  def test_mode? do
+    Application.get_env(:meadow, :test_mode, false)
   end
 
   @doc "Locate a path relative to the priv directory"

--- a/test/meadow/config_test.exs
+++ b/test/meadow/config_test.exs
@@ -35,7 +35,7 @@ defmodule Meadow.ConfigTest do
            ]
   end
 
-  test "start_pipeline?" do
-    assert Config.start_pipeline?() == false
+  test "test_mode?" do
+    assert Config.test_mode?() == true
   end
 end


### PR DESCRIPTION
I thought `mix release` would evaluate `Mix.env()` at compile-time and do the right thing, but it doesn't, and apparently our staging build has been failing to deploy since the bulk indexer was merged. This PR repurposes `start_pipeline?` as `test_mode?` and uses it to determine whether to start both the `IndexWorker` and the `Pipeline`.