### PR TITLE
Changes to search page to use work components toggler

### DIFF
--- a/assets/js/components/IngestSheet/Completed.jsx
+++ b/assets/js/components/IngestSheet/Completed.jsx
@@ -47,13 +47,12 @@ const IngestSheetCompleted = ({ sheetId }) => {
     return {
       id: work.id,
       representativeImage: work.representativeImage,
-      title: work.title,
-      descriptiveMetadata: work.descriptiveMetadata,
+      title: work.descriptiveMetadata.title,
       workType: work.workType,
       visibility: work.visibility,
       published: work.published,
       accessionNumber: work.accessionNumber,
-      fileSets: work.fileSets,
+      fileSets: work.fileSets.length,
       manifestUrl: work.manifestUrl,
       updatedAt: work.updatedAt,
     };

--- a/assets/js/components/IngestSheet/Completed.jsx
+++ b/assets/js/components/IngestSheet/Completed.jsx
@@ -6,7 +6,6 @@ import {
   INGEST_SHEET_COMPLETED_ERRORS,
 } from "./ingestSheet.query";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-
 import Error from "../UI/Error";
 import IngestSheetCompletedErrors from "./Completed/Errors";
 import WorkListItem from "../Work/UIWorkListItem";
@@ -39,6 +38,26 @@ const IngestSheetCompleted = ({ sheetId }) => {
 
   const works = worksData.ingestSheetWorks;
   let ingestSheetErrors = [];
+
+  const getWorkObject = (work) => {
+    // Destructuring work here involves assigning a const to each
+    // field and returning all constants. Tried various mappings to assign
+    // destructured props to new obj and return with single liner
+    // but nothing good with DRY kind of code.
+    return {
+      id: work.id,
+      representativeImage: work.representativeImage,
+      title: work.title,
+      descriptiveMetadata: work.descriptiveMetadata,
+      workType: work.workType,
+      visibility: work.visibility,
+      published: work.published,
+      accessionNumber: work.accessionNumber,
+      fileSets: work.fileSets,
+      manifestUrl: work.manifestUrl,
+      updatedAt: work.updatedAt,
+    };
+  };
 
   try {
     ingestSheetErrors = errorsData.ingestSheetErrors;
@@ -87,7 +106,7 @@ const IngestSheetCompleted = ({ sheetId }) => {
               key={work.id}
               className="column is-half-tablet is-one-quarter-desktop"
             >
-              <WorkCardItem key={work.id} work={work} />
+              <WorkCardItem key={work.id} {...getWorkObject(work)} />
             </div>
           ))}
         </div>
@@ -96,7 +115,7 @@ const IngestSheetCompleted = ({ sheetId }) => {
         <>
           {works.map((work) => (
             <div key={work.id} className="box">
-              <WorkListItem key={work.id} work={work} />
+              <WorkListItem key={work.id} {...getWorkObject(work)} />
             </div>
           ))}
         </>

--- a/assets/js/components/Work/UIWorkCardItem.jsx
+++ b/assets/js/components/Work/UIWorkCardItem.jsx
@@ -44,7 +44,7 @@ const WorkCardItem = ({
 
         <div className="content">
           <p>
-            <span className="tag">{workType.label}</span>
+            <span className="tag">{workType.label.toUpperCase()}</span>
             {visibility && (
               <span
                 data-testid="tag-visibility"

--- a/assets/js/components/Work/UIWorkCardItem.jsx
+++ b/assets/js/components/Work/UIWorkCardItem.jsx
@@ -1,45 +1,59 @@
-import React from "react";
+import React, { useContext } from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import { setVisibilityClass, formatDate } from "../../services/helpers";
+import { IIIFProvider, IIIFContext } from "../../components/IIIF/IIIFProvider";
 
-const WorkCardItem = ({ work }) => {
+const WorkCardItem = ({
+  id,
+  representativeImage,
+  title,
+  descriptiveMetadata,
+  workType,
+  visibility,
+  published,
+  accessionNumber,
+  fileSets,
+  manifestUrl,
+  updatedAt,
+}) => {
+  const iiifServerUrl = useContext(IIIFContext);
   return (
     <div className="card " data-testid="ui-workcard">
       <div className="card-image">
         <figure className="image is-4by3">
-          <Link to={`/work/${work.id}`}>
+          <Link to={`/work/${id}`}>
             <img
               src={`${
-                work.representativeImage
-                  ? work.representativeImage + "/full/1280,960/0/default.jpg"
-                  : "/images/1280x960.png"
+                representativeImage.id
+                  ? iiifServerUrl +
+                    representativeImage.id +
+                    "/square/500,500/0/default.jpg"
+                  : representativeImage + "/full/1280,960/0/default.jpg"
               }`}
               data-testid="image-work"
-              alt={work.title}
+              alt={title}
             />
           </Link>
         </figure>
       </div>
       <div className="card-content">
         <h3 className="title is-size-4">
-          {work.descriptiveMetadata.title
-            ? work.descriptiveMetadata.title
-            : "Untitled"}
+          {descriptiveMetadata.title ? descriptiveMetadata.title : "Untitled"}
         </h3>
 
         <div className="content">
           <p>
-            <span className="tag">{work.workType && work.workType.label}</span>
-            {work.visibility && (
+            <span className="tag">{workType.label}</span>
+            {visibility && (
               <span
                 data-testid="tag-visibility"
-                className={`tag ${setVisibilityClass(work.visibility.id)}`}
+                className={`tag ${setVisibilityClass(visibility.id)}`}
               >
-                {work.visibility.label.toUpperCase()}
+                {visibility.label.toUpperCase()}
               </span>
             )}
-            {work.published && (
+            {published && (
               <span data-testid="dd-published" className="tag is-success">
                 PUBLISHED
               </span>
@@ -47,18 +61,18 @@ const WorkCardItem = ({ work }) => {
           </p>
           <dl>
             <dt>Accession Number:</dt>
-            <dd data-testid="dd-accession-number">{work.accessionNumber}</dd>
+            <dd data-testid="dd-accession-number">{accessionNumber}</dd>
             <dt>Filesets:</dt>
             <dd>
               <span className="tag is-light" data-testid="dd-filesets-length">
-                {work.fileSets.length}
+                {fileSets.length}
               </span>
             </dd>
             <dt>Last Updated: </dt>
-            <dd data-testid="dd-updated-date">{formatDate(work.updatedAt)}</dd>
+            <dd data-testid="dd-updated-date">{formatDate(updatedAt)}</dd>
             <dt>IIIF Manifest:</dt>
             <dd>
-              <a href={work.manifestUrl} target="_blank">
+              <a href={manifestUrl} target="_blank">
                 <u>JSON File</u>
               </a>
             </dd>

--- a/assets/js/components/Work/UIWorkCardItem.jsx
+++ b/assets/js/components/Work/UIWorkCardItem.jsx
@@ -2,13 +2,11 @@ import React, { useContext } from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import { setVisibilityClass, formatDate } from "../../services/helpers";
-import { IIIFProvider, IIIFContext } from "../../components/IIIF/IIIFProvider";
 
 const WorkCardItem = ({
   id,
   representativeImage,
   title,
-  descriptiveMetadata,
   workType,
   visibility,
   published,
@@ -17,7 +15,6 @@ const WorkCardItem = ({
   manifestUrl,
   updatedAt,
 }) => {
-  const iiifServerUrl = useContext(IIIFContext);
   return (
     <div className="card " data-testid="ui-workcard">
       <div className="card-image">
@@ -26,9 +23,7 @@ const WorkCardItem = ({
             <img
               src={`${
                 representativeImage.id
-                  ? iiifServerUrl +
-                    representativeImage.id +
-                    "/square/500,500/0/default.jpg"
+                  ? representativeImage.url + "/square/500,500/0/default.jpg"
                   : representativeImage + "/full/1280,960/0/default.jpg"
               }`}
               data-testid="image-work"
@@ -38,9 +33,7 @@ const WorkCardItem = ({
         </figure>
       </div>
       <div className="card-content">
-        <h3 className="title is-size-4">
-          {descriptiveMetadata.title ? descriptiveMetadata.title : "Untitled"}
-        </h3>
+        <h3 className="title is-size-4">{title ? title : "Untitled"}</h3>
 
         <div className="content">
           <p>
@@ -54,22 +47,32 @@ const WorkCardItem = ({
               </span>
             )}
             {published && (
-              <span data-testid="dd-published" className="tag is-success">
+              <span
+                data-testid="result-item-published"
+                className="tag is-success"
+              >
                 PUBLISHED
               </span>
             )}
           </p>
           <dl>
             <dt>Accession Number:</dt>
-            <dd data-testid="dd-accession-number">{accessionNumber}</dd>
+            <dd data-testid="result-item-accession-number">
+              {accessionNumber}
+            </dd>
             <dt>Filesets:</dt>
             <dd>
-              <span className="tag is-light" data-testid="dd-filesets-length">
-                {fileSets.length}
+              <span
+                className="tag is-light"
+                data-testid="result-item-filesets-length"
+              >
+                {fileSets}
               </span>
             </dd>
             <dt>Last Updated: </dt>
-            <dd data-testid="dd-updated-date">{formatDate(updatedAt)}</dd>
+            <dd data-testid="result-item-updated-date">
+              {formatDate(updatedAt)}
+            </dd>
             <dt>IIIF Manifest:</dt>
             <dd>
               <a href={manifestUrl} target="_blank">

--- a/assets/js/components/Work/UIWorkCardItem.test.js
+++ b/assets/js/components/Work/UIWorkCardItem.test.js
@@ -1,10 +1,24 @@
 import React from "react";
 import UIWorkCardItem from "./UIWorkCardItem";
-import { mockWork } from "../../services/testing-helpers";
+import { mockWork as work } from "../../services/testing-helpers";
 import { renderWithRouter } from "../../services/testing-helpers";
 
+const workObject = {
+  id: work.id,
+  representativeImage: work.representativeImage,
+  title: work.title,
+  descriptiveMetadata: work.descriptiveMetadata,
+  workType: work.workType,
+  visibility: work.visibility,
+  published: work.published,
+  accessionNumber: work.accessionNumber,
+  fileSets: work.fileSets,
+  manifestUrl: work.manifestUrl,
+  updatedAt: work.updatedAt,
+};
+
 function setupTests() {
-  return renderWithRouter(<UIWorkCardItem work={mockWork} />);
+  return renderWithRouter(<UIWorkCardItem {...workObject} />);
 }
 
 it("Displays Work card", () => {

--- a/assets/js/components/Work/UIWorkCardItem.test.js
+++ b/assets/js/components/Work/UIWorkCardItem.test.js
@@ -7,12 +7,11 @@ const workObject = {
   id: work.id,
   representativeImage: work.representativeImage,
   title: work.title,
-  descriptiveMetadata: work.descriptiveMetadata,
   workType: work.workType,
   visibility: work.visibility,
   published: work.published,
   accessionNumber: work.accessionNumber,
-  fileSets: work.fileSets,
+  fileSets: work.fileSets.length,
   manifestUrl: work.manifestUrl,
   updatedAt: work.updatedAt,
 };
@@ -42,20 +41,22 @@ describe("Shows Work content", () => {
   });
   it("Displays Accession Number", () => {
     const { getByTestId } = setupTests();
-    expect(getByTestId("dd-accession-number").innerHTML).toBe("Example-34");
+    expect(getByTestId("result-item-accession-number").innerHTML).toBe(
+      "Example-34"
+    );
   });
   it("Displays FileSets Length", () => {
     const { getByTestId } = setupTests();
-    expect(getByTestId("dd-filesets-length").innerHTML).toBe("2");
+    expect(getByTestId("result-item-filesets-length").innerHTML).toBe("2");
   });
   it("Displays Updated Date", () => {
     const { getByTestId } = setupTests();
-    expect(getByTestId("dd-updated-date").innerHTML).toBe(
+    expect(getByTestId("result-item-updated-date").innerHTML).toBe(
       "Dec 2, 2019 10:22 PM"
     );
   });
   it("Displays Published Flag", () => {
     const { queryByTestId } = setupTests();
-    expect(queryByTestId("dd-published")).not.toBeInTheDocument();
+    expect(queryByTestId("result-item-published")).not.toBeInTheDocument();
   });
 });

--- a/assets/js/components/Work/UIWorkListItem.jsx
+++ b/assets/js/components/Work/UIWorkListItem.jsx
@@ -1,48 +1,62 @@
-import React from "react";
+import React, { useContext } from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import { setVisibilityClass, formatDate } from "../../services/helpers";
+import { IIIFProvider, IIIFContext } from "../../components/IIIF/IIIFProvider";
 
-const WorkListItem = ({ work }) => {
+const WorkListItem = ({
+  id,
+  representativeImage,
+  title,
+  descriptiveMetadata,
+  workType,
+  visibility,
+  published,
+  accessionNumber,
+  fileSets,
+  manifestUrl,
+  updatedAt,
+}) => {
+  const iiifServerUrl = useContext(IIIFContext);
   return (
     <>
-      <article className="media " data-testid="ui-worklist-item">
+      <article className="media" data-testid="ui-worklist-item">
         <figure className="media-left">
           <p
             className="image is-square"
             style={{ width: "250px", height: "250px" }}
           >
-            <Link to={`/work/${work.id}`}>
+            <Link to={`/work/${id}`}>
               <img
                 src={`${
-                  work.representativeImage
-                    ? work.representativeImage + "/full/1280,960/0/default.jpg"
-                    : "/images/1280x960.png"
+                  representativeImage.id
+                    ? iiifServerUrl +
+                      representativeImage.id +
+                      "/square/500,500/0/default.jpg"
+                    : representativeImage + "/full/1280,960/0/default.jpg"
                 }`}
                 data-testid="image-work"
-                alt={work.title}
+                alt={title}
               />
             </Link>
           </p>
         </figure>
         <div className="media-content">
           <h3 className="title is-size-4">
-            {work.descriptiveMetadata.title
-              ? work.descriptiveMetadata.title
-              : "Untitled"}
+            {descriptiveMetadata.title ? descriptiveMetadata.title : "Untitled"}
           </h3>
           <div className="content ">
             <p>
-              <span className="tag">{work.workType.label}</span>
-              {work.visibility && (
+              <span className="tag">{workType.label}</span>
+              {visibility && (
                 <span
                   data-testid="tag-visibility"
-                  className={`tag ${setVisibilityClass(work.visibility.id)}`}
+                  className={`tag ${setVisibilityClass(visibility.id)}`}
                 >
-                  {work.visibility.label.toUpperCase()}
+                  {visibility.label.toUpperCase()}
                 </span>
               )}
-              {work.published && (
+              {published && (
                 <span data-testid="dd-published" className="tag is-success">
                   PUBLISHED
                 </span>
@@ -59,22 +73,18 @@ const WorkListItem = ({ work }) => {
               </thead>
               <tbody>
                 <tr>
-                  <td data-testid="dd-accession-number">
-                    {work.accessionNumber}
-                  </td>
+                  <td data-testid="dd-accession-number">{accessionNumber}</td>
                   <td>
                     <span
                       className="tag is-light"
                       data-testid="dd-filesets-length"
                     >
-                      {work.fileSets.length}
+                      {fileSets.length}
                     </span>
                   </td>
-                  <td data-testid="dd-updated-date">
-                    {formatDate(work.updatedAt)}
-                  </td>
+                  <td data-testid="dd-updated-date">{formatDate(updatedAt)}</td>
                   <td>
-                    <a href={work.manifestUrl} target="_blank">
+                    <a href={manifestUrl} target="_blank">
                       <u>JSON File</u>
                     </a>
                   </td>

--- a/assets/js/components/Work/UIWorkListItem.jsx
+++ b/assets/js/components/Work/UIWorkListItem.jsx
@@ -2,13 +2,11 @@ import React, { useContext } from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import { setVisibilityClass, formatDate } from "../../services/helpers";
-import { IIIFProvider, IIIFContext } from "../../components/IIIF/IIIFProvider";
 
 const WorkListItem = ({
   id,
   representativeImage,
   title,
-  descriptiveMetadata,
   workType,
   visibility,
   published,
@@ -17,7 +15,6 @@ const WorkListItem = ({
   manifestUrl,
   updatedAt,
 }) => {
-  const iiifServerUrl = useContext(IIIFContext);
   return (
     <>
       <article className="media" data-testid="ui-worklist-item">
@@ -30,9 +27,7 @@ const WorkListItem = ({
               <img
                 src={`${
                   representativeImage.id
-                    ? iiifServerUrl +
-                      representativeImage.id +
-                      "/square/500,500/0/default.jpg"
+                    ? representativeImage.url + "/square/500,500/0/default.jpg"
                     : representativeImage + "/full/1280,960/0/default.jpg"
                 }`}
                 data-testid="image-work"
@@ -42,9 +37,7 @@ const WorkListItem = ({
           </p>
         </figure>
         <div className="media-content">
-          <h3 className="title is-size-4">
-            {descriptiveMetadata.title ? descriptiveMetadata.title : "Untitled"}
-          </h3>
+          <h3 className="title is-size-4">{title ? title : "Untitled"}</h3>
           <div className="content ">
             <p>
               <span className="tag">{workType.label.toUpperCase()}</span>
@@ -57,7 +50,10 @@ const WorkListItem = ({
                 </span>
               )}
               {published && (
-                <span data-testid="dd-published" className="tag is-success">
+                <span
+                  data-testid="result-item-published"
+                  className="tag is-success"
+                >
                   PUBLISHED
                 </span>
               )}
@@ -73,16 +69,20 @@ const WorkListItem = ({
               </thead>
               <tbody>
                 <tr>
-                  <td data-testid="dd-accession-number">{accessionNumber}</td>
+                  <td data-testid="result-item-accession-number">
+                    {accessionNumber}
+                  </td>
                   <td>
                     <span
                       className="tag is-light"
-                      data-testid="dd-filesets-length"
+                      data-testid="result-item-filesets-length"
                     >
-                      {fileSets.length}
+                      {fileSets}
                     </span>
                   </td>
-                  <td data-testid="dd-updated-date">{formatDate(updatedAt)}</td>
+                  <td data-testid="result-item-updated-date">
+                    {formatDate(updatedAt)}
+                  </td>
                   <td>
                     <a href={manifestUrl} target="_blank">
                       <u>JSON File</u>

--- a/assets/js/components/Work/UIWorkListItem.jsx
+++ b/assets/js/components/Work/UIWorkListItem.jsx
@@ -47,7 +47,7 @@ const WorkListItem = ({
           </h3>
           <div className="content ">
             <p>
-              <span className="tag">{workType.label}</span>
+              <span className="tag">{workType.label.toUpperCase()}</span>
               {visibility && (
                 <span
                   data-testid="tag-visibility"

--- a/assets/js/components/Work/UIWorkListItem.test.js
+++ b/assets/js/components/Work/UIWorkListItem.test.js
@@ -1,10 +1,24 @@
 import React from "react";
 import UIWorkListItem from "./UIWorkListItem";
-import { mockWork } from "../../services/testing-helpers";
+import { mockWork as work } from "../../services/testing-helpers";
 import { renderWithRouter } from "../../services/testing-helpers";
 
+const workObject = {
+  id: work.id,
+  representativeImage: work.representativeImage,
+  title: work.title,
+  descriptiveMetadata: work.descriptiveMetadata,
+  workType: work.workType,
+  visibility: work.visibility,
+  published: work.published,
+  accessionNumber: work.accessionNumber,
+  fileSets: work.fileSets,
+  manifestUrl: work.manifestUrl,
+  updatedAt: work.updatedAt,
+};
+
 function setupTests() {
-  return renderWithRouter(<UIWorkListItem work={mockWork} />);
+  return renderWithRouter(<UIWorkListItem {...workObject} />);
 }
 
 it("Displays Work List Item", () => {

--- a/assets/js/components/Work/UIWorkListItem.test.js
+++ b/assets/js/components/Work/UIWorkListItem.test.js
@@ -7,12 +7,11 @@ const workObject = {
   id: work.id,
   representativeImage: work.representativeImage,
   title: work.title,
-  descriptiveMetadata: work.descriptiveMetadata,
   workType: work.workType,
   visibility: work.visibility,
   published: work.published,
   accessionNumber: work.accessionNumber,
-  fileSets: work.fileSets,
+  fileSets: work.fileSets.length,
   manifestUrl: work.manifestUrl,
   updatedAt: work.updatedAt,
 };
@@ -42,20 +41,22 @@ describe("Shows Work content", () => {
   });
   it("Displays Accession Number", () => {
     const { getByTestId } = setupTests();
-    expect(getByTestId("dd-accession-number").innerHTML).toBe("Example-34");
+    expect(getByTestId("result-item-accession-number").innerHTML).toBe(
+      "Example-34"
+    );
   });
   it("Displays FileSets Length", () => {
     const { getByTestId } = setupTests();
-    expect(getByTestId("dd-filesets-length").innerHTML).toBe("2");
+    expect(getByTestId("result-item-filesets-length").innerHTML).toBe("2");
   });
   it("Displays Updated Date", () => {
     const { getByTestId } = setupTests();
-    expect(getByTestId("dd-updated-date").innerHTML).toBe(
+    expect(getByTestId("result-item-updated-date").innerHTML).toBe(
       "Dec 2, 2019 10:22 PM"
     );
   });
   it("Displays Published Flag", () => {
     const { queryByTestId } = setupTests();
-    expect(queryByTestId("dd-published")).not.toBeInTheDocument();
+    expect(queryByTestId("result-item-published")).not.toBeInTheDocument();
   });
 });

--- a/assets/js/screens/Work/List.jsx
+++ b/assets/js/screens/Work/List.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import Layout from "../Layout";
 import { ReactiveList } from "@appbaseio/reactivesearch";
-import { IIIFProvider, IIIFContext } from "../../components/IIIF/IIIFProvider";
+import { IIIFProvider } from "../../components/IIIF/IIIFProvider";
 import WorkCardItem from "../../components/Work/UIWorkCardItem";
 import WorkListItem from "../../components/Work/UIWorkListItem";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -18,8 +18,7 @@ const ScreensWorkList = () => {
       manifestUrl: res.iiif_manifest,
       published: res.published,
       visibility: res.visibility_term,
-      descriptiveMetadata: { title: res.title, description: res.description },
-      fileSets: res.file_sets,
+      fileSets: res.file_sets.length,
       accessionNumber: res.accession_number,
       workType: res.work_type,
     };
@@ -71,7 +70,7 @@ const ScreensWorkList = () => {
               })}
               innerClass={{
                 list: `${isListView ? "" : "columns is-multiline"}`,
-                resultStats: "is-size-6 has-text-grey",
+                resultStats: "column is-size-6 has-text-grey",
               }}
               react={{
                 and: ["SearchSensor"],

--- a/assets/js/screens/Work/List.jsx
+++ b/assets/js/screens/Work/List.jsx
@@ -1,53 +1,103 @@
-import React from "react";
+import React, { useState } from "react";
 import Layout from "../Layout";
-import SearchResultItem from "../../components/Search/ResultItem";
 import { ReactiveList } from "@appbaseio/reactivesearch";
-import { IIIFProvider } from "../../components/IIIF/IIIFProvider";
+import { IIIFProvider, IIIFContext } from "../../components/IIIF/IIIFProvider";
+import WorkCardItem from "../../components/Work/UIWorkCardItem";
+import WorkListItem from "../../components/Work/UIWorkListItem";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 const ScreensWorkList = () => {
+  const [isListView, setIsListView] = useState(false);
+
+  const getWorkItem = (res) => {
+    return {
+      id: res._id,
+      title: res.title,
+      updatedAt: res.modified_date,
+      representativeImage: { id: res.representative_file_set_id, value: null },
+      manifestUrl: res.iiif_manifest,
+      published: res.published,
+      visibility: res.visibility.id
+        ? res.visibility
+        : { id: res.visibility, label: res.visibility },
+      descriptiveMetadata: { title: res.title, description: res.description },
+      fileSets: res.file_sets,
+      accessionNumber: res.accession_number,
+      workType: { label: res.model.name, id: res.model.name },
+    };
+  };
+
   return (
     <Layout>
       <section className="section">
+        <div className="column is-hidden-touch">
+          <div className="buttons is-right ">
+            <button
+              className="button is-text"
+              onClick={() => setIsListView(false)}
+              title="Grid View"
+            >
+              <span className={`icon ${isListView ? "has-text-grey" : ""}`}>
+                <FontAwesomeIcon size="2x" icon="th-large" />
+              </span>
+            </button>
+
+            <button
+              className="button is-text"
+              onClick={() => setIsListView(true)}
+              title="List View"
+            >
+              <span className={`icon ${!isListView ? "has-text-grey" : ""}`}>
+                <FontAwesomeIcon size="2x" icon="th-list" />
+              </span>
+            </button>
+          </div>
+        </div>
         <div className="container">
-          <div className="box">
-            <IIIFProvider>
-              <ReactiveList
-                componentId="SearchResult"
-                dataField="accession_number"
-                defaultQuery={() => ({
-                  query: {
-                    bool: {
-                      must: [
-                        {
-                          match: {
-                            "model.name": "Image"
-                          }
-                        }
-                      ]
-                    }
-                  }
-                })}
-                innerClass={{
-                  list: "columns is-multiline",
-                  resultStats: "is-size-6 has-text-grey"
-                }}
-                react={{
-                  and: ["SearchSensor"]
-                }}
-                renderItem={res => {
+          <IIIFProvider>
+            <ReactiveList
+              componentId="SearchResult"
+              dataField="accession_number"
+              defaultQuery={() => ({
+                query: {
+                  bool: {
+                    must: [
+                      {
+                        match: {
+                          "model.name": "Image",
+                        },
+                      },
+                    ],
+                  },
+                },
+              })}
+              innerClass={{
+                list: `${isListView ? "" : "columns is-multiline"}`,
+                resultStats: "is-size-6 has-text-grey",
+              }}
+              react={{
+                and: ["SearchSensor"],
+              }}
+              renderItem={(res) => {
+                if (isListView) {
                   return (
-                    <div
-                      key={res._id}
-                      className="column is-half-tablet is-one-third-desktop is-one-quarter-widescreen"
-                    >
-                      <SearchResultItem res={res} />
+                    <div key={res._id} className="box">
+                      <WorkListItem key={res._id} {...getWorkItem(res)} />
                     </div>
                   );
-                }}
-                showResultStats={true}
-              />
-            </IIIFProvider>
-          </div>
+                }
+                return (
+                  <div
+                    key={res._id}
+                    className="column is-half-tablet is-one-third-desktop is-one-quarter-widescreen"
+                  >
+                    <WorkCardItem key={res._id} {...getWorkItem(res)} />
+                  </div>
+                );
+              }}
+              showResultStats={true}
+            />
+          </IIIFProvider>
         </div>
       </section>
     </Layout>

--- a/assets/js/screens/Work/List.jsx
+++ b/assets/js/screens/Work/List.jsx
@@ -14,16 +14,14 @@ const ScreensWorkList = () => {
       id: res._id,
       title: res.title,
       updatedAt: res.modified_date,
-      representativeImage: { id: res.representative_file_set_id, value: null },
+      representativeImage: res.representative_file_set,
       manifestUrl: res.iiif_manifest,
       published: res.published,
-      visibility: res.visibility.id
-        ? res.visibility
-        : { id: res.visibility, label: res.visibility },
+      visibility: res.visibility_term,
       descriptiveMetadata: { title: res.title, description: res.description },
       fileSets: res.file_sets,
       accessionNumber: res.accession_number,
-      workType: { label: res.model.name, id: res.model.name },
+      workType: res.work_type,
     };
   };
 


### PR DESCRIPTION
Search page uses toggle view with `workcard` and `worklist` components.
Tests have been modified after rebasing with deploy/staging due to changes in search results and work component structure.

<img width="1381" alt="Screen Shot 2020-05-06 at 3 46 31 PM" src="https://user-images.githubusercontent.com/14085957/81232306-460a7180-8fba-11ea-802b-452564cb7f8f.png">
<img width="1294" alt="Screen Shot 2020-05-06 at 3 49 59 PM" src="https://user-images.githubusercontent.com/14085957/81232316-49056200-8fba-11ea-9a21-28740778289a.png">
<img width="634" alt="Screen Shot 2020-05-06 at 4 48 48 PM" src="https://user-images.githubusercontent.com/14085957/81232317-499df880-8fba-11ea-8f11-20c769eb7572.png">





