### PR TITLE
Fix bugs in removing Controlled Term field array form elements

### DIFF
--- a/assets/js/components/UI/Form/ControlledTermArray.jsx
+++ b/assets/js/components/UI/Form/ControlledTermArray.jsx
@@ -6,15 +6,6 @@ import UIFormSelect from "./Select";
 import UIFormControlledTermArrayItem from "./ControlledTermArrayItem";
 import { hasRole } from "../../../services/metadata";
 
-const styles = {
-  inputWrapper: {
-    marginBottom: "1rem",
-  },
-  deleteButton: {
-    marginTop: "1rem",
-  },
-};
-
 const UIFormControlledTermArray = ({
   codeLists: { authorities = [], marcRelators = [] },
   control,
@@ -27,24 +18,26 @@ const UIFormControlledTermArray = ({
 }) => {
   const { fields, append, remove } = useFieldArray({
     control,
-    name,
+    name, // Metadata item form name
+    keyName: "useFieldArrayId",
   });
 
   return (
     <>
-      <ul style={styles.inputWrapper}>
+      <ul className="mb-3">
         {fields.map((item, index) => {
+          // Metadata item name combined with it's index in the array of multiple entries
           const itemName = `${name}[${index}]`;
 
           return (
-            <li key={item.id}>
+            <li key={item.useFieldArrayId}>
               <fieldset>
                 <legend
                   className="has-text-grey has-text-weight-light"
                   data-testid="legend"
                 >{`${label} #${index + 1}`}</legend>
 
-                {/* Existing values are NOT editable, so we save them in hidden fields */}
+                {/* Existing values are NOT editable, so we save form data needed in the POST update, in hidden fields here */}
                 {!item.new && (
                   <>
                     <p>
@@ -67,6 +60,7 @@ const UIFormControlledTermArray = ({
                   </>
                 )}
 
+                {/* New form entries */}
                 {item.new && (
                   <>
                     {hasRole(name) && (
@@ -77,6 +71,7 @@ const UIFormControlledTermArray = ({
                             !!(errors[name] && errors[name][index].roleId)
                           }
                           name={`${itemName}.roleId`}
+                          defaultValue={item.roleId}
                           label="Role"
                           options={marcRelators}
                           register={register}
@@ -101,9 +96,8 @@ const UIFormControlledTermArray = ({
 
                 <button
                   type="button"
-                  className="button is-light is-small"
+                  className="button is-light is-small mt-3"
                   onClick={() => remove(index)}
-                  style={styles.deleteButton}
                   data-testid="button-delete-field-array-row"
                 >
                   <span className="icon">
@@ -121,7 +115,7 @@ const UIFormControlledTermArray = ({
         type="button"
         className="button is-text is-small"
         onClick={() => {
-          append({ new: true });
+          append({ new: true, id: "", label: "", roleId: "" });
         }}
         data-testid="button-add-field-array-row"
       >

--- a/assets/js/components/UI/Form/ControlledTermArrayItem.jsx
+++ b/assets/js/components/UI/Form/ControlledTermArrayItem.jsx
@@ -19,6 +19,7 @@ const UIFormControlledTermArrayItem = ({
   const [getAuthResults, { error, loading, data }] = useLazyQuery(
     AUTHORITY_SEARCH
   );
+
   const inputName = `${[name]}[${index}]`;
   const hasErrors = errors[name] && errors[name][index].label;
 
@@ -26,6 +27,7 @@ const UIFormControlledTermArrayItem = ({
     setCurrentAuthority(e.target.value);
   };
 
+  // Handle user entering search input
   const handleInputChange = (val) => {
     getAuthResults({
       variables: {
@@ -35,8 +37,10 @@ const UIFormControlledTermArrayItem = ({
     });
   };
 
+  // Handle user selecting an item in the dropdown list
   const handleItemSelected = (val) => {
-    control.setValue([{ [`${inputName}.id`]: val.id }]);
+    // Set new value with React Hook Form of the hidden variable below
+    control.setValue(`${inputName}.id`, val.id);
   };
 
   return (
@@ -44,10 +48,12 @@ const UIFormControlledTermArrayItem = ({
       <div className="field">
         <label className="label">Authority</label>
         <UIFormSelect
-          name={`${[name]}Authority[${index}]`}
+          defaultValue={item.authority}
+          name={`${inputName}.authority`}
           label="Authority"
-          options={authorities}
           onChange={handleAuthorityChange}
+          options={authorities}
+          register={register}
         />
       </div>
 
@@ -61,6 +67,7 @@ const UIFormControlledTermArrayItem = ({
           handleItemSelected={handleItemSelected}
           hasErrors={hasErrors}
           inputName={inputName}
+          initialInputValue={item.label || ""}
           register={register}
         />
         {hasErrors && (
@@ -79,6 +86,7 @@ function DropDownComboBox({
   handleItemSelected,
   hasErrors,
   inputName,
+  initialInputValue,
   register,
 }) {
   const {
@@ -91,6 +99,7 @@ function DropDownComboBox({
     isOpen,
     selectedItem,
   } = useCombobox({
+    initialInputValue,
     items: authoritiesSearch,
     itemToString: (item) => (item ? item.label : ""),
     onInputValueChange: ({ inputValue }) => {

--- a/assets/js/components/Work/Tabs/About.jsx
+++ b/assets/js/components/Work/Tabs/About.jsx
@@ -34,7 +34,8 @@ const WorkTabsAbout = ({ work }) => {
   useEffect(() => {
     // TODO: Automate the populating of values below from DESCRIPTIVE_METADATA constant
 
-    // Tell React Hook Form to update field array form values when a Work updates
+    // Tell React Hook Form to update field array form values
+    // with existing values, or when a Work updates
     reset({
       abstract: descriptiveMetadata.abstract,
       alternateTitle: descriptiveMetadata.alternateTitle,

--- a/assets/js/components/Work/Tabs/About/DescriptiveMetadata.jsx
+++ b/assets/js/components/Work/Tabs/About/DescriptiveMetadata.jsx
@@ -34,7 +34,6 @@ const WorkTabsAboutDescriptiveMetadata = ({
   if (marcLoading || authorityLoading) return <UISkeleton rows={20} />;
   if (marcErrors || authorityErrors)
     return <UIError error={marcErrors || authorityErrors} />;
-
   if (!authorityData || !marcData) {
     return <UIError error={{ message: "No Authority data or no Marc data" }} />;
   }


### PR DESCRIPTION
This fixes some unhandled scenarios for adding & removing ControlledTerm items _before_ submitting the form.  To test, add some items (with and without roles), remove them, and verify all the information doesn't reset or disappear.

![image](https://user-images.githubusercontent.com/3020266/86287703-3f5d3c80-bbae-11ea-8e4f-115ddacd4c0b.png)
