### PR TITLE
Index FileSets on Work document in Elasticsearch

### DIFF
--- a/lib/meadow/data/schemas/work.ex
+++ b/lib/meadow/data/schemas/work.ex
@@ -78,6 +78,15 @@ defmodule Meadow.Data.Schemas.Work do
             nil -> %{}
             collection -> %{id: collection.id, title: collection.name}
           end,
+        file_sets:
+          work.file_sets
+          |> Enum.map(fn file_set ->
+            %{
+              id: file_set.id,
+              accession_number: file_set.accession_number,
+              label: file_set.metadata.label
+            }
+          end),
         create_date: work.inserted_at,
         iiif_manifest: IIIF.manifest_id(work.id),
         modified_date: work.updated_at

--- a/lib/meadow/elasticsearch_diff_store.ex
+++ b/lib/meadow/elasticsearch_diff_store.ex
@@ -30,7 +30,7 @@ defmodule Meadow.ElasticsearchDiffStore do
     |> Repo.stream()
     |> Stream.chunk_every(@chunk_size)
     |> Stream.flat_map(fn chunk ->
-      Repo.preload(chunk, :collection)
+      Repo.preload(chunk, [:collection, :file_sets])
     end)
   end
 

--- a/lib/meadow/elasticsearch_store.ex
+++ b/lib/meadow/elasticsearch_store.ex
@@ -15,7 +15,7 @@ defmodule Meadow.ElasticsearchStore do
     |> Repo.stream()
     |> Stream.chunk_every(10)
     |> Stream.flat_map(fn chunk ->
-      Repo.preload(chunk, :collection)
+      Repo.preload(chunk, [:collection, :file_sets])
     end)
   end
 


### PR DESCRIPTION
FileSets get indexed into works like this: 
```elixir
file_sets: [
    %{
      accession_number: "PwyKWICT",
      id: "b7917457-6904-412f-8271-a3a68e5b1de1",
      label: "test"
    }
]
```