### PR TITLE
Add ADR and mix task to help with semantic versioning and tagging

### DIFF
--- a/doc/architecture/decisions/0024-version-management.md
+++ b/doc/architecture/decisions/0024-version-management.md
@@ -1,0 +1,28 @@
+# 24. Version Management
+
+Date: 2020-03-05
+
+## Status
+
+Accepted
+
+## Context
+
+Meadow has been on version 0.1.0 since it was created. We need an easy way to update the
+version in `mix.exs` and update git tags as necessary.
+
+## Decision
+
+- Add a Mix task, `mix meadow.version X.Y.Z`, that will:
+  - Update the version string in `mix.exs` to the given X.Y.Z`
+  - Commit `mix.exs`
+  - Create a new git tag `vX.Y.Z`
+- _After_ a merge to staging that merits a version change, one developer should:
+  - Check out and pull `deploy/staging`
+  - Run `mix meadow.version NEW_VERSION`
+  - Push changes and tags with `git push --tags deploy/staging`
+
+## Consequences
+
+- Updating the Meadow version is easy
+- Tags stay in sync

--- a/lib/mix/tasks/version.ex
+++ b/lib/mix/tasks/version.ex
@@ -1,0 +1,64 @@
+defmodule Mix.Tasks.Meadow.Version do
+  @moduledoc """
+  Update mix.exs with the given semantic version string
+  """
+  use Mix.Task
+  require Logger
+
+  @shortdoc @moduledoc
+  def run([]) do
+    IO.puts("Usage: mix meadow.version MAJOR.MINOR.PATCH")
+  end
+
+  def run([version]) do
+    if working_copy_dirty?(), do: raise("Cannot update version; working copy is not clean")
+
+    version
+    |> update_mix!()
+    |> commit_mix!()
+    |> tag!()
+
+    Logger.info("Version updated to v#{version}")
+  rescue
+    err in RuntimeError -> Logger.error("Error: #{err.message}")
+  end
+
+  defp working_copy_dirty?() do
+    with {result, _} <- System.cmd("git", ["status", "--porcelain"]) do
+      result
+      |> String.split(~r/\n/)
+      |> Enum.any?(&String.match?(&1, ~r/^ [MADRCU]/))
+    end
+  end
+
+  defp update_mix!(version) do
+    with mix_exs <-
+           File.read!("mix.exs")
+           |> String.replace(~r/@app_version "\d+.\d+.\d+.*"/, "@app_version #{version}") do
+      File.write!("mix.exs", mix_exs)
+      version
+    end
+  end
+
+  defp commit_mix!(version) do
+    git(["add", "mix.exs"])
+    git(["commit", "-m", "Update version to #{version}"])
+    version
+  end
+
+  defp tag!(version) do
+    git(["tag", "v#{version}"])
+  end
+
+  defp git(args) do
+    case System.cmd("git", args, stderr_to_stdout: true) do
+      {_, 0} ->
+        :noop
+
+      {error, status} ->
+        raise(
+          "`git #{Enum.join(args, " ")}` failed with error #{error} and exit status #{status}"
+        )
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,10 +1,12 @@
 defmodule Meadow.MixProject do
   use Mix.Project
 
+  @app_version "0.1.0"
+
   def project do
     [
       app: :meadow,
-      version: "0.1.0",
+      version: @app_version,
       elixir: "~> 1.9",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix, :gettext] ++ Mix.compilers(),


### PR DESCRIPTION
In light of how far Meadow has come while still retaining the same hard-coded version number, @bmquinn and I were discussing when and how to update it. This draft PR includes a proposed ADR and mix task to deal with it in a relatively simple fashion, which will also help when it's time to implement https://github.com/nulib/repodev_planning_and_docs/issues/575