### PR TITLE
730 refine ui loading

### DIFF
--- a/assets/js/components/IngestSheet/Completed.jsx
+++ b/assets/js/components/IngestSheet/Completed.jsx
@@ -10,6 +10,7 @@ import Error from "../UI/Error";
 import IngestSheetCompletedErrors from "./Completed/Errors";
 import WorkListItem from "../Work/ListItem";
 import WorkCardItem from "../Work/CardItem";
+import UISkeleton from "../UI/Skeleton";
 
 const IngestSheetCompleted = ({ sheetId }) => {
   const [isListView, setIsListView] = useState(false);
@@ -27,12 +28,7 @@ const IngestSheetCompleted = ({ sheetId }) => {
     data: errorsData,
   } = useQuery(INGEST_SHEET_COMPLETED_ERRORS, { variables: { id: sheetId } });
 
-  if (worksLoading || errorsLoading)
-    return (
-      <progress className="progress is-primary" max="100">
-        30%
-      </progress>
-    );
+  if (worksLoading || errorsLoading) return <UISkeleton rows={10} />;
   if (worksError) return <Error error={worksError} />;
   if (errorsError) return <Error error={errorsError} />;
 

--- a/assets/js/components/IngestSheet/IngestSheet.jsx
+++ b/assets/js/components/IngestSheet/IngestSheet.jsx
@@ -1,13 +1,10 @@
 import React, { useEffect } from "react";
 import { useQuery } from "@apollo/react-hooks";
 import Error from "../UI/Error";
-import UILoadingPage from "../UI/LoadingPage";
-import UILoading from "../UI/Loading";
+import UISkeleton from "../UI/Skeleton";
 import IngestSheetValidations from "./Validations";
 import { GET_INGEST_SHEET_VALIDATION_PROGRESS } from "./ingestSheet.gql";
-import IngestSheetAlert from "./Alert";
 import PropTypes from "prop-types";
-import IngestSheetActionRow from "./ActionRow";
 import IngestSheetApprovedInProgress from "./ApprovedInProgress";
 import IngestSheetCompleted from "./Completed";
 
@@ -37,38 +34,45 @@ const IngestSheet = ({
     subscribeToIngestSheetUpdates();
   }, []);
 
-  if (progressLoading) return <UILoading />;
+  //if (progressLoading) return <UILoading />;
   if (progressError) return <Error error={progressError} />;
 
   const styles = { h2IsHidden: { display: "none" } };
 
   return (
     <div className="box">
-      <h2
-        className="title is-size-5"
-        style={["COMPLETED"].indexOf(status) > -1 ? styles.h2IsHidden : {}}
-      >
-        Ingest Sheet Contents
-      </h2>
-      {["APPROVED"].indexOf(status) > -1 && (
+      {progressLoading ? (
+        <UISkeleton rows={15} />
+      ) : (
         <>
-          <IngestSheetApprovedInProgress ingestSheet={ingestSheetData} />
-        </>
-      )}
+          <h2
+            className="title is-size-5"
+            style={["COMPLETED"].indexOf(status) > -1 ? styles.h2IsHidden : {}}
+          >
+            Ingest Sheet Contents
+          </h2>
+          {["APPROVED"].indexOf(status) > -1 && (
+            <>
+              <IngestSheetApprovedInProgress ingestSheet={ingestSheetData} />
+            </>
+          )}
 
-      {["COMPLETED"].indexOf(status) > -1 && (
-        <>
-          <IngestSheetCompleted sheetId={ingestSheetData.id} />
-        </>
-      )}
+          {["COMPLETED"].indexOf(status) > -1 && (
+            <>
+              <IngestSheetCompleted sheetId={ingestSheetData.id} />
+            </>
+          )}
 
-      {["VALID", "ROW_FAIL", "FILE_FAIL", "UPLOADED"].indexOf(status) > -1 && (
-        <IngestSheetValidations
-          sheetId={id}
-          status={status}
-          initialProgress={progressData.ingestSheetValidationProgress}
-          subscribeToIngestSheetValidationProgress={progressSubscribeToMore}
-        />
+          {["VALID", "ROW_FAIL", "FILE_FAIL", "UPLOADED"].indexOf(status) >
+            -1 && (
+            <IngestSheetValidations
+              sheetId={id}
+              status={status}
+              initialProgress={progressData.ingestSheetValidationProgress}
+              subscribeToIngestSheetValidationProgress={progressSubscribeToMore}
+            />
+          )}
+        </>
       )}
     </div>
   );

--- a/assets/js/components/Project/List.jsx
+++ b/assets/js/components/Project/List.jsx
@@ -8,6 +8,7 @@ import { DELETE_PROJECT, GET_PROJECTS } from "./project.gql.js";
 import UIModalDelete from "../UI/Modal/Delete";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { formatDate, toastWrapper } from "../../services/helpers";
+import UISkeleton from "../UI/Skeleton";
 
 const ProjectList = () => {
   const [modalOpen, setModalOpen] = useState(false);
@@ -29,7 +30,7 @@ const ProjectList = () => {
     },
   });
 
-  if (loading) return <Loading />;
+  if (loading) return <UISkeleton rows={20} />;
   if (error) return <Error error={error} />;
 
   const onOpenModal = (e, project) => {

--- a/assets/js/components/UI/Form/FieldArray.jsx
+++ b/assets/js/components/UI/Form/FieldArray.jsx
@@ -21,6 +21,8 @@ const UIFormFieldArray = ({
   control,
   required,
   defaultValue = `New ${label}`,
+  mocked,
+  notLive,
   ...passedInProps
 }) => {
   const { fields, append, remove } = useFieldArray({
@@ -30,7 +32,10 @@ const UIFormFieldArray = ({
 
   return (
     <fieldset {...passedInProps}>
-      <legend data-testid="legend">{label}</legend>
+      <legend data-testid="legend">
+        {label} {mocked && <span className="tag">Mocked</span>}{" "}
+        {notLive && <span className="tag">Not Live</span>}
+      </legend>
 
       <ul style={styles.inputWrapper}>
         {fields.map((item, index) => {
@@ -89,7 +94,9 @@ UIFormFieldArray.propTypes = {
   control: PropTypes.object.isRequired,
   defaultValue: PropTypes.string,
   label: PropTypes.string.isRequired,
+  mocked: PropTypes.bool,
   name: PropTypes.string.isRequired,
+  notLive: PropTypes.bool,
   register: PropTypes.func,
   required: PropTypes.bool,
   type: PropTypes.string,

--- a/assets/js/components/UI/Form/FieldArray.test.js
+++ b/assets/js/components/UI/Form/FieldArray.test.js
@@ -41,7 +41,7 @@ describe("InputMultiple component", () => {
     const { getByTestId, getByLabelText } = setUpTests();
     expect(getByTestId("fieldset-ima-multi"));
     const legend = getByTestId("legend");
-    expect(legend.innerHTML).toEqual(props.label);
+    expect(legend.innerHTML.trim()).toEqual(props.label);
   });
 
   it("renders a field group with a form input, default value, and delete button", () => {

--- a/assets/js/components/UI/Form/FieldArrayDisplay.jsx
+++ b/assets/js/components/UI/Form/FieldArrayDisplay.jsx
@@ -1,11 +1,17 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const UIFormFieldArrayDisplay = ({ items = [], label = "" }) => {
+const UIFormFieldArrayDisplay = ({
+  items = [],
+  label = "",
+  mocked,
+  notLive,
+}) => {
   return (
     <div className="field content">
       <p data-testid="items-label">
-        <strong>{label}</strong>
+        <strong>{label}</strong> {mocked && <span className="tag">Mocked</span>}{" "}
+        {notLive && <span className="tag">Not Live</span>}
       </p>
       <ul data-testid="field-array-item-list">
         {items.map((item, i) => (
@@ -19,6 +25,8 @@ const UIFormFieldArrayDisplay = ({ items = [], label = "" }) => {
 UIFormFieldArrayDisplay.propTypes = {
   items: PropTypes.array,
   label: PropTypes.string.isRequired,
+  mocked: PropTypes.bool,
+  notLive: PropTypes.bool,
 };
 
 export default UIFormFieldArrayDisplay;

--- a/assets/js/components/UI/Skeleton.jsx
+++ b/assets/js/components/UI/Skeleton.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 // Reference: https://cssninja.io/blog/post/facebook-placeholders
 
-const UIPlaceholder = ({ isActive, type = "text", rows = 10 }) => {
+const UISkeleton = ({ type = "text", rows = 10 }) => {
   const buildRows = () => {
     let arr = [];
     for (let i = 0; i < rows; i++) {
@@ -11,8 +11,9 @@ const UIPlaceholder = ({ isActive, type = "text", rows = 10 }) => {
     }
     return arr;
   };
+
   return (
-    <div className={`loader-wrapper ${isActive ? "is-active" : ""}`}>
+    <div className="loader-wrapper is-active">
       <div className="placeload">
         {type === "text" && (
           <div className="header">
@@ -42,10 +43,10 @@ const UIPlaceholder = ({ isActive, type = "text", rows = 10 }) => {
   );
 };
 
-UIPlaceholder.propTypes = {
-  isActive: PropTypes.bool,
+UISkeleton.propTypes = {
+  loading: PropTypes.bool,
   rows: PropTypes.number,
   type: PropTypes.oneOf(["text", "full"]),
 };
 
-export default UIPlaceholder;
+export default UISkeleton;

--- a/assets/js/components/Work/CardItem.jsx
+++ b/assets/js/components/Work/CardItem.jsx
@@ -70,9 +70,9 @@ const WorkCardItem = ({
         </div>
       </div>
       <footer className="card-footer">
-        <a href="#" className="card-footer-item">
+        <Link to={`/work/${id}`} className="card-footer-item">
           View Work
-        </a>
+        </Link>
         <a href={manifestUrl} target="_blank" className="card-footer-item">
           <figure className="image is-32x32">
             <img

--- a/assets/js/components/Work/Tabs/About.jsx
+++ b/assets/js/components/Work/Tabs/About.jsx
@@ -7,7 +7,7 @@ import { useMutation } from "@apollo/react-hooks";
 import useIsEditing from "../../../hooks/useIsEditing";
 import { GET_WORK, UPDATE_WORK } from "../work.gql.js";
 import WorkTabsHeader from "./Header";
-import UIPlaceholder from "../../UI/Placeholder";
+import UISkeleton from "../../UI/Skeleton";
 import WorkTabsAboutCoreMetadata from "./About/CoreMetadata";
 import WorkTabsAboutDescriptiveMetadata from "./About/DescriptiveMetadata";
 import {
@@ -165,6 +165,7 @@ const WorkTabsAbout = ({ work }) => {
   };
 
   if (updateWorkError) return <UIError error={updateWorkError} />;
+  if (updateWorkLoading) return <UISkeleton rows={20} />;
 
   return (
     <form name="work-about-form" onSubmit={handleSubmit(onSubmit)}>
@@ -201,8 +202,6 @@ const WorkTabsAbout = ({ work }) => {
       </WorkTabsHeader>
 
       <div className="box is-relative" style={{ marginTop: "1rem" }}>
-        <UIPlaceholder isActive={updateWorkLoading} rows={10} />
-
         <h2 className="title is-size-5">
           Core Metadata{" "}
           <a onClick={() => setShowCoreMetadata(!showCoreMetadata)}>
@@ -222,8 +221,6 @@ const WorkTabsAbout = ({ work }) => {
       </div>
 
       <div className="box is-relative">
-        <UIPlaceholder isActive={updateWorkLoading} rows={10} />
-
         <h2 className="title is-size-5">
           Descriptive Metadata{" "}
           <a

--- a/assets/js/components/Work/Tabs/About.jsx
+++ b/assets/js/components/Work/Tabs/About.jsx
@@ -165,7 +165,7 @@ const WorkTabsAbout = ({ work }) => {
   };
 
   if (updateWorkError) return <UIError error={updateWorkError} />;
-  if (updateWorkLoading) return <UISkeleton rows={20} />;
+  //if (updateWorkLoading) return <UISkeleton rows={20} />;
 
   return (
     <form name="work-about-form" onSubmit={handleSubmit(onSubmit)}>
@@ -210,14 +210,18 @@ const WorkTabsAbout = ({ work }) => {
             />
           </a>
         </h2>
-        <WorkTabsAboutCoreMetadata
-          descriptiveMetadata={descriptiveMetadata}
-          errors={errors}
-          isEditing={isEditing}
-          register={register}
-          showCoreMetadata={showCoreMetadata}
-          updateWorkLoading={updateWorkLoading}
-        />
+        {updateWorkLoading ? (
+          <UISkeleton rows={10} />
+        ) : (
+          <WorkTabsAboutCoreMetadata
+            descriptiveMetadata={descriptiveMetadata}
+            errors={errors}
+            isEditing={isEditing}
+            register={register}
+            showCoreMetadata={showCoreMetadata}
+            updateWorkLoading={updateWorkLoading}
+          />
+        )}
       </div>
 
       <div className="box is-relative">
@@ -231,14 +235,18 @@ const WorkTabsAbout = ({ work }) => {
             />
           </a>
         </h2>
-        <WorkTabsAboutDescriptiveMetadata
-          control={control}
-          descriptiveMetadata={descriptiveMetadata}
-          errors={errors}
-          isEditing={isEditing}
-          register={register}
-          showDescriptiveMetadata={showDescriptiveMetadata}
-        />
+        {updateWorkLoading ? (
+          <UISkeleton rows={10} />
+        ) : (
+          <WorkTabsAboutDescriptiveMetadata
+            control={control}
+            descriptiveMetadata={descriptiveMetadata}
+            errors={errors}
+            isEditing={isEditing}
+            register={register}
+            showDescriptiveMetadata={showDescriptiveMetadata}
+          />
+        )}
       </div>
     </form>
   );

--- a/assets/js/components/Work/Tabs/About/CoreMetadata.jsx
+++ b/assets/js/components/Work/Tabs/About/CoreMetadata.jsx
@@ -83,7 +83,7 @@ const WorkTabsAboutCoreMetadata = ({
       </div>
       <div className="column is-half">
         {/* Date Created */}
-        <UIFormField label="Date Created">
+        <UIFormField label="Date Created" notLive>
           {isEditing ? (
             <UIInput
               register={register}

--- a/assets/js/components/Work/Tabs/About/DescriptiveMetadata.jsx
+++ b/assets/js/components/Work/Tabs/About/DescriptiveMetadata.jsx
@@ -9,6 +9,7 @@ import UIFormControlledTermArray from "../../../UI/Form/ControlledTermArray";
 import { useQuery } from "@apollo/react-hooks";
 import UIError from "../../../UI/Error";
 import { DESCRIPTIVE_METADATA } from "../../../../services/metadata";
+import UISkeleton from "../../../UI/Skeleton";
 
 const WorkTabsAboutDescriptiveMetadata = ({
   control,
@@ -30,7 +31,7 @@ const WorkTabsAboutDescriptiveMetadata = ({
     errors: authorityErrors,
   } = useQuery(CODE_LIST_QUERY, { variables: { scheme: "AUTHORITY" } });
 
-  if (marcLoading || authorityLoading) return null;
+  if (marcLoading || authorityLoading) return <UISkeleton rows={20} />;
   if (marcErrors || authorityErrors)
     return <UIError error={marcErrors || authorityErrors} />;
 

--- a/assets/js/components/Work/Tabs/Administrative.jsx
+++ b/assets/js/components/Work/Tabs/Administrative.jsx
@@ -15,7 +15,7 @@ import UICodedTermItem from "../../UI/CodedTerm/Item";
 import UIFormFieldArray from "../../UI/Form/FieldArray";
 import UIFormInput from "../../UI/Form/Input.jsx";
 import UIFormFieldArrayDisplay from "../../UI/Form/FieldArrayDisplay";
-import UIPlaceholder from "../../UI/Placeholder";
+import UIPlaceholder from "../../UI/Skeleton";
 
 const WorkTabsAdministrative = ({ work }) => {
   const { id, administrativeMetadata, collection, project, sheet } = work;
@@ -166,7 +166,7 @@ const WorkTabsAdministrative = ({ work }) => {
       <div className="columns">
         <div className="column is-two-thirds">
           <div className="box is-relative">
-            <UIPlaceholder isActive={updateWorkLoading} rows={10} />
+            {/* <UIPlaceholder isActive={updateWorkLoading} rows={10} /> */}
             <UIFormField label="Collection">
               {isEditing ? (
                 <UIFormSelect
@@ -246,7 +246,7 @@ const WorkTabsAdministrative = ({ work }) => {
         </div>
         <div className="column one-third">
           <div className="box is-relative">
-            <UIPlaceholder isActive={updateWorkLoading} rows={10} />
+            {/* <UIPlaceholder isActive={updateWorkLoading} rows={10} /> */}
             <UIFormField label="Project">
               <Link to={`/project/${project.id}`}>{project.name}</Link>
             </UIFormField>

--- a/assets/js/components/Work/Tabs/Administrative.jsx
+++ b/assets/js/components/Work/Tabs/Administrative.jsx
@@ -15,7 +15,7 @@ import UICodedTermItem from "../../UI/CodedTerm/Item";
 import UIFormFieldArray from "../../UI/Form/FieldArray";
 import UIFormInput from "../../UI/Form/Input.jsx";
 import UIFormFieldArrayDisplay from "../../UI/Form/FieldArrayDisplay";
-import UIPlaceholder from "../../UI/Skeleton";
+import UISkeleton from "../../UI/Skeleton";
 
 const WorkTabsAdministrative = ({ work }) => {
   const { id, administrativeMetadata, collection, project, sheet } = work;
@@ -98,16 +98,18 @@ const WorkTabsAdministrative = ({ work }) => {
       administrativeMetadata: {
         preservationLevel: { id: preservationLevel },
         status: { id: status },
-        projectName,
-        projectDesc,
-        projectProposer,
-        projectManager,
-        projectTaskNumber,
-        projectCycle,
+        // TODO: Should these be field arrays or singular values?
+        // projectName,
+        // projectDesc,
+        // projectProposer,
+        // projectManager,
+        // projectTaskNumber,
+        // projectCycle,
       },
       collectionId: collection,
-      visibility: visibility,
+      visibility: { id: visibility },
     };
+
     updateWork({
       variables: { id, work: workUpdateInput },
     });
@@ -251,7 +253,7 @@ const WorkTabsAdministrative = ({ work }) => {
               <Link to={`/project/${project.id}`}>{project.name}</Link>
             </UIFormField>
 
-            <UIFormField label="Project Cycle">
+            <UIFormField label="Project Cycle" notLive>
               {isEditing ? (
                 <UIFormInput
                   placeholder="Project Cycle"
@@ -277,6 +279,7 @@ const WorkTabsAdministrative = ({ work }) => {
                   label={item.label}
                   errors={errors}
                   key={item.name}
+                  notLive
                 />
               ))}
             {!isEditing &&
@@ -285,6 +288,8 @@ const WorkTabsAdministrative = ({ work }) => {
                   items={administrativeMetadata[item.name]}
                   label={item.label}
                   key={item.name}
+                  mocked
+                  notLive
                 />
               ))}
           </div>

--- a/assets/js/screens/Collection/Collection.jsx
+++ b/assets/js/screens/Collection/Collection.jsx
@@ -9,6 +9,7 @@ import {
 } from "../../components/Collection/collection.gql";
 import Error from "../../components//UI/Error";
 import UILoadingPage from "../../components//UI/LoadingPage";
+import UISkeleton from "../../components//UI/Skeleton";
 import { Link, useParams, useHistory } from "react-router-dom";
 import { useMutation } from "@apollo/react-hooks";
 import UIModalDelete from "../../components/UI/Modal/Delete";
@@ -36,7 +37,6 @@ const ScreensCollection = () => {
     },
   });
 
-  if (loading) return <UILoadingPage />;
   if (error) return <Error error={error} />;
 
   const onOpenModal = () => {
@@ -52,57 +52,78 @@ const ScreensCollection = () => {
     deleteCollection({ variables: { collectionId: id } });
   };
 
-  const crumbs = [
-    {
-      label: "Collections",
-      route: "/collection/list",
-    },
-    {
-      label: data.collection.name,
-      route: `/collection/${id}`,
-      isActive: true,
-    },
-  ];
+  function getCrumbs() {
+    return [
+      {
+        label: "Collections",
+        route: "/collection/list",
+      },
+      {
+        label: data.collection.name,
+        route: `/collection/${id}`,
+        isActive: true,
+      },
+    ];
+  }
 
   return (
     <Layout>
       <section className="section" data-testid="collection-screen-hero">
         <div className="container">
-          <UIBreadcrumbs items={crumbs} />
-          <div className="box">
-            <div className="columns">
-              <div className="column is-two-thirds">
-                <h1 className="title">{data.collection.name || ""}</h1>
-              </div>
-              <div className="column is-one-third buttons has-text-right">
-                <Link
-                  to={`/collection/form/${id}`}
-                  className="button is-primary"
-                  data-testid="edit-button"
-                >
-                  Edit
-                </Link>
-                <button
-                  className="button"
-                  onClick={onOpenModal}
-                  data-testid="delete-button"
-                >
-                  Delete
-                </button>
-              </div>
-            </div>
+          {loading ? (
+            <UISkeleton rows={1} />
+          ) : (
+            <UIBreadcrumbs items={getCrumbs()} />
+          )}
 
-            <Collection collection={data.collection} />
+          <div className="box">
+            {loading ? (
+              <UISkeleton rows={10} />
+            ) : (
+              <>
+                <div className="columns">
+                  <div className="column is-two-thirds">
+                    <h1 className="title">{data.collection.name || ""}</h1>
+                  </div>
+                  <div className="column is-one-third buttons has-text-right">
+                    <Link
+                      to={`/collection/form/${id}`}
+                      className="button is-primary"
+                      data-testid="edit-button"
+                    >
+                      Edit
+                    </Link>
+                    <button
+                      className="button"
+                      onClick={onOpenModal}
+                      data-testid="delete-button"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+
+                <Collection collection={data.collection} />
+              </>
+            )}
           </div>
-          <CollectionSearch collection={data.collection} />
+
+          {loading ? (
+            <UISkeleton rows={10} />
+          ) : (
+            <CollectionSearch collection={data.collection} />
+          )}
         </div>
       </section>
-      <UIModalDelete
-        isOpen={modalOpen}
-        handleClose={onCloseModal}
-        handleConfirm={handleDeleteClick}
-        thingToDeleteLabel={`Collection ${data.collection.name}`}
-      />
+
+      {data && (
+        <UIModalDelete
+          isOpen={modalOpen}
+          handleClose={onCloseModal}
+          handleConfirm={handleDeleteClick}
+          thingToDeleteLabel={`Collection ${data.collection.name}`}
+        />
+      )}
     </Layout>
   );
 };

--- a/assets/js/screens/Collection/Collection.test.js
+++ b/assets/js/screens/Collection/Collection.test.js
@@ -69,9 +69,8 @@ function setupTests() {
 it("renders without crashing", async () => {
   const { container, queryByTestId } = setupTests();
 
-  expect(queryByTestId("loading")).toBeInTheDocument();
+  //expect(queryByTestId("loading")).toBeInTheDocument();
 
-  // This "waitFor()" magically makes Apollo MockProvider warning messages go away
   await waitFor(() => {
     expect(queryByTestId("loading")).not.toBeInTheDocument();
     expect(container).toBeTruthy();

--- a/assets/js/screens/Collection/Form.jsx
+++ b/assets/js/screens/Collection/Form.jsx
@@ -4,6 +4,7 @@ import CollectionForm from "../../components/Collection/Form";
 import Layout from "../Layout";
 import Error from "../../components/UI/Error";
 import UILoadingPage from "../../components/UI/LoadingPage";
+import UISkeleton from "../../components/UI/Skeleton";
 import { GET_COLLECTION } from "../../components/Collection/collection.gql.js";
 import { useQuery } from "@apollo/react-hooks";
 import UIBreadcrumbs from "../../components/UI/Breadcrumbs";

--- a/assets/js/screens/Collection/List.jsx
+++ b/assets/js/screens/Collection/List.jsx
@@ -6,7 +6,7 @@ import {
   DELETE_COLLECTION,
 } from "../../components/Collection/collection.gql.js";
 import Error from "../../components/UI/Error";
-import UILoadingPage from "../../components/UI/LoadingPage";
+import UISkeleton from "../../components/UI/Skeleton";
 import { Link, useHistory } from "react-router-dom";
 import { useMutation } from "@apollo/react-hooks";
 import { toastWrapper } from "../../services/helpers";
@@ -42,9 +42,6 @@ const ScreensCollectionList = () => {
     },
   });
 
-  if (loading) {
-    return <UILoadingPage />;
-  }
   if (error) {
     return <Error error={error} />;
   }
@@ -65,15 +62,6 @@ const ScreensCollectionList = () => {
     setActiveCollection();
   };
 
-  const createCrumbs = () => {
-    return [
-      {
-        label: "Collections",
-        link: "/collection/list",
-      },
-    ];
-  };
-
   const handleFilterChange = (e) => {
     const searchValue = inputEl.current.value.toLowerCase();
 
@@ -92,7 +80,9 @@ const ScreensCollectionList = () => {
     <Layout>
       <section className="section" data-testid="collection-list-wrapper">
         <div className="container">
-          <UIBreadcrumbs items={[{ label: "Themes & Collections" }]} />
+          <UIBreadcrumbs
+            items={[{ label: "Themes & Collections", isActive: true }]}
+          />
 
           <div className="columns">
             <div className="column is-6">
@@ -121,32 +111,38 @@ const ScreensCollectionList = () => {
             </div>
           </div>
           <div className="box" data-testid="collection-list">
-            <h3 className="title is-size-5">All Collections</h3>
-            <UIFormField childClass="has-icons-left">
-              <UIFormInput
-                placeholder="Search collections"
-                name="collectionSearch"
-                label="Filter collections"
-              />
-              <span className="icon is-small is-left">
-                <FontAwesomeIcon icon="search" />
-              </span>
-            </UIFormField>
-
-            <ul>
-              {filteredCollections.length > 0 &&
-                filteredCollections.map((collection) => (
-                  <CollectionListRow
-                    key={collection.id}
-                    collection={collection}
-                    onOpenModal={onOpenModal}
+            {loading ? (
+              <UISkeleton rows={10} />
+            ) : (
+              <>
+                <h3 className="title is-size-5">All Collections</h3>
+                <UIFormField childClass="has-icons-left">
+                  <UIFormInput
+                    placeholder="Search collections"
+                    name="collectionSearch"
+                    label="Filter collections"
                   />
-                ))}
-            </ul>
-            {data.collections.length === 0 && (
-              <div className="content">
-                <p className="notification">No collections returned</p>
-              </div>
+                  <span className="icon is-small is-left">
+                    <FontAwesomeIcon icon="search" />
+                  </span>
+                </UIFormField>
+
+                <ul>
+                  {filteredCollections.length > 0 &&
+                    filteredCollections.map((collection) => (
+                      <CollectionListRow
+                        key={collection.id}
+                        collection={collection}
+                        onOpenModal={onOpenModal}
+                      />
+                    ))}
+                </ul>
+                {data.collections.length === 0 && (
+                  <div className="content">
+                    <p className="notification">No collections returned</p>
+                  </div>
+                )}
+              </>
             )}
           </div>
         </div>

--- a/assets/js/screens/IngestSheet/IngestSheet.jsx
+++ b/assets/js/screens/IngestSheet/IngestSheet.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import Error from "../../components/UI/Error";
 import UILoadingPage from "../../components/UI/LoadingPage";
 import UILoading from "../../components/UI/Loading";
+import UISkeleton from "../../components/UI/Skeleton";
 import IngestSheet from "../../components/IngestSheet/IngestSheet";
 import gql from "graphql-tag";
 import { useQuery } from "@apollo/react-hooks";
@@ -51,11 +52,9 @@ const ScreensIngestSheet = ({ match }) => {
     fetchPolicy: "network-only",
   });
 
-  if (crumbsLoading || sheetLoading) return <UILoading />;
   if (crumbsError || sheetError)
     return <Error error={crumbsError ? crumbsError : sheetError} />;
 
-  const { ingestSheet } = crumbsData;
   const createCrumbs = () => {
     return [
       {
@@ -63,7 +62,7 @@ const ScreensIngestSheet = ({ match }) => {
         route: `/project/list`,
       },
       {
-        label: `${ingestSheet.project.title}`,
+        label: `${crumbsData.ingestSheet.project.title}`,
         route: `/project/${id}`,
       },
       {
@@ -71,7 +70,7 @@ const ScreensIngestSheet = ({ match }) => {
         route: `/project/${id}`,
       },
       {
-        label: ingestSheet.name,
+        label: crumbsData.ingestSheet.name,
         route: `/project/${id}/ingest-sheet/${sheetId}`,
         isActive: true,
       },
@@ -82,38 +81,61 @@ const ScreensIngestSheet = ({ match }) => {
     <Layout>
       <section className="section">
         <div className="container">
-          <UIBreadcrumbs items={createCrumbs()} />
-          <div className="box">
-            <div className="columns">
-              <div className="column is-half">
-                <h1 className="title">
-                  {ingestSheet.name}{" "}
-                  <span
-                    className={`tag ${getClassFromIngestSheetStatus(
-                      sheetData.ingestSheet.status
-                    )}`}
-                  >
-                    {TEMP_USER_FRIENDLY_STATUS[sheetData.ingestSheet.status]}
-                  </span>
-                </h1>
-                <h2 className="subtitle">Ingest Sheet</h2>
-              </div>
-              <div className="column is-half">
-                <IngestSheetActionRow
-                  sheetId={sheetId}
-                  projectId={id}
-                  status={sheetData.ingestSheet.status}
-                  name={sheetData.ingestSheet.name}
-                />
-              </div>
-            </div>
+          {crumbsLoading ? (
+            <UISkeleton rows={2} />
+          ) : (
+            <UIBreadcrumbs items={createCrumbs()} />
+          )}
 
-            {["APPROVED", "FILE_FAIL", "ROW_FAIL", "UPLOADED", "VALID"].indexOf(
-              sheetData.ingestSheet.status
-            ) > -1 && <IngestSheetAlert ingestSheet={sheetData.ingestSheet} />}
+          <div className="box">
+            {sheetLoading ? (
+              <UISkeleton rows={5} />
+            ) : (
+              <>
+                <div className="columns">
+                  <div className="column is-half">
+                    <h1 className="title">
+                      {sheetData.ingestSheet.name}{" "}
+                      <span
+                        className={`tag ${getClassFromIngestSheetStatus(
+                          sheetData.ingestSheet.status
+                        )}`}
+                      >
+                        {
+                          TEMP_USER_FRIENDLY_STATUS[
+                            sheetData.ingestSheet.status
+                          ]
+                        }
+                      </span>
+                    </h1>
+                    <h2 className="subtitle">Ingest Sheet</h2>
+                  </div>
+                  <div className="column is-half">
+                    <IngestSheetActionRow
+                      sheetId={sheetId}
+                      projectId={id}
+                      status={sheetData.ingestSheet.status}
+                      name={sheetData.ingestSheet.name}
+                    />
+                  </div>
+                </div>
+
+                {[
+                  "APPROVED",
+                  "FILE_FAIL",
+                  "ROW_FAIL",
+                  "UPLOADED",
+                  "VALID",
+                ].indexOf(sheetData.ingestSheet.status) > -1 && (
+                  <IngestSheetAlert ingestSheet={sheetData.ingestSheet} />
+                )}
+              </>
+            )}
           </div>
 
-          <div className="">
+          {sheetLoading ? (
+            <UISkeleton rows={20} />
+          ) : (
             <IngestSheet
               ingestSheetData={sheetData.ingestSheet}
               projectId={id}
@@ -130,7 +152,7 @@ const ScreensIngestSheet = ({ match }) => {
                 })
               }
             />
-          </div>
+          )}
         </div>
       </section>
     </Layout>

--- a/assets/js/screens/Project/Project.jsx
+++ b/assets/js/screens/Project/Project.jsx
@@ -4,7 +4,7 @@ import Layout from "../Layout";
 import IngestSheetList from "../../components/IngestSheet/List";
 import { Link } from "react-router-dom";
 import Error from "../../components/UI/Error";
-import UILoadingPage from "../../components/UI/LoadingPage";
+import UISkeleton from "../../components/UI/Skeleton";
 import { useQuery } from "@apollo/react-hooks";
 import UIBreadcrumbs from "../../components/UI/Breadcrumbs";
 import {
@@ -50,79 +50,86 @@ const ScreensProject = () => {
     };
   };
 
-  if (loading) return <UILoadingPage />;
   if (error) return <Error error={error} />;
-
-  const { project } = data;
-
-  const breadCrumbs = [
-    {
-      label: "Projects",
-      route: "/project/list",
-    },
-    {
-      label: `${project.title}`,
-      route: `/project/${project.id}`,
-      isActive: true,
-    },
-  ];
 
   return (
     <Layout>
-      {project && (
-        <div>
-          <section className="section">
-            <div className="container">
+      <div>
+        <section className="section">
+          <div className="container">
+            {loading ? (
+              <UISkeleton rows={1} />
+            ) : (
               <UIBreadcrumbs
-                items={breadCrumbs}
+                items={[
+                  {
+                    label: "Projects",
+                    route: "/project/list",
+                  },
+                  {
+                    label: `${data.project.title}`,
+                    route: `/project/${id}`,
+                    isActive: true,
+                  },
+                ]}
                 data-testid="project-breadcrumbs"
               />
+            )}
+            <>
               <div className="box">
-                <div className="columns" data-testid="screen-header">
-                  <div className="column is-two-thirds content">
-                    <h1 className="title">{project.title}</h1>
-                    <dl>
-                      <dt>Last updated</dt>
-                      <dd>{formatDate(project.updatedAt)}</dd>
-                      <dt>Total Ingest Sheets</dt>
-                      <dd>{project.ingestSheets.length}</dd>
-                    </dl>
-                  </div>
-                  <div className="column is-one-third">
-                    <div className="buttons is-right">
-                      <Link
-                        to={{
-                          pathname: `/project/${id}/ingest-sheet/upload`,
-                          state: { projectId: project.id },
-                        }}
-                        className="button is-primary"
-                        data-testid="button-new-ingest-sheet"
-                      >
-                        <span className="icon">
-                          <FontAwesomeIcon icon="file-csv" />
-                        </span>{" "}
-                        <span>Add an Ingest Sheet</span>
-                      </Link>
+                {loading ? (
+                  <UISkeleton rows={5} />
+                ) : (
+                  <div className="columns" data-testid="screen-header">
+                    <div className="column is-two-thirds content">
+                      <h1 className="title">{data.project.title}</h1>
+                      <dl>
+                        <dt>Last updated</dt>
+                        <dd>{formatDate(data.project.updatedAt)}</dd>
+                        <dt>Total Ingest Sheets</dt>
+                        <dd>{data.project.ingestSheets.length}</dd>
+                      </dl>
+                    </div>
+                    <div className="column is-one-third">
+                      <div className="buttons is-right">
+                        <Link
+                          to={{
+                            pathname: `/project/${id}/ingest-sheet/upload`,
+                            state: { projectId: id },
+                          }}
+                          className="button is-primary"
+                          data-testid="button-new-ingest-sheet"
+                        >
+                          <span className="icon">
+                            <FontAwesomeIcon icon="file-csv" />
+                          </span>{" "}
+                          <span>Add an Ingest Sheet</span>
+                        </Link>
+                      </div>
                     </div>
                   </div>
-                </div>
+                )}
               </div>
               <div className="box" data-testid="screen-content">
-                <IngestSheetList
-                  project={project}
-                  subscribeToIngestSheetStatusChanges={() =>
-                    subscribeToMore({
-                      document: INGEST_SHEET_STATUS_UPDATES_FOR_PROJECT_SUBSCRIPTION,
-                      variables: { projectId: project.id },
-                      updateQuery: handleIngestSheetStatusChange,
-                    })
-                  }
-                />
+                {loading ? (
+                  <UISkeleton rows={15} />
+                ) : (
+                  <IngestSheetList
+                    project={data.project}
+                    subscribeToIngestSheetStatusChanges={() =>
+                      subscribeToMore({
+                        document: INGEST_SHEET_STATUS_UPDATES_FOR_PROJECT_SUBSCRIPTION,
+                        variables: { projectId: id },
+                        updateQuery: handleIngestSheetStatusChange,
+                      })
+                    }
+                  />
+                )}
               </div>
-            </div>
-          </section>
-        </div>
-      )}
+            </>
+          </div>
+        </section>
+      </div>
     </Layout>
   );
 };

--- a/assets/js/screens/Work/Work.jsx
+++ b/assets/js/screens/Work/Work.jsx
@@ -10,7 +10,7 @@ import { useHistory } from "react-router-dom";
 import { useParams } from "react-router-dom";
 import Layout from "../Layout";
 import Error from "../../components/UI/Error";
-import UILoadingPage from "../../components/UI/LoadingPage";
+import UISkeleton from "../../components/UI/Skeleton";
 import Work from "../../components/Work/Work";
 import UIBreadcrumbs from "../../components/UI/Breadcrumbs";
 import { setVisibilityClass, toastWrapper } from "../../services/helpers";
@@ -55,20 +55,7 @@ const ScreensWork = () => {
     setDeleteModalOpen(false);
   };
 
-  if (loading) return <UILoadingPage />;
   if (error) return <Error error={error} />;
-
-  const {
-    work: {
-      accessionNumber,
-      published,
-      descriptiveMetadata,
-      project,
-      sheet,
-      visibility,
-      workType,
-    },
-  } = data;
 
   const breadCrumbs = [
     {
@@ -83,7 +70,7 @@ const ScreensWork = () => {
 
   const handlePublishClick = () => {
     let workUpdateInput = {
-      published: !published,
+      published: !data.work.published,
     };
 
     updateWork({
@@ -97,76 +84,97 @@ const ScreensWork = () => {
         <div className="container">
           <UIBreadcrumbs items={breadCrumbs} data-testid="work-breadcrumbs" />
           <div className="box">
-            <div className="columns">
-              <div className="column is-two-thirds">
-                <h1 className="title">
-                  {descriptiveMetadata.title || "Untitled"}{" "}
-                </h1>
-                <p>
-                  <span
-                    className={`tag ${published ? "is-info" : "is-warning"}`}
-                  >
-                    {published ? "Published" : "Not Published"}
-                  </span>{" "}
-                  <span className={`tag ${setVisibilityClass(visibility.id)}`}>
-                    {visibility.label}
-                  </span>{" "}
-                  <span className={`tag is-info`}>{workType.label}</span>
-                </p>
-              </div>
-              <div className="column is-one-third">
-                <div className="buttons is-right">
-                  <button
-                    className={`button is-primary ${
-                      published ? "is-outlined" : ""
-                    }`}
-                    data-testid="publish-button"
-                    onClick={handlePublishClick}
-                  >
-                    {!published ? "Publish" : "Unpublish"}
-                  </button>
-                  <button
-                    className="button"
-                    data-testid="delete-button"
-                    onClick={onOpenModal}
-                  >
-                    Delete
-                  </button>
+            {loading ? (
+              <UISkeleton rows={5} />
+            ) : (
+              <>
+                <div className="columns">
+                  <div className="column is-two-thirds">
+                    <h1 className="title">
+                      {data.work.descriptiveMetadata.title || "Untitled"}{" "}
+                    </h1>
+                    <p>
+                      <span
+                        className={`tag ${
+                          data.work.published ? "is-info" : "is-warning"
+                        }`}
+                      >
+                        {data.work.published ? "Published" : "Not Published"}
+                      </span>{" "}
+                      <span
+                        className={`tag ${setVisibilityClass(
+                          data.work.visibility.id
+                        )}`}
+                      >
+                        {data.work.visibility.label}
+                      </span>{" "}
+                      <span className={`tag is-info`}>
+                        {data.work.workType.label}
+                      </span>
+                    </p>
+                  </div>
+                  <div className="column is-one-third">
+                    <div className="buttons is-right">
+                      <button
+                        className={`button is-primary ${
+                          data.work.published ? "is-outlined" : ""
+                        }`}
+                        data-testid="publish-button"
+                        onClick={handlePublishClick}
+                      >
+                        {!data.work.published ? "Publish" : "Unpublish"}
+                      </button>
+                      <button
+                        className="button"
+                        data-testid="delete-button"
+                        onClick={onOpenModal}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </div>
 
-            <div className="content">
-              <dl>
-                <dt>Accession Number</dt>
-                <dd>{accessionNumber}</dd>
-                <dt>Project</dt>
-                <dd>
-                  <Link to={`/project/${project.id}`}>{project.name}</Link>
-                </dd>
-                <dt>Ingest Sheet</dt>
-                <dd>
-                  <Link to={`/project/${project.id}/ingest-sheet/${sheet.id}`}>
-                    {sheet.name}
-                  </Link>
-                </dd>
-              </dl>
-            </div>
+                <div className="content">
+                  <dl>
+                    <dt>Accession Number</dt>
+                    <dd>{data.work.accessionNumber}</dd>
+                    <dt>Project</dt>
+                    <dd>
+                      <Link to={`/project/${data.work.project.id}`}>
+                        {data.work.project.name}
+                      </Link>
+                    </dd>
+                    <dt>Ingest Sheet</dt>
+                    <dd>
+                      <Link
+                        to={`/project/${data.work.project.id}/ingest-sheet/${data.work.sheet.id}`}
+                      >
+                        {data.work.sheet.name}
+                      </Link>
+                    </dd>
+                  </dl>
+                </div>
+              </>
+            )}
           </div>
         </div>
       </section>
-      <Work work={data.work} />
 
-      <UIModalDelete
-        isOpen={deleteModalOpen}
-        handleClose={onCloseModal}
-        handleConfirm={handleDeleteClick}
-        thingToDeleteLabel={`Work ${
-          descriptiveMetadata
-            ? descriptiveMetadata.title || accessionNumber
-            : accessionNumber
-        }`}
-      />
+      {loading ? <UISkeleton rows={20} /> : <Work work={data.work} />}
+
+      {data && (
+        <UIModalDelete
+          isOpen={deleteModalOpen}
+          handleClose={onCloseModal}
+          handleConfirm={handleDeleteClick}
+          thingToDeleteLabel={`Work ${
+            data.work.descriptiveMetadata
+              ? data.work.descriptiveMetadata.title || data.work.accessionNumber
+              : data.work.accessionNumber
+          }`}
+        />
+      )}
     </Layout>
   );
 };

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -14,4 +14,4 @@
 
 @import "./scss/mixins";
 @import "./scss/base";
-@import "./scss/loading";
+@import "./scss/skeleton";

--- a/assets/styles/scss/_skeleton.scss
+++ b/assets/styles/scss/_skeleton.scss
@@ -1,9 +1,9 @@
 .loader-wrapper {
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
+  // position: absolute;
+  // top: 0;
+  // left: 0;
+  // height: 100%;
+  // width: 100%;
   background: #fff;
   opacity: 0;
   z-index: -1;

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -6675,10 +6675,10 @@ phoenix@^1.4.0:
   integrity sha512-0cTQ5XfAqt8l3+KnnX0AW3hww0N37bOgTTeyt1cH80VJNeEMab8+0bK421XhVoaQ8R0Vsc0GS3W6CyI4eND0Ew==
 
 "phoenix@file:../deps/phoenix":
-  version "1.4.17"
+  version "1.5.2"
 
 "phoenix_html@file:../deps/phoenix_html":
-  version "2.14.1"
+  version "2.14.2"
 
 picomatch@^2.0.4, picomatch@^2.0.5:
   version "2.2.2"


### PR DESCRIPTION
Overall, this PR replaces almost all front-end "loaders" and progress bars scattered through the app, with "skeletons", which ideally should provide better UX and less distracting, things bouncing around syndrome.

![image](https://user-images.githubusercontent.com/3020266/83073748-8ea3d080-a036-11ea-8d06-4f79e71d4ae2.png)

Usage of loaders has been somewhat challenging, as we seem to have a lot of individual GraphQL queries, and might not be using GraphQL as fully intended (limited network requests....ideally one per screen).  This work makes that a little more apparent, and something to think about as we enter the next cycle?
