### PR TITLE
Fix flappy SetCollectionImage test

### DIFF
--- a/test/gql/SetCollectionImage.gql
+++ b/test/gql/SetCollectionImage.gql
@@ -4,6 +4,7 @@ mutation($collection_id: ID!, $work_id: ID!) {
   setCollectionImage(collection_id: $collection_id, work_id: $work_id) {
     ...CollectionFields
     works {
+      id
       representativeImage
     }
   }

--- a/test/meadow_web/schema/mutation/set_collection_image_test.exs
+++ b/test/meadow_web/schema/mutation/set_collection_image_test.exs
@@ -35,7 +35,7 @@ defmodule MeadowWeb.Schema.Mutation.SetCollectionImageTest do
     url = get_in(query_data, [:data, "setCollectionImage", "representativeImage"])
 
     assert get_in(query_data, [:data, "setCollectionImage", "works"])
-           |> Enum.at(1)
+           |> Enum.find(fn work -> Map.get(work, "id") == expected_work.id end)
            |> Map.get("representativeImage") == expected_work.representative_image
 
     assert url == expected_work.representative_image


### PR DESCRIPTION
Works are unordered within collections. Make sure the test compares the right one.