### PR TITLE
Clean up display of Ingest Sheet completed state

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## Initial setup:
 
 - Make sure you've done the [Local Authentication Setup](https://github.com/nulib/donut/wiki/Authentication-setup-for-dev-environment)
-- Install yarn if it's not already present: `brew install npm`, `npm -g install yarn`, or `asdf install yarn [VERSION]`
+- Install yarn if it's not already present: `npm -g install yarn`, or `asdf install yarn [VERSION]`
 - From the `meadow` project root, install Elixir dependencies with `mix deps.get`
 - Run `devstack up meadow` to start the [devstack](https://github.com/nulib/devstack) environment:
   - The [Kibana](https://www.elastic.co/kibana) utility is not part of the stack by default

--- a/assets/js/components/IngestSheet/ActionRow.jsx
+++ b/assets/js/components/IngestSheet/ActionRow.jsx
@@ -58,11 +58,11 @@ const IngestSheetActionRow = ({ projectId, sheetId, status }) => {
             <span>Approve ingest sheet</span>
           </button>
         )}
-        <button className={`button is-small`} onClick={onOpenModal}>
+        <button className={`button`} onClick={onOpenModal}>
           <span className="icon">
             <FontAwesomeIcon icon="trash" />
           </span>{" "}
-          <span>Delete ingest sheet / job and start over</span>
+          <span>Delete ingest sheet and start over</span>
         </button>
       </ButtonGroup>
 

--- a/assets/js/components/IngestSheet/Completed.jsx
+++ b/assets/js/components/IngestSheet/Completed.jsx
@@ -1,35 +1,47 @@
 import React, { useState } from "react";
-import WorkRow from "../Work/Row";
 import { useQuery } from "@apollo/react-hooks";
 import PropTypes from "prop-types";
-import { INGEST_SHEET_WORKS } from "./ingestSheet.query";
+import {
+  INGEST_SHEET_WORKS,
+  INGEST_SHEET_COMPLETED_ERRORS
+} from "./ingestSheet.query";
 import Error from "../UI/Error";
 import IngestSheetCompletedErrors from "./Completed/Errors";
-import IngestSheetDownload from "./Completed/Download";
 import WorkListItem from "../Work/ListItem";
 
 const IngestSheetCompleted = ({ sheetId }) => {
-  const { loading, error, data } = useQuery(INGEST_SHEET_WORKS, {
+  const {
+    loading: worksLoading,
+    error: worksError,
+    data: worksData
+  } = useQuery(INGEST_SHEET_WORKS, {
     variables: { id: sheetId }
   });
-  const [showErrors, setShowErrors] = useState(false);
+  const {
+    loading: errorsLoading,
+    error: errorsError,
+    data: errorsData
+  } = useQuery(INGEST_SHEET_COMPLETED_ERRORS, { variables: { id: sheetId } });
 
-  if (loading) return "Loading...";
-  if (error) return <Error error={error.message} />;
+  if (worksLoading || errorsLoading) return "Loading...";
+  if (worksError) return <Error error={worksError.message} />;
+  if (errorsError) return <Error error={errorsError.message} />;
 
-  const works = data.ingestSheetWorks;
+  const works = worksData.ingestSheetWorks;
+  let ingestSheetErrors = [];
+  console.log("errorsData :", errorsData);
+  try {
+    ingestSheetErrors = errorsData.ingestSheetErrors;
+  } catch (e) {}
 
   return (
     <>
-      {/* <IngestSheetDownload sheetId={sheetId} /> */}
-      <p>
-        <label className="checkbox">
-          <input type="checkbox" onChange={() => setShowErrors(!showErrors)} />
-          Show errors
-        </label>
-      </p>
+      {ingestSheetErrors.length > 0 && (
+        <section className="section">
+          <IngestSheetCompletedErrors errors={ingestSheetErrors} />
+        </section>
+      )}
 
-      {showErrors && <IngestSheetCompletedErrors sheetId={sheetId} />}
       <section className="section">
         <div className="columns is-multiline">
           {works.map(work => (

--- a/assets/js/components/IngestSheet/Completed/Errors.jsx
+++ b/assets/js/components/IngestSheet/Completed/Errors.jsx
@@ -1,76 +1,64 @@
 import React from "react";
 import PropTypes from "prop-types";
-import UIAlert from "../../UI/Alert";
-import { INGEST_SHEET_COMPLETED_ERRORS } from "../ingestSheet.query";
-import { useQuery } from "@apollo/react-hooks";
-import Error from "../../UI/Error";
 
-const IngestSheetCompletedErrors = ({ sheetId }) => {
-  const { loading, error, data } = useQuery(INGEST_SHEET_COMPLETED_ERRORS, {
-    variables: { id: sheetId }
-  });
+const styles = {
+  tableWrapper: {
+    height: "500px",
+    overflowY: "auto"
+  }
+};
 
-  if (loading) return "Loading...";
-  if (error) return <Error error={error} />;
-
-  const fileSets = data.ingestSheetErrors;
-  const errorBody = (
-    <table className="table is-fullwidth is-striped">
-      <thead>
-        <tr>
-          <th>Row</th>
-          <th>Work Accession Number</th>
-          <th>Accession Number</th>
-          <th>Filename</th>
-          <th>Action</th>
-          <th>Errors</th>
-        </tr>
-      </thead>
-      <tbody>
-        {fileSets.map(row => {
-          var errorMsg =
-            row.outcome == "SKIPPED"
-              ? "Skipped due to error(s) on other row(s)"
-              : row.errors;
-          return (
-            <tr key={row.rowNumber}>
-              <td>{row.rowNumber}</td>
-              <td>{row.workAccessionNumber}</td>
-              <td>{row.accessionNumber}</td>
-              <td>{row.filename}</td>
-              <td>
-                {row.action
-                  .split(".")
-                  .slice(-1)
-                  .pop()}
-              </td>
-              <td>{errorMsg}</td>
-              <td></td>
-            </tr>
-          );
-        })}
-      </tbody>
-    </table>
-  );
-  console.log(errorBody);
+const IngestSheetCompletedErrors = ({ errors = [] }) => {
   return (
-    // <UIAlert
-    //   title="Errors creating works from filesets"
-    //   type="danger"
-    //   body={errorBody}
-    // />
-    <article className="message is-danger">
-      <div className="message-header">
-        <p>Errors creating works from filesets</p>
-        <button className="delete" aria-label="delete"></button>
+    <>
+      <p className="notification is-danger">
+        There were errrors creating works from filesets
+      </p>
+      <div className="box" style={styles.tableWrapper}>
+        <table className="table is-fullwidth is-striped">
+          <caption>Errors creating works</caption>
+          <thead>
+            <tr>
+              <th>Row</th>
+              <th>Work Accession Number</th>
+              <th>Accession Number</th>
+              <th>Filename</th>
+              <th>Action</th>
+              <th>Errors</th>
+            </tr>
+          </thead>
+          <tbody>
+            {errors.map(row => {
+              var errorMsg =
+                row.outcome == "SKIPPED"
+                  ? "Skipped due to error(s) on other row(s)"
+                  : row.errors;
+              return (
+                <tr key={row.rowNumber}>
+                  <td>{row.rowNumber}</td>
+                  <td>{row.workAccessionNumber}</td>
+                  <td>{row.accessionNumber}</td>
+                  <td>{row.filename}</td>
+                  <td>
+                    {row.action
+                      .split(".")
+                      .slice(-1)
+                      .pop()}
+                  </td>
+                  <td>{errorMsg}</td>
+                  <td></td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
       </div>
-      <div className="message-body">{errorBody}</div>
-    </article>
+    </>
   );
 };
 
 IngestSheetCompletedErrors.propTypes = {
-  sheetId: PropTypes.string
+  errors: PropTypes.array
 };
 
 export default IngestSheetCompletedErrors;

--- a/assets/js/components/IngestSheet/IngestSheet.jsx
+++ b/assets/js/components/IngestSheet/IngestSheet.jsx
@@ -41,7 +41,9 @@ const IngestSheet = ({
 
   return (
     <>
-      <IngestSheetAlert ingestSheet={ingestSheetData} />
+      {status !== "COMPLETED" && (
+        <IngestSheetAlert ingestSheet={ingestSheetData} />
+      )}
 
       {["APPROVED"].indexOf(status) > -1 && (
         <IngestSheetApprovedInProgress ingestSheet={ingestSheetData} />

--- a/assets/js/components/IngestSheet/List.jsx
+++ b/assets/js/components/IngestSheet/List.jsx
@@ -8,17 +8,7 @@ import { useToasts } from "react-toast-notifications";
 import UINotification from "../UI/Notification";
 import { getClassFromIngestSheetStatus } from "../../services/helpers";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-
-// delete/refine later
-// TODO: Pull this into a common service
-export const TEMP_USER_FRIENDLY_STATUS = {
-  UPLOADED: "Validation in progress...",
-  ROW_FAIL: "Validation Errors",
-  FILE_FAIL: "Validation Errors",
-  VALID: "Valid, waiting for approval",
-  APPROVED: "Ingest in progress...",
-  COMPLETED: "Ingest Complete"
-};
+import { formatDate, TEMP_USER_FRIENDLY_STATUS } from "../../services/helpers";
 
 const IngestSheetList = ({ project, subscribeToIngestSheetStatusChanges }) => {
   const [modalOpen, setModalOpen] = useState(false);
@@ -116,7 +106,7 @@ const IngestSheetList = ({ project, subscribeToIngestSheetStatusChanges }) => {
                       {name}
                     </Link>
                   </td>
-                  <td className="has-text-right">{updatedAt}</td>
+                  <td className="has-text-right">{formatDate(updatedAt)}</td>
                   <td>
                     <span
                       className={`tag ${getClassFromIngestSheetStatus(status)}`}

--- a/assets/js/components/IngestSheet/Upload.jsx
+++ b/assets/js/components/IngestSheet/Upload.jsx
@@ -137,35 +137,18 @@ const IngestSheetUpload = ({ projectId, presignedUrl }) => {
                 <span className="file-name">{fileNameString}</span>
               </label>
             </div>
-            {/* <div className="file">
-              <label className="file-label">
-                <input
-                  className="file-input"
-                  id={"file"}
-                  name="file"
-                  type="file"
-                  onChange={handleInputChange}
-                />
-                <span className="file-cta">
-                  <span className="file-icon">
-                    <FontAwesomeIcon icon="file-upload" />
-                  </span>
-                  <span className="file-label">Choose a file…</span>
-                </span>
-              </label>
-            </div> */}
           </div>
 
-          <div className="buttons">
+          <div className="buttons is-right">
+            <button type="button" className="button" onClick={handleCancel}>
+              Cancel
+            </button>
             <button
               type="submit"
               className="button is-primary"
               disabled={isSubmitDisabled()}
             >
               Submit
-            </button>
-            <button type="button" className="button" onClick={handleCancel}>
-              Cancel
             </button>
           </div>
         </form>

--- a/assets/js/components/Project/Form.jsx
+++ b/assets/js/components/Project/Form.jsx
@@ -78,20 +78,20 @@ const ProjectForm = ({ showForm, setShowForm }) => {
               </div>
               <div className="buttons is-right">
                 <button
-                  type="submit"
-                  className="button is-primary"
-                  disabled={submitDisabled || formError}
-                  data-testid="submit-button"
-                >
-                  Create
-                </button>
-                <button
                   type="button"
                   className="button"
                   onClick={() => setShowForm(false)}
                   data-testid="cancel-button"
                 >
                   Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="button is-primary"
+                  disabled={submitDisabled || formError}
+                  data-testid="submit-button"
+                >
+                  Create
                 </button>
               </div>
             </div>

--- a/assets/js/components/UI/Layout/Footer.jsx
+++ b/assets/js/components/UI/Layout/Footer.jsx
@@ -1,12 +1,36 @@
 import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+const styles = {
+  span: {
+    paddingLeft: "1rem"
+  }
+};
 
 const UILayoutFooter = () => {
   return (
     <footer className="footer">
       <div className="content has-text-centered">
         <p>
-          <strong>Meadow</strong> by @nulib. The source code is licensed
-          <a href="http://opensource.org/licenses/mit-license.php"> MIT</a>.
+          <span className="icon">
+            <FontAwesomeIcon icon="leaf" />
+          </span>
+          <strong>Meadow v1.0</strong> by{" "}
+          <a href="https://github.com/nulib" target="_blank">
+            @nulib
+          </a>
+          .{" "}
+          <span style={styles.span}>
+            An{" "}
+            <a href="https://elixir-lang.org/" target="_blank">
+              Elixir
+            </a>
+            /
+            <a href="https://reactjs.org/" target="_blank">
+              React
+            </a>{" "}
+            repository application.{" "}
+          </span>
         </p>
       </div>
     </footer>

--- a/assets/js/components/UI/Layout/NavBar.jsx
+++ b/assets/js/components/UI/Layout/NavBar.jsx
@@ -48,7 +48,7 @@ const UILayoutNavBar = () => {
 
         <div className="navbar-end">
           <Link to="/" className="navbar-item">
-            Home
+            <FontAwesomeIcon icon="home" />
           </Link>
           <Link
             to="/project/list"
@@ -91,6 +91,15 @@ const UILayoutNavBar = () => {
               </button>
             </div>
           )}
+          <div className="navbar-item has-dropdown is-hoverable">
+            <a className="navbar-link">
+              <FontAwesomeIcon icon="bell" />
+            </a>
+            <div className="navbar-dropdown is-right">
+              <a className="navbar-item">Some alert #1</a>
+              <a className="navbar-item">Some alert #2</a>
+            </div>
+          </div>
           {currentUser && (
             <div className="navbar-item has-dropdown is-hoverable">
               <a className="navbar-link">

--- a/assets/js/font-awesome-setup.js
+++ b/assets/js/font-awesome-setup.js
@@ -2,10 +2,13 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { fab } from "@fortawesome/free-brands-svg-icons";
 import {
   faAngleDown,
+  faBell,
   faCheck,
   faEdit,
   faFileDownload,
   faFileUpload,
+  faHome,
+  faLeaf,
   faPlus,
   faProjectDiagram,
   faSearch,
@@ -18,10 +21,13 @@ export default function setupFontAwesome() {
   return library.add(
     fab,
     faAngleDown,
+    faBell,
     faCheck,
     faEdit,
     faFileDownload,
     faFileUpload,
+    faHome,
+    faLeaf,
     faPlus,
     faProjectDiagram,
     faSearch,

--- a/assets/js/screens/IngestSheet/IngestSheet.jsx
+++ b/assets/js/screens/IngestSheet/IngestSheet.jsx
@@ -5,13 +5,15 @@ import Loading from "../../components/UI/Loading";
 import IngestSheet from "../../components/IngestSheet/IngestSheet";
 import gql from "graphql-tag";
 import { useQuery } from "@apollo/react-hooks";
-import { Link } from "react-router-dom";
 import {
   INGEST_SHEET_SUBSCRIPTION,
   INGEST_SHEET_QUERY
 } from "../../components/IngestSheet/ingestSheet.query";
 import Layout from "../Layout";
-import { getClassFromIngestSheetStatus } from "../../services/helpers";
+import {
+  getClassFromIngestSheetStatus,
+  TEMP_USER_FRIENDLY_STATUS
+} from "../../services/helpers";
 import IngestSheetDownload from "../../components/IngestSheet/Completed/Download";
 import UIBreadcrumbs from "../../components/UI/Breadcrumbs";
 
@@ -84,7 +86,7 @@ const ScreensIngestSheet = ({ match }) => {
                   sheetData.ingestSheet.status
                 )}`}
               >
-                Status should go here
+                {TEMP_USER_FRIENDLY_STATUS[sheetData.ingestSheet.status]}
               </span>
             </h1>
             <h2 className="subtitle">Ingest Sheet</h2>
@@ -115,30 +117,6 @@ const ScreensIngestSheet = ({ match }) => {
         </div>
       </section>
     </Layout>
-    // <>
-    //   <ScreenHeader
-    //     title="Ingest Sheet"
-    //     description="Feedback on the current status of an Ingest Sheet .csv file moving into the system."
-    //     breadCrumbs={createCrumbs()}
-    //   />
-    //   <ScreenContent>
-    //     <IngestSheet
-    //       ingestSheetData={sheetData.ingestSheet}
-    //       projectId={id}
-    //       subscribeToIngestSheetUpdates={() =>
-    //         subscribeToMore({
-    //           document: INGEST_SHEET_SUBSCRIPTION,
-    //           variables: { sheetId },
-    //           updateQuery: (prev, { subscriptionData }) => {
-    //             if (!subscriptionData.data) return prev;
-    //             const updatedSheet = subscriptionData.data.ingestSheetUpdate;
-    //             return { ingestSheet: { ...updatedSheet } };
-    //           }
-    //         })
-    //       }
-    //     />
-    //   </ScreenContent>
-    // </>
   );
 };
 

--- a/assets/js/services/helpers.js
+++ b/assets/js/services/helpers.js
@@ -1,5 +1,14 @@
 import moment from "moment";
 
+/**
+ * Escape double quotes (which may interfere with Search queries)
+ * @param {string} str
+ * @returns {string}
+ */
+export function escapeDoubleQuotes(str) {
+  return str.replace(/["]+/g, '%5C"');
+}
+
 export function formatDate(date) {
   if (!date) return "";
   return moment(date).format("MMM Do YYYY, h:mm:ss a");
@@ -21,11 +30,11 @@ export function getClassFromIngestSheetStatus(status) {
   return "";
 }
 
-/**
- * Escape double quotes (which may interfere with Search queries)
- * @param {string} str
- * @returns {string}
- */
-export function escapeDoubleQuotes(str) {
-  return str.replace(/["]+/g, '%5C"');
-}
+export const TEMP_USER_FRIENDLY_STATUS = {
+  UPLOADED: "Validation in progress...",
+  ROW_FAIL: "Validation Errors",
+  FILE_FAIL: "Validation Errors",
+  VALID: "Valid, waiting for approval",
+  APPROVED: "Ingest in progress...",
+  COMPLETED: "Ingest Complete"
+};

--- a/assets/package.json
+++ b/assets/package.json
@@ -36,7 +36,6 @@
     "rc-progress": "^2.5.2",
     "react-apollo": "^3.1.3",
     "react-csv": "^1.1.2",
-    "react-responsive-modal": "^4.0.1",
     "react-toast-notifications": "^2.4.0"
   },
   "devDependencies": {

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -2,7 +2,7 @@
 @import "./scss/fonts";
 
 // Get access to Bulma variables
-@import "bulma/sass/utilities/initial-variables";
+// @import "bulma/sass/utilities/initial-variables";
 
 // Custom variables go before importing Bulma
 @import "./scss/variables";

--- a/assets/styles/scss/_base.scss
+++ b/assets/styles/scss/_base.scss
@@ -23,3 +23,18 @@ table {
 .small-title {
   @include small-title;
 }
+
+// This override is only necessary due to a CSS nameing collision with npm "react-toastify" package
+.notification {
+  &.is-danger {
+    background-color: $red !important;
+  }
+}
+
+// TODO: Find a better way to override these overrides via Bulma variables
+.message.is-success .message-body {
+  color: $success;
+}
+.tag:not(body).is-success.is-light {
+  color: $success;
+}

--- a/assets/styles/scss/_variables.scss
+++ b/assets/styles/scss/_variables.scss
@@ -49,15 +49,13 @@ $CamptonExtraBold: "Campton Extra Bold", Impact, sans-serif;
 $CamptonExtraLight: "Campton Extra Light", "Courier New", sans-serif;
 
 // Customize Bulma with these variables
-// $primary: $nu-purple;
-// $link: $nu-purple;
-// $info: $nu-purple-30;
-// $success: $dark-green;
-// $warning: $gold;
-// $danger: $red;
+$primary: $nu-purple;
+$link: $nu-purple;
+$info: $nu-purple-30;
+$success: $dark-green;
+$warning: $gold;
+$danger: $red;
 
 $family-primary: $AkkuratProRegular;
 $family-secondary: $CamptonBook;
-// $breadcrumb-item-color: white;
-// $breadcrumb-item-active-color: $grey-lighter;
-$breadcrumb-item-separator-color: $grey-darker;
+$breadcrumb-item-separator-color: $rich-black-50;

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -3897,21 +3897,6 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-focus-trap-react@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-4.0.1.tgz#3cffd39341df3b2f546a4a2fe94cfdea66154683"
-  integrity sha512-UUZKVEn5cFbF6yUnW7lbXNW0iqN617ShSqYKgxctUvWw1wuylLtyVmC0RmPQNnJ/U+zoKc/djb0tZMs0uN/0QQ==
-  dependencies:
-    focus-trap "^3.0.0"
-
-focus-trap@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-3.0.0.tgz#4d2ee044ae66bf7eb6ebc6c93bd7a1039481d7dc"
-  integrity sha512-jTFblf0tLWbleGjj2JZsAKbgtZTdL1uC48L8FcmSDl4c2vDoU4NycN1kgV5vJhuq1mxNFkw7uWZ1JAGlINWvyw==
-  dependencies:
-    tabbable "^3.1.0"
-    xtend "^4.0.1"
-
 follow-redirects@1.5.10:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
@@ -5896,11 +5881,6 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-no-scroll@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/no-scroll/-/no-scroll-2.1.1.tgz#f37e08cb159b75a5bdbfc0a87cd9223e120e6e27"
-  integrity sha512-YTzGAJOo/B6hkodeT5SKKHpOhAzjMfkUCCXjLJwjWk2F4/InIg+HbdH9kmT7bKpleDuqLZDTRy2OdNtAj0IVyQ==
-
 node-fetch@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
@@ -7165,17 +7145,6 @@ react-redux@^6.0.1:
     prop-types "^15.7.2"
     react-is "^16.8.2"
 
-react-responsive-modal@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/react-responsive-modal/-/react-responsive-modal-4.0.1.tgz#f3de0fc2571be96ed8a013ee45d572f42ed1e7c5"
-  integrity sha512-R+exyFDILtWtggYfiwiQv4V0cGRplTNRnUGf2qSXDDD4L2HCia+LjpUCHnhb/7dAl10ASq9BwzAxSOJj0GHjCg==
-  dependencies:
-    classnames "^2.2.6"
-    focus-trap-react "^4.0.1"
-    no-scroll "^2.1.1"
-    prop-types "^15.6.2"
-    react-transition-group "^4.0.0"
-
 react-router-dom@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.1.2.tgz#06701b834352f44d37fbb6311f870f84c76b9c18"
@@ -7276,7 +7245,7 @@ react-transition-group@^2.2.1:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react-transition-group@^4, react-transition-group@^4.0.0, react-transition-group@^4.3.0:
+react-transition-group@^4, react-transition-group@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.3.0.tgz#fea832e386cf8796c58b61874a3319704f5ce683"
   integrity sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==
@@ -8317,11 +8286,6 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-tabbable@^3.1.0:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-3.1.2.tgz#f2d16cccd01f400e38635c7181adfe0ad965a4a2"
-  integrity sha512-wjB6puVXTYO0BSFtCmWQubA/KIn7Xvajw0x0l6eJUudMG/EAiJvIUnyNX6xO4NpGrJ16lbD0eUseB9WxW0vlpQ==
-
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
@@ -9063,7 +9027,7 @@ xmlchars@^2.1.1:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
+xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==


### PR DESCRIPTION
General cleanup of screens which feature a completed Ingest Sheet, but shows errors.  This PR also:

- Adds status to Ingest Sheet title on Ingest Sheet home screen
- Puts all Ingest Sheet errors in a nicely formatting, scrollable table
- Displays errors if they exist.  Previously a checkbox was used to show/hide errors, but these should be front and center to the user I'd guess?
- Adds in Northwestern Global marketing color palate.  
- Some new icons in the Navbar
- Updated footer

![image](https://user-images.githubusercontent.com/3020266/74960449-f57b7300-53d1-11ea-98e0-edc3e0084e21.png)

![image](https://user-images.githubusercontent.com/3020266/74960533-1cd24000-53d2-11ea-9010-107733ee6827.png)

![image](https://user-images.githubusercontent.com/3020266/74960590-3c696880-53d2-11ea-984e-d25276095cab.png)

![image](https://user-images.githubusercontent.com/3020266/74960637-5145fc00-53d2-11ea-85f6-660bfdb3e171.png)

