### PR TITLE
Add form field array component to work with React Hook Form patterns

### DIFF
--- a/assets/js/components/UI/Form/Field.jsx
+++ b/assets/js/components/UI/Form/Field.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const UIFormFieldAndDisplay = ({ label, children }) => {
+const UIFormField = ({ label, children }) => {
   return (
     <div className="field">
       <label className="label">{label}</label>
@@ -10,9 +10,9 @@ const UIFormFieldAndDisplay = ({ label, children }) => {
   );
 };
 
-UIFormFieldAndDisplay.propTypes = {
+UIFormField.propTypes = {
   label: PropTypes.string,
   children: PropTypes.node,
 };
 
-export default UIFormFieldAndDisplay;
+export default UIFormField;

--- a/assets/js/components/UI/Form/FieldArray.jsx
+++ b/assets/js/components/UI/Form/FieldArray.jsx
@@ -1,0 +1,92 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useFieldArray } from "react-hook-form";
+
+const styles = {
+  inputWrapper: {
+    marginBottom: "1rem",
+  },
+  deleteButton: {
+    marginLeft: "5px",
+  },
+};
+
+const UIFormFieldArray = ({
+  name,
+  label,
+  type = "text",
+  errors,
+  register,
+  control,
+  required,
+  defaultValue = { value: `New ${label}` },
+  ...passedInProps
+}) => {
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name,
+  });
+
+  return (
+    <fieldset {...passedInProps}>
+      <legend data-testid="legend">{label}</legend>
+
+      <ul style={styles.inputWrapper}>
+        {fields.map((item, index) => {
+          return (
+            <li key={item.id} className="field">
+              <>
+                <div className="is-flex">
+                  <input
+                    name={`${[name]}[${index}].value`}
+                    className="input"
+                    defaultValue={`${item.value}`} // make sure to set up defaultValue
+                    ref={register({ required })}
+                    data-testid="input-field-array"
+                  />
+                  <button
+                    type="button"
+                    className="button"
+                    onClick={() => remove(index)}
+                    style={styles.deleteButton}
+                    data-testid="button-delete-field-array-row"
+                  >
+                    <FontAwesomeIcon icon="trash" />
+                  </button>
+                </div>
+                {errors[name] && errors[name][index] && (
+                  <p data-testid="input-errors" className="help is-danger">
+                    {label || name} field is required
+                  </p>
+                )}
+              </>
+            </li>
+          );
+        })}
+      </ul>
+
+      <button
+        type="button"
+        className="button is-text is-small"
+        onClick={() => {
+          append(defaultValue);
+        }}
+        data-testid="button-add-field-array-row"
+      >
+        <span className="icon">
+          <FontAwesomeIcon icon="plus" />
+        </span>
+        <span>Add another</span>
+      </button>
+    </fieldset>
+  );
+};
+
+UIFormFieldArray.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  control: PropTypes.object.isRequired,
+};
+
+export default UIFormFieldArray;

--- a/assets/js/components/UI/Form/FieldArray.test.js
+++ b/assets/js/components/UI/Form/FieldArray.test.js
@@ -1,0 +1,96 @@
+import React from "react";
+import { render, fireEvent, screen } from "@testing-library/react";
+import UIFormFieldArray from "./FieldArray";
+import { useForm } from "react-hook-form";
+
+const name = "imaMulti";
+const defaultValue = "New Ima Multi";
+const props = {
+  "data-testid": "fieldset-ima-multi",
+  name,
+  label: "Ima Multi",
+  errors: {},
+};
+
+const withReactHookFormControl = (WrappedComponent) => {
+  const HOC = () => {
+    const { control, register } = useForm({
+      defaultValues: {
+        imaMulti: [{ value: defaultValue }],
+      },
+    });
+    return (
+      <WrappedComponent {...props} control={control} register={register} />
+    );
+  };
+
+  return HOC;
+};
+
+describe("InputMultiple component", () => {
+  function setUpTests() {
+    const Wrapped = withReactHookFormControl(UIFormFieldArray);
+    return render(<Wrapped {...props} />);
+  }
+
+  it("renders without crashing", () => {
+    expect(setUpTests());
+  });
+
+  it("renders the wrapper fieldset element with the proper display label", () => {
+    const { getByTestId, getByLabelText } = setUpTests();
+    expect(getByTestId("fieldset-ima-multi"));
+    const legend = getByTestId("legend");
+    expect(legend.innerHTML).toEqual(props.label);
+  });
+
+  it("renders a field group with a form input, default value, and delete button", () => {
+    const { getByTestId, getAllByTestId } = setUpTests();
+    expect(getAllByTestId("input-field-array")).toHaveLength(1);
+    expect(getByTestId("button-delete-field-array-row"));
+  });
+
+  it("renders an Add field button, which when clicked adds a new field array input row", () => {
+    const { getByTestId, getAllByTestId } = setUpTests();
+    const addButton = getByTestId("button-add-field-array-row");
+    expect(addButton);
+
+    // Change the input value
+    const firstInput = getByTestId("input-field-array");
+    fireEvent.input(firstInput, { target: { value: "foobar " } });
+
+    // Add a new input row
+    fireEvent.click(addButton);
+    expect(getAllByTestId("input-field-array")).toHaveLength(2);
+    expect(screen.getByDisplayValue(defaultValue));
+  });
+
+  it("deletes the proper field array row successfully", () => {
+    const { getByTestId, getAllByTestId, queryByDisplayValue } = setUpTests();
+    const addButton = getByTestId("button-add-field-array-row");
+
+    // Add new input rows
+    fireEvent.click(addButton);
+    fireEvent.click(addButton);
+    fireEvent.click(addButton);
+
+    const inputs = getAllByTestId("input-field-array");
+
+    // Change the input values
+    fireEvent.input(inputs[0], {
+      target: { value: "aaa" },
+    });
+    fireEvent.input(inputs[1], {
+      target: { value: "bbb" },
+    });
+    fireEvent.input(inputs[2], {
+      target: { value: "ccc" },
+    });
+
+    const buttons = getAllByTestId("button-delete-field-array-row");
+    fireEvent.click(buttons[1]);
+    expect(queryByDisplayValue("aaa"));
+    expect(queryByDisplayValue("ccc"));
+    expect(queryByDisplayValue("bbb")).toBeNull();
+  });
+});

