### PR TITLE
Return collections representative work info in queries

### DIFF
--- a/lib/meadow/data/schemas/collection.ex
+++ b/lib/meadow/data/schemas/collection.ex
@@ -58,7 +58,21 @@ defmodule Meadow.Data.Schemas.Collection do
         create_date: collection.inserted_at,
         modified_date: collection.updated_at,
         visibility: "RESTRICTED",
-        visibility_term: %{id: "RESTRICTED", label: "Private"}
+        visibility_term: %{id: "RESTRICTED", label: "Private"},
+        representative_image:
+          case collection.representative_work_id do
+            nil ->
+              %{}
+
+            representative_work_id ->
+              %{
+                work_id: representative_work_id,
+                url:
+                  Meadow.IIIF.image_service_id(
+                    collection.representative_work.representative_file_set_id
+                  )
+              }
+          end
       }
     end
   end

--- a/lib/meadow/data/works.ex
+++ b/lib/meadow/data/works.ex
@@ -83,6 +83,13 @@ defmodule Meadow.Data.Works do
     |> add_representative_image()
   end
 
+  def get_work(id) do
+    Work
+    |> Sheets.works_with_sheets()
+    |> Repo.get(id)
+    |> add_representative_image()
+  end
+
   @doc """
   Gets a work by accession_number
 

--- a/lib/meadow/elasticsearch_diff_store.ex
+++ b/lib/meadow/elasticsearch_diff_store.ex
@@ -35,6 +35,17 @@ defmodule Meadow.ElasticsearchDiffStore do
   end
 
   @impl true
+  def stream(Schemas.Collection = schema) do
+    schema
+    |> out_of_date()
+    |> Repo.stream()
+    |> Stream.chunk_every(@chunk_size)
+    |> Stream.flat_map(fn chunk ->
+      Repo.preload(chunk, :representative_work)
+    end)
+  end
+
+  @impl true
   def stream(Schemas.FileSet = schema) do
     schema
     |> out_of_date()

--- a/lib/meadow/elasticsearch_store.ex
+++ b/lib/meadow/elasticsearch_store.ex
@@ -30,6 +30,16 @@ defmodule Meadow.ElasticsearchStore do
   end
 
   @impl true
+  def stream(Schemas.Collection = schema) do
+    schema
+    |> Repo.stream()
+    |> Stream.chunk_every(10)
+    |> Stream.flat_map(fn chunk ->
+      Repo.preload(chunk, :representative_work)
+    end)
+  end
+
+  @impl true
   def stream(schema) do
     schema
     |> Repo.stream()

--- a/lib/meadow/iiif/iiif.ex
+++ b/lib/meadow/iiif/iiif.ex
@@ -45,7 +45,13 @@ defmodule Meadow.IIIF do
     "http://localhost:8184/iiif/2/37ad25ec-7eff-45d0-b759-eca65c9d560f"
   """
   def image_service_id(file_set_id) do
-    Config.iiif_server_url() <> file_set_id
+    case file_set_id do
+      nil ->
+        nil
+
+      id ->
+        Config.iiif_server_url() <> id
+    end
   end
 
   defp write_to_s3(manifest, key) do

--- a/lib/meadow_web/resolvers/collections.ex
+++ b/lib/meadow_web/resolvers/collections.ex
@@ -18,6 +18,22 @@ defmodule MeadowWeb.Resolvers.Data.Collections do
     {:ok, Works.get_works_by_collection(collection.id)}
   end
 
+  def representative_work(collection, _, _) do
+    case collection.representative_work do
+      nil ->
+        {:ok, nil}
+
+      representative_work ->
+        work = Works.get_work(representative_work.id)
+
+        {:ok,
+         %{
+           work_id: representative_work.id,
+           url: work.representative_image
+         }}
+    end
+  end
+
   def create_collection(_, args, _) do
     case Collections.create_collection(args) do
       {:error, changeset} ->

--- a/lib/meadow_web/schema/types/data/collection_types.ex
+++ b/lib/meadow_web/schema/types/data/collection_types.ex
@@ -97,6 +97,18 @@ defmodule MeadowWeb.Schema.Data.CollectionTypes do
     field :finding_aid_url, :string
     field :published, :boolean
     field :works, list_of(:work), resolve: &Resolvers.Data.Collections.collection_works/3
-    field :representative_image, :string
+
+    field :representative_image, :string do
+      deprecate("Use  `representativeWork`.")
+    end
+
+    field :representative_work, :representative_work,
+      resolve: &Resolvers.Data.Collections.representative_work/3
+  end
+
+  object :representative_work do
+    field :work_id, :string
+    field :label, :string
+    field :url, :string
   end
 end

--- a/test/meadow/data/indexer_test.exs
+++ b/test/meadow/data/indexer_test.exs
@@ -53,7 +53,20 @@ defmodule Meadow.Data.IndexerTest do
       end)
     end
 
