### PR TITLE
Index sheet & project on work

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -18,9 +18,10 @@ alias Meadow.Data.Schemas.{
 }
 
 alias Meadow.Ingest.{Sheets, Projects}
-alias Meadow.Ingest.Projects.{Bucket, Project}
+alias Meadow.Ingest.Projects.Bucket
 
 alias Meadow.Ingest.Schemas.{
+  Project,
   Sheet,
   Row,
   Validator,

--- a/lib/meadow/data/schemas/work.ex
+++ b/lib/meadow/data/schemas/work.ex
@@ -36,6 +36,8 @@ defmodule Meadow.Data.Schemas.Work do
       on_delete: :delete_all
 
     belongs_to :collection, Collection
+
+    field :extra_index_fields, :map, virtual: true, default: %{}
   end
 
   def changeset(work, attrs) do
@@ -76,6 +78,7 @@ defmodule Meadow.Data.Schemas.Work do
         create_date: work.inserted_at,
         modified_date: work.updated_at
       }
+      |> Map.merge(work.extra_index_fields)
     end
   end
 end

--- a/lib/meadow/elasticsearch_diff_store.ex
+++ b/lib/meadow/elasticsearch_diff_store.ex
@@ -6,6 +6,7 @@ defmodule Meadow.ElasticsearchDiffStore do
   @behaviour Elasticsearch.Store
 
   alias Meadow.Data.Schemas
+  alias Meadow.Ingest.Sheets
   alias Meadow.Repo
   import Ecto.Query
 
@@ -25,6 +26,7 @@ defmodule Meadow.ElasticsearchDiffStore do
   def stream(Schemas.Work = schema) do
     schema
     |> out_of_date()
