### PR TITLE
Add remaining uncontrolled fields to WorkDescriptiveMetadata

### DIFF
--- a/lib/meadow/data/schemas/work.ex
+++ b/lib/meadow/data/schemas/work.ex
@@ -80,9 +80,7 @@ defmodule Meadow.Data.Schemas.Work do
     def encode(work) do
       %{
         model: %{application: "Meadow", name: String.capitalize(work.work_type)},
-        title: work.descriptive_metadata.title,
         accession_number: work.accession_number,
-        description: work.descriptive_metadata.description,
         visibility: work.visibility,
         published: work.published,
         collection:
@@ -104,7 +102,18 @@ defmodule Meadow.Data.Schemas.Work do
         modified_date: work.updated_at,
         representative_file_set_id: work.representative_file_set_id
       }
+      |> Map.merge(work |> descriptive_metadata_fields())
       |> Map.merge(work.extra_index_fields)
+    end
+
+    defp descriptive_metadata_fields(work) do
+      with md <- work.descriptive_metadata do
+        WorkDescriptiveMetadata.field_names()
+        |> Enum.map(fn field_name ->
+          {field_name, md |> Map.get(field_name)}
+        end)
+        |> Enum.into(%{})
+      end
     end
   end
 end

--- a/lib/meadow/data/schemas/work_descriptive_metadata.ex
+++ b/lib/meadow/data/schemas/work_descriptive_metadata.ex
@@ -6,23 +6,53 @@ defmodule Meadow.Data.Schemas.WorkDescriptiveMetadata do
   import Ecto.Changeset
   use Ecto.Schema
 
+  # {field_name, repeating}
+  @fields [
+    {:abstract, true},
+    {:alternate_title, true},
+    {:ark, false},
+    {:box_name, true},
+    {:box_number, true},
+    {:call_number, true},
+    {:caption, true},
+    {:catalog_key, true},
+    {:citation, true},
+    {:description, true},
+    {:folder_name, true},
+    {:folder_number, true},
+    {:identifier, true},
+    {:keywords, true},
+    {:legacy_identifier, true},
+    {:notes, true},
+    {:physical_description_material, true},
+    {:physical_description_size, true},
+    {:provenance, true},
+    {:publisher, true},
+    {:related_material, true},
+    {:related_url, true},
+    {:rights_holder, true},
+    {:scope_and_contents, true},
+    {:series, true},
+    {:source, true},
+    {:table_of_contents, true},
+    {:title, false}
+  ]
+
   @timestamps_opts [type: :utc_datetime_usec]
   embedded_schema do
-    field :description, :string
-    field :keywords, {:array, :string}, default: []
-    field :nul_subject, {:array, :string}, default: []
-    field :title, :string
+    @fields
+    |> Enum.each(fn
+      {f, true} -> field f, {:array, :string}, default: []
+      {f, false} -> field f, :string
+    end)
 
     timestamps()
   end
 
   def changeset(metadata, params) do
     metadata
-    |> cast(params, [
-      :description,
-      :keywords,
-      :nul_subject,
-      :title
-    ])
+    |> cast(params, field_names())
   end
+
+  def field_names, do: @fields |> Enum.map(fn {f, _} -> f end)
 end

--- a/lib/meadow/utils/data_loader.ex
+++ b/lib/meadow/utils/data_loader.ex
@@ -31,9 +31,8 @@ defmodule Meadow.Utils.DataLoader do
         rights_statement: Faker.Lorem.sentence()
       },
       descriptive_metadata: %WorkDescriptiveMetadata{
-        description: Faker.Lorem.sentence(),
+        description: [Faker.Lorem.sentence()],
         keywords: Faker.Lorem.words(1..5),
-        nul_subject: Faker.Lorem.words(1..5),
         title: Faker.Lorem.sentence()
       },
       file_sets: insert_file_sets()

--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -117,27 +117,58 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     end
   end
 
