### PR TITLE
Remove hard coded dev  iiif server url

### DIFF
--- a/assets/js/components/Search/ResultItem.jsx
+++ b/assets/js/components/Search/ResultItem.jsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { useContext } from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
-import { buildImageURL } from "../../services/helpers";
+import { IIIFContext } from "../IIIF/IIIFProvider";
 
 const setVisibilityClass = visibility => {
   if (visibility.toUpperCase() === "RESTRICTED") {
@@ -14,11 +14,14 @@ const setVisibilityClass = visibility => {
 };
 
 const SearchResultItem = ({ res }) => {
+  const iiifServerUrl = useContext(IIIFContext);
+
   const {
     _id,
     accession_number,
     file_sets = [],
     model,
+    representative_file_set_id,
     published,
     title,
     visibility
@@ -32,7 +35,7 @@ const SearchResultItem = ({ res }) => {
           {file_sets.length > 0 && (
             <Link to={`/work/${_id}`}>
               <img
-                src={`${buildImageURL(file_sets[0].id, "IIIF_SQUARE")}`}
+                src={`${iiifServerUrl}${representative_file_set_id}/square/500,500/0/default.jpg`}
                 alt="Placeholder image"
               />
             </Link>
@@ -45,15 +48,14 @@ const SearchResultItem = ({ res }) => {
         </h3>
         <p className="subtitle is-size-6">Accession Number</p>
         <h4 className="subtitle">
-          Filesets{" "}
-          <span className="tag is-link is-light">{file_sets.length}</span>
+          Filesets <span className="tag is-light">{file_sets.length}</span>
         </h4>
-        <div className="list is-hoverable">
+        <div className="list is-hoverable has-background-light">
           {file_sets.map((fileSet, i) =>
             i < fileSetsToDisplay - 1 ? (
-              <a key={fileSet.id} className="list-item">
+              <p key={fileSet.id} className="list-item">
                 {fileSet.label}
-              </a>
+              </p>
             ) : null
           )}
         </div>

--- a/assets/js/screens/Work/List.jsx
+++ b/assets/js/screens/Work/List.jsx
@@ -3,47 +3,50 @@ import Layout from "../Layout";
 import Loading from "../../components/UI/Loading";
 import SearchResultItem from "../../components/Search/ResultItem";
 import { ReactiveList } from "@appbaseio/reactivesearch";
+import { IIIFProvider } from "../../components/IIIF/IIIFProvider";
 
 const ScreensWorkList = () => {
   return (
     <Layout>
       <section className="section">
         <div className="container">
-          <ReactiveList
-            componentId="SearchResult"
-            dataField="accession_number"
-            defaultQuery={() => ({
-              query: {
-                bool: {
-                  must: [
-                    {
-                      match: {
-                        "model.name": "Image"
+          <IIIFProvider>
+            <ReactiveList
+              componentId="SearchResult"
+              dataField="accession_number"
+              defaultQuery={() => ({
+                query: {
+                  bool: {
+                    must: [
+                      {
+                        match: {
+                          "model.name": "Image"
+                        }
                       }
-                    }
-                  ]
+                    ]
+                  }
                 }
-              }
-            })}
-            innerClass={{
-              list: "columns is-multiline",
-              resultStats: "is-size-6 has-text-grey"
-            }}
-            react={{
-              and: ["SearchSensor"]
-            }}
-            renderItem={res => {
-              return (
-                <div
-                  key={res._id}
-                  className="column is-half-tablet is-one-third-desktop is-one-quarter-widescreen"
-                >
-                  <SearchResultItem res={res} />
-                </div>
-              );
-            }}
-            showResultStats={true}
-          />
+              })}
+              innerClass={{
+                list: "columns is-multiline",
+                resultStats: "is-size-6 has-text-grey"
+              }}
+              react={{
+                and: ["SearchSensor"]
+              }}
+              renderItem={res => {
+                return (
+                  <div
+                    key={res._id}
+                    className="column is-half-tablet is-one-third-desktop is-one-quarter-widescreen"
+                  >
+                    <SearchResultItem res={res} />
+                  </div>
+                );
+              }}
+              showResultStats={true}
+            />
+          </IIIFProvider>
         </div>
       </section>
     </Layout>

--- a/assets/js/services/helpers.js
+++ b/assets/js/services/helpers.js
@@ -1,19 +1,5 @@
 import moment from "moment";
 import { toast } from "bulma-toast";
-import { IIIF_SIZES } from "./global-vars";
-
-/**
- * Builds IIIF url for placeholder images
- * @param {string} id This ID is a filesetId
- * @param {object} imageSize This is an image size type
- * @return {string} This returns a URL for the image
- */
-export function buildImageURL(id, imageSize) {
-  const srcPath = id
-    ? `http://localhost:8183/iiif/2/${id}`
-    : "/images/1280x960.png";
-  return srcPath + (id ? `${IIIF_SIZES[imageSize]}` : "");
-}
 
 /**
  * Escape double quotes (which may interfere with Search queries)

--- a/assets/js/services/helpers.test.js
+++ b/assets/js/services/helpers.test.js
@@ -5,20 +5,6 @@ import {
   getClassFromIngestSheetStatus
 } from "./helpers";
 
-describe("Build Image URL function", () => {
-  it("should return a URL containing correct IIIF params", () => {
-    const expected =
-      "http://localhost:8183/iiif/2/ABC123/square/500,500/0/default.jpg";
-    const actual = buildImageURL("ABC123", "IIIF_SQUARE");
-    expect(expected).toEqual(actual);
-  });
-  it("should return default URL for placeholder Image", () => {
-    const expected = "/images/1280x960.png";
-    const actual = buildImageURL("", "IIIF_SQUARE");
-    expect(expected).toEqual(actual);
-  });
-});
-
 it("should escape double quotes", () => {
   const expected = 'This is a %5C"doubleQuoted%5C" expression';
   const actual = escapeDoubleQuotes(`This is a "doubleQuoted" expression`);

--- a/lib/meadow/data/schemas/work.ex
+++ b/lib/meadow/data/schemas/work.ex
@@ -101,7 +101,8 @@ defmodule Meadow.Data.Schemas.Work do
           end),
         create_date: work.inserted_at,
         iiif_manifest: IIIF.manifest_id(work.id),
-        modified_date: work.updated_at
+        modified_date: work.updated_at,
+        representative_file_set_id: work.representative_file_set_id
       }
       |> Map.merge(work.extra_index_fields)
     end


### PR DESCRIPTION
- Added `representative_file_set_id` to work index doc

- Wrapped the result list in `IIIFProvider` so we can access the `iiifServerUrl` and pulled the `representative_file_set_id` from the Elasticsearch doc.

- Works now. **You'll need to `down -v`**  






<img width="1254" alt="Screen Shot 2020-03-05 at 10 43 25 AM" src="https://user-images.githubusercontent.com/6372022/76004449-1dd59800-5ecf-11ea-86ac-a61fb51532a8.png">

