### PR TITLE
Add mock to get supported vocabularies for search

### DIFF
--- a/assets/js/client-mocks.js
+++ b/assets/js/client-mocks.js
@@ -1,5 +1,8 @@
 export const codeListMock = (scheme) => {
   switch (scheme) {
+    case "AUTHORITY":
+      return authorityMock;
+      break;
     case "RIGHTS_STATEMENT":
       return rightsStatementMock;
       break;
@@ -239,6 +242,44 @@ export const subjectRoleMock = [
   {
     id: "TOPICAL",
     label: "Topical",
+    __typename: "CodedTerm",
+  },
+];
+
+export const authorityMock = [
+  {
+    id: "AAT",
+    label: "Getty Art & Architecture Thesaurus© (AAT)",
+    __typename: "CodedTerm",
+  },
+  {
+    id: "FAST",
+    label: "OCLC FAST (Faceted Application of Subject Terminology)",
+    __typename: "CodedTerm",
+  },
+  {
+    id: "GEONAMES",
+    label: "Geonames",
+    __typename: "CodedTerm",
+  },
+  {
+    id: "LCNAF",
+    label: "Library of Congress Name Authority File (LCNAF) ",
+    __typename: "CodedTerm",
+  },
+  {
+    id: "LCSH",
+    label: "Library of Congress Subject Headings (LCSH)",
+    __typename: "CodedTerm",
+  },
+  {
+    id: "ULAN",
+    label: "Getty Union List of Artist Names® (ULAN)",
+    __typename: "CodedTerm",
+  },
+  {
+    id: "VIAF",
+    label: "Virtual International Authority File",
     __typename: "CodedTerm",
   },
 ];

--- a/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
+++ b/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
@@ -83,7 +83,7 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
 
   @desc "NOT YET IMPLEMENTED: Schemes for code list table. (Ex: Subjects, MARC relators, prevervation levels, etc)"
   enum :code_list_scheme do
-    value(:authorities, as: "authorities", description: "Authorities")
+    value(:authority, as: "authority", description: "Authority")
     value(:license, as: "license", description: "License")
     value(:marc_relator, as: "marc_relator", description: "MARC Relator")
     value(:preservation_level, as: "preservation_level", description: "Preservation Level")


### PR DESCRIPTION
This will give you the codeList query to get the list of authorities for the authority switcher. i.e.:

<img width="605" alt="Screen Shot 2020-05-06 at 11 39 00 AM" src="https://user-images.githubusercontent.com/6372022/81204037-47be4000-8f8e-11ea-8f3b-5356bf940c79.png">
