### PR TITLE
Temporary static values for visibility and work_type in Elasticsearch

### DIFF
--- a/lib/meadow/data/schemas/collection.ex
+++ b/lib/meadow/data/schemas/collection.ex
@@ -56,7 +56,9 @@ defmodule Meadow.Data.Schemas.Collection do
         title: collection.name,
         published: collection.published,
         create_date: collection.inserted_at,
-        modified_date: collection.updated_at
+        modified_date: collection.updated_at,
+        visibility: "RESTRICTED",
+        visibility_term: %{id: "RESTRICTED", label: "Private"}
       }
     end
   end

--- a/lib/meadow/data/schemas/work.ex
+++ b/lib/meadow/data/schemas/work.ex
@@ -101,6 +101,9 @@ defmodule Meadow.Data.Schemas.Work do
         create_date: work.inserted_at,
         iiif_manifest: IIIF.manifest_id(work.id),
         modified_date: work.updated_at,
+        visibility: "RESTRICTED",
+        visibility_term: %{id: "RESTRICTED", label: "Private"},
+        work_type: %{id: "IMAGE", label: "Image"},
         representative_file_set:
           case work.representative_file_set_id do
             nil ->


### PR DESCRIPTION
Index static placeholder for `visibility` and `work_type` in works and collections so the front end doesn't break.

The proxy/IIIF server expects the string for visibility so I'm not sure we are just going to change it to an object but I went ahead and indexed the object as well with a different name since that's how we are handling it in meadow. This probably is what the front end needs. 

```
visibility: "RESTRICTED",
visibility_term: {id: "RESTRICTED", label: "Private"},
work_type: {id: "IMAGE", label: "Image"},
```