### PR TITLE
Index static public visiblity on file set

### DIFF
--- a/lib/meadow/data/schemas/file_set.ex
+++ b/lib/meadow/data/schemas/file_set.ex
@@ -57,6 +57,7 @@ defmodule Meadow.Data.Schemas.FileSet do
         description: file_set.metadata.description,
         create_date: file_set.inserted_at,
         modified_date: file_set.updated_at,
+        visibility: "open",
         work_id: file_set.work.id
       }
     end


### PR DESCRIPTION
- Index all `FileSet`s temporarily as 'open' so that the IIIF server will authorize them to view in Fen before the metadata model is complete.