### PR TITLE
Update notifications to be less loud

### DIFF
--- a/assets/js/components/IngestSheet/Alert.jsx
+++ b/assets/js/components/IngestSheet/Alert.jsx
@@ -14,14 +14,14 @@ const IngestSheetAlert = ({ ingestSheet }) => {
         type: "is-info",
         title: "Approved",
         body:
-          "The Ingest Sheet has been approved and the ingest is in progress."
+          "The Ingest Sheet has been approved and the ingest is in progress.",
       };
       break;
     case "COMPLETED":
       alertObj = {
         type: "is-success",
         title: "Ingestion Complete",
-        body: "All files have been processed."
+        body: "All files have been processed.",
       };
       break;
     case "DELETED":
@@ -29,14 +29,14 @@ const IngestSheetAlert = ({ ingestSheet }) => {
       alertObj = {
         type: "is-danger",
         title: "Deleted",
-        body: "Ingest sheet no longer exists."
+        body: "Ingest sheet no longer exists.",
       };
       break;
     case "FILE_FAIL":
       alertObj = {
         type: "is-danger",
         title: "File errors",
-        body: fileErrors.length > 0 ? fileErrors.join(", ") : ""
+        body: fileErrors.length > 0 ? fileErrors.join(", ") : "",
       };
       break;
     case "ROW_FAIL":
@@ -45,21 +45,21 @@ const IngestSheetAlert = ({ ingestSheet }) => {
       alertObj = {
         type: "is-danger",
         title: "File has failing rows",
-        body: "See the error report below for details."
+        body: "See the error report below for details.",
       };
       break;
     case "UPLOADED":
       alertObj = {
         type: "is-info",
         title: "File uploaded",
-        body: "Ingest sheet validation is in progress."
+        body: "Ingest sheet validation is in progress.",
       };
       break;
     case "VALID":
       alertObj = {
         type: "is-success",
         title: "File is valid",
-        body: "All checks have passed and the ingest sheet is valid."
+        body: "All checks have passed and the ingest sheet is valid.",
       };
       break;
     default:
@@ -67,22 +67,19 @@ const IngestSheetAlert = ({ ingestSheet }) => {
   }
 
   return showMessage ? (
-    <article className={`message ${alertObj.type}`} data-testid="ui-alert">
-      <div className="message-header">
-        <p>{alertObj.title}</p>
-        <button
-          className="delete"
-          aria-label="delete"
-          onClick={() => setShowMessage(false)}
-        ></button>
-      </div>
-      <div className="message-body">{alertObj.body}</div>
+    <article
+      className={`notification is-light ${alertObj.type}`}
+      data-testid="ui-alert"
+    >
+      <p>
+        {alertObj.title}. {alertObj.body}
+      </p>
     </article>
   ) : null;
 };
 
 IngestSheetAlert.propTypes = {
-  ingestSheet: PropTypes.object
+  ingestSheet: PropTypes.object,
 };
 
 export default IngestSheetAlert;

--- a/assets/js/components/IngestSheet/Alert.test.jsx
+++ b/assets/js/components/IngestSheet/Alert.test.jsx
@@ -11,18 +11,18 @@ const fileFail = {
   state: [
     {
       name: "file",
-      state: "FAIL"
+      state: "FAIL",
     },
     {
       name: "rows",
-      state: "PENDING"
+      state: "PENDING",
     },
     {
       name: "overall",
-      state: "FAIL"
-    }
+      state: "FAIL",
+    },
   ],
-  status: "FILE_FAIL"
+  status: "FILE_FAIL",
 };
 
 it("renders without crashing", () => {
@@ -38,9 +38,11 @@ it("displays danger alert with file fail message when the Ingest Sheet status is
 
   expect(alertElement).toBeInTheDocument();
   expect(alertElement).toHaveClass("is-danger");
-  expect(getByText("File errors")).toBeInTheDocument();
+  expect(getByText("File errors", { exact: false })).toBeInTheDocument();
   expect(
-    getByText("Invalid csv file: unexpected escape character...")
+    getByText("Invalid csv file: unexpected escape character...", {
+      exact: false,
+    })
   ).toBeInTheDocument();
 });
 
@@ -53,18 +55,18 @@ const rowFail = {
   state: [
     {
       name: "file",
-      state: "PASS"
+      state: "PASS",
     },
     {
       name: "rows",
-      state: "FAIL"
+      state: "FAIL",
     },
     {
       name: "overall",
-      state: "FAIL"
-    }
+      state: "FAIL",
+    },
   ],
-  status: "ROW_FAIL"
+  status: "ROW_FAIL",
 };
 
 it("renders without crashing", () => {
@@ -80,7 +82,9 @@ it("displays danger alert with row fail message when the Ingest Sheet status is 
 
   expect(alertElement).toBeInTheDocument();
   expect(alertElement).toHaveClass("is-danger");
-  expect(getByText("File has failing rows")).toBeInTheDocument();
+  expect(
+    getByText("File has failing rows", { exact: false })
+  ).toBeInTheDocument();
 });
 
 const valid = {
@@ -92,18 +96,18 @@ const valid = {
   state: [
     {
       name: "file",
-      state: "PASS"
+      state: "PASS",
     },
     {
       name: "rows",
-      state: "PASS"
+      state: "PASS",
     },
     {
       name: "overall",
-      state: "PASS"
-    }
+      state: "PASS",
+    },
   ],
-  status: "VALID"
+  status: "VALID",
 };
 
 it("renders without crashing", () => {
@@ -119,9 +123,11 @@ it("displays success alert with valid file message when the Ingest Sheet status 
 
   expect(alertElement).toBeInTheDocument();
   expect(alertElement).toHaveClass("is-success");
-  expect(getByText("File is valid")).toBeInTheDocument();
+  expect(getByText("File is valid", { exact: false })).toBeInTheDocument();
   expect(
-    getByText("All checks have passed and the ingest sheet is valid.")
+    getByText("All checks have passed and the ingest sheet is valid.", {
+      exact: false,
+    })
   ).toBeInTheDocument();
 });
 
@@ -134,18 +140,18 @@ const approved = {
   state: [
     {
       name: "file",
-      state: "PASS"
+      state: "PASS",
     },
     {
       name: "rows",
-      state: "PASS"
+      state: "PASS",
     },
     {
       name: "overall",
-      state: "PASS"
-    }
+      state: "PASS",
+    },
   ],
-  status: "APPROVED"
+  status: "APPROVED",
 };
 
 it("renders without crashing", () => {
@@ -161,10 +167,11 @@ it("displays info alert with approved message when the Ingest Sheet status is AP
 
   expect(alertElement).toBeInTheDocument();
   expect(alertElement).toHaveClass("is-info");
-  expect(getByText("Approved")).toBeInTheDocument();
+  expect(getByText("Approved", { exact: false })).toBeInTheDocument();
   expect(
     getByText(
-      "The Ingest Sheet has been approved and the ingest is in progress."
+      "The Ingest Sheet has been approved and the ingest is in progress.",
+      { exact: false }
     )
   ).toBeInTheDocument();
 });
@@ -178,18 +185,18 @@ const completed = {
   state: [
     {
       name: "file",
-      state: "PASS"
+      state: "PASS",
     },
     {
       name: "rows",
-      state: "PASS"
+      state: "PASS",
     },
     {
       name: "overall",
-      state: "PASS"
-    }
+      state: "PASS",
+    },
   ],
-  status: "COMPLETED"
+  status: "COMPLETED",
 };
 
 it("renders without crashing", () => {
@@ -205,8 +212,10 @@ it("displays success alert with completed message when the Ingest Sheet status i
 
   expect(alertElement).toBeInTheDocument();
   expect(alertElement).toHaveClass("is-success");
-  expect(getByText("Ingestion Complete")).toBeInTheDocument();
-  expect(getByText("All files have been processed.")).toBeInTheDocument();
+  expect(getByText("Ingestion Complete", { exact: false })).toBeInTheDocument();
+  expect(
+    getByText("All files have been processed.", { exact: false })
+  ).toBeInTheDocument();
 });
 
 const deleted = {
@@ -218,18 +227,18 @@ const deleted = {
   state: [
     {
       name: "file",
-      state: "PASS"
+      state: "PASS",
     },
     {
       name: "rows",
-      state: "PASS"
+      state: "PASS",
     },
     {
       name: "overall",
-      state: "PASS"
-    }
+      state: "PASS",
+    },
   ],
-  status: "DELETED"
+  status: "DELETED",
 };
 
 it("renders without crashing", () => {
@@ -245,6 +254,8 @@ it("displays success alert with completed message when the Ingest Sheet status i
 
   expect(alertElement).toBeInTheDocument();
   expect(alertElement).toHaveClass("is-danger");
-  expect(getByText("Deleted")).toBeInTheDocument();
-  expect(getByText("Ingest sheet no longer exists.")).toBeInTheDocument();
+  expect(getByText("Deleted", { exact: false })).toBeInTheDocument();
+  expect(
+    getByText("Ingest sheet no longer exists.", { exact: false })
+  ).toBeInTheDocument();
 });

--- a/assets/js/components/IngestSheet/IngestSheet.jsx
+++ b/assets/js/components/IngestSheet/IngestSheet.jsx
@@ -43,7 +43,7 @@ const IngestSheet = ({
   const styles = { h2IsHidden: { display: "none" } };
 
   return (
-    <>
+    <div className="box">
       <h2
         className="title is-size-5"
         style={["COMPLETED"].indexOf(status) > -1 ? styles.h2IsHidden : {}}
@@ -52,7 +52,6 @@ const IngestSheet = ({
       </h2>
       {["APPROVED"].indexOf(status) > -1 && (
         <>
-          {/* <IngestSheetAlert ingestSheet={ingestSheetData} /> */}
           <IngestSheetApprovedInProgress ingestSheet={ingestSheetData} />
         </>
       )}
@@ -71,7 +70,7 @@ const IngestSheet = ({
           subscribeToIngestSheetValidationProgress={progressSubscribeToMore}
         />
       )}
-    </>
+    </div>
   );
 };
 

--- a/assets/js/components/UI/Alert.jsx
+++ b/assets/js/components/UI/Alert.jsx
@@ -4,28 +4,22 @@ import PropTypes from "prop-types";
 const UIAlert = ({
   title = "You should include a title",
   body = "You should probably have a message body",
-  type = "info"
+  type = "is-info",
 }) => {
   return (
-    <div data-testid="ui-alert" className={`alert my-4 ${type}`} role="alert">
-      <div className="flex">
-        <div className="py-1">
-          {type === "success" && "success checkmark icon here"}
-          {type !== "success" && "info icon here"}
-        </div>
-        <div>
-          <p className="font-bold">{title}</p>
-          <div className="text-sm">{body}</div>
-        </div>
+    <article data-testid="ui-alert" className={`message ${type}`}>
+      <div className="message-header">
+        <p>{title}</p>
       </div>
-    </div>
+      <div className="message-body">{body}</div>
+    </article>
   );
 };
 
 UIAlert.propTypes = {
   title: PropTypes.string.isRequired,
   body: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  type: PropTypes.oneOf(["info", "danger", "success"])
+  type: PropTypes.oneOf(["is-info", "is-danger", "is-success"]),
 };
 
 export default UIAlert;

--- a/assets/js/components/UI/Error.js
+++ b/assets/js/components/UI/Error.js
@@ -22,12 +22,12 @@ const Error = ({ error }) => {
   if (isNetworkError) {
     if (error.networkError.statusCode === 404) {
       return (
-        <UIAlert type="danger" title="Network Error" body="404: Not Found" />
+        <UIAlert type="is-danger" title="Network Error" body="404: Not Found" />
       );
     } else {
       return (
         <UIAlert
-          type="danger"
+          type="is-danger"
           title="Network Error"
           body={`${error.networkError.statusCode}: ${error.networkError.message}`}
         />
@@ -42,7 +42,7 @@ const Error = ({ error }) => {
               <span className="message">{message}</span>
               {details && (
                 <ul>
-                  {Object.keys(details).map(key => (
+                  {Object.keys(details).map((key) => (
                     <li key={key}>
                       {key} {details[key]}
                     </li>
@@ -54,18 +54,20 @@ const Error = ({ error }) => {
         </ul>
       </>
     );
-    return <UIAlert type="danger" title="GraphQL Error" body={errorMessage} />;
+    return (
+      <UIAlert type="is-danger" title="GraphQL Error" body={errorMessage} />
+    );
   } else {
-    return <UIAlert type="danger" title="Whoops!" body={error.message} />;
+    return <UIAlert type="is-danger" title="Whoops!" body={error.message} />;
   }
 };
 
 Error.propTypes = {
-  error: PropTypes.object
+  error: PropTypes.object,
 };
 
 Error.defaultProps = {
-  error: {}
+  error: {},
 };
 
 export default Error;

--- a/assets/js/components/UI/LevelItem.jsx
+++ b/assets/js/components/UI/LevelItem.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const UILevelItem = ({ heading, content }) => (
+  <div className="level-item has-text-centered">
+    <div>
+      <p className="heading">{heading}</p>
+      <p className="title">{content}</p>
+    </div>
+  </div>
+);
+
+UILevelItem.propTypes = {
+  heading: PropTypes.string.isRequired,
+  content: PropTypes.string.isRequired,
+};
+
+export default UILevelItem;

--- a/assets/js/screens/IngestSheet/IngestSheet.jsx
+++ b/assets/js/screens/IngestSheet/IngestSheet.jsx
@@ -108,7 +108,9 @@ const ScreensIngestSheet = ({ match }) => {
               </div>
             </div>
 
-            <IngestSheetAlert ingestSheet={sheetData.ingestSheet} />
+            {["APPROVED", "FILE_FAIL", "ROW_FAIL", "UPLOADED", "VALID"].indexOf(
+              sheetData.ingestSheet.status
+            ) > -1 && <IngestSheetAlert ingestSheet={sheetData.ingestSheet} />}
           </div>
 
           <div className="">

--- a/assets/js/screens/Project/List.jsx
+++ b/assets/js/screens/Project/List.jsx
@@ -7,6 +7,7 @@ import UIBreadcrumbs from "../../components/UI/Breadcrumbs";
 import UIFormInput from "../../components/UI/Form/Input";
 import UIFormField from "../../components/UI/Form/Field";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import UILevelItem from "../../components/UI/LevelItem";
 
 const ScreensProjectList = () => {
   const [showForm, setShowForm] = useState();
@@ -22,10 +23,10 @@ const ScreensProjectList = () => {
             <div className="columns" data-testid="screen-header">
               <div className="column is-8">
                 <h1 className="title">Projects</h1>
-                <h2 className="subtitle">
-                  Projects contain{" "}
-                  <span className="is-italic">Ingest Sheets</span>
-                </h2>
+                <p>
+                  Projects are a way to organize{" "}
+                  <span className="is-italic">Ingest Sheets</span>.{" "}
+                </p>
               </div>
               <div className="column is-4 has-text-right">
                 <button
@@ -35,14 +36,16 @@ const ScreensProjectList = () => {
                 >
                   Add Project
                 </button>
-                {/* <PrimaryButton
-                  data-testid="button-new-project"
-                  onClick={() => setShowForm(!showForm)}
-                >
-                  Add Project
-                </PrimaryButton> */}
               </div>
             </div>
+            <div className="level">
+              <UILevelItem heading="Total Projects" content="XXX" />
+              <UILevelItem heading="Total Sheets Ingested" content="12" />
+              <UILevelItem heading="Total Works Processed" content="5,384" />
+            </div>
+          </div>
+
+          <div className="box">
             <UIFormField childClass="has-icons-left">
               <UIFormInput
                 placeholder="Search projects"

--- a/assets/js/services/helpers.js
+++ b/assets/js/services/helpers.js
@@ -65,7 +65,7 @@ export function setVisibilityClass(visibility) {
     return "is-danger";
   }
   if (visibility.toUpperCase() === "AUTHENTICATED") {
-    return "is-primary is-light";
+    return "is-primary";
   }
   if (visibility.toUpperCase() === "OPEN") {
     return "is-success";

--- a/assets/styles/scss/_variables.scss
+++ b/assets/styles/scss/_variables.scss
@@ -52,7 +52,7 @@ $CamptonExtraLight: "Campton Extra Light", "Courier New", sans-serif;
 // Colors
 $primary: $nu-purple;
 $link: $nu-purple;
-$info: $rich-black-80;
+$info: $nu-purple-30;
 $success: $bright-green;
 $warning: $yellow;
 $danger: $red2;


### PR DESCRIPTION
This is some general clean up to Notifications on the Ingest Sheet process (using Bulma's new "is-light" class for `notification` class.   Also fixes the `<UIAlert />` component which displays GraphQL network errors to be a styled alert.

Also fixes the Project Screen "Add Project" button to be less confused with the search projects functionality.   And experimenting with some callout UI when we have some real numbers data flowing through the system... 

![image](https://user-images.githubusercontent.com/3020266/82708185-430eb280-9c43-11ea-99d2-97ceee5fc05a.png)

![image](https://user-images.githubusercontent.com/3020266/82708261-6fc2ca00-9c43-11ea-823a-423d34959ac1.png)

![image](https://user-images.githubusercontent.com/3020266/82708329-997bf100-9c43-11ea-862e-19890936fc1a.png)

![image](https://user-images.githubusercontent.com/3020266/82708357-a8fb3a00-9c43-11ea-9c6f-fb6dea6f09c8.png)