-    # @tag :skip
+    @tag unboxed: true
+    test "work representative image change cascades to a collection" do
+      Sandbox.unboxed_run(Repo, fn ->
+        %{collection: collection, works: [work | _]} = indexable_data()
+        Meadow.Data.Collections.set_representative_image(collection, work)
+
+        Indexer.synchronize_index()
+
+        assert indexed_doc(collection.id) |> get_in(["representative_image", "work_id"]) ==
+                 work.id
+      end)
+    end
+
+    # @tag unboxed: true
     # test "work visibility cascades to file set" do
     #   Sandbox.unboxed_run(Repo, fn ->
     #     %{works: [work | _], file_sets: [file_set | _]} = indexable_data()

--- a/test/meadow/data/indexer_test.exs
+++ b/test/meadow/data/indexer_test.exs
@@ -5,6 +5,7 @@ defmodule Meadow.Data.IndexerTest do
   alias Ecto.Adapters.SQL.Sandbox
   alias Meadow.Data.{Collections, Indexer, Works}
   alias Meadow.Ingest.SheetWorks
+  alias Meadow.Repo
   alias Mix.Tasks.Elasticsearch.Build, as: BuildTask
 
   describe "indexing" do
@@ -57,12 +58,24 @@ defmodule Meadow.Data.IndexerTest do
     test "work representative image change cascades to a collection" do
       Sandbox.unboxed_run(Repo, fn ->
         %{collection: collection, works: [work | _]} = indexable_data()
-        Meadow.Data.Collections.set_representative_image(collection, work)
+        Collections.set_representative_image(collection, work)
 
         Indexer.synchronize_index()
 
         assert indexed_doc(collection.id) |> get_in(["representative_image", "work_id"]) ==
                  work.id
+
+        file_set = file_set_fixture(%{work_id: work.id})
+        {:ok, work} = Works.update_work(work, %{file_sets: [file_set]})
+        {:ok, work} = Works.set_representative_image(work, file_set)
+
+        Indexer.synchronize_index()
+
+        assert indexed_doc(work.id)
+               |> get_in(["representative_file_set", "id"]) == file_set.id
+
+        assert indexed_doc(collection.id)
+               |> get_in(["representative_image", "url"]) == work.representative_image
       end)
     end
 

--- a/test/meadow_web/schema/mutation/set_collection_image_test.exs
+++ b/test/meadow_web/schema/mutation/set_collection_image_test.exs
@@ -32,7 +32,12 @@ defmodule MeadowWeb.Schema.Mutation.SetCollectionImageTest do
     collection = Collections.get_collection!(collection.id)
     assert collection.representative_image == expected_work.representative_image
 
-    url = get_in(query_data, [:data, "setCollectionImage", "representativeImage"])
+    url =
+      get_in(query_data, [
+        :data,
+        "setCollectionImage",
+        "representativeImage"
+      ])
 
     assert get_in(query_data, [:data, "setCollectionImage", "works"])
            |> Enum.find(fn work -> Map.get(work, "id") == expected_work.id end)

--- a/test/support/index_case.ex
+++ b/test/support/index_case.ex
@@ -4,6 +4,7 @@ defmodule Meadow.IndexCase do
   """
   use ExUnit.CaseTemplate
   alias Ecto.Adapters.SQL.Sandbox
+  alias Meadow.Data.{Collections, Works}
   alias Meadow.Data.Schemas.{Collection, FileSet, IndexTime, Work}
   alias Meadow.ElasticsearchCluster, as: Cluster
   alias Meadow.Ingest.Schemas.{Project, Sheet}
@@ -43,7 +44,7 @@ defmodule Meadow.IndexCase do
       end
 
       def indexable_data do
-        collection = collection_fixture()
+        collection = collection_fixture() |> Collections.add_representative_image()
 
         works =
           1..5
@@ -54,6 +55,7 @@ defmodule Meadow.IndexCase do
               published: false
             })
           end)
+          |> Works.add_representative_image()
 
         file_sets =
           works


### PR DESCRIPTION
 - return `work_id` and `url` of `representative_image` in Collections GraphQL and Elasticsearch requests. 
- deprecate existing `representativeImage` field in GraphQL schema in favor of `representativeWork` (we can change it back to `representativeImage` for consistency w/ES after the front end has updated if we want but didn't want to break the front end)
- updated the database trigger so that collections are reindexed if the work's reprsentative fileSet id is changed. 

@katdivyareddy10 - you might need to do a `down -v` to test this



<img width="907" alt="Screen Shot 2020-05-07 at 9 57 26 AM" src="https://user-images.githubusercontent.com/6372022/81310712-12772800-904a-11ea-8990-e2fc7b814d03.png">


<img width="679" alt="Screen Shot 2020-05-07 at 9 56 16 AM" src="https://user-images.githubusercontent.com/6372022/81310722-199e3600-904a-11ea-8306-6ab79322441e.png">


<img width="689" alt="Screen Shot 2020-05-07 at 9 56 33 AM" src="https://user-images.githubusercontent.com/6372022/81310749-228f0780-904a-11ea-9419-5812415bb9b1.png">
