### PR TITLE
Add hint to mocking and cleanup

### DIFF
--- a/assets/js/client-local.js
+++ b/assets/js/client-local.js
@@ -35,7 +35,7 @@ export const resolvers = {
     authoritiesSearch: (root, { _authority, _query }) =>
       mockAuthoritiesSearch(),
     fetchControlledTermLabel: (root, { _id }) =>
-      mockLabelFetch("ControlledTerm"),
+      mockLabelFetch("ControlledValue"),
     fetchCodedTermLabel: () => mockLabelFetch("CodedTerm"),
   },
 };
@@ -74,7 +74,7 @@ export const mockContributors = () => {
 };
 
 export const mockSubjects = () => {
-  let ids = ["topicial", "temporal", "geographical"];
+  let ids = ["topicial", "geographical"];
   let results = [];
   let size = Math.floor(Math.random() * Math.floor(4));
   for (let i = 0; i < size; i++) {
@@ -96,13 +96,13 @@ export const mockSubjects = () => {
 
 export const mockAuthoritiesSearch = () => {
   let results = [];
-  let size = Math.floor(Math.random() * Math.floor(4));
+  let size = Math.floor(Math.random() * Math.floor(10));
   for (let i = 0; i < size; i++) {
     results.push({
       id: faker.internet.url(),
       label: faker.lorem.words(),
-      role: null,
-      __typename: "CodedTerm",
+      hint: faker.lorem.words(),
+      __typename: "ControlledValue",
     });
   }
   return results;

--- a/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
+++ b/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
@@ -18,7 +18,7 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
     end
 
     @desc "NOT YET IMPLEMENTED Get the label for a controlled_term by its id"
-    field :fetch_controlled_term_label, :controlled_term do
+    field :fetch_controlled_term_label, :controlled_value do
       arg(:id, non_null(:id))
       middleware(Middleware.Authenticate)
 
@@ -54,6 +54,7 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
   object :controlled_value do
     field :id, :id
     field :label, :string
+    field :hint, :string
   end
 
   @desc "NOT YET IMPLEMENTED"


### PR DESCRIPTION
Added `hint` to `authoritiesSearch` results and also noticed a few other mistakes/cleanup in the mocking. 