### PR TITLE
Set simpler authority variable in ControlledTermArrayItem component

### DIFF
--- a/assets/js/components/UI/Form/ControlledTermArrayItem.jsx
+++ b/assets/js/components/UI/Form/ControlledTermArrayItem.jsx
@@ -29,10 +29,7 @@ const UIFormControlledTermArrayItem = ({
   const handleInputChange = (val) => {
     getAuthResults({
       variables: {
-        authority: {
-          id: currentAuthority,
-          scheme: "AUTHORITY",
-        },
+        authority: currentAuthority,
         query: val,
       },
     });


### PR DESCRIPTION
- Sets the correct authority variable (just the ID string) in `ControlledTermArrayItem`