### PR TITLE
Add Meadow.Data.IndexTimes and Meadow.Data.Indexer.reindex_all!/0

### DIFF
--- a/lib/meadow/data/index_times.ex
+++ b/lib/meadow/data/index_times.ex
@@ -1,0 +1,14 @@
+defmodule Meadow.Data.IndexTimes do
+  @moduledoc """
+  The IndexTimes context.
+  """
+
+  alias Meadow.Data.Schemas.IndexTime
+  alias Meadow.Repo
+
+  require Logger
+
+  def reset_all! do
+    Repo.delete_all(IndexTime)
+  end
+end

--- a/lib/meadow/data/indexer.ex
+++ b/lib/meadow/data/indexer.ex
@@ -2,6 +2,7 @@ defmodule Meadow.Data.Indexer do
   @moduledoc """
   Indexes individual structs into Elasticsearch, preloading if necessary.
   """
+  alias Meadow.Data.IndexTimes
   alias Meadow.Data.Schemas.{Collection, FileSet, IndexTime, Work}
   alias Meadow.ElasticsearchCluster, as: Cluster
   alias Meadow.ElasticsearchDiffStore, as: Store
@@ -16,6 +17,11 @@ defmodule Meadow.Data.Indexer do
     |> Enum.each(&synchronize_schema/1)
 
     Elasticsearch.Index.refresh(Cluster, to_string(@index))
+  end
+
+  def reindex_all! do
+    IndexTimes.reset_all!()
+    synchronize_index()
   end
 
   def synchronize_schema(schema) do

--- a/test/meadow/data/index_times_test.exs
+++ b/test/meadow/data/index_times_test.exs
@@ -1,0 +1,25 @@
+defmodule Meadow.Data.IndexTimesTest do
+  use Meadow.DataCase
+
+  alias Meadow.Data.IndexTimes
+  alias Meadow.Data.Schemas.IndexTime
+
+  @valid_attrs %{
+    id: Ecto.UUID.generate(),
+    indexed_at: DateTime.utc_now()
+  }
+
+  setup do
+    {:ok, index_time} =
+      %IndexTime{}
+      |> IndexTime.changeset(@valid_attrs)
+      |> Repo.insert()
+
+    {:ok, index_time: index_time}
+  end
+
+  test "reset_all!/0" do
+    IndexTimes.reset_all!()
+    assert Repo.aggregate(IndexTime, :count) == 0
+  end
+end

--- a/test/meadow/data/indexer_test.exs
+++ b/test/meadow/data/indexer_test.exs
@@ -18,6 +18,13 @@ defmodule Meadow.Data.IndexerTest do
       assert indexed_doc_count() == count
     end
 
+    test "reindex_all!/0", %{count: count} do
+      Indexer.synchronize_index()
+      assert indexed_doc_count() == count
+      Indexer.reindex_all!()
+      assert indexed_doc_count() == count
+    end
+
     test "deleted", %{count: count, works: [work | _]} do
       assert indexed_doc_count() == 0
       Indexer.synchronize_index()


### PR DESCRIPTION
- Adds `Meadow.Data.IndexTimes` including one function: `reset_all!/0`
- Adds `Meadow.Data.Indexer.reindex_all!/0`
- Includes tests and 100% code coverage