### PR TITLE
Add representative_image and support code to Work schema & context

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -37,12 +37,8 @@ config :meadow,
   upload_bucket: "test-uploads",
   preservation_bucket: "test-preservation",
   pyramid_bucket: "test-pyramids",
-  iiif_server_url: System.get_env("IIIF_SERVER_URL", "http://localhost:8184/iiif/2/"),
-  iiif_manifest_url:
-    System.get_env(
-      "IIIF_MANIFEST_URL",
-      "http://localhost:9002/minio/test-pyramids/public/"
-    )
+  iiif_server_url: "http://localhost:8184/iiif/2/",
+  iiif_manifest_url: "http://localhost:9002/minio/test-pyramids/public/"
 
 config :meadow,
   test_mode: true

--- a/lib/meadow/config.ex
+++ b/lib/meadow/config.ex
@@ -40,11 +40,13 @@ defmodule Meadow.Config do
   @doc "Retrieve the IIIF server endpoint"
   def iiif_server_url do
     Application.get_env(:meadow, :iiif_server_url)
+    |> ensure_trailing_slash()
   end
 
   @doc "Retrieve the IIIF server endpoint"
   def iiif_manifest_url do
     Application.get_env(:meadow, :iiif_manifest_url)
+    |> ensure_trailing_slash()
   end
 
   @doc "Retrieve a list of configured buckets"
@@ -103,5 +105,11 @@ defmodule Meadow.Config do
           [{'AWS_S3_ENDPOINT', to_charlist(endpoint)} | result]
       end
     end
+  end
+
+  defp ensure_trailing_slash(value) do
+    if value |> String.ends_with?("/"),
+      do: value,
+      else: value <> "/"
   end
 end

--- a/lib/meadow/data/schemas/work.ex
+++ b/lib/meadow/data/schemas/work.ex
@@ -23,6 +23,7 @@ defmodule Meadow.Data.Schemas.Work do
     field :visibility, :string
     field :work_type, :string
     field :published, :boolean, default: false
+    field :representative_file_set_id, Ecto.UUID, default: nil
     timestamps()
 
     embeds_one :descriptive_metadata, WorkDescriptiveMetadata, on_replace: :update
@@ -37,12 +38,13 @@ defmodule Meadow.Data.Schemas.Work do
 
     belongs_to :collection, Collection
 
+    field :representative_image, :string, virtual: true, default: nil
     field :extra_index_fields, :map, virtual: true, default: %{}
   end
 
   def changeset(work, attrs) do
     required_params = [:accession_number, :visibility, :work_type]
-    optional_params = [:collection_id]
+    optional_params = [:collection_id, :representative_file_set_id]
 
     work
     |> cast(attrs, required_params ++ optional_params)

--- a/lib/meadow/data/works.ex
+++ b/lib/meadow/data/works.ex
@@ -4,7 +4,7 @@ defmodule Meadow.Data.Works do
   """
 
   import Ecto.Query, warn: false
-  alias Meadow.Data.Schemas.Work
+  alias Meadow.Data.Schemas.{FileSet, Work}
   alias Meadow.Repo
 
   @doc """
@@ -17,7 +17,9 @@ defmodule Meadow.Data.Works do
 
   """
   def list_works do
-    Repo.all(Work)
+    Work
+    |> Repo.all()
+    |> add_representative_image()
   end
 
   @doc """
@@ -29,7 +31,7 @@ defmodule Meadow.Data.Works do
   """
 
   def list_works(criteria) do
-    query = from(w in Work)
+    query = from(Work)
 
     Enum.reduce(criteria, query, fn
       {:limit, limit}, query ->
@@ -42,6 +44,7 @@ defmodule Meadow.Data.Works do
         from p in query, order_by: [{^order, :id}]
     end)
     |> Repo.all()
+    |> add_representative_image()
   end
 
   defp filter_with(filters, query) do
@@ -74,7 +77,10 @@ defmodule Meadow.Data.Works do
       ** (Ecto.NoResultsError)
 
   """
