### PR TITLE
Add UICodedTerm and UIControlledTerm components for metadata display

### DIFF
--- a/assets/js/client-local.js
+++ b/assets/js/client-local.js
@@ -60,7 +60,7 @@ export const mockContributors = () => {
   for (let i = 0; i < size; i++) {
     results.push({
       id: faker.internet.url(),
-      label: faker.lorem.words(),
+      label: faker.name.findName(),
       role: {
         id: "aut",
         label: "Author",
@@ -148,7 +148,7 @@ const mockStatus = () => {
   };
 };
 
-const mockVisibility = () => {
+export const mockVisibility = () => {
   return {
     label: "Institution",
     id: "AUTHENTICATED",
@@ -156,7 +156,7 @@ const mockVisibility = () => {
   };
 };
 
-const mockWorkType = () => {
+export const mockWorkType = () => {
   return {
     id: "IMAGE",
     label: "Image",

--- a/assets/js/components/UI/CodedTerm/Item.jsx
+++ b/assets/js/components/UI/CodedTerm/Item.jsx
@@ -1,0 +1,17 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const UICodedTermItem = ({ item = {} }) => {
+  if (!item.id) return null;
+
+  return <p>{item.label}</p>;
+};
+
+UICodedTermItem.propTypes = {
+  item: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+  }),
+};
+
+export default UICodedTermItem;

--- a/assets/js/components/UI/CodedTerm/Item.test.jsx
+++ b/assets/js/components/UI/CodedTerm/Item.test.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { render, queryByText } from "@testing-library/react";
+import UICodedTermItem from "./Item";
+
+describe("UIControlledVocabList", () => {
+  it("renders without crashing", () => {
+    const { getByTestId } = render(<UICodedTermItem />);
+  });
+
+  it("renders display value only if id and label passed in", () => {
+    const item1 = render(<UICodedTermItem item={{ label: "Ima label" }} />);
+    expect(item1.queryByText("Ima label")).toBeNull();
+
+    const item2 = render(
+      <UICodedTermItem item={{ label: "Ima label", id: "ABC123" }} />
+    );
+    expect(item2.queryByText("Ima label"));
+  });
+});

--- a/assets/js/components/UI/ControlledTerm/List.jsx
+++ b/assets/js/components/UI/ControlledTerm/List.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const UIControlledTermList = ({ items = [] }) => {
+  if (!items) return;
+
+  return (
+    <ul data-testid="controlled-term-list">
+      {items.map((item) => (
+        <li key={item.id}>
+          {item.label} {item.role && `(${item.role.label})`}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+UIControlledTermList.propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      role: PropTypes.obj,
+    })
+  ),
+};
+
+export default UIControlledTermList;

--- a/assets/js/components/UI/ControlledTerm/List.test.jsx
+++ b/assets/js/components/UI/ControlledTerm/List.test.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import UIControlledTermList from "./List";
+
+describe("UIControlledVocabList", () => {
+  it("renders UIControlledTermList", () => {
+    const { getByTestId } = render(<UIControlledTermList />);
+    expect(getByTestId("controlled-term-list"));
+  });
+
+  // TODO: fill these out
+});

--- a/assets/js/components/Work/Tabs/About.jsx
+++ b/assets/js/components/Work/Tabs/About.jsx
@@ -14,6 +14,8 @@ import UIFormTextarea from "../../UI/Form/Textarea";
 import UIFormField from "../../UI/Form/Field";
 import UIFormFieldArray from "../../UI/Form/FieldArray";
 import UIFormSelect from "../../UI/Form/Select";
+import UIControlledTermList from "../../UI/ControlledTerm/List";
+import UICodedTermItem from "../../UI/CodedTerm/Item";
 import WorkTabsHeader from "./Header";
 import { CODE_LIST_QUERY } from "../controlledVocabulary.query.js";
 
@@ -163,7 +165,7 @@ const WorkTabsAbout = ({ work }) => {
                   )}
                 </UIFormField>
 
-                <UIFormField label="Rights Statement">
+                <UIFormField label="Rights Statement" notLive mocked>
                   {isEditing ? (
                     <UIFormSelect
                       register={register}
@@ -178,15 +180,9 @@ const WorkTabsAbout = ({ work }) => {
                       errors={errors}
                     />
                   ) : (
-                    <>
-                      <UITagNotYetSupported label="Data is mocked" />
-                      <UITagNotYetSupported label="Update not yet supported" />
-                      <p>
-                        {descriptiveMetadata
-                          ? descriptiveMetadata.rightsStatement.label
-                          : "None selected"}
-                      </p>
-                    </>
+                    <UICodedTermItem
+                      item={descriptiveMetadata.rightsStatement}
+                    />
                   )}
                 </UIFormField>
 
@@ -230,56 +226,89 @@ const WorkTabsAbout = ({ work }) => {
               </a>
             </h2>
             {showDescriptiveMetadata && (
-              <>
-                <UIFormField label="Creators">
-                  <UITagNotYetSupported label="Display not yet supported" />{" "}
-                  <UITagNotYetSupported label="Update not yet supported" />
-                  <ul>
-                    <li>
-                      <Link to="/">Creator 1 as a link</Link>
-                    </li>
-                    <li>
-                      <Link to="/">Creator 2 as a link</Link>
-                    </li>
-                    <li>
-                      <Link to="/">Creator 3 as a link</Link>
-                    </li>
-                  </ul>
+              <div className="content">
+                <UIFormField label="Contributors" mocked notLive>
+                  {isEditing ? (
+                    <p>Form elements go here</p>
+                  ) : (
+                    <UIControlledTermList
+                      items={descriptiveMetadata.contributor}
+                    />
+                  )}
                 </UIFormField>
 
-                <UIFormField label="Contributors">
-                  <UITagNotYetSupported label="Display not yet supported" />{" "}
-                  <UITagNotYetSupported label="Update not yet supported" />
-                  <ul>
-                    <li>
-                      <Link to="/">Contributor 1 as a link</Link>
-                    </li>
-                    <li>
-                      <Link to="/">Contributor 2 as a link</Link>
-                    </li>
-                    <li>
-                      <Link to="/">Contributor 3 as a link</Link>
-                    </li>
-                  </ul>
+                <UIFormField label="Creators" mocked notLive>
+                  {isEditing ? (
+                    <p>Form elements go here</p>
+                  ) : (
+                    <UIControlledTermList items={descriptiveMetadata.creator} />
+                  )}
                 </UIFormField>
 
-                <UIFormField label="Genre">
-                  <UITagNotYetSupported label="Data is mocked" />{" "}
-                  <UITagNotYetSupported label="Update not yet supported" />
-                  {descriptiveMetadata.genre &&
-                    descriptiveMetadata.genre.length > 0 && (
-                      <ul>
-                        {descriptiveMetadata.genre.map((genre) => {
-                          return (
-                            <li key={genre.id}>
-                              <a href={genre.id}>{genre.label}</a>
-                            </li>
-                          );
-                        })}
-                      </ul>
-                    )}
+                <UIFormField label="Genre" mocked notLive>
+                  {isEditing ? (
+                    <p>Form elements go here</p>
+                  ) : (
+                    <UIControlledTermList items={descriptiveMetadata.genre} />
+                  )}
                 </UIFormField>
-              </>
+
+                <UIFormField label="License" mocked notLive>
+                  {isEditing ? (
+                    <p>Form elements go here</p>
+                  ) : (
+                    <UICodedTermItem item={descriptiveMetadata.license} />
+                  )}
+                </UIFormField>
+
+                <UIFormField label="Location" mocked notLive>
+                  {isEditing ? (
+                    <p>Form elements go here</p>
+                  ) : (
+                    <UIControlledTermList
+                      items={descriptiveMetadata.location}
+                    />
+                  )}
+                </UIFormField>
+
+                <UIFormField label="Language" mocked notLive>
+                  {isEditing ? (
+                    <p>Form elements go here</p>
+                  ) : (
+                    <UIControlledTermList
+                      items={descriptiveMetadata.language}
+                    />
+                  )}
+                </UIFormField>
+
+                <UIFormField label="Style Period" mocked notLive>
+                  {isEditing ? (
+                    <p>Form elements go here</p>
+                  ) : (
+                    <UIControlledTermList
+                      items={descriptiveMetadata.stylePeriod}
+                    />
+                  )}
+                </UIFormField>
+
+                <UIFormField label="Subject" mocked notLive>
+                  {isEditing ? (
+                    <p>Form elements go here</p>
+                  ) : (
+                    <UIControlledTermList items={descriptiveMetadata.subject} />
+                  )}
+                </UIFormField>
+
+                <UIFormField label="Technique" mocked notLive>
+                  {isEditing ? (
+                    <p>Form elements go here</p>
+                  ) : (
+                    <UIControlledTermList
+                      items={descriptiveMetadata.technique}
+                    />
+                  )}
+                </UIFormField>
+              </div>
             )}
           </div>
         </div>

--- a/assets/js/components/Work/Tabs/Administrative.jsx
+++ b/assets/js/components/Work/Tabs/Administrative.jsx
@@ -12,6 +12,7 @@ import UIFormField from "../../UI/Form/Field";
 import WorkTabsHeader from "./Header";
 import { CODE_LIST_QUERY } from "../controlledVocabulary.query.js";
 import { setVisibilityClass } from "../../../services/helpers";
+import UICodedTermItem from "../../UI/CodedTerm/Item";
 
 const WorkTabsAdministrative = ({ work }) => {
   const { id, administrativeMetadata, collection, project, sheet } = work;
@@ -203,13 +204,7 @@ const WorkTabsAdministrative = ({ work }) => {
                   errors={errors}
                 />
               ) : (
-                work.visibility && (
-                  <p
-                    className={`tag ${setVisibilityClass(work.visibility.id)}`}
-                  >
-                    {work.visibility.label.toUpperCase()}
-                  </p>
-                )
+                <UICodedTermItem item={work.visibility} />
               )}
             </UIFormField>
           </div>

--- a/assets/js/screens/Work/Work.jsx
+++ b/assets/js/screens/Work/Work.jsx
@@ -13,8 +13,8 @@ import Error from "../../components/UI/Error";
 import UILoadingPage from "../../components/UI/LoadingPage";
 import Work from "../../components/Work/Work";
 import UIBreadcrumbs from "../../components/UI/Breadcrumbs";
-import ButtonGroup from "../../components/UI/ButtonGroup";
-import { toastWrapper } from "../../services/helpers";
+import { setVisibilityClass, toastWrapper } from "../../services/helpers";
+import { Link } from "react-router-dom";
 
 const ScreensWork = () => {
   const { id } = useParams();
@@ -59,28 +59,24 @@ const ScreensWork = () => {
   if (error) return <Error error={error} />;
 
   const {
-    work: { accessionNumber, published, descriptiveMetadata, project, sheet },
+    work: {
+      accessionNumber,
+      published,
+      descriptiveMetadata,
+      project,
+      sheet,
+      visibility,
+      workType,
+    },
   } = data;
 
   const breadCrumbs = [
     {
-      label: `Projects`,
-      route: `/project/list`,
+      label: `Search Works`,
+      route: `/work/list`,
     },
     {
-      label: `${project.name}`,
-      route: `/project/${project.id}`,
-    },
-    {
-      label: "Ingest Sheets",
-      route: `/project/${project.id}`,
-    },
-    {
-      label: `${sheet.name}`,
-      route: `/project/${project.id}/ingest-sheet/${sheet.id}`,
-    },
-    {
-      label: accessionNumber,
+      label: "Work",
       isActive: true,
     },
   ];
@@ -101,29 +97,55 @@ const ScreensWork = () => {
         <div className="container">
           <UIBreadcrumbs items={breadCrumbs} data-testid="work-breadcrumbs" />
           <div className="box">
-            <h1 className="title">
-              {accessionNumber}{" "}
-              <span className={`tag ${published ? "is-info" : "is-warning"}`}>
-                {published ? "Published" : "Not Published"}
-              </span>
-            </h1>
-            <h2 className="subtitle">Work</h2>
-            <ButtonGroup>
-              <button
-                className="button is-primary is-outlined"
-                data-testid="publish-button"
-                onClick={handlePublishClick}
-              >
-                {!published ? "Publish" : "Unpublish"}
-              </button>
-              <button
-                className="button"
-                data-testid="delete-button"
-                onClick={onOpenModal}
-              >
-                Delete
-              </button>
-            </ButtonGroup>
+            <div className="columns">
+              <div className="column is-two-thirds">
+                <h1 className="title">
+                  {descriptiveMetadata.title || "Untitled"}{" "}
+                </h1>
+                <p>
+                  <span
+                    className={`tag ${published ? "is-info" : "is-warning"}`}
+                  >
+                    {published ? "Published" : "Not Published"}
+                  </span>{" "}
+                  <span className={`tag ${setVisibilityClass(visibility.id)}`}>
+                    {visibility.label}
+                  </span>{" "}
+                  <span className={`tag is-info`}>{workType.label}</span>
+                </p>
+              </div>
+              <div className="column is-one-third">
+                <div className="buttons is-right">
+                  <button
+                    className={`button is-primary ${
+                      published ? "is-outlined" : ""
+                    }`}
+                    data-testid="publish-button"
+                    onClick={handlePublishClick}
+                  >
+                    {!published ? "Publish" : "Unpublish"}
+                  </button>
+                  <button
+                    className="button"
+                    data-testid="delete-button"
+                    onClick={onOpenModal}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            <div className="content">
+              <dl>
+                <dt>Accession Number</dt>
+                <dd>{accessionNumber}</dd>
+                <dt>Project</dt>
+                <dd>
+                  <Link to={`/project/${id}`}>{project.name}</Link>
+                </dd>
+              </dl>
+            </div>
           </div>
         </div>
       </section>

--- a/assets/js/screens/Work/Work.test.jsx
+++ b/assets/js/screens/Work/Work.test.jsx
@@ -4,6 +4,7 @@ import { Route } from "react-router-dom";
 import { renderWithRouterApollo } from "../../services/testing-helpers";
 import { GET_WORK } from "../../components/Work/work.query";
 import { waitForElement } from "@testing-library/react";
+import { mockVisibility, mockWorkType } from "../../client-local";
 
 const mocks = [
   {
@@ -145,6 +146,8 @@ const mocks = [
           id: "ABC123",
           insertedAt: "2020-02-04T19:16:16",
           published: false,
+          visibility: mockVisibility(),
+          workType: mockWorkType(),
           project: {
             id: "28b6dd45-ef3e-45df-b380-985c9af8b495",
             name: "Foo",


### PR DESCRIPTION
This PR handles display only updates to Coded Term and Controlled Term lists.

![image](https://user-images.githubusercontent.com/3020266/81605022-6eb5b100-9396-11ea-85e4-c405f47cd420.png)

![image](https://user-images.githubusercontent.com/3020266/81605054-7ecd9080-9396-11ea-8a54-64361128032b.png)
