### PR TITLE
Include port in elasticsearch proxy endpoint.

### DIFF
--- a/assets/js/services/elasticsearch.js
+++ b/assets/js/services/elasticsearch.js
@@ -1,6 +1,7 @@
 const protocol = location.protocol;
 const slashes = protocol.concat("//");
 const host = slashes.concat(window.location.hostname);
+const port = window.location.port;
 
-export const ELASTICSEARCH_PROXY_ENDPOINT = `${host}/elasticsearch`;
+export const ELASTICSEARCH_PROXY_ENDPOINT = `${host}:${port}/elasticsearch`;
 export const ELASTICSEARCH_INDEX_NAME = "meadow";


### PR DESCRIPTION
Fixes nulib/repodev_planning_and_docs/issues/706 by including the Meadow port in the Elasticsearch Proxy endpoint.