-  def get_work!(id), do: Repo.get!(Work, id)
+  def get_work!(id) do
+    Repo.get!(Work, id)
+    |> add_representative_image()
+  end
 
   @doc """
   Gets a work by accession_number
@@ -83,6 +89,7 @@ defmodule Meadow.Data.Works do
   """
   def get_work_by_accession_number!(accession_number) do
     Repo.get_by!(Work, accession_number: accession_number)
+    |> add_representative_image()
   end
 
   @doc """
@@ -108,9 +115,10 @@ defmodule Meadow.Data.Works do
 
   """
   def create_work(attrs \\ %{}) do
-    %Work{}
-    |> Work.changeset(attrs)
-    |> Repo.insert()
+    case %Work{} |> Work.changeset(attrs) |> Repo.insert() do
+      {:ok, work} -> set_default_representative_image(work)
+      other -> other
+    end
   end
 
   @doc """
@@ -120,6 +128,7 @@ defmodule Meadow.Data.Works do
     %Work{}
     |> Work.changeset(attrs)
     |> Repo.insert!()
+    |> set_default_representative_image!()
   end
 
   @doc """
@@ -150,6 +159,7 @@ defmodule Meadow.Data.Works do
     work
     |> Work.changeset(attrs)
     |> Repo.update()
+    |> add_representative_image()
   end
 
   @doc """
@@ -168,6 +178,7 @@ defmodule Meadow.Data.Works do
     work
     |> Work.changeset(%{collection_id: collection_id})
     |> Repo.update()
+    |> add_representative_image()
   end
 
   @doc """
@@ -187,11 +198,11 @@ defmodule Meadow.Data.Works do
   def get_works_by_title(title) do
     map = %{"title" => title}
 
-    q =
-      from Work,
-        where: fragment("descriptive_metadata @> ?::jsonb", ^map)
-
-    Repo.all(q)
+    from(Work,
+      where: fragment("descriptive_metadata @> ?::jsonb", ^map)
+    )
+    |> Repo.all()
+    |> add_representative_image()
   end
 
   @doc """
@@ -199,5 +210,89 @@ defmodule Meadow.Data.Works do
   """
   def delete_work(%Work{} = work) do
     Repo.delete(work)
+  end
+
+  @doc """
+  Sets the representative_file_set_id for a work based
+  on a file set
+
+  ## Examples
+
+      iex> set_representative_image(work, file_set)
+      {:ok, %Work{}}
+  """
+  def set_representative_image(%Work{} = work, %FileSet{id: id}) do
+    work
+    |> update_work(%{representative_file_set_id: id})
+  end
+
+  def set_representative_image(%Work{} = work, nil) do
+    work
+    |> update_work(%{representative_file_set_id: nil})
+  end
+
+  @doc """
+  Sets the default representative_file_set_id for a work
+
+  ## Examples
+
+      iex> set_default_representative_image(work)
+      {:ok, %Work{}}
+  """
+  def set_default_representative_image(%Work{} = work) do
+    work =
+      if Ecto.assoc_loaded?(work.file_sets),
+        do: work,
+        else: work |> Repo.preload(file_sets: from(FileSet, order_by: :rank, limit: 1))
+
+    work
+    |> set_representative_image(work.file_sets |> List.first())
+  end
+
+  @doc """
+  Sets the default representative_file_set_id for a work
+
+  ## Examples
+
+      iex> set_default_representative_image!(work)
+      %Work{}
+  """
+  def set_default_representative_image!(%Work{} = work) do
+    case set_default_representative_image(work) do
+      {:ok, work} -> work
+      {:error, err} -> raise err
+    end
+  end
+
+  @doc """
+  Sets the value of the representative_image virtual field
+  for a work, list of works, or stream of works
+  """
+  def add_representative_image(%Work{} = work) do
+    case work.representative_file_set_id do
+      nil -> Map.put(work, :representative_image, nil)
+      id -> Map.put(work, :representative_image, representative_image_url(id))
+    end
+  end
+
+  def add_representative_image(%Stream{} = stream),
+    do: Stream.map(stream, &add_representative_image/1)
+
+  def add_representative_image(works) when is_list(works),
+    do: Enum.map(works, &add_representative_image/1)
+
+  def add_representative_image({:ok, object}),
+    do: {:ok, add_representative_image(object)}
+
+  def add_representative_image(x), do: x
+
+  defp representative_image_url(nil), do: nil
+
+  defp representative_image_url(id) do
+    with uri <- URI.parse(Meadow.Config.iiif_server_url()) do
+      uri
+      |> URI.merge(id)
+      |> URI.to_string()
+    end
   end
 end

