### PR TITLE
Configure Absinthe to use GraphQL Playground

### DIFF
--- a/lib/meadow_web/router.ex
+++ b/lib/meadow_web/router.ex
@@ -36,6 +36,7 @@ defmodule MeadowWeb.Router do
 
     forward "/graphiql", Absinthe.Plug.GraphiQL,
       schema: MeadowWeb.Schema,
+      interface: :playground,
       socket: MeadowWeb.UserSocket
 
     forward "/", Plug.Static,


### PR DESCRIPTION
@adamjarling - @bmquinn mentioned switching from GraphiQL to GraphQL Playground a few weeks ago. It's a one liner configuration.

Could you and @katdivyareddy10 take a look and see if it seems better than GraphiQL to you? 

<img width="1427" alt="Screen Shot 2020-02-21 at 7 20 05 AM" src="https://user-images.githubusercontent.com/6372022/75042777-97f42e80-5484-11ea-8bb9-097b0605daab.png">
