### PR TITLE
Changes to expose preservation work data in the tab

### DIFF
--- a/assets/js/components/Work/Tabs/Preservation.jsx
+++ b/assets/js/components/Work/Tabs/Preservation.jsx
@@ -1,12 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import UITagNotYetSupported from "../../UI/TagNotYetSupported";
 
 const WorkTabsPreservation = ({ work }) => {
   return (
     <div className="columns is-centered">
       <div className="column">
-        <table className="table is-fullwidth is-striped is-hoverable">
+        <table className="table is-fullwidth is-striped is-hoverable is-fixed">
           <thead>
             <tr>
               <th>Role</th>
@@ -24,15 +25,17 @@ const WorkTabsPreservation = ({ work }) => {
                 return (
                   <tr key={fileset.id}>
                     <td>{fileset.role}</td>
-                    <td>{metadata ? metadata.originalFilename : " "}</td>
-                    <td className="notification is-warning">
-                      {metadata.sha256}
+                    <td className="break-word">
+                      {metadata ? metadata.originalFilename : " "}
                     </td>
-                    <td className="notification is-warning">
-                      TODO: Need this exposed in GraphQL
+                    <td className="break-word">
+                      {metadata ? metadata.sha256 : ""}
                     </td>
-                    <td className="notification is-warning">
-                      TODO: Need this exposed in GraphQL
+                    <td className="break-word">
+                      {metadata ? metadata.location : ""}
+                    </td>
+                    <td>
+                      <UITagNotYetSupported label="Display not yet supported" />
                     </td>
                     <td>
                       <div className="buttons-end">

--- a/assets/styles/scss/_base.scss
+++ b/assets/styles/scss/_base.scss
@@ -8,8 +8,14 @@ table {
     @extend .is-italic;
     @extend .is-size-6;
   }
+  &.is-fixed {
+    table-layout: fixed;
+  }
 }
 
+.break-word {
+  overflow-wrap: break-word;
+}
 .buttons-end {
   @extend .field;
   @extend .has-addons;


### PR DESCRIPTION
Added checksum and s3 values to preservation table.

I checked using table className="is-two-thirds" and "is-three-quarters" and the table looks congested.

![Screen Shot 2020-03-04 at 12 37 34 PM](https://user-images.githubusercontent.com/14085957/75911378-181b7c00-5e15-11ea-8715-4221056d2a16.png)
