### PR TITLE
Replace representativeImage with representativeWork in collections

### DIFF
--- a/assets/js/components/Collection/Collection.jsx
+++ b/assets/js/components/Collection/Collection.jsx
@@ -7,7 +7,7 @@ const Collection = ({ collection }) => {
   const {
     adminEmail,
     description,
-    representativeImage,
+    representativeWork,
     findingAidUrl,
     keywords = [],
   } = collection;
@@ -23,8 +23,9 @@ const Collection = ({ collection }) => {
           <figure className="image is-square">
             <img
               src={
-                representativeImage != null
-                  ? representativeImage + "/square/500,500/0/default.jpg"
+                representativeWork
+                  ? representativeWork.representativeImage +
+                    "/square/500,500/0/default.jpg"
                   : "/images/480x480.png"
               }
             />

--- a/assets/js/components/Collection/Collection.jsx
+++ b/assets/js/components/Collection/Collection.jsx
@@ -24,8 +24,7 @@ const Collection = ({ collection }) => {
             <img
               src={
                 representativeWork
-                  ? representativeWork.representativeImage +
-                    "/square/500,500/0/default.jpg"
+                  ? `${representativeWork.representativeImage}/square/500,500/0/default.jpg`
                   : "/images/480x480.png"
               }
             />

--- a/assets/js/components/Collection/Collection.test.jsx
+++ b/assets/js/components/Collection/Collection.test.jsx
@@ -13,7 +13,7 @@ const mockCollection = {
   name: "Ima collection",
   published: false,
   works: [],
-  representativeImage: "",
+  representativeWork: null,
 };
 
 function setUpTests() {

--- a/assets/js/components/Collection/CollectionImageModal.jsx
+++ b/assets/js/components/Collection/CollectionImageModal.jsx
@@ -101,8 +101,7 @@ const CollectionImageModal = ({ collection, isModalOpen, handleClose }) => {
                     <img
                       src={
                         work && work.representativeImage != null
-                          ? work.representativeImage +
-                            "/square/500,500/0/default.jpg"
+                          ? `${work.representativeImage}/square/500,500/0/default.jpg`
                           : "/images/480x480.png"
                       }
                     />

--- a/assets/js/components/Collection/CollectionImageModal.jsx
+++ b/assets/js/components/Collection/CollectionImageModal.jsx
@@ -8,6 +8,9 @@ const CollectionImageModal = ({ collection, isModalOpen, handleClose }) => {
   const [selectedWork, setSelectedWork] = useState();
   const [filteredWorkImages, setFilteredWorkImages] = useState();
   useEffect(() => {
+    setSelectedWork(
+      collection.representativeWork ? collection.representativeWork.id : ""
+    );
     setFilteredWorkImages(collection ? collection.works : []);
   }, []);
 

--- a/assets/js/components/Collection/CollectionImageModal.test.js
+++ b/assets/js/components/Collection/CollectionImageModal.test.js
@@ -17,7 +17,10 @@ const mocks = [
       data: {
         setCollectionImage: {
           id: "01DWHQQYTVKC2THHW8SHRBH2XP",
-          representativeImage: "repImage1url.com",
+          representativeWork: {
+            id: "1id-23343432",
+            representativeImage: "repImage1url.com",
+          },
         },
       },
     },
@@ -27,7 +30,7 @@ const mocks = [
 const mockCollection = {
   adminEmail: "admin@nu.com",
   description: "asdf asdfasdf",
-  representativeImage: "https://thisIsTest.com",
+  representativeWork: null,
   featured: true,
   findingAidUrl: "http://something.com",
   id: "01DWHQQYTVKC2THHW8SHRBH2XP",

--- a/assets/js/components/Collection/Form.test.jsx
+++ b/assets/js/components/Collection/Form.test.jsx
@@ -20,7 +20,7 @@ const mocks = [
           {
             adminEmail: "admin@nu.com",
             description: "asdf asdfasdf",
-            representativeImage: "https://thisIsTest.com",
+            representativeWork: null,
             featured: true,
             findingAidUrl: "http://something.com",
             id: "01DWHQQYTVKC2THHW8SHRBH2XP",
@@ -49,7 +49,7 @@ const mocks = [
 const mockCollection = {
   adminEmail: "admin@nu.com",
   description: "asdf asdfasdf",
-  representativeImage: "https://thisIsTest.com",
+  representativeWork: null,
   featured: true,
   findingAidUrl: "http://something.com",
   id: "01DWHQQYTVKC2THHW8SHRBH2XP",

--- a/assets/js/components/Collection/ListRow.jsx
+++ b/assets/js/components/Collection/ListRow.jsx
@@ -4,7 +4,13 @@ import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 const CollectionListRow = ({ collection, onOpenModal }) => {
-  const { id, name = "", description = "", keywords = [] } = collection;
+  const {
+    id,
+    name = "",
+    description = "",
+    keywords = [],
+    representativeWork,
+  } = collection;
   const styles = { listItem: { marginBottom: "1rem" } };
   return (
     <li data-testid="collection-list-row" style={styles.listItem}>
@@ -13,10 +19,10 @@ const CollectionListRow = ({ collection, onOpenModal }) => {
           <p className="image is-128x128">
             <img
               src={
-                collection.representativeImage
-                  ? collection.representativeImage +
+                representativeWork
+                  ? representativeWork.representativeImage +
                     "/square/500,500/0/default.jpg"
-                  : "https://bulma.io/images/placeholders/128x128.png"
+                  : "/images/480x480.png"
               }
             />
           </p>

--- a/assets/js/components/Collection/ListRow.jsx
+++ b/assets/js/components/Collection/ListRow.jsx
@@ -20,8 +20,7 @@ const CollectionListRow = ({ collection, onOpenModal }) => {
             <img
               src={
                 representativeWork
-                  ? representativeWork.representativeImage +
-                    "/square/500,500/0/default.jpg"
+                  ? `${representativeWork.representativeImage}/square/500,500/0/default.jpg`
                   : "/images/480x480.png"
               }
             />

--- a/assets/js/components/Collection/collection.query.js
+++ b/assets/js/components/Collection/collection.query.js
@@ -51,7 +51,10 @@ export const SET_COLLECTION_IMAGE = gql`
   mutation SetCollectionImage($collectionId: ID!, $workId: ID!) {
     setCollectionImage(collectionId: $collectionId, workId: $workId) {
       id
-      representativeImage
+      representativeWork {
+        id
+        representativeImage
+      }
     }
   }
 `;
@@ -82,7 +85,10 @@ export const GET_COLLECTION = gql`
       published
       name
       description
-      representativeImage
+      representativeWork {
+        id
+        representativeImage
+      }
       id
       keywords
       works {
@@ -115,7 +121,10 @@ export const GET_COLLECTIONS = gql`
       description
       id
       keywords
-      representativeImage
+      representativeWork {
+        id
+        representativeImage
+      }
       works {
         id
         representativeImage

--- a/assets/js/components/Work/CardItem.jsx
+++ b/assets/js/components/Work/CardItem.jsx
@@ -21,11 +21,11 @@ const WorkCardItem = ({
         <figure className="image is-4by3">
           <Link to={`/work/${id}`}>
             <img
-              src={`${
+              src={
                 representativeImage.file_set_id
-                  ? representativeImage.url + "/square/500,500/0/default.jpg"
-                  : representativeImage + "/full/1280,960/0/default.jpg"
-              }`}
+                  ? `${representativeImage.url}/square/500,500/0/default.jpg`
+                  : `${representativeImage}/full/1280,960/0/default.jpg`
+              }
               data-testid="image-work"
               alt={title}
             />

--- a/assets/js/components/Work/CardItem.jsx
+++ b/assets/js/components/Work/CardItem.jsx
@@ -22,7 +22,7 @@ const WorkCardItem = ({
           <Link to={`/work/${id}`}>
             <img
               src={`${
-                representativeImage.id
+                representativeImage.file_set_id
                   ? representativeImage.url + "/square/500,500/0/default.jpg"
                   : representativeImage + "/full/1280,960/0/default.jpg"
               }`}

--- a/assets/js/components/Work/ListItem.jsx
+++ b/assets/js/components/Work/ListItem.jsx
@@ -23,7 +23,7 @@ const WorkListItem = ({
             <Link to={`/work/${id}`}>
               <img
                 src={`${
-                  representativeImage.id
+                  representativeImage.file_set_id
                     ? representativeImage.url + "/square/500,500/0/default.jpg"
                     : representativeImage + "/full/1280,960/0/default.jpg"
                 }`}

--- a/assets/js/components/Work/ListItem.jsx
+++ b/assets/js/components/Work/ListItem.jsx
@@ -22,11 +22,11 @@ const WorkListItem = ({
           <p className="image is-128x128">
             <Link to={`/work/${id}`}>
               <img
-                src={`${
+                src={
                   representativeImage.file_set_id
-                    ? representativeImage.url + "/square/500,500/0/default.jpg"
-                    : representativeImage + "/full/1280,960/0/default.jpg"
-                }`}
+                    ? `${representativeImage.url}/square/500,500/0/default.jpg`
+                    : `${representativeImage}/full/1280,960/0/default.jpg`
+                }
                 data-testid="image-work"
                 alt={title}
               />


### PR DESCRIPTION
`representativeImage` has been replaced with `representativeWork`, tests have been updated and update image modal collection now displays selected `workId`