### PR TITLE
Remove Jason.encode! from S3 body

### DIFF
--- a/lib/mix/tasks/meadow.ex
+++ b/lib/mix/tasks/meadow.ex
@@ -39,7 +39,6 @@ defmodule Mix.Tasks.Meadow.Buckets.Create do
         ],
         "Version" => "2012-10-17"
       }
-      |> Jason.encode!()
 
       bucket |> ExAws.S3.put_bucket_policy(policy) |> ExAws.request!()
     end


### PR DESCRIPTION
The spec for `ExAws.S3.put_bucket_policy` is defined as
```elixir
put_bucket_policy(bucket :: binary, policy :: map())
```
so Dialyzer complains if `policy` is binary JSON, even though it actually _works_ OK (because `ExAws.request!` is happy to encode a map _or_ take an already-encoded binary representation).