--- a/assets/js/components/UI/Form/Input.jsx
+++ b/assets/js/components/UI/Form/Input.jsx
@@ -5,7 +5,7 @@ const UIFormInput = ({
   name,
   label,
   type = "text",
-  errors,
+  errors = {},
   register,
   required,
   ...passedInProps

--- a/assets/js/components/Work/Tabs/About.jsx
+++ b/assets/js/components/Work/Tabs/About.jsx
@@ -11,13 +11,21 @@ import UITagNotYetSupported from "../../UI/TagNotYetSupported";
 import UIInput from "../../UI/Form/Input";
 import UIFormTextarea from "../../UI/Form/Textarea";
 import UIFormField from "../../UI/Form/Field";
+import UIFormFieldArray from "../../UI/Form/FieldArray";
 import WorkTabsHeader from "./Header";
 
 const WorkTabsAbout = ({ work }) => {
   const { descriptiveMetadata } = work;
   const [showCoreMetadata, setShowCoreMetadata] = useState(true);
   const [showDescriptiveMetadata, setShowDescriptiveMetadata] = useState(true);
-  const { register, handleSubmit, watch, errors } = useForm();
+
+  // React hook form setup
+  const { register, handleSubmit, watch, errors, control } = useForm({
+    defaultValues: {
+      imaMulti: [{ value: "New Ima Multi" }],
+    },
+  });
+
   const [isEditing, setIsEditing] = useIsEditing();
 
   const [updateWork] = useMutation(UPDATE_WORK, {
@@ -105,6 +113,25 @@ const WorkTabsAbout = ({ work }) => {
                     <p>{descriptiveMetadata.title || "No value"}</p>
                   )}
                 </UIFormField>
+
+                {/* Test form field array element */}
+                {isEditing ? (
+                  <UIFormFieldArray
+                    register={register}
+                    control={control}
+                    required
+                    name="imaMulti"
+                    label="Ima Multi"
+                    data-testid="fieldset-ima-multi"
+                    errors={errors}
+                  />
+                ) : (
+                  <div className="field">
+                    <label className="label">Ima Multi</label>
+                    <UITagNotYetSupported label="Display not yet supported" />
+                    <UITagNotYetSupported label="Update not yet supported" />
+                  </div>
+                )}
 
                 {/* Description */}
                 <UIFormField label="Description">

--- a/assets/styles/scss/_base.scss
+++ b/assets/styles/scss/_base.scss
@@ -6,6 +6,16 @@ dt {
   font-weight: bold;
 }
 
+fieldset {
+  border: 1px dashed $rich-black-20;
+  padding: 1rem;
+  margin-bottom: 1rem;
+
+  legend {
+    font-weight: bold;
+  }
+}
+
 footer {
   .logo {
     max-width: 250px;


### PR DESCRIPTION
This adds support for Field Array Inputs for now.  The component is `<UIFormFieldArray />` Eventually we can build in support for `<select>` too.   

It uses uncontrolled form components, same pattern as we use in existing forms with React Hook Form.   Currently it's just a demo and not wired up to anything yet.  Once the data gets a little more real (which it might be now actually), we'll wire it up to a real metadata field.

![image](https://user-images.githubusercontent.com/3020266/81012145-ad8bba00-8e1e-11ea-875b-252c037f83e7.png)
