### PR TITLE
Use bitnami elasticsearch image to save memory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ jobs:
           POSTGRES_PASSWORD: d0ck3r
       - image: nulib/goaws
       - image: nulib/ldap-alpine
-      - image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
+      - image: bitnami/elasticsearch:6
         environment:
-          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+          ELASTICSEARCH_HEAP_SIZE: "256m"
       - image: minio/minio
         environment:
           MINIO_ACCESS_KEY: minio


### PR DESCRIPTION
I'm not 100% sure this will solve all of our CircleCI stalls and timeouts, because some of them (especially the most recent ones) seem related to the infrastructure itself. But this elasticsearch image consumes several hundred MB less RAM than the official one – ~520MB vs. ~980MB - so it's worth a shot.

It will require further testing before we switch devstack over to it (to make sure devstack's more fine-grained configuration customization works with the new image), but since it runs all of Meadow's tests just fine, there's no reason not to use it here.