--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -86,6 +86,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     field :updated_at, non_null(:datetime)
     field :collection, :collection, resolve: dataloader(Data)
     field :file_sets, list_of(:file_set), resolve: dataloader(Data)
+    field :representative_image, :string
   end
 
   #

--- a/priv/repo/migrations/20200227174324_add_representative_id_to_work.exs
+++ b/priv/repo/migrations/20200227174324_add_representative_id_to_work.exs
@@ -1,0 +1,9 @@
+defmodule Meadow.Repo.Migrations.AddRepresentativeIdToWork do
+  use Ecto.Migration
+
+  def change do
+    alter table("works") do
+      add(:representative_file_set_id, references("file_sets", on_delete: :nilify_all))
+    end
+  end
+end

--- a/test/meadow/config_test.exs
+++ b/test/meadow/config_test.exs
@@ -52,4 +52,39 @@ defmodule Meadow.ConfigTest do
       assert env |> get_val.('AWS_S3_ENDPOINT') |> Enum.slice(0..16) == 'http://localhost:'
     end
   end
+
+  describe "IIIF configs" do
+    setup do
+      prior_values = %{
+        server: Application.get_env(:meadow, :iiif_server_url),
+        manifest: Application.get_env(:meadow, :iiif_manifest_url)
+      }
+
+      on_exit(fn ->
+        Application.put_env(:meadow, :iiif_server_url, prior_values.server)
+        Application.put_env(:meadow, :iiif_manifest_url, prior_values.manifest)
+      end)
+    end
+
+    test "iiif_server_url" do
+      assert Config.iiif_server_url() == "http://localhost:8184/iiif/2/"
+    end
+
+    test "iiif_manifest_url" do
+      assert Config.iiif_manifest_url() == "http://localhost:9002/minio/test-pyramids/public/"
+    end
+
+    test "trailing slashes" do
+      Application.put_env(:meadow, :iiif_server_url, "http://no-slash-test/iiif/2")
+
+      Application.put_env(
+        :meadow,
+        :iiif_manifest_url,
+        "http://no-slash-test/minio/test-pyramids/public"
+      )
+
+      assert Config.iiif_server_url() == "http://no-slash-test/iiif/2/"
+      assert Config.iiif_manifest_url() == "http://no-slash-test/minio/test-pyramids/public/"
+    end
+  end
 end

--- a/test/meadow/data/works_test.exs
+++ b/test/meadow/data/works_test.exs
@@ -2,7 +2,8 @@ defmodule Meadow.Data.WorksTest do
   use Meadow.DataCase
 
   alias Meadow.Data.Schemas.Work
