### PR TITLE
Fix DB deadlocks on Elixir 1.10.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     working_directory: ~/meadow
     docker:
-      - image: circleci/elixir:1.9-node
+      - image: circleci/elixir:1.10-node
         environment:
           DATABASE_URL: ecto://root@localhost/circle_test
           DB_PORT: "5432"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Install elixir & npm dependencies
-FROM nulib/elixir-phoenix-base AS deps
+FROM nulib/elixir-phoenix-base:1.10 AS deps
 LABEL edu.northwestern.library.app=meadow \
   edu.northwestern.library.cache=true \
   edu.northwestern.library.stage=deps
@@ -18,7 +18,7 @@ WORKDIR /app/priv/tiff
 RUN yarn install
 
 # Create elixir release
-FROM nulib/elixir-phoenix-base AS release
+FROM nulib/elixir-phoenix-base:1.10 AS release
 ENV MIX_ENV=prod
 COPY . /app
 COPY --from=deps /app/_build /app/_build

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,7 +7,8 @@ config :meadow, Meadow.Repo,
   database: "meadow_test",
   hostname: "localhost",
   port: System.get_env("DB_PORT", "5434"),
-  pool: Ecto.Adapters.SQL.Sandbox
+  pool: Ecto.Adapters.SQL.Sandbox,
+  queue_target: 5000
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.

--- a/test/meadow_web/schema/query/ingest_errors_test.exs
+++ b/test/meadow_web/schema/query/ingest_errors_test.exs
@@ -7,7 +7,12 @@ defmodule MeadowWeb.Schema.Query.IngestErrorsTest do
 
   describe "ingest with errors" do
     test "duplicate FileSet accession number", %{ingest_sheet: sheet} do
-      file_set_fixture(%{accession_number: "Donohue_001_02"})
+      accession_number =
+        Meadow.Ingest.Rows.list_ingest_sheet_rows(sheet: sheet)
+        |> Enum.at(1)
+        |> Map.get(:file_set_accession_number)
+
+      file_set_fixture(%{accession_number: accession_number})
       sheet = create_works(sheet)
 
       {:ok, result} = query_gql(variables: %{"sheetId" => sheet.id}, context: gql_context())
@@ -29,7 +34,14 @@ defmodule MeadowWeb.Schema.Query.IngestErrorsTest do
     end
 
     test "duplicate Work accession number", %{ingest_sheet: sheet} do
-      work_fixture(%{accession_number: "Donohue_002"})
+      accession_number =
+        Meadow.Ingest.Rows.list_ingest_sheet_rows(sheet: sheet)
+        |> Enum.at(4)
+        |> Map.get(:fields)
+        |> Enum.find(fn %{header: header} -> header == "work_accession_number" end)
+        |> Map.get(:value)
+
+      work_fixture(%{accession_number: accession_number})
       sheet = create_works(sheet)
 
       {:ok, result} = query_gql(variables: %{"sheetId" => sheet.id}, context: gql_context())


### PR DESCRIPTION
Concurrent tests involving unique fields need to use unique data to prevent deadlocks. I don't know why the deadlocks didn't crop up under 1.9.4, but it likely has to do with a change in how concurrent tests were being run. The only place in the test suite that hit the deadlock issue was the ingest sheet validation, so I changed the fixture loader to alter the work and file set accession numbers when the fixture sheet is loaded.