### PR TITLE
Remove links from FileSets on work cards

### DIFF
--- a/assets/js/components/Work/ListItem.jsx
+++ b/assets/js/components/Work/ListItem.jsx
@@ -26,18 +26,17 @@ const WorkListItem = ({ work }) => {
         </h3>
         <p className="subtitle is-size-6">Accession Number</p>
         <h4 className="subtitle">
-          Filesets{" "}
-          <span className="tag is-link is-light">{work.fileSets.length}</span>
+          Filesets <span className="tag is-light">{work.fileSets.length}</span>
         </h4>
-        <div className="list is-hoverable">
+        <div className="list has-background-light">
           {work.fileSets.map((fileSet, i) =>
             i < fileSetsToDisplay - 1 ? (
-              <a key={fileSet.id} className="list-item">
+              <span key={fileSet.id} className="list-item">
                 {fileSet.accessionNumber} -{" "}
                 {fileSet.metadata &&
                   fileSet.metadata.description &&
                   fileSet.metadata.description}
-              </a>
+              </span>
             ) : null
           )}
         </div>

--- a/assets/js/components/Work/Tabs/Structure.jsx
+++ b/assets/js/components/Work/Tabs/Structure.jsx
@@ -44,13 +44,13 @@ const WorkTabsStructure = ({ work }) => {
                         <strong>{accessionNumber}</strong>
                       </div>
                       <div className="field">
-                        <div class="field is-horizontal">
-                          <div class="field-label is-normal">
-                            <label class="label">Label</label>
+                        <div className="field is-horizontal">
+                          <div className="field-label is-normal">
+                            <label className="label">Label</label>
                           </div>
-                          <div class="field-body">
-                            <div class="field">
-                              <p class="control">
+                          <div className="field-body">
+                            <div className="field">
+                              <p className="control">
                                 <input
                                   ref={register({ required: true })}
                                   name={`label-${id}`}
@@ -74,13 +74,13 @@ const WorkTabsStructure = ({ work }) => {
                       </div>
 
                       <div className="field">
-                        <div class="field is-horizontal">
-                          <div class="field-label is-normal">
-                            <label class="label">Description</label>
+                        <div className="field is-horizontal">
+                          <div className="field-label is-normal">
+                            <label className="label">Description</label>
                           </div>
-                          <div class="field-body">
-                            <div class="field">
-                              <p class="control">
+                          <div className="field-body">
+                            <div className="field">
+                              <p className="control">
                                 <textarea
                                   ref={register({ required: true })}
                                   name={`metadataDescription-${id}`}


### PR DESCRIPTION
- Removed non-functional links from FileSets on work cards. 
- Also replaced `class` with `className` on Structure tab to get rid of warning.

<img width="593" alt="Screen Shot 2020-03-05 at 8 18 18 AM" src="https://user-images.githubusercontent.com/6372022/75994246-486c2480-5ec0-11ea-8f0f-6459223f8506.png">


<img width="1266" alt="Screen Shot 2020-03-05 at 9 06 28 AM" src="https://user-images.githubusercontent.com/6372022/75994461-a13bbd00-5ec0-11ea-827b-adebb904ecee.png">

