### PR TITLE
Fix update mutation on Work Administrative tab

### DIFF
--- a/assets/js/components/UI/Form/Field.jsx
+++ b/assets/js/components/UI/Form/Field.jsx
@@ -1,10 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const UIFormField = ({ label, children, childClass = "" }) => {
+const UIFormField = ({ label, children, childClass = "", mocked, notLive }) => {
   return (
     <div className="field">
-      <label className="label">{label}</label>
+      <label className="label">
+        {label} {mocked && <span className="tag">Mocked</span>}{" "}
+        {notLive && <span className="tag">Not Live</span>}
+      </label>
       <div className={`control ${childClass}`}>{children}</div>
     </div>
   );

--- a/assets/js/components/UI/Form/Select.jsx
+++ b/assets/js/components/UI/Form/Select.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 
 const UIFormSelect = ({
@@ -50,7 +50,7 @@ UIFormSelect.propTypes = {
   options: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string,
-      label: PropTypes.string,
+      label: PropTypes.string.isRequired,
       value: PropTypes.string,
     })
   ),

--- a/assets/js/components/Work/Tabs/About.test.jsx
+++ b/assets/js/components/Work/Tabs/About.test.jsx
@@ -4,7 +4,7 @@ import {
   renderWithRouterApollo,
 } from "../../../services/testing-helpers";
 import WorkTabsAbout from "./About";
-import { fireEvent } from "@testing-library/react";
+import { act, fireEvent } from "@testing-library/react";
 
 import { CODE_LIST_QUERY } from "../controlledVocabulary.query";
 
@@ -41,6 +41,7 @@ describe("Work About tab component", () => {
   function setupTests() {
     return renderWithRouterApollo(<WorkTabsAbout work={mockWork} />, { mocks });
   }
+
   it("renders without crashing", () => {
     expect(setupTests());
   });

--- a/assets/js/services/helpers.js
+++ b/assets/js/services/helpers.js
@@ -65,7 +65,7 @@ export function setVisibilityClass(visibility) {
     return "is-danger";
   }
   if (visibility.toUpperCase() === "AUTHENTICATED") {
-    return "is-info";
+    return "is-primary is-light";
   }
   if (visibility.toUpperCase() === "OPEN") {
     return "is-success";

--- a/doc/architecture/decisions/0025-ui-component-directory-structure.md
+++ b/doc/architecture/decisions/0025-ui-component-directory-structure.md
@@ -1,0 +1,44 @@
+# 25. ui-component-directory-structure
+
+Date: 2020-05-06
+
+## Status
+
+Accepted
+
+## Context
+
+As front end projects grow, having a consistent directory structure and file naming patterns will help manage scaling and an understanding of what lives where.
+
+## Decision
+
+The general idea is that the component directory dictates its filename.
+
+Say we have 2 folders under /assets/js/components/
+
+- /assets/js/components/Work
+- /assets/js/components/UI
+
+Taking the Work components as an example, say we have a few components:
+
+/assets/js/components/Work/List.js
+/assets/js/components/Work/View.js
+
+The "List" component should be defined in it's file something like:
+
+```
+const WorkList = () => <p>Im a component</p>;
+```
+
+and imported like such:
+
+```
+import React from 'react';
+import WorkList from '../components/Work/List';
+```
+
+The actual filename (Name.jsx) of a component should ideally not have any camel casing or references to its parent directory.
+
+## Consequences
+
+This might seem overly verbose in the beginning, but in my experience it scales relatively well and makes searching for files in VSCode easier.


### PR DESCRIPTION
This PR fixes the competing mutations in the `onSubmit()` callback for the Work Administrative tab form.

I also added `Status` mocked field to the form, and did some general UI cleanup.

Finally I added an ADR about how the `assets/js/` folders are structured and the reasoning behind it.