### PR TITLE
Add addWorksToCollection and removeWorksFromCollection mutations

### DIFF
--- a/lib/meadow_web/resolvers/collections.ex
+++ b/lib/meadow_web/resolvers/collections.ex
@@ -38,6 +38,30 @@ defmodule MeadowWeb.Resolvers.Data.Collections do
     end
   end
 
+  def add_works(_, %{collection_id: collection_id, work_ids: work_ids}, _) do
+    collection = Collections.get_collection!(collection_id)
+
+    case Collections.add_works(collection, work_ids) do
+      {:error, error} ->
+        {:error, message: "Could not add works to collection", details: error.message}
+
+      {:ok, collection} ->
+        {:ok, collection}
+    end
+  end
+
+  def remove_works(_, %{collection_id: collection_id, work_ids: work_ids}, _) do
+    collection = Collections.get_collection!(collection_id)
+
+    case Collections.remove_works(collection, work_ids) do
+      {:error, error} ->
+        {:error, message: "Could not add works to collection", details: error.message}
+
+      {:ok, collection} ->
+        {:ok, collection}
+    end
+  end
+
   def set_collection_image(_, %{collection_id: collection_id, work_id: work_id}, _) do
     collection = Collections.get_collection!(collection_id)
     work = Works.get_work!(work_id)

--- a/lib/meadow_web/schema/types/data/collection_types.ex
+++ b/lib/meadow_web/schema/types/data/collection_types.ex
@@ -52,6 +52,22 @@ defmodule MeadowWeb.Schema.Data.CollectionTypes do
       resolve(&Resolvers.Data.Collections.update_collection/3)
     end
 
+    @desc "Add Works to a Collection"
+    field :add_works_to_collection, :collection do
+      arg(:collection_id, non_null(:id))
+      arg(:work_ids, list_of(:id))
+      middleware(Middleware.Authenticate)
+      resolve(&Resolvers.Data.Collections.add_works/3)
+    end
+
+    @desc "Remove Works from a Collection"
+    field :remove_works_from_collection, :collection do
+      arg(:collection_id, non_null(:id))
+      arg(:work_ids, list_of(:id))
+      middleware(Middleware.Authenticate)
+      resolve(&Resolvers.Data.Collections.remove_works/3)
+    end
+
     @desc "Set the representative Work for a Collection"
     field :set_collection_image, :collection do
       arg(:collection_id, non_null(:id))

--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -155,6 +155,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     field :descriptive_metadata, :work_descriptive_metadata_input
     field :visibility, :visibility
     field :published, :boolean
+    field :collection_id, :id
   end
 
   #

--- a/test/gql/AddWorksToCollection.gql
+++ b/test/gql/AddWorksToCollection.gql
@@ -1,0 +1,8 @@
+mutation($workIds: [ID!], $collectionId: ID!) {
+  addWorksToCollection(workIds: $workIds, collectionId: $collectionId) {
+    id
+    works {
+      id
+    }
+  }
+}

--- a/test/gql/RemoveWorksFromCollection.gql
+++ b/test/gql/RemoveWorksFromCollection.gql
@@ -1,0 +1,8 @@
+mutation($workIds: [ID!], $collectionId: ID!) {
+  removeWorksFromCollection(workIds: $workIds, collectionId: $collectionId) {
+    id
+    works {
+      id
+    }
+  }
+}

--- a/test/gql/UpdateWork.gql
+++ b/test/gql/UpdateWork.gql
@@ -1,8 +1,8 @@
 #import "./WorkFields.frag.gql"
 #import "./FileSetFields.frag.gql"
 
