### PR TITLE
Mock search and fetch endpoints

### DIFF
--- a/assets/js/client-local.js
+++ b/assets/js/client-local.js
@@ -32,6 +32,11 @@ export const resolvers = {
   },
   Query: {
     codeList: (root, { scheme }) => codeListMock(scheme),
+    authoritiesSearch: (root, { _authority, _query }) =>
+      mockAuthoritiesSearch(),
+    fetchControlledTermLabel: (root, { _id }) =>
+      mockLabelFetch("ControlledTerm"),
+    fetchCodedTermLabel: () => mockLabelFetch("CodedTerm"),
   },
 };
 
@@ -87,6 +92,28 @@ export const mockSubjects = () => {
     });
   }
   return results;
+};
+
+export const mockAuthoritiesSearch = () => {
+  let results = [];
+  let size = Math.floor(Math.random() * Math.floor(4));
+  for (let i = 0; i < size; i++) {
+    results.push({
+      id: faker.internet.url(),
+      label: faker.lorem.words(),
+      role: null,
+      __typename: "CodedTerm",
+    });
+  }
+  return results;
+};
+
+export const mockLabelFetch = (typename) => {
+  return {
+    id: faker.internet.url(),
+    label: faker.lorem.words(),
+    __typename: typename,
+  };
 };
 
 const mockRightsStatement = () => {

--- a/assets/js/components/Work/controlledVocabulary.query.js
+++ b/assets/js/components/Work/controlledVocabulary.query.js
@@ -1,8 +1,16 @@
 import gql from "graphql-tag";
 
-export const CODED_TERM_QUERY = gql`
-  query CodedTermQuery($id: ID!) {
-    codedTerm(id: $id) {
+export const FETCH_CODED_TERM_QUERY = gql`
+  query FetchCodedTermLabelQuery($id: ID!, $scheme: CodeListScheme!) {
+    fetchCodedTermLabel(id: $id, scheme: $scheme) {
+      label
+    }
+  }
+`;
+
+export const FETCH_CONTROLLED_TERM_QUERY = gql`
+  query FetchControlledTermLabelQuery($id: ID!) {
+    fetchControlledTermLabel(id: $id) {
       label
     }
   }
@@ -11,6 +19,15 @@ export const CODED_TERM_QUERY = gql`
 export const CODE_LIST_QUERY = gql`
   query CodeListQuery($scheme: CodeListScheme!) {
     codeList(scheme: $scheme) @client {
+      id
+      label
+    }
+  }
+`;
+
+export const AUTHORITY_SEARCH = gql`
+  query AuthoritiesSearch($authority: codedTermInput!, $query: String!) {
+    authoritiesSearch(authority: $authority, query: $query) @client {
       id
       label
     }

--- a/assets/js/components/Work/work.query.js
+++ b/assets/js/components/Work/work.query.js
@@ -98,11 +98,11 @@ export const GET_WORK = gql`
         name
       }
       updatedAt
-      visibility {
+      visibility @client {
         id
         label
       }
-      workType {
+      workType @client {
         id
         label
       }
@@ -144,11 +144,11 @@ export const GET_WORKS = gql`
       published
       representativeImage
       updatedAt
-      workType {
+      workType @client {
         id
         label
       }
-      visibility {
+      visibility @client {
         id
         label
       }

--- a/assets/js/services/helpers.js
+++ b/assets/js/services/helpers.js
@@ -1,6 +1,5 @@
 import moment from "moment";
 import { toast } from "bulma-toast";
-import { visibilityMock } from "../client-mocks";
 
 /**
  * Escape double quotes (which may interfere with Search queries)

--- a/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
+++ b/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
@@ -17,8 +17,8 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
       end)
     end
 
-    @desc "NOT YET IMPLEMENTED Get the label for a code list item by its id"
-    field :coded_term, :coded_term do
+    @desc "NOT YET IMPLEMENTED Get the label for a controlled_term by its id"
+    field :fetch_controlled_term_label, :controlled_term do
       arg(:id, non_null(:id))
       middleware(Middleware.Authenticate)
 
@@ -26,12 +26,39 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
         {:ok, nil}
       end)
     end
+
+    @desc "NOT YET IMPLEMENTED Get the label for a coded_term by its id and scheme"
+    field :fetch_coded_term_label, :coded_term do
+      arg(:id, non_null(:id))
+      arg(:scheme, non_null(:code_list_scheme))
+      middleware(Middleware.Authenticate)
+
+      resolve(fn %{id: _id}, _ ->
+        {:ok, nil}
+      end)
+    end
+
+    @desc "NOT YET IMPLEMENTED Get the label for a code list item by its id"
+    field :authorities_search, list_of(:controlled_value) do
+      arg(:authority, non_null(:coded_term_input))
+      arg(:query, non_null(:string))
+      middleware(Middleware.Authenticate)
+
+      resolve(fn %{authority: _authority, query: _query}, _ ->
+        {:ok, nil}
+      end)
+    end
+  end
+
+  @desc "NOT YET IMPLEMENTED"
+  object :controlled_value do
+    field :id, :id
+    field :label, :string
   end
 
   @desc "NOT YET IMPLEMENTED"
   object :controlled_term do
-    field :id, :id
-    field :label, :string
+    import_fields(:controlled_value)
     field :role, :coded_term
   end
 
@@ -56,12 +83,13 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
 
   @desc "NOT YET IMPLEMENTED: Schemes for code list table. (Ex: Subjects, MARC relators, prevervation levels, etc)"
   enum :code_list_scheme do
-    value(:rights_statement, as: "rights_statement", description: "Rights Statement")
-    value(:preservation_level, as: "preservation_level", description: "Preservation Level")
-    value(:status, as: "status", description: "Status")
+    value(:authorities, as: "authorities", description: "Authorities")
     value(:license, as: "license", description: "License")
     value(:marc_relator, as: "marc_relator", description: "MARC Relator")
+    value(:preservation_level, as: "preservation_level", description: "Preservation Level")
+    value(:rights_statement, as: "rights_statement", description: "Rights Statement")
     value(:subject, as: "subjects", description: "Subject")
+    value(:status, as: "status", description: "Status")
     value(:visibility, as: "visibility", description: "Visibility")
     value(:work_type, as: "work_type", description: "Work Type")
   end


### PR DESCRIPTION
Adds endpoint for authority search and client side mocked response

```bash
# authority search
query{
  authoritiesSearch(authority: {id: "getty/aat"}, query: "tom") @client {
    id
    label
  }
}

# authority search response
{
  "data": {
    "authoritiesSearch": [
      {
        "id": "https://cloyd.biz",
        "label": "sint mollitia a",
        "__typename": "ControlledTerm"
      },
      {
        "id": "https://taylor.biz",
        "label": "quibusdam ut soluta",
        "__typename": "ControlledTerm"
      }
    ]
  }
```


Also, endpoints to fetch labels for given ids. and client side mocked data
```bash
query  {
  fetchControlledTermLabel(id: "http://vocab.getty.edu/aat/300420991") @client {
    label
  }
  }


{
  "data": {
    "fetchControlledTermLabel": {
      "label": "veritatis libero excepturi",
      "__typename": "ControlledTerm"
    }
  }
}



query  {
  fetchCodedTermLabel(id: "DONE", scheme: "STATUS") @client {
    label
  }
  }

{
  "data": {
    "fetchCodedTermLabel": {
      "label": "qui quis ipsum",
      "__typename": "CodedTerm"
    }
  },
  
```

