### PR TITLE
Index visibility lowercase

### DIFF
--- a/lib/meadow/data/schemas/collection.ex
+++ b/lib/meadow/data/schemas/collection.ex
@@ -57,8 +57,8 @@ defmodule Meadow.Data.Schemas.Collection do
         published: collection.published,
         create_date: collection.inserted_at,
         modified_date: collection.updated_at,
-        visibility: "OPEN",
-        visibility_term: %{id: "OPEN", label: "Public"},
+        visibility: "open",
+        visibility_term: %{id: "open", label: "Public"},
         representative_image:
           case collection.representative_work do
             nil ->

--- a/lib/meadow/data/schemas/work.ex
+++ b/lib/meadow/data/schemas/work.ex
@@ -102,8 +102,8 @@ defmodule Meadow.Data.Schemas.Work do
         create_date: work.inserted_at,
         iiif_manifest: IIIF.manifest_id(work.id),
         modified_date: work.updated_at,
-        visibility: "OPEN",
-        visibility_term: %{id: "OPEN", label: "Public"},
+        visibility: "open",
+        visibility_term: %{id: "open", label: "Public"},
         work_type: %{id: "IMAGE", label: "Image"},
         representative_file_set:
           case work.representative_file_set_id do


### PR DESCRIPTION
- Temporary hard-coded indexing was writing `visibility` as `OPEN`
- IIIF server wrapper wants lowercase: https://github.com/nulib/nulterra/blob/efd9b2b404995848b1a3a5c088946647e16dbb2a/stack/lambdas/iiif/lib/authorize.js#L88