+    |> Sheets.works_with_sheets()
     |> Repo.stream()
     |> Stream.chunk_every(@chunk_size)
     |> Stream.flat_map(fn chunk ->

--- a/lib/meadow/elasticsearch_store.ex
+++ b/lib/meadow/elasticsearch_store.ex
@@ -5,11 +5,13 @@ defmodule Meadow.ElasticsearchStore do
   @behaviour Elasticsearch.Store
 
   alias Meadow.Data.Schemas
+  alias Meadow.Ingest.Sheets
   alias Meadow.Repo
 
   @impl true
   def stream(Schemas.Work = schema) do
     schema
+    |> Sheets.works_with_sheets()
     |> Repo.stream()
     |> Stream.chunk_every(10)
     |> Stream.flat_map(fn chunk ->

--- a/lib/meadow/ingest/sheets.ex
+++ b/lib/meadow/ingest/sheets.ex
@@ -7,7 +7,7 @@ defmodule Meadow.Ingest.Sheets do
   alias Meadow.Data.Schemas.FileSet
   alias Meadow.Data.Schemas.Work
   alias Meadow.Ingest.Notifications
-  alias Meadow.Ingest.Schemas.{Row, Sheet, SheetWorks}
+  alias Meadow.Ingest.Schemas.{Project, Row, Sheet, SheetWorks}
   alias Meadow.Repo
   alias Meadow.Utils.MapList
 
@@ -419,5 +419,22 @@ defmodule Meadow.Ingest.Sheets do
           r.file_set_accession_number == f.accession_number,
       where: iw.sheet_id == ^sheet_id
     )
+  end
+
+  @doc "Composable query to add sheet_name and project_name to works"
+  def works_with_sheets(query \\ Work) do
+    from w in query,
+      left_join: sw in SheetWorks,
+      on: w.id == sw.work_id,
+      left_join: s in Sheet,
+      on: sw.sheet_id == s.id,
+      left_join: p in Project,
+      on: s.project_id == p.id,
+      select_merge: %{
+        extra_index_fields: %{
+          sheet: %{id: s.id, name: s.name},
+          project: %{id: p.id, name: p.title}
+        }
+      }
   end
 end

--- a/lib/meadow/ingest/sheets_to_works.ex
+++ b/lib/meadow/ingest/sheets_to_works.ex
@@ -52,7 +52,10 @@ defmodule Meadow.Ingest.SheetsToWorks do
       visibility: @default_visibility,
       published: false,
       work_type: "image",
-      metadata: %{},
+      administrative_metadata: %{
+        project: "",
+        sheet: ""
+      },
       file_sets:
         file_set_rows
         |> Enum.map(fn row ->

--- a/priv/repo/migrations/20200210224830_create_dependency_triggers.exs
+++ b/priv/repo/migrations/20200210224830_create_dependency_triggers.exs
@@ -1,4 +1,4 @@
-defmodule Meadow.Repo.Migrations.TouchWorksOnCollectionUpdate do
+defmodule Meadow.Repo.Migrations.CreateDependencyTriggers do
   use Ecto.Migration
 
   def up do
@@ -20,9 +20,7 @@ defmodule Meadow.Repo.Migrations.TouchWorksOnCollectionUpdate do
         RETURNS trigger AS $$
       BEGIN
         IF #{condition} THEN
-          UPDATE #{child}
-          SET updated_at = NOW()
-          WHERE #{Inflex.singularize(parent)}_id = NEW.id;
+          UPDATE #{child} SET updated_at = NOW() WHERE #{Inflex.singularize(parent)}_id = NEW.id;
         END IF;
         RETURN NEW;
       END;
@@ -41,8 +39,8 @@ defmodule Meadow.Repo.Migrations.TouchWorksOnCollectionUpdate do
 
   defp drop_dependency_trigger(parent, child) do
     with {function_name, trigger_name} <- object_names(parent, child) do
-      execute("DROP TRIGGER #{trigger_name};")
-      execute("DROP FUNCTION #{function_name};")
+      execute("DROP TRIGGER IF EXISTS #{trigger_name} ON #{parent};")
+      execute("DROP FUNCTION IF EXISTS #{function_name};")
     end
   end
 

--- a/priv/repo/migrations/20200224193516_create_sheet_work_association_trigger.exs
+++ b/priv/repo/migrations/20200224193516_create_sheet_work_association_trigger.exs
@@ -1,0 +1,33 @@
+defmodule Meadow.Repo.Migrations.CreateSheetWorkAssociationTrigger do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    CREATE OR REPLACE FUNCTION reindex_work_when_sheet_changes()
+      RETURNS trigger AS $$
+    BEGIN
+      IF (TG_OP = 'DELETE') THEN
+        UPDATE works SET updated_at = NOW() WHERE id = OLD.work_id;
+        RETURN OLD;
+      ELSE
+        UPDATE works SET updated_at = NOW() WHERE id = NEW.work_id;
+        RETURN NEW;
+      END IF;
+    END;
+    $$ LANGUAGE plpgsql
+    """
+
+    execute """
+    CREATE TRIGGER sheet_works_work_reindex
+      AFTER INSERT OR UPDATE OR DELETE
+      ON ingest_sheet_works
+      FOR EACH ROW
+      EXECUTE PROCEDURE reindex_work_when_sheet_changes()
+    """
+  end
+
+  def down do
+    execute "DROP TRIGGER IF EXISTS sheet_works_work_reindex ON ingest_sheet_works;"
+    execute "DROP FUNCTION IF EXISTS reindex_work_when_sheet_changes;"
+  end
+end

--- a/test/support/index_case.ex
+++ b/test/support/index_case.ex
@@ -6,6 +6,7 @@ defmodule Meadow.IndexCase do
   alias Ecto.Adapters.SQL.Sandbox
   alias Meadow.Data.Schemas.{Collection, FileSet, IndexTime, Work}
   alias Meadow.ElasticsearchCluster, as: Cluster
+  alias Meadow.Ingest.Schemas.{Project, Sheet}
   alias Meadow.Repo
 
   setup tags do
@@ -16,7 +17,7 @@ defmodule Meadow.IndexCase do
     on_exit(fn ->
       if tags[:unboxed] do
         Sandbox.unboxed_run(Repo, fn ->
-          [IndexTime, FileSet, Work, Collection]
+          [IndexTime, FileSet, Project, Sheet, Work, Collection]
           |> Enum.each(fn schema -> Repo.delete_all(schema) end)
         end)
       end


### PR DESCRIPTION
- Create schema association between works & sheets
- Add `ingest` block to work index document
- Add insert/update/delete trigger on `ingest_sheet_works` association table to keep works in sync
- Don't forget to run `mix ecto.migrate` before using