### PR TITLE
Bug Fix for deleting Ingest Sheets

### DIFF
--- a/assets/js/components/IngestSheet/List.jsx
+++ b/assets/js/components/IngestSheet/List.jsx
@@ -23,27 +23,6 @@ const IngestSheetList = ({ project, subscribeToIngestSheetStatusChanges }) => {
     deleteIngestSheet,
     { data: deleteIngestSheetData, error: deleteIngestSheetError }
   ] = useMutation(DELETE_INGEST_SHEET, {
-    update(cache, { data: { deleteIngestSheet } }) {
-      try {
-        const { project } = client.readQuery({
-          query: GET_INGEST_SHEETS,
-          variables: { projectId }
-        });
-
-        const index = project.ingestSheets.findIndex(
-          ingestSheet => ingestSheet.id === deleteIngestSheet.id
-        );
-
-        project.ingestSheets.splice(index, 1);
-
-        client.writeQuery({
-          query: GET_INGEST_SHEETS,
-          data: { project }
-        });
-      } catch (error) {
-        console.log("Error reading from cache", error);
-      }
-    },
     onCompleted({ deleteIngestSheet }) {
       toastWrapper("is-success", "Ingest sheet deleted successfully");
     }


### PR DESCRIPTION
- Fixed ApolloClient cache error for ingest sheet delete option by updating the cache on every delete instance.
- Fixed the projectId not found error on ingest sheet deletion which is a part of #544 by removing the additional code. This page is already using a subscription which removes the deleted ingest sheet automatically and the code that is causing the bug was no longer needed.
