### PR TITLE
Make works' representative images show up in collection query

### DIFF
--- a/lib/meadow/data/works.ex
+++ b/lib/meadow/data/works.ex
@@ -203,6 +203,26 @@ defmodule Meadow.Data.Works do
   end
 
   @doc """
+  Fetches all works for a given collection ID.
+
+  Returns [] if the query returns no matches
+
+  ## Examples
+
+      iex> get_works_by_collection("db36d92c-dc17-417b-b662-f8c9e112de31")
+      [%Work{},...]
+
+      iex> get_work!("db36d92c-dc17-417b-b662-f8c9e112de32")
+      []
+
+  """
+  def get_works_by_collection(collection_id) do
+    from(w in Work, where: w.collection_id == ^collection_id)
+    |> Repo.all()
+    |> add_representative_image()
+  end
+
+  @doc """
   Fetches all works that include a Metadata title.
 
   Returns [] if the query returns no matches

--- a/lib/meadow_web/resolvers/collections.ex
+++ b/lib/meadow_web/resolvers/collections.ex
@@ -14,6 +14,10 @@ defmodule MeadowWeb.Resolvers.Data.Collections do
     {:ok, Collections.get_collection!(id)}
   end
 
+  def collection_works(collection, _, _) do
+    {:ok, Works.get_works_by_collection(collection.id)}
+  end
+
   def create_collection(_, args, _) do
     case Collections.create_collection(args) do
       {:error, changeset} ->

--- a/lib/meadow_web/schema/types/data/collection_types.ex
+++ b/lib/meadow_web/schema/types/data/collection_types.ex
@@ -4,10 +4,8 @@ defmodule MeadowWeb.Schema.Data.CollectionTypes do
 
   """
   use Absinthe.Schema.Notation
-  alias Meadow.Data
   alias MeadowWeb.Resolvers
   alias MeadowWeb.Schema.Middleware
-  import Absinthe.Resolution.Helpers, only: [dataloader: 1]
 
   object :collection_queries do
     @desc "Get a list of collections"
@@ -98,7 +96,7 @@ defmodule MeadowWeb.Schema.Data.CollectionTypes do
     field :admin_email, :string
     field :finding_aid_url, :string
     field :published, :boolean
-    field :works, list_of(:work), resolve: dataloader(Data)
+    field :works, list_of(:work), resolve: &Resolvers.Data.Collections.collection_works/3
     field :representative_image, :string
   end
 end

--- a/test/gql/SetCollectionImage.gql
+++ b/test/gql/SetCollectionImage.gql
@@ -3,5 +3,8 @@
 mutation($collection_id: ID!, $work_id: ID!) {
   setCollectionImage(collection_id: $collection_id, work_id: $work_id) {
     ...CollectionFields
+    works {
+      representativeImage
+    }
   }
 }

--- a/test/meadow_web/schema/mutation/set_collection_image_test.exs
+++ b/test/meadow_web/schema/mutation/set_collection_image_test.exs
@@ -33,6 +33,11 @@ defmodule MeadowWeb.Schema.Mutation.SetCollectionImageTest do
     assert collection.representative_image == expected_work.representative_image
 
     url = get_in(query_data, [:data, "setCollectionImage", "representativeImage"])
+
+    assert get_in(query_data, [:data, "setCollectionImage", "works"])
+           |> Enum.at(1)
+           |> Map.get("representativeImage") == expected_work.representative_image
+
     assert url == expected_work.representative_image
   end
 end


### PR DESCRIPTION
Using Absinthe's default DataLoader to load works into collections bypasses populating the virtual fields. This PR adds a custom resolver that takes care of populating that field without adding any additional database overhead.