### PR TITLE
Add project and sheet to works in GraphQL

### DIFF
--- a/assets/js/components/Work/Tabs/Administrative.jsx
+++ b/assets/js/components/Work/Tabs/Administrative.jsx
@@ -12,9 +12,10 @@ import { GET_COLLECTIONS } from "../../Collection/collection.query";
 import { UPDATE_WORK, ADD_WORK_TO_COLLECTION, GET_WORK } from "../work.query";
 import { useForm } from "react-hook-form";
 import UITagNotYetSupported from "../../UI/TagNotYetSupported";
+import { Link } from "react-router-dom";
 
 const WorkTabsAdministrative = ({ work }) => {
-  const { id, administrativeMetadata, collection } = work;
+  const { id, administrativeMetadata, collection, project, sheet } = work;
   const [isEditing, setIsEditing] = useIsEditing();
   const { register, handleSubmit } = useForm();
   const [updateWork] = useMutation(UPDATE_WORK, {
@@ -185,6 +186,17 @@ const WorkTabsAdministrative = ({ work }) => {
                   </p>
                 )}
               </div>
+            </div>
+
+            <div className="field">
+              <label className="label">Project</label>
+              <Link to={`/project/${project.id}`}>{project.name}</Link>
+            </div>
+            <div className="field">
+              <label className="label">Ingest Sheet</label>
+              <Link to={`/project/${project.id}/ingest-sheet/${sheet.id}`}>
+                {sheet.name}
+              </Link>
             </div>
           </div>
         </div>

--- a/assets/js/components/Work/work.query.js
+++ b/assets/js/components/Work/work.query.js
@@ -23,6 +23,14 @@ export const GET_WORK = gql`
       }
       insertedAt
       manifestUrl
+      project {
+        id
+        name
+      }
+      sheet {
+        id
+        name
+      }
       published
       representativeImage
       updatedAt
@@ -63,6 +71,14 @@ export const GET_WORKS = gql`
       }
       insertedAt
       manifestUrl
+      project {
+        id
+        name
+      }
+      sheet {
+        id
+        name
+      }
       published
       representativeImage
       updatedAt

--- a/assets/js/screens/Work/Work.test.jsx
+++ b/assets/js/screens/Work/Work.test.jsx
@@ -82,6 +82,14 @@ const mocks = [
           id: "ABC123",
           insertedAt: "2020-02-04T19:16:16",
           published: false,
+          project: {
+            id: "28b6dd45-ef3e-45df-b380-985c9af8b495",
+            name: "Foo"
+          },
+          sheet: {
+            id: "28b6dd45-ef3e-45df-b380-985c9af8b495",
+            name: "Bar"
+          },
           updatedAt: "2020-02-04T19:16:16",
           visibility: "RESTRICTED",
           workType: "IMAGE",

--- a/assets/js/services/testing-helpers.js
+++ b/assets/js/services/testing-helpers.js
@@ -106,6 +106,14 @@ export const mockWork = {
   visibility: "RESTRICTED",
   workType: "IMAGE",
   published: false,
+  project: {
+    id: "28b6dd45-ef3e-45df-b380-985c9af8b495",
+    name: "Foo"
+  },
+  sheet: {
+    id: "28b6dd45-ef3e-45df-b380-985c9af8b495",
+    name: "Bar"
+  },
   manifestUrl: "http://foobar",
   representativeImage: "http://foobar"
 };

--- a/lib/meadow/data/works.ex
+++ b/lib/meadow/data/works.ex
@@ -6,6 +6,7 @@ defmodule Meadow.Data.Works do
   import Ecto.Query, warn: false
   alias Meadow.Config
   alias Meadow.Data.Schemas.{FileSet, Work}
+  alias Meadow.Ingest.Sheets
   alias Meadow.Repo
   alias Meadow.Utils.Pairtree
 
@@ -20,6 +21,7 @@ defmodule Meadow.Data.Works do
   """
   def list_works do
     Work
+    |> Sheets.works_with_sheets()
     |> Repo.all()
     |> add_representative_image()
   end
@@ -45,6 +47,7 @@ defmodule Meadow.Data.Works do
       {:order, order}, query ->
         from p in query, order_by: [{^order, :id}]
     end)
+    |> Sheets.works_with_sheets()
     |> Repo.all()
     |> add_representative_image()
   end
@@ -80,7 +83,9 @@ defmodule Meadow.Data.Works do
 
   """
   def get_work!(id) do
-    Repo.get!(Work, id)
+    Work
+    |> Sheets.works_with_sheets()
+    |> Repo.get!(id)
     |> add_representative_image()
   end
 
@@ -90,7 +95,9 @@ defmodule Meadow.Data.Works do
   Raises `Ecto.NoResultsError` if the Work does not exist
   """
   def get_work_by_accession_number!(accession_number) do
-    Repo.get_by!(Work, accession_number: accession_number)
+    Work
+    |> Sheets.works_with_sheets()
+    |> Repo.get_by!(accession_number: accession_number)
     |> add_representative_image()
   end
 
@@ -99,9 +106,11 @@ defmodule Meadow.Data.Works do
   """
   def with_file_sets(id) do
     Work
+    |> Sheets.works_with_sheets()
     |> where([work], work.id == ^id)
     |> preload(:file_sets)
     |> Repo.one()
+    |> add_representative_image()
   end
 
   @doc """

--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -103,6 +103,18 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     field :collection, :collection, resolve: dataloader(Data)
     field :file_sets, list_of(:file_set), resolve: dataloader(Data)
     field :representative_image, :string
+
+    field :project, :work_project do
+      resolve(fn work, _, _ ->
+        {:ok, work.extra_index_fields.project}
+      end)
+    end
+
+    field :sheet, :work_sheet do
+      resolve(fn work, _, _ ->
+        {:ok, work.extra_index_fields.sheet}
+      end)
+    end
   end
 
   #
@@ -165,6 +177,18 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
   object :work_administrative_metadata do
     field :preservation_level, :integer
     field :rights_statement, :string
+  end
+
+  @desc "Project info"
+  object :work_project do
+    field :id, :string
+    field :name, :string
+  end
+
+  @desc "Sheet info"
+  object :work_sheet do
+    field :id, :id
+    field :name, :string
   end
 
   @desc "visibility setting for the object"


### PR DESCRIPTION
* Exposed project and ingest sheet on the work object in GraphQL
* Added `Sheets.works_with_sheets/1` to works queries (except sheet-works query - so requesting project/sheet info in `ingestSheetWorks` query will cause error. Out of scope for this PR. We'll open issue... We may not need to do this if we are all aware...)
* Displayed on  the Administrative tab 

![Screen Shot 2020-03-04 at 3 41 31 PM](https://user-images.githubusercontent.com/6372022/75925647-a7815900-5e2e-11ea-91b5-663407734ad5.png)