-mutation($id: ID!, $visibility: Visibility!, $descriptive_metadata: WorkDescriptiveMetadataInput!) {
-  updateWork(id: $id, work: { visibility: $visibility, descriptive_metadata: $descriptive_metadata }) {
+mutation($id: ID!, $collection_id: ID!, $visibility: Visibility!, $descriptive_metadata: WorkDescriptiveMetadataInput!) {
+  updateWork(id: $id, work: { collection_id: $collection_id, visibility: $visibility, descriptive_metadata: $descriptive_metadata }) {
     ...WorkFields
   }
 }

--- a/test/meadow_web/schema/mutation/add_works_to_collection_test.exs
+++ b/test/meadow_web/schema/mutation/add_works_to_collection_test.exs
@@ -1,0 +1,34 @@
+defmodule MeadowWeb.Schema.Mutation.AddWorksToCollectionTest do
+  use MeadowWeb.ConnCase, acync: true
+  use Wormwood.GQLCase
+
+  alias Meadow.Data.Collections
+  alias Meadow.Repo
+
+  load_gql(MeadowWeb.Schema, "test/gql/AddWorksToCollection.gql")
+
+  test "should be a valid mutation" do
+    collection = collection_fixture() |> Repo.preload(:works)
+    assert collection.works |> Enum.empty?()
+
+    works = [work_fixture(), work_fixture(), work_fixture()]
+    work_ids = works |> Enum.map(& &1.id)
+
+    result =
+      query_gql(
+        variables: %{"workIds" => work_ids, "collectionId" => collection.id},
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+
+    work_list =
+      get_in(query_data, [:data, "addWorksToCollection", "works"])
+      |> Enum.map(& &1["id"])
+
+    assert work_list == work_ids
+
+    collection = Collections.get_collection!(collection.id) |> Repo.preload(:works)
+    assert collection.works |> length() == 3
+  end
+end

--- a/test/meadow_web/schema/mutation/remove_works_from_collection_test.exs
+++ b/test/meadow_web/schema/mutation/remove_works_from_collection_test.exs
@@ -1,0 +1,37 @@
+defmodule MeadowWeb.Schema.Mutation.RemoveWorksFromCollectionTest do
+  use MeadowWeb.ConnCase, acync: true
+  use Wormwood.GQLCase
+
+  alias Meadow.Data.Collections
+  alias Meadow.Repo
+
+  load_gql(MeadowWeb.Schema, "test/gql/RemoveWorksFromCollection.gql")
+
+  test "should be a valid mutation" do
+    collection = collection_fixture()
+
+    works = [
+      work_fixture(%{collection_id: collection.id}),
+      work_fixture(%{collection_id: collection.id}),
+      work_fixture(%{collection_id: collection.id})
+    ]
+
+    collection = Collections.get_collection!(collection.id) |> Repo.preload(:works)
+    assert collection.works |> length() == 3
+
+    work_ids = works |> Enum.map(& &1.id)
+
+    result =
+      query_gql(
+        variables: %{"workIds" => work_ids, "collectionId" => collection.id},
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+
+    assert get_in(query_data, [:data, "removeWorksFromCollection", "works"]) == []
+
+    collection = Collections.get_collection!(collection.id) |> Repo.preload(:works)
+    assert collection.works |> Enum.empty?()
+  end
+end

--- a/test/meadow_web/schema/mutation/update_work_test.exs
+++ b/test/meadow_web/schema/mutation/update_work_test.exs
@@ -2,15 +2,21 @@ defmodule MeadowWeb.Schema.Mutation.UpdateWorkTest do
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 
+  alias Meadow.Data.Works
+  alias Meadow.Repo
+
   load_gql(MeadowWeb.Schema, "test/gql/UpdateWork.gql")
 
   test "should be a valid mutation" do
     work = work_fixture()
+    collection = collection_fixture() |> Repo.preload(:works)
+    assert collection.works |> Enum.empty?()
 
     result =
       query_gql(
         variables: %{
           "id" => work.id,
+          "collection_id" => collection.id,
           "visibility" => "RESTRICTED",
           "descriptive_metadata" => %{"title" => "Something"}
         },
@@ -21,5 +27,8 @@ defmodule MeadowWeb.Schema.Mutation.UpdateWorkTest do
 
     title = get_in(query_data, [:data, "updateWork", "descriptiveMetadata", "title"])
     assert title == "Something"
+
+    work = Works.get_work!(work.id) |> Repo.preload(:collection)
+    assert work.collection.id == collection.id
   end
 end


### PR DESCRIPTION
- Add `add_works/2` and `remove_works/2` to `Meadow.Data.Collections`

We should consider removing `addWorkToCollection` during the bi-fortnight since `addWorksToCollection` is more flexible.