### PR TITLE
Added fileset images to Work page and Work page structure tab

### DIFF
--- a/assets/js/components/Work/ListItem.jsx
+++ b/assets/js/components/Work/ListItem.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
-import { buildImageURL } from "../../services/global-vars";
+import { buildImageURL } from "../../services/helpers";
 
 const WorkListItem = ({ work }) => {
   const fileSetsToDisplay = 5;
@@ -16,6 +16,9 @@ const WorkListItem = ({ work }) => {
             <img
               src={`${buildImageURL(imageIdToDisplay, "IIIF_SQUARE")}`}
               alt="Placeholder image"
+              onError={e => {
+                e.target.src = "/images/1280x960.png";
+              }}
             />
           </Link>
         </figure>

--- a/assets/js/components/Work/ListItem.jsx
+++ b/assets/js/components/Work/ListItem.jsx
@@ -6,7 +6,7 @@ import { buildImageURL } from "../../services/helpers";
 const WorkListItem = ({ work }) => {
   const fileSetsToDisplay = 5;
   const imageIdToDisplay =
-    work.fileSets && work.fileSets[0] ? work.fileSets[0].id : "";
+    work.fileSets && work.fileSets.length > 0 ? work.fileSets[0].id : "";
 
   return (
     <div className="card">

--- a/assets/js/components/Work/ListItem.jsx
+++ b/assets/js/components/Work/ListItem.jsx
@@ -1,16 +1,22 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
+import { buildImageURL } from "../../services/global-vars";
 
 const WorkListItem = ({ work }) => {
   const fileSetsToDisplay = 5;
+  const imageIdToDisplay =
+    work.fileSets && work.fileSets[0] ? work.fileSets[0].id : "";
 
   return (
     <div className="card">
       <div className="card-image">
         <figure className="image is-4by3">
           <Link to={`/work/${work.id}`}>
-            <img src="/images/1280x960.png" alt="Placeholder image" />
+            <img
+              src={`${buildImageURL(imageIdToDisplay, "IIIF_SQUARE")}`}
+              alt="Placeholder image"
+            />
           </Link>
         </figure>
       </div>

--- a/assets/js/components/Work/Tabs/Structure.jsx
+++ b/assets/js/components/Work/Tabs/Structure.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { buildImageURL } from "../../../services/global-vars";
+import { buildImageURL } from "../../../services/helpers";
 
 const WorkTabsStructure = ({ work }) => {
   if (!work) {
@@ -17,6 +17,9 @@ const WorkTabsStructure = ({ work }) => {
                 <img
                   src={`${buildImageURL(id, "IIIF_SQUARE")}`}
                   placeholder="Fileset Image"
+                  onError={e => {
+                    e.target.src = "/images/1280x960.png";
+                  }}
                 />
               </p>
             </figure>

--- a/assets/js/components/Work/Tabs/Structure.jsx
+++ b/assets/js/components/Work/Tabs/Structure.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { buildImageURL } from "../../../services/global-vars";
 
 const WorkTabsStructure = ({ work }) => {
   if (!work) {
@@ -13,7 +14,10 @@ const WorkTabsStructure = ({ work }) => {
           <article key={id} className="media">
             <figure className="media-left">
               <p className="image is-64x64">
-                <img src="https://bulma.io/images/placeholders/128x128.png" />
+                <img
+                  src={`${buildImageURL(id, "IIIF_SQUARE")}`}
+                  placeholder="Fileset Image"
+                />
               </p>
             </figure>
             <div className="media-content">

--- a/assets/js/services/global-vars.js
+++ b/assets/js/services/global-vars.js
@@ -3,3 +3,7 @@ export const VISIBILITY_OPTIONS = [
   { label: "Public", value: "OPEN" },
   { label: "Private", value: "RESTRICTED" }
 ];
+export const IIIF_SIZES = {
+  IIIF_SQUARE: "/square/500,500/0/default.jpg",
+  IIIF_FULL: "/full/full/0/default.jpg"
+};

--- a/assets/js/services/helpers.js
+++ b/assets/js/services/helpers.js
@@ -9,10 +9,10 @@ import { IIIF_SIZES } from "./global-vars";
  * @return {string} This returns a URL for the image
  */
 export function buildImageURL(id, imageSize) {
-  const imageHost = id
+  const srcPath = id
     ? `http://localhost:8183/iiif/2/${id}`
     : "/images/1280x960.png";
-  return imageHost + (id ? `${IIIF_SIZES[imageSize]}` : "");
+  return srcPath + (id ? `${IIIF_SIZES[imageSize]}` : "");
 }
 
 /**

--- a/assets/js/services/helpers.js
+++ b/assets/js/services/helpers.js
@@ -1,5 +1,19 @@
 import moment from "moment";
 import { toast } from "bulma-toast";
+import { IIIF_SIZES } from "./global-vars";
+
+/**
+ * Builds IIIF url for placeholder images
+ * @param {string} id This ID is a filesetId
+ * @param {object} imageSize This is an image size type
+ * @return {string} This returns a URL for the image
+ */
+export function buildImageURL(id, imageSize) {
+  const imageHost = id
+    ? `http://localhost:8183/iiif/2/${id}`
+    : "/images/1280x960.png";
+  return imageHost + (id ? `${IIIF_SIZES[imageSize]}` : "");
+}
 
 /**
  * Escape double quotes (which may interfere with Search queries)

--- a/assets/js/services/helpers.test.js
+++ b/assets/js/services/helpers.test.js
@@ -1,0 +1,75 @@
+import {
+  buildImageURL,
+  escapeDoubleQuotes,
+  formatDate,
+  getClassFromIngestSheetStatus
+} from "./helpers";
+
+describe("Build Image URL function", () => {
+  it("should return URL", () => {
+    const expected =
+      "http://localhost:8183/iiif/2/filesetId/square/500,500/0/default.jpg";
+    const actual = buildImageURL("filesetId", "IIIF_SQUARE");
+    expect(expected).toEqual(actual);
+  });
+  it("should return default URL", () => {
+    const expected = "/images/1280x960.png";
+    const actual = buildImageURL("", "IIIF_SQUARE");
+    expect(expected).toEqual(actual);
+  });
+});
+
+it("should escape double quotes", () => {
+  const expected = 'This is a %5C"doubleQuoted%5C" expression';
+  const actual = escapeDoubleQuotes(`This is a "doubleQuoted" expression`);
+  expect(expected).toMatch(actual);
+});
+
+describe("Convert String to Date function", () => {
+  it("should format date", () => {
+    const expected = "Feb 26th 2020, 2:57:09 am";
+    const actual = formatDate("2020-02-26T14:57:09.263182Z");
+    expect(expected).toEqual(actual);
+  });
+  it("should NOT format date", () => {
+    const actual = formatDate("");
+    expect(actual).toBe("");
+  });
+});
+
+describe("IngestSheet status CSS-Class function", () => {
+  it("should return is-danger for ROW_FAIL", () => {
+    const expected = "is-danger";
+    const actual = getClassFromIngestSheetStatus("ROW_FAIL");
+    expect(expected).toEqual(actual);
+  });
+  it("should return is-danger for FILE_FAIL", () => {
+    const expected = "is-danger";
+    const actual = getClassFromIngestSheetStatus("FILE_FAIL");
+    expect(expected).toEqual(actual);
+  });
+  it("should return is-warning for UPLOADED", () => {
+    const expected = "is-warning";
+    const actual = getClassFromIngestSheetStatus("UPLOADED");
+    expect(expected).toEqual(actual);
+  });
+  it("should return is-success for COMPLETED", () => {
+    const expected = "is-success";
+    const actual = getClassFromIngestSheetStatus("COMPLETED");
+    expect(expected).toEqual(actual);
+  });
+  it("should return is-success & is-light for APPROVED", () => {
+    const expected = "is-success is-light";
+    const actual = getClassFromIngestSheetStatus("APPROVED");
+    expect(expected).toEqual(actual);
+  });
+  it("should return is-success & is-light for VALID", () => {
+    const expected = "is-success is-light";
+    const actual = getClassFromIngestSheetStatus("VALID");
+    expect(expected).toEqual(actual);
+  });
+  it("should return empty", () => {
+    const actual = getClassFromIngestSheetStatus();
+    expect(actual).toBe("");
+  });
+});

--- a/assets/js/services/helpers.test.js
+++ b/assets/js/services/helpers.test.js
@@ -6,13 +6,13 @@ import {
 } from "./helpers";
 
 describe("Build Image URL function", () => {
-  it("should return URL", () => {
+  it("should return a URL containing correct IIIF params", () => {
     const expected =
-      "http://localhost:8183/iiif/2/filesetId/square/500,500/0/default.jpg";
-    const actual = buildImageURL("filesetId", "IIIF_SQUARE");
+      "http://localhost:8183/iiif/2/ABC123/square/500,500/0/default.jpg";
+    const actual = buildImageURL("ABC123", "IIIF_SQUARE");
     expect(expected).toEqual(actual);
   });
-  it("should return default URL", () => {
+  it("should return default URL for placeholder Image", () => {
     const expected = "/images/1280x960.png";
     const actual = buildImageURL("", "IIIF_SQUARE");
     expect(expected).toEqual(actual);

--- a/assets/js/services/helpers.test.js
+++ b/assets/js/services/helpers.test.js
@@ -27,7 +27,7 @@ it("should escape double quotes", () => {
 
 describe("Convert String to Date function", () => {
   it("should format date", () => {
-    const expected = "Feb 26th 2020, 2:57:09 am";
+    const expected = "Feb 26th 2020, 2:57:09 pm";
     const actual = formatDate("2020-02-26T14:57:09.263182Z");
     expect(expected).toEqual(actual);
   });


### PR DESCRIPTION
I created a global function 'buildImageURL' to retrieve the correct image source and this function accepts the filesetId and imageSize as parameters. This would be useful to generate the source for any IIIF images in the future. Also added Tests for functions in Helpers.js



![Screen Shot 2020-02-26 at 1 41 07 PM](https://user-images.githubusercontent.com/14085957/75381336-3249dd00-589e-11ea-91c1-780cc0b8f2cf.png)
![Screen Shot 2020-02-26 at 1 41 21 PM](https://user-images.githubusercontent.com/14085957/75381340-337b0a00-589e-11ea-909f-be7f5358596f.png)
![Screen Shot 2020-02-27 at 9 14 06 AM](https://user-images.githubusercontent.com/14085957/75457237-e5b7dd80-5941-11ea-8d18-b8e08cb144e7.png)