-  alias Meadow.Data.Works
+  alias Meadow.Data.{FileSets, Works}
+  alias Meadow.Repo
 
   describe "queries" do
     @valid_attrs %{
@@ -30,6 +31,14 @@ defmodule Meadow.Data.WorksTest do
 
     test "create_work/1 with invalid data does not create a work" do
       assert {:error, %Ecto.Changeset{}} = Works.create_work(@invalid_attrs)
+    end
+
+    test "create_work!/1 with valid data creates a work" do
+      assert %Work{} = Works.create_work!(@valid_attrs)
+    end
+
+    test "create_work!/1 with invalid data does not create a work" do
+      assert_raise(Ecto.InvalidChangesetError, fn -> Works.create_work!(@invalid_attrs) end)
     end
 
     test "update_work/2 updates a work" do
@@ -88,6 +97,94 @@ defmodule Meadow.Data.WorksTest do
 
       assert work.descriptive_metadata.title == nil
       assert work.administrative_metadata.preservation_level == nil
+    end
+  end
+
+  describe "representative images" do
+    setup do
+      work = work_fixture()
+      file_sets = 0..2 |> Enum.map(fn _ -> file_set_fixture(%{work_id: work.id}) end)
+      file_set = file_sets |> Enum.at(1)
+
+      {:ok, %Work{} = work} = Works.set_representative_image(work, file_set)
+
+      {:ok,
+       work: work,
+       image_id: file_set.id,
+       image_url: Meadow.Config.iiif_server_url() <> file_set.id}
+    end
+
+    test "no representative image assigned", %{work: work} do
+      {:ok, work} = Works.set_representative_image(work, nil)
+      assert(is_nil(work.representative_image))
+    end
+
+    test "list_works/0", %{image_url: image_url} do
+      [work] = Works.list_works()
+      assert(work.representative_image == image_url)
+    end
+
+    test "get_work!/1", %{work: work, image_url: image_url} do
+      assert(
+        Works.get_work!(work.id)
+        |> Map.get(:representative_image) == image_url
+      )
+    end
+
+    test "get_work_by_accession_number!/1", %{work: work, image_url: image_url} do
+      assert(
+        Works.get_work_by_accession_number!(work.accession_number)
+        |> Map.get(:representative_image) == image_url
+      )
+    end
+
+    test "get_works_by_title/1", %{work: work, image_url: image_url} do
+      with title <- work.descriptive_metadata.title do
+        [work] = Works.get_works_by_title(title)
+        assert(work.representative_image == image_url)
+      end
+    end
+
+    test "add_representative_image/1 single work", %{work: work, image_url: image_url} do
+      work =
+        Work
+        |> Repo.get!(work.id)
+        |> Works.add_representative_image()
+
+      assert work.representative_image == image_url
+    end
+
+    test "add_representative_image/1 list of works", %{image_url: image_url} do
+      [work] =
+        Work
+        |> Repo.all()
+        |> Works.add_representative_image()
+
+      assert work.representative_image == image_url
+    end
+
+    test "add_representative_image/1 stream of works", %{image_url: image_url} do
+      stream =
+        Work
+        |> Repo.stream()
+        |> Works.add_representative_image()
+
+      {:ok, [work]} = Repo.transaction(fn -> stream |> Enum.into([]) end)
+      assert work.representative_image == image_url
+    end
+
+    test "add_representative_image/1 passthrough" do
+      assert "Not a work" |> Works.add_representative_image() == "Not a work"
+    end
+
+    test "deleting a file set nilifies the representative image", %{
+      image_id: image_id,
+      image_url: image_url,
+      work: work
+    } do
+      assert(Works.get_work!(work.id) |> Map.get(:representative_image) == image_url)
+      FileSets.get_file_set!(image_id) |> FileSets.delete_file_set()
+      assert(is_nil(Works.get_work!(work.id) |> Map.get(:representative_image)))
     end
   end
 end


### PR DESCRIPTION
This PR uses a virtual field and a loosely coupled UUID to indicate which `FileSet` should be used as the representative image for a `Work`. It also adds `representativeImage` to the API's `work` type and returns the correct value.

## Details & Caveats

- A work that is created with file sets via `create_work` will always have its initial representative file set to the first ranked file set.
- All of the create/load/get/update functions in the `Works` context automatically populate the virtual `representative_image` field.
- Deleting the file set that is designated as the representative image for a work will nil out the work's representative image field via a database constraint.
- There is currently no logic to make sure that a work always has a representative image set, or that the image specified is actually a file set owned by the work. These can be addressed by Postgres triggers if desirable.
- This PR contains a migration.

## Takeaways

- Virtual fields are cool.