### PR TITLE
Clean up collection screen component

### DIFF
--- a/assets/js/components/Collection/Collection.jsx
+++ b/assets/js/components/Collection/Collection.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import PropTypes, { shape } from "prop-types";
 import CollectionImageModal from "./CollectionImageModal";
+import { Link } from "react-router-dom";
 
 const Collection = ({ collection }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -10,6 +11,7 @@ const Collection = ({ collection }) => {
     representativeWork,
     findingAidUrl,
     keywords = [],
+    works,
   } = collection;
 
   const onCloseModal = () => {
@@ -29,16 +31,18 @@ const Collection = ({ collection }) => {
               }
             />
           </figure>
-          <p className="has-text-centered">
-            <button
-              data-testid="button-open-image-modal"
-              type="button"
-              className="button is-light is-small"
-              onClick={() => setIsModalOpen(true)}
-            >
-              Update Image
-            </button>
-          </p>
+          {works.length > 0 && (
+            <p className="has-text-centered" style={{ paddingTop: "1rem" }}>
+              <button
+                data-testid="button-open-image-modal"
+                type="button"
+                className="button is-light is-small"
+                onClick={() => setIsModalOpen(true)}
+              >
+                Update Image
+              </button>
+            </p>
+          )}
         </div>
         <div className="column content">
           <dl>
@@ -53,7 +57,11 @@ const Collection = ({ collection }) => {
             <dt>
               <strong>Finding Aid URL</strong>
             </dt>
-            <dd>{findingAidUrl}</dd>
+            <dd>
+              <a href={findingAidUrl} target="_blank">
+                {findingAidUrl}
+              </a>
+            </dd>
             <dt>
               <strong>Keywords</strong>
             </dt>

--- a/assets/js/screens/Collection/Collection.jsx
+++ b/assets/js/screens/Collection/Collection.jsx
@@ -73,7 +73,6 @@ const ScreensCollection = () => {
             <div className="columns">
               <div className="column is-two-thirds">
                 <h1 className="title">{data.collection.name || ""}</h1>
-                <h2 className="subtitle">Collection</h2>
               </div>
               <div className="column is-one-third buttons has-text-right">
                 <Link


### PR DESCRIPTION
- Removed subtitle `Collection`
- `findingAidUrl` is a link
- Added padding to `Update Image` button
- `Update Image` button is now hidden if collection has no works

<img width="1112" alt="Screen Shot 2020-05-19 at 3 44 09 PM" src="https://user-images.githubusercontent.com/14085957/82376360-9684c480-99e7-11ea-9000-8bbcddb4750f.png">
