### PR TITLE
Fix bug in publish flag

### DIFF
--- a/assets/js/components/Work/work.query.js
+++ b/assets/js/components/Work/work.query.js
@@ -76,11 +76,6 @@ export const UPDATE_WORK = gql`
   mutation UpdateWork($id: ID!, $work: WorkUpdateInput!) {
     updateWork(id: $id, work: $work) {
       id
-      descriptiveMetadata {
-        title
-        description
-      }
-      visibility
       administrativeMetadata {
         preservationLevel
         rightsStatement
@@ -89,7 +84,13 @@ export const UPDATE_WORK = gql`
         name
         id
       }
+      descriptiveMetadata {
+        title
+        description
+      }
       insertedAt
+      published
+      visibility
     }
   }
 `;

--- a/assets/js/screens/Work/Work.jsx
+++ b/assets/js/screens/Work/Work.jsx
@@ -17,8 +17,10 @@ const ScreensWork = () => {
   });
   const [updateWork] = useMutation(UPDATE_WORK, {
     onCompleted({ updateWork }) {
-      console.log("updateWork :", updateWork);
-      toastWrapper("is-success", "Work form has been updated");
+      toastWrapper(
+        "is-success",
+        `Work has been ${updateWork.published ? "published" : "unpublished"}`
+      );
     }
   });
 
@@ -67,15 +69,13 @@ const ScreensWork = () => {
             </h1>
             <h2 className="subtitle">Work Accession Number</h2>
             <ButtonGroup>
-              {!published && (
-                <button
-                  className="button is-primary is-outlined"
-                  data-testid="publish-button"
-                  onClick={handlePublishClick}
-                >
-                  {!published ? "Publish" : "Unpublish"}
-                </button>
-              )}
+              <button
+                className="button is-primary is-outlined"
+                data-testid="publish-button"
+                onClick={handlePublishClick}
+              >
+                {!published ? "Publish" : "Unpublish"}
+              </button>
               <button className="button" data-testid="delete-button">
                 Delete
               </button>

--- a/lib/meadow/data/schemas/work.ex
+++ b/lib/meadow/data/schemas/work.ex
@@ -61,6 +61,18 @@ defmodule Meadow.Data.Schemas.Work do
     |> unique_constraint(:accession_number)
   end
 
+  def update_changeset(work, attrs) do
+    allowed_params = [:published, :visibility, :collection_id, :representative_file_set_id]
+
+    work
+    |> cast(attrs, allowed_params)
+    |> prepare_embed(:administrative_metadata)
+    |> prepare_embed(:descriptive_metadata)
+    |> cast_embed(:administrative_metadata)
+    |> cast_embed(:descriptive_metadata)
+    |> assoc_constraint(:collection)
+  end
+
   defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Work do
     def id(work), do: work.id
     def routing(_), do: false

--- a/lib/meadow/data/works.ex
+++ b/lib/meadow/data/works.ex
@@ -169,7 +169,7 @@ defmodule Meadow.Data.Works do
   """
   def update_work(%Work{} = work, attrs) do
     work
-    |> Work.changeset(attrs)
+    |> Work.update_changeset(attrs)
     |> Repo.update()
     |> add_representative_image()
   end
@@ -188,7 +188,7 @@ defmodule Meadow.Data.Works do
   """
   def add_to_collection(%Work{} = work, collection_id) do
     work
-    |> Work.changeset(%{collection_id: collection_id})
+    |> Work.update_changeset(%{collection_id: collection_id})
     |> Repo.update()
     |> add_representative_image()
   end

--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -141,10 +141,8 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
   input_object :work_update_input do
     field :administrative_metadata, :work_administrative_metadata_input
     field :descriptive_metadata, :work_descriptive_metadata_input
-    field :work_type, :work_type
     field :visibility, :visibility
     field :published, :boolean
-    field :file_sets, list_of(:file_set_input)
   end
 
   #

--- a/test/meadow/data/works_test.exs
+++ b/test/meadow/data/works_test.exs
@@ -52,7 +52,7 @@ defmodule Meadow.Data.WorksTest do
 
     test "update_work/2 with invalid attributes returns an error" do
       work = work_fixture()
-      assert {:error, %Ecto.Changeset{}} = Works.update_work(work, %{work_type: "Dictionary"})
+      assert {:error, %Ecto.Changeset{}} = Works.update_work(work, %{published: "Dictionary"})
     end
 
     test "delete_work/1 deletes a work" do


### PR DESCRIPTION
Publish flag was not being `cast` in the changeset and so updating it through the `updateWork` mutation wasn't working. 

I created a separate `update_changeset` since we don't have the same requirements for updating fields as creating fields. (can't edit accession_number, required fields not the same, etc...)