+  @desc "`uncontrolled_descriptive_fields` represents all uncontrolled descriptive metadata fields."
+  object :uncontrolled_descriptive_fields do
+    field :abstract, list_of(:string)
+    field :alternate_title, list_of(:string)
+    field :box_name, list_of(:string)
+    field :box_number, list_of(:string)
+    field :call_number, list_of(:string)
+    field :caption, list_of(:string)
+    field :catalog_key, list_of(:string)
+    field :description, list_of(:string)
+    field :folder_name, list_of(:string)
+    field :folder_number, list_of(:string)
+    field :identifier, list_of(:string)
+    field :keywords, list_of(:string)
+    field :legacy_identifier, list_of(:string)
+    field :notes, list_of(:string)
+    field :physical_description_material, list_of(:string)
+    field :physical_description_size, list_of(:string)
+    field :provenance, list_of(:string)
+    field :publisher, list_of(:string)
+    field :related_url, list_of(:string)
+    field :related_material, list_of(:string)
+    field :rights_holder, list_of(:string)
+    field :scope_and_contents, list_of(:string)
+    field :series, list_of(:string)
+    field :source, list_of(:string)
+    field :table_of_contents, list_of(:string)
+    field :title, :string
+  end
+
   @desc "`work_descriptive_metadata` represents all descriptive metadata associated with a work object. It is stored in a single json field."
   object :work_descriptive_metadata do
     @desc "NOT YET IMPLEMENTED"
     field :contributor, list_of(:controlled_vocabulary)
     @desc "NOT YET IMPLEMENTED"
     field :creator, list_of(:controlled_vocabulary)
-    field :description, :string
     @desc "NOT YET IMPLEMENTED"
     field :genre, list_of(:controlled_vocabulary)
-    field :keywords, list_of(:string)
     @desc "NOT YET IMPLEMENTED"
     field :language, list_of(:controlled_vocabulary)
     @desc "NOT YET IMPLEMENTED"
     field :location, list_of(:controlled_vocabulary)
-    field :nul_subject, list_of(:string)
     @desc "NOT YET IMPLEMENTED"
     field :style_period, list_of(:controlled_vocabulary)
     @desc "NOT YET IMPLEMENTED"
     field :subject, list_of(:controlled_vocabulary)
+    @desc "NOT YET IMPLEMENTED"
     field :technique, list_of(:controlled_vocabulary)
-    field :title, :string
+
+    field :ark, :string
+    field :citation, list_of(:string)
+    import_fields(:uncontrolled_descriptive_fields)
   end
 
   @desc "`work_administrative_metadata` represents all administrative metadata associated with a work object. It is stored in a single json field."
@@ -170,7 +201,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     @desc "By visibility"
     field :visibility, :visibility
 
-    @desc "By work_type"
+    @desc "By work type"
     field :work_type, :work_type
   end
 
@@ -182,26 +213,24 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
 
   @desc "Same as `work_descriptive_metadata`. This represents all descriptive metadata associated with a work object. It is stored in a single json field."
   input_object :work_descriptive_metadata_input do
-    field :description, :string
     @desc "NOT YET IMPLEMENTED"
     field :contributor, list_of(:controlled_vocabulary_input)
     @desc "NOT YET IMPLEMENTED"
     field :creator, list_of(:controlled_vocabulary_input)
     @desc "NOT YET IMPLEMENTED"
     field :genre, list_of(:controlled_vocabulary_input)
-    field :keywords, list_of(:string)
     @desc "NOT YET IMPLEMENTED"
     field :language, list_of(:controlled_vocabulary_input)
     @desc "NOT YET IMPLEMENTED"
     field :location, list_of(:controlled_vocabulary_input)
-    field :nul_subject, list_of(:string)
     @desc "NOT YET IMPLEMENTED"
     field :subject, list_of(:controlled_vocabulary_input)
     @desc "NOT YET IMPLEMENTED"
     field :style_period, list_of(:controlled_vocabulary_input)
-    field :title, :string
     @desc "NOT YET IMPLEMENTED"
     field :technique, list_of(:controlled_vocabulary_input)
+
+    import_fields(:uncontrolled_descriptive_fields)
   end
 
   @desc "Fields that can be updated on a work object"


### PR DESCRIPTION
Updates `WorkDescriptiveMetadata` and the associated GraphQL types to match the field names / repeatability in the [metadata model](https://docs.google.com/spreadsheets/d/1PBvp9FJAvG6JIP6RZwmiZSDhgYLQ6VRSknUnkodEH8Q/edit#gid=396400352)