### PR TITLE
Rename work card and list view items

### DIFF
--- a/assets/js/components/IngestSheet/Completed.jsx
+++ b/assets/js/components/IngestSheet/Completed.jsx
@@ -9,8 +9,8 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import Error from "../UI/Error";
 import IngestSheetCompletedErrors from "./Completed/Errors";
-import WorkListItem from "../Work/UIWorkListItem";
-import WorkCardItem from "../Work/UIWorkCardItem";
+import WorkListItem from "../Work/ListViewItem";
+import WorkCardItem from "../Work/CardViewItem";
 
 const IngestSheetCompleted = ({ sheetId }) => {
   const [isListView, setIsListView] = useState(false);

--- a/assets/js/components/Work/CardViewItem.jsx
+++ b/assets/js/components/Work/CardViewItem.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import { setVisibilityClass, formatDate } from "../../services/helpers";
 
-const WorkCardItem = ({ work }) => {
+const WorkCardViewItem = ({ work }) => {
   return (
     <div className="card " data-testid="ui-workcard">
       <div className="card-image">
@@ -69,8 +69,8 @@ const WorkCardItem = ({ work }) => {
   );
 };
 
-WorkCardItem.propTypes = {
+WorkCardViewItem.propTypes = {
   work: PropTypes.object,
 };
 
-export default WorkCardItem;
+export default WorkCardViewItem;

--- a/assets/js/components/Work/CardViewItem.test.js
+++ b/assets/js/components/Work/CardViewItem.test.js
@@ -1,10 +1,10 @@
 import React from "react";
-import UIWorkCardItem from "./UIWorkCardItem";
+import CardViewItem from "./CardViewItem";
 import { mockWork } from "../../services/testing-helpers";
 import { renderWithRouter } from "../../services/testing-helpers";
 
 function setupTests() {
-  return renderWithRouter(<UIWorkCardItem work={mockWork} />);
+  return renderWithRouter(<CardViewItem work={mockWork} />);
 }
 
 it("Displays Work card", () => {

--- a/assets/js/components/Work/ListViewItem.jsx
+++ b/assets/js/components/Work/ListViewItem.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import { setVisibilityClass, formatDate } from "../../services/helpers";
 
-const WorkListItem = ({ work }) => {
+const ListViewItem = ({ work }) => {
   return (
     <>
       <article className="media " data-testid="ui-worklist-item">
@@ -89,8 +89,8 @@ const WorkListItem = ({ work }) => {
   );
 };
 
-WorkListItem.propTypes = {
+ListViewItem.propTypes = {
   work: PropTypes.object,
 };
 
-export default WorkListItem;
+export default ListViewItem;

--- a/assets/js/components/Work/ListViewItem.test.js
+++ b/assets/js/components/Work/ListViewItem.test.js
@@ -1,10 +1,10 @@
 import React from "react";
-import UIWorkListItem from "./UIWorkListItem";
+import ListViewItem from "./ListViewItem";
 import { mockWork } from "../../services/testing-helpers";
 import { renderWithRouter } from "../../services/testing-helpers";
 
 function setupTests() {
-  return renderWithRouter(<UIWorkListItem work={mockWork} />);
+  return renderWithRouter(<ListViewItem work={mockWork} />);
 }
 
 it("Displays Work List Item", () => {

--- a/assets/js/screens/Project/Project.test.js
+++ b/assets/js/screens/Project/Project.test.js
@@ -7,7 +7,6 @@ import {
 import { renderWithRouterApollo } from "../../services/testing-helpers";
 import "@testing-library/jest-dom/extend-expect";
 import { Route } from "react-router-dom";
-import { waitFor } from "@testing-library/react";
 
 const MOCK_PROJECT_TITLE = "Mock project title";
 const mocks = [


### PR DESCRIPTION
Work re-usable components have been renamed to `CardViewItem` and `ListViewItem` to be consistent as `ListItem` has already been taken under Work folder.