### PR TITLE
Wire up setWorkImage UI in Work Structure tab

### DIFF
--- a/assets/js/components/Work/Tabs/Structure.jsx
+++ b/assets/js/components/Work/Tabs/Structure.jsx
@@ -1,18 +1,43 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import PropTypes from "prop-types";
 import { IIIFContext } from "../../IIIF/IIIFProvider";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import useIsEditing from "../../../hooks/useIsEditing";
 import { useForm } from "react-hook-form";
+import { useMutation } from "@apollo/react-hooks";
+import { SET_WORK_IMAGE } from "../work.query";
+import { toastWrapper } from "../../../services/helpers";
+
+const parseWorkRepresentativeImage = work => {
+  if (!work.representativeImage) return;
+  const arr = work.representativeImage.split("/");
+  return arr[arr.length - 1];
+};
 
 const WorkTabsStructure = ({ work }) => {
   const [isEditing, setIsEditing] = useIsEditing();
+  const [workImageFilesetId, setWorkImageFilesetId] = useState(
+    parseWorkRepresentativeImage(work)
+  );
   const { register, handleSubmit, errors } = useForm();
   const iiifServerUrl = useContext(IIIFContext);
+
+  const [setWorkImage] = useMutation(SET_WORK_IMAGE, {
+    onCompleted({ setWorkImage }) {
+      toastWrapper("is-success", "Work image has been updated");
+    }
+  });
 
   if (!work) {
     return null;
   }
+
+  const handleWorkImageChange = id => {
+    if (id === workImageFilesetId) return;
+
+    setWorkImageFilesetId(id === workImageFilesetId ? null : id);
+    setWorkImage({ variables: { fileSetId: id, workId: work.id } });
+  };
 
   const onSubmit = data => {
     // TODO : add logic to update filesets for given work.
@@ -26,107 +51,112 @@ const WorkTabsStructure = ({ work }) => {
           {work.fileSets.map(({ id, accessionNumber, metadata }) => (
             <article key={id} className="media">
               <figure className="media-left">
-                <p className="image is-64x64">
+                <p className="image is-128x128">
                   <img
                     src={`${iiifServerUrl}${id}/square/500,500/0/default.jpg`}
                     placeholder="Fileset Image"
-                    onError={e => {
-                      e.target.src = "/images/1280x960.png";
-                    }}
                   />
                 </p>
               </figure>
               <div className="media-content">
                 <div className="content">
-                  {isEditing ? (
-                    <>
-                      <div className="field">
-                        <strong>{accessionNumber}</strong>
-                      </div>
-                      <div className="field">
-                        <div className="field is-horizontal">
-                          <div className="field-label is-normal">
-                            <label className="label">Label</label>
-                          </div>
-                          <div className="field-body">
-                            <div className="field">
-                              <p className="control">
-                                <input
-                                  ref={register({ required: true })}
-                                  name={`label-${id}`}
-                                  data-testid="input-label"
-                                  className={`input ${
-                                    errors[`label-${id}`] ? "is-danger" : ""
-                                  }`}
-                                  type="text"
-                                  placeholder="Label"
-                                  defaultValue={metadata.label}
-                                />
-                              </p>
-                              {errors[`label-${id}`] && (
-                                <p className="help is-danger">
-                                  Label is required
-                                </p>
-                              )}
-                            </div>
-                          </div>
-                        </div>
-                      </div>
+                  <p>
+                    <span className="tag is-medium">
+                      Accession Number: {accessionNumber}
+                    </span>
+                  </p>
 
-                      <div className="field">
-                        <div className="field is-horizontal">
-                          <div className="field-label is-normal">
-                            <label className="label">Description</label>
-                          </div>
-                          <div className="field-body">
-                            <div className="field">
-                              <p className="control">
-                                <textarea
-                                  ref={register({ required: true })}
-                                  name={`metadataDescription-${id}`}
-                                  data-testid="textarea-metadata-description"
-                                  className={`input ${
-                                    errors[`metadataDescription-${id}`]
-                                      ? "is-danger"
-                                      : ""
-                                  }`}
-                                  defaultValue={metadata.description}
-                                  type="text"
-                                ></textarea>
-                              </p>
-                              {errors[`metadataDescription-${id}`] && (
-                                <p className="help is-danger">
-                                  Metadata Description is required
-                                </p>
-                              )}
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    </>
-                  ) : (
-                    <p>
-                      <strong>{accessionNumber}</strong>
-                      <br />
-                      {metadata.label}
-                      <br />
-                      {metadata.description}
-                    </p>
-                  )}
+                  <div className="field">
+                    <label className="label">Label</label>
+                    <div className="control">
+                      {isEditing ? (
+                        <input
+                          ref={register({ required: true })}
+                          name={`label-${id}`}
+                          data-testid="input-label"
+                          className={`input ${
+                            errors[`label-${id}`] ? "is-danger" : ""
+                          }`}
+                          type="text"
+                          placeholder="Label"
+                          defaultValue={metadata.label}
+                        />
+                      ) : (
+                        <p>{metadata.label}</p>
+                      )}
+                    </div>
+                    {errors[`label-${id}`] && (
+                      <p className="help is-danger">Label is required</p>
+                    )}
+                  </div>
+
+                  <div className="field">
+                    <label className="label">Description</label>
+                    <div className="control">
+                      {isEditing ? (
+                        <textarea
+                          ref={register({ required: true })}
+                          name={`metadataDescription-${id}`}
+                          data-testid="textarea-metadata-description"
+                          className={`input ${
+                            errors[`metadataDescription-${id}`]
+                              ? "is-danger"
+                              : ""
+                          }`}
+                          defaultValue={metadata.description}
+                          type="text"
+                        ></textarea>
+                      ) : (
+                        <p>{metadata.description}</p>
+                      )}
+                    </div>
+                    {errors[`metadataDescription-${id}`] && (
+                      <p className="help is-danger">
+                        Metadata Description is required
+                      </p>
+                    )}
+                  </div>
                 </div>
               </div>
-              {isEditing ? (
-                ""
-              ) : (
-                <div className="media-right">
-                  <button className="button">
-                    <FontAwesomeIcon icon="file-download" /> .tiff
-                  </button>
-                  <button className="button">
-                    <FontAwesomeIcon icon="file-download" /> .jpg
-                  </button>
-                </div>
-              )}
+              <div className="media-right has-text-right">
+                {isEditing ? (
+                  ""
+                ) : (
+                  <>
+                    <div className="field">
+                      <input
+                        id={`checkbox-work-switch-${id}`}
+                        type="checkbox"
+                        name={`checkbox-work-switch-${id}`}
+                        className="switch"
+                        checked={workImageFilesetId === id}
+                        onChange={e => handleWorkImageChange(id)}
+                      />
+                      <label htmlFor={`checkbox-work-switch-${id}`}>
+                        Work image
+                      </label>
+                    </div>
+                    <div className="field has-addons">
+                      <p className="control">
+                        <button className="button">
+                          <span className="icon">
+                            <FontAwesomeIcon icon="file-download" />
+                          </span>{" "}
+                          <span>TIFF</span>
+                        </button>
+                      </p>
+                      <p className="control">
+                        <button className="button">
+                          <span className="icon">
+                            <FontAwesomeIcon icon="file-download" />
+                          </span>{" "}
+                          <span>JPG</span>
+                        </button>
+                      </p>
+                    </div>
+                  </>
+                )}
+              </div>
             </article>
           ))}
 
@@ -175,7 +205,7 @@ const WorkTabsStructure = ({ work }) => {
                 </button>
                 <button
                   type="button"
-                  className="button"
+                  className="button is-text"
                   onClick={() => setIsEditing(false)}
                 >
                   Cancel

--- a/assets/js/components/Work/work.query.js
+++ b/assets/js/components/Work/work.query.js
@@ -88,6 +88,15 @@ export const GET_WORKS = gql`
   }
 `;
 
+export const SET_WORK_IMAGE = gql`
+  mutation SetWorkImage($fileSetId: ID!, $workId: ID!) {
+    setWorkImage(fileSetId: $fileSetId, workId: $workId) {
+      id
+      representativeImage
+    }
+  }
+`;
+
 export const UPDATE_WORK = gql`
   mutation UpdateWork($id: ID!, $work: WorkUpdateInput!) {
     updateWork(id: $id, work: $work) {

--- a/assets/package.json
+++ b/assets/package.json
@@ -26,6 +26,7 @@
     "bulma": "^0.8.0",
     "bulma-checkradio": "^1.1.1",
     "bulma-pageloader": "^0.3.0",
+    "bulma-switch": "^2.0.0",
     "bulma-toast": "^1.5.4",
     "elasticsearch": "^16.6.0",
     "graphql": "^14.6.0",

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -8,6 +8,9 @@
 @import "./scss/variables";
 
 @import "~bulma/bulma";
+@import "~bulma-switch/dist/css/bulma-switch";
+@import "~bulma-checkradio/dist/css/bulma-checkradio";
+@import "~bulma-pageloader/dist/css/bulma-pageloader";
 
 @import "./scss/mixins";
 @import "./scss/base";

--- a/assets/styles/scss/_variables.scss
+++ b/assets/styles/scss/_variables.scss
@@ -62,4 +62,4 @@ $dark: $rich-black-80;
 $breadcrumb-item-separator-color: $rich-black-50;
 $family-primary: $AkkuratProRegular;
 $family-secondary: $CamptonBook;
-$navbar-height: 5rem;
+$navbar-height: 4rem;

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -2446,6 +2446,11 @@ bulma-pageloader@^0.3.0:
   resolved "https://registry.yarnpkg.com/bulma-pageloader/-/bulma-pageloader-0.3.0.tgz#94a4ff7d9129cbe01dbc5cae4e64508e13563cf1"
   integrity sha512-lbahiqhBCov5AYdziHFnC5/JOhCrJWFTpdRiAkwW49IM/mf0whCWHVe8MuejZFu2PEs1mtH8Gnz8exEks4Q+7g==
 
+bulma-switch@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bulma-switch/-/bulma-switch-2.0.0.tgz#7a187cd1bb8073e9a542478d936b89315f1ffcd8"
+  integrity sha512-myD38zeUfjmdduq+pXabhJEe3x2hQP48l/OI+Y0fO3HdDynZUY/VJygucvEAJKRjr4HxD5DnEm4yx+oDOBXpAA==
+
 bulma-toast@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/bulma-toast/-/bulma-toast-1.5.4.tgz#ee72a1f49a1da07c49c0507ffa4ade6c1d3026f8"


### PR DESCRIPTION
Partial PR for https://github.com/nulib/repodev_planning_and_docs/issues/556

This feature happens asynchronously, outside of "Edit" mode.   It disallows the ability to have no representative image after one has been used also... assuming we want that @davidschober ?  

![image](https://user-images.githubusercontent.com/3020266/76006871-c33e3b00-5ed2-11ea-980e-339269006904.png)
