### PR TITLE
UIProgressBar bug fix

### DIFF
--- a/assets/js/components/IngestSheet/ApprovedInProgress.jsx
+++ b/assets/js/components/IngestSheet/ApprovedInProgress.jsx
@@ -23,7 +23,7 @@ const IngestSheetApprovedInProgress = ({ ingestSheet }) => {
     <section>
       <div className="pt-12">
         <UIProgressBar
-          percentComplete={ingestProgress.percentComplete}
+          percentComplete={Number(ingestProgress.percentComplete)}
           totalValue={ingestProgress.totalFileSets}
         />
       </div>

--- a/assets/js/components/IngestSheet/Upload.jsx
+++ b/assets/js/components/IngestSheet/Upload.jsx
@@ -64,7 +64,7 @@ const IngestSheetUpload = ({ projectId, presignedUrl }) => {
       }
     });
     toastWrapper(
-      "is-danger",
+      "is-success",
       `Ingest Sheet ${ingest_sheet_name} created successfully`
     );
 

--- a/assets/js/components/IngestSheet/Validations.jsx
+++ b/assets/js/components/IngestSheet/Validations.jsx
@@ -49,9 +49,7 @@ function IngestSheetValidations({
     const { percentComplete } = progress;
     return (
       <UIProgressBar
-        percentComplete={
-          percentComplete ? percentComplete.toFixed(2) : percentComplete
-        }
+        percentComplete={Number(percentComplete)}
         label="Please wait for validation"
       />
     );

--- a/priv/tiff/cli.js
+++ b/priv/tiff/cli.js
@@ -25,7 +25,8 @@ process.stdin.on("data", data => {
     .createPyramidTiff(source, target)
     .then(_dest => {
       portlog("ok");
-    }).catch(err => {
+    })
+    .catch(err => {
       portlog("fatal", err.message);
     });
 });

--- a/priv/tiff/pyramid.js
+++ b/priv/tiff/pyramid.js
@@ -8,7 +8,7 @@ const portlog = require("./portlog");
 const createPyramidTiff = async (source, dest) => {
   const inputFile = await makeInputFile(source);
   try {
-    portlog("info", `Creating pyramidal TIFF from ${inputFile}`)
+    portlog("info", `Creating pyramidal TIFF from ${inputFile}`);
     const pyramidTiff = await sharp(inputFile)
       .limitInputPixels(false)
       .resize({
@@ -28,9 +28,11 @@ const createPyramidTiff = async (source, dest) => {
       .toBuffer();
     await sendToDestination(pyramidTiff, dest);
   } finally {
-    portlog("info", `Deleting ${inputFile}`)
+    portlog("info", `Deleting ${inputFile}`);
     fs.unlink(inputFile, err => {
-      if (err) { throw err; }
+      if (err) {
+        throw err;
+      }
     });
   }
 };


### PR DESCRIPTION
ProgressBar lead to console warning due to progessComplete field not being a number.
I could have fixed this in UIProgressBar prop types to expect any value and then pass it as a number like 
```
<ProgressBar percent={Number(percentComplete)} strokeColor="#2cb1bc" />
```
But this would mean that propType validation would fail. 

Instead added a fix on the files calling component 'UIProgressBar' to send a definite number. 
I also tried to send an integer like 
```
<UIProgressBar
          percentComplete={ParseInt(ingestProgress.percentComplete, 10)}
          totalValue={ingestProgress.totalFileSets}
        />
``` 
This would mean providing extra argument as parseInt takes base or the default is octal.

I also made a minor change the class on ingest sheet success message from is-danger to is-success.