### PR TITLE
Fix dependency trigger to account for NULLs

### DIFF
--- a/test/meadow/data/indexer_test.exs
+++ b/test/meadow/data/indexer_test.exs
@@ -5,6 +5,7 @@ defmodule Meadow.Data.IndexerTest do
   alias Ecto.Adapters.SQL.Sandbox
   alias Meadow.Data.{Collections, Indexer, Works}
   alias Meadow.Ingest.SheetWorks
+  alias Meadow.Repo
   alias Mix.Tasks.Elasticsearch.Build, as: BuildTask
 
   describe "indexing" do
@@ -57,12 +58,24 @@ defmodule Meadow.Data.IndexerTest do
     test "work representative image change cascades to a collection" do
       Sandbox.unboxed_run(Repo, fn ->
         %{collection: collection, works: [work | _]} = indexable_data()
-        Meadow.Data.Collections.set_representative_image(collection, work)
+        Collections.set_representative_image(collection, work)
 
         Indexer.synchronize_index()
 
         assert indexed_doc(collection.id) |> get_in(["representative_image", "work_id"]) ==
                  work.id
+
+        file_set = file_set_fixture(%{work_id: work.id})
+        {:ok, work} = Works.update_work(work, %{file_sets: [file_set]})
+        {:ok, work} = Works.set_representative_image(work, file_set)
+
+        Indexer.synchronize_index()
+
+        assert indexed_doc(work.id)
+               |> get_in(["representative_file_set", "id"]) == file_set.id
+
+        assert indexed_doc(collection.id)
+               |> get_in(["representative_image", "url"]) == work.representative_image
       end)
     end
 

--- a/test/meadow_web/schema/mutation/set_collection_image_test.exs
+++ b/test/meadow_web/schema/mutation/set_collection_image_test.exs
@@ -32,7 +32,12 @@ defmodule MeadowWeb.Schema.Mutation.SetCollectionImageTest do
     collection = Collections.get_collection!(collection.id)
     assert collection.representative_image == expected_work.representative_image
 
-    url = get_in(query_data, [:data, "setCollectionImage", "representativeImage"])
+    url =
+      get_in(query_data, [
+        :data,
+        "setCollectionImage",
+        "representativeImage"
+      ])
 
     assert get_in(query_data, [:data, "setCollectionImage", "works"])
            |> Enum.find(fn work -> Map.get(work, "id") == expected_work.id end)

--- a/test/support/index_case.ex
+++ b/test/support/index_case.ex
@@ -4,6 +4,7 @@ defmodule Meadow.IndexCase do
   """
   use ExUnit.CaseTemplate
   alias Ecto.Adapters.SQL.Sandbox
+  alias Meadow.Data.{Collections, Works}
   alias Meadow.Data.Schemas.{Collection, FileSet, IndexTime, Work}
   alias Meadow.ElasticsearchCluster, as: Cluster
   alias Meadow.Ingest.Schemas.{Project, Sheet}
@@ -43,7 +44,7 @@ defmodule Meadow.IndexCase do
       end
 
       def indexable_data do
-        collection = collection_fixture()
+        collection = collection_fixture() |> Collections.add_representative_image()
 
         works =
           1..5
@@ -54,6 +55,7 @@ defmodule Meadow.IndexCase do
               published: false
             })
           end)
+          |> Works.add_representative_image()
 
         file_sets =
           works


### PR DESCRIPTION
The trigger as written failed to take into account that you can't do `<>` comparisons on `NULL` values in SQL.