### PR TITLE
Make sure the request method is an atom by the time it gets to the API request

### DIFF
--- a/lib/meadow_web/plugs/elasticsearch.ex
+++ b/lib/meadow_web/plugs/elasticsearch.ex
@@ -21,7 +21,7 @@ defmodule MeadowWeb.Plugs.Elasticsearch do
       false ->
         conn
         |> put_resp_content_type("application/json")
-        |> resp(401, "Unauthorized")
+        |> resp(400, "Bad Request")
         |> send_resp()
     end
   end

--- a/lib/meadow_web/plugs/elasticsearch.ex
+++ b/lib/meadow_web/plugs/elasticsearch.ex
@@ -37,7 +37,13 @@ defmodule MeadowWeb.Plugs.Elasticsearch do
         Application.get_env(:meadow, Meadow.ElasticsearchCluster)
       )
 
-    case config |> config[:api].request(conn.method, path <> query_string, body, []) do
+    method = case conn.method do
+      x when is_atom(x) -> x
+      x when is_binary(x) -> String.to_atom(x)
+      x -> String.to_atom(to_string(x))
+    end
+
+    case config |> config[:api].request(method, path <> query_string, body, []) do
       {:ok, response} ->
         conn
         |> put_resp_content_type("application/json")

--- a/test/meadow_web/plugs/elasticsearch_test.exs
+++ b/test/meadow_web/plugs/elasticsearch_test.exs
@@ -11,7 +11,7 @@ defmodule ElasticsearchTest do
         |> auth_user(user_fixture())
         |> delete("/elasticsearch/meadow/_doc/#{work.id}")
 
-      assert conn.status == 401
+      assert conn.status == 400
     end
 
     test "returns results for _search reqeusts" do


### PR DESCRIPTION
Running in dev and test mode, `conn.method` always seems to be an atom (`:get`, `:post`, etc.). While investigating why the `/elasticsearch/` route was returning a 500 Server Error on staging, I discovered the following in the log:

```
2020-02-18 09:49:12 Request: GET /elasticsearch/meadow
2020-02-18 09:49:12 ** (exit) an exception was raised:
2020-02-18 09:49:12 ** (ArgumentError) argument error
2020-02-18 09:49:12 :erlang.atom_to_binary("GET", :utf8)
```

This PR coerces the method into an atom before sending it along to the Elasticsearch API