### PR TITLE
Seed fields table

### DIFF
--- a/lib/meadow/utils/logging.ex
+++ b/lib/meadow/utils/logging.ex
@@ -1,0 +1,22 @@
+defmodule Meadow.Utils.Logging do
+  @moduledoc "Logging utilities"
+
+  @doc """
+  Transparently change the logging level around a function
+
+  Examples:
+    iex> Meadow.Utils.Logging.with_log_level(:warn, fn ->
+    ...>   8 * 8
+    ...> end)
+    64
+  """
+  def with_log_level(level, fun) do
+    old_level = Logger.level()
+    try do
+      Logger.configure(level: level)
+      fun.()
+    after
+      Logger.configure(level: old_level)
+    end
+  end
+end

--- a/lib/mix/tasks/meadow.ex
+++ b/lib/mix/tasks/meadow.ex
@@ -51,6 +51,7 @@ defmodule Mix.Tasks.Meadow.Seed do
   Run database seeds
   """
   use Mix.Task
+  alias Meadow.Utils.Logging
 
   def run([]), do: run("seeds.exs")
   def run([name|[]]), do: run("seeds/#{name}.exs")
@@ -61,10 +62,12 @@ defmodule Mix.Tasks.Meadow.Seed do
   end
 
   def run(name) do
-    Ecto.Migrator.with_repo(Meadow.Repo, fn _ ->
-      Path.expand("priv/repo/#{name}")
-      |> Code.compile_file()
-      |> Enum.each(fn {module, _} -> module.run() end)
+    Logging.with_log_level(:info, fn ->
+      Ecto.Migrator.with_repo(Meadow.Repo, fn _ ->
+        Path.expand("priv/repo/#{name}")
+        |> Code.compile_file()
+        |> Enum.each(fn {module, _} -> module.run() end)
+      end)
     end)
   end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -10,12 +10,14 @@
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
 
-# Run all modules
+# Run all modules in priv/repo/seeds/
 Path.relative_to_cwd(__ENV__.file)
 |> Path.dirname()
 |> Path.join("seeds/**/*.exs")
 |> Path.wildcard()
 |> Enum.each(fn seed_file ->
-     Code.compile_file(seed_file)
-     |> Enum.each(fn {module, _} -> module.run() end)
-   end)
+  case Code.require_file(seed_file) do
+    nil -> :noop
+    code -> code |> Enum.each(fn {module, _} -> module.run() end)
+  end
+end)

--- a/priv/repo/seeds/coded_terms.exs
+++ b/priv/repo/seeds/coded_terms.exs
@@ -5,17 +5,11 @@ defmodule Meadow.Repo.Seeds.CodedTerms do
   require Logger
 
   def run do
-    old_level = Logger.level()
-    try do
-      Logger.configure(level: :info)
-      Path.relative_to_cwd(__ENV__.file)
-      |> Path.dirname()
-      |> Path.join("coded_terms/*.json")
-      |> Path.wildcard()
-      |> Enum.each(&seed/1)
-    after
-      Logger.configure(level: old_level)
-    end
+    Path.relative_to_cwd(__ENV__.file)
+    |> Path.dirname()
+    |> Path.join("coded_terms/*.json")
+    |> Path.wildcard()
+    |> Enum.each(&seed/1)
   end
 
   def seed(file) do

--- a/priv/repo/seeds/fields.exs
+++ b/priv/repo/seeds/fields.exs
@@ -1,0 +1,24 @@
+defmodule Meadow.Repo.Seeds.Fields do
+  alias Meadow.Data.Schemas.Field
+  alias Meadow.Repo
+
+  require Logger
+
+  def run do
+    Path.relative_to_cwd(__ENV__.file)
+    |> Path.dirname()
+    |> Path.join("fields.json")
+    |> seed()
+  end
+
+  def seed(file) do
+    Logger.info("Seeding fields")
+    seed_time = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    data = File.read!(file)
+            |> Jason.decode!(keys: :atoms)
+            |> Enum.map(fn field ->
+              Map.merge(field, %{inserted_at: seed_time, updated_at: seed_time})
+            end)
+    Repo.insert_all(Field, data, on_conflict: :replace_all, conflict_target: [:id])
+  end
+end

--- a/priv/repo/seeds/fields.json
+++ b/priv/repo/seeds/fields.json
@@ -1,0 +1,100 @@
+[
+  {
+    "metadata_class": "administrative",
+    "id": "preservation_level",
+    "label": "Preservation Level",
+    "required": true,
+    "repeating": false
+  },
+  {
+    "metadata_class": "core",
+    "id": "resource_type",
+    "label": "Resource Type",
+    "required": true,
+    "repeating": false
+  },
+  {
+    "metadata_class": "core",
+    "id": "status",
+    "label": "Status",
+    "required": true,
+    "repeating": false
+  },
+  {
+    "metadata_class": "core",
+    "id": "visibility",
+    "label": "Visibility",
+    "required": true,
+    "repeating": false
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "based_near",
+    "label": "Location (Place of Publication)",
+    "required": false,
+    "repeating": true
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "contributor",
+    "label": "Contributor",
+    "required": false,
+    "repeating": true
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "creator",
+    "label": "Creator",
+    "required": false,
+    "repeating": true
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "genre",
+    "label": "Genre",
+    "required": false,
+    "repeating": true
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "language",
+    "label": "Language",
+    "required": false,
+    "repeating": true
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "license",
+    "label": "License",
+    "required": true,
+    "repeating": false
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "rights_statement",
+    "label": "Rights Statement",
+    "required": true,
+    "repeating": false
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "style_period",
+    "label": "Style Period",
+    "required": false,
+    "repeating": true
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "subject",
+    "label": "Subject",
+    "required": false,
+    "repeating": true
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "technique",
+    "label": "Technique",
+    "required": false,
+    "repeating": true
+  }
+]

--- a/test/meadow/data/schemas/field_test.exs
+++ b/test/meadow/data/schemas/field_test.exs
@@ -6,10 +6,9 @@ defmodule Meadow.Data.Schemas.FieldTest do
 
   describe "fields" do
     @valid_attrs %{
-      id: "contributor",
-      label: "Contributor",
+      id: "foo",
+      label: "Foo",
       metadata_class: "descriptive",
-      source_type: "image",
       repeating: true,
       required: false
     }

--- a/test/meadow/utils/logging_test.exs
+++ b/test/meadow/utils/logging_test.exs
@@ -1,0 +1,28 @@
+defmodule Meadow.Utils.LoggingTest do
+  use ExUnit.Case
+  import ExUnit.CaptureLog
+  require Logger
+  alias Meadow.Utils.Logging
+
+  doctest Logging
+
+  test "log level is only changed within the passed fn" do
+    logged = capture_log(fn ->
+               assert Logger.level() == :info
+               Logger.debug("This is a debug message")
+             end)
+    refute String.match?(logged , ~r/This is a debug message/)
+
+    logged = capture_log([level: :debug], fn ->
+               assert Logger.level() == :info
+               result = Logging.with_log_level(:debug, fn ->
+                 assert Logger.level() == :debug
+                 Logger.debug("This is a debug message")
+                 {:ok, :inner_fn_result}
+               end)
+               assert result == {:ok, :inner_fn_result}
+               assert Logger.level() == :info
+             end)
+    assert String.match?(logged, ~r/This is a debug message/)
+  end
+end


### PR DESCRIPTION
* Extract log level wrapper from `coded_terms.exs` for reusability
* Improve `ReleaseTasks.seed()` handling of multiple seed names
* Seed fields using data from spreadsheet