### PR TITLE
Set up batch edit route and skeleton screen

### DIFF
--- a/assets/js/components/BatchEdit/PreviewItems.js
+++ b/assets/js/components/BatchEdit/PreviewItems.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function BatchEditPreviewItems() {
+  return <h2 className="title is-size-4">Preview of items go here</h2>;
+}

--- a/assets/js/components/BatchEdit/Tabs.jsx
+++ b/assets/js/components/BatchEdit/Tabs.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from "react";
+
+export default function BatchEditTabs() {
+  const [activeTab, setActiveTab] = useState("tab-about");
+
+  const handleTabClick = (e) => {
+    setActiveTab(e.target.id);
+  };
+
+  return (
+    <>
+      <div className="tabs is-centered is-boxed" data-testid="tabs">
+        <ul>
+          <li className={`${activeTab === "tab-about" && "is-active"}`}>
+            <a id="tab-about" data-testid="tab-about" onClick={handleTabClick}>
+              About this item
+            </a>
+          </li>
+          <li
+            className={`${activeTab === "tab-administrative" && "is-active"}`}
+          >
+            <a
+              id="tab-administrative"
+              data-testid="tab-administrative"
+              onClick={handleTabClick}
+            >
+              Administrative
+            </a>
+          </li>
+        </ul>
+      </div>
+      <div className="tabs-container">
+        <div
+          data-testid="tab-about-content"
+          className={`${activeTab !== "tab-about" ? "is-hidden" : ""}`}
+        >
+          <p>content here</p>
+        </div>
+        <div
+          data-testid="tab-administrative-content"
+          className={`${activeTab !== "tab-administrative" ? "is-hidden" : ""}`}
+        >
+          <p>administrative content here</p>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/assets/js/screens/BatchEdit/BatchEdit.jsx
+++ b/assets/js/screens/BatchEdit/BatchEdit.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+import Layout from "../Layout";
+import UIBreadcrumbs from "../../components/UI/Breadcrumbs";
+import BatchEditPreviewItems from "../../components/BatchEdit/PreviewItems";
+import BatchEditTabs from "../../components/BatchEdit/Tabs";
+
+export default function BatchEdit() {
+  return (
+    <Layout>
+      <section className="section">
+        <div className="container">
+          <UIBreadcrumbs
+            items={[
+              { label: "Batch Edit", route: "/batch-edit", isActive: true },
+            ]}
+          />
+          <div className="box">
+            <h1 className="title" data-testid="title">
+              Batch Edit
+            </h1>
+            <p data-testid="num-results">Editing 50 rows</p>
+          </div>
+
+          <div className="box" data-testid="preview-wrapper">
+            <BatchEditPreviewItems />
+          </div>
+
+          <div className="box" data-testid="tabs-wrapper">
+            <BatchEditTabs />
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/assets/js/screens/BatchEdit/BatchEdit.test.js
+++ b/assets/js/screens/BatchEdit/BatchEdit.test.js
@@ -1,0 +1,36 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { renderWithRouter } from "../../services/testing-helpers";
+import ScreensBatchEdit from "./BatchEdit";
+
+describe("BatchEdit component", () => {
+  function setupComponent() {
+    return renderWithRouter(<ScreensBatchEdit />);
+  }
+
+  it("renders without crashing", () => {
+    expect(setupComponent());
+  });
+
+  it("renders breadcrumbs", () => {
+    const { getByTestId } = setupComponent();
+    expect(getByTestId("breadcrumbs")).toBeInTheDocument();
+  });
+
+  it("renders screen title and number of records editing", () => {
+    const { getByTestId, queryByText } = setupComponent();
+    expect(getByTestId("title")).toBeInTheDocument();
+    expect(getByTestId("num-results")).toBeInTheDocument();
+    expect(queryByText("Editing 50 rows")).toBeInTheDocument();
+  });
+
+  it("renders the item preview window", () => {
+    const { getByTestId } = setupComponent();
+    expect(getByTestId("preview-wrapper")).toBeInTheDocument();
+  });
+
+  it("renders Tabs section", () => {
+    const { getByTestId } = setupComponent();
+    expect(getByTestId("tabs-wrapper")).toBeInTheDocument();
+  });
+});

--- a/assets/js/screens/Root.jsx
+++ b/assets/js/screens/Root.jsx
@@ -13,6 +13,7 @@ import ScreensWorkList from "./Work/List";
 import ScreensCollectionList from "./Collection/List";
 import ScreensCollection from "./Collection/Collection";
 import ScreensCollectionForm from "./Collection/Form";
+import ScreensBatchEdit from "./BatchEdit/BatchEdit";
 import Login from "./Login";
 import PrivateRoute from "../components/Auth/PrivateRoute";
 import ScrollToTop from "../components/ScrollToTop";
@@ -36,6 +37,11 @@ export default class Root extends React.Component {
             <ScrollToTop />
             <Switch>
               <Route exact path="/login" component={Login} />
+              <PrivateRoute
+                exact
+                path="/batch-edit"
+                component={ScreensBatchEdit}
+              />
               <PrivateRoute
                 exact
                 path="/project/list"

--- a/assets/js/screens/Work/List.jsx
+++ b/assets/js/screens/Work/List.jsx
@@ -5,6 +5,7 @@ import { IIIFProvider } from "../../components/IIIF/IIIFProvider";
 import WorkCardItem from "../../components/Work/CardItem";
 import WorkListItem from "../../components/Work/ListItem";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Link } from "react-router-dom";
 
 const ScreensWorkList = () => {
   const [isListView, setIsListView] = useState(false);
@@ -51,6 +52,9 @@ const ScreensWorkList = () => {
           </div>
         </div>
         <div className="container">
+          <p>
+            <Link to="/batch-edit">Go to batch edit</Link>
+          </p>
           <IIIFProvider>
             <ReactiveList
               componentId="SearchResult"


### PR DESCRIPTION
Sets up the bones of batch edit screen and route:  You can access the new screen from a placeholder link on the Search screen.

![image](https://user-images.githubusercontent.com/3020266/86377360-dd541400-bc4d-11ea-8dd0-a523ee67b516.png)


![image](https://user-images.githubusercontent.com/3020266/86377194-a251e080-bc4d-11ea-9ff6-4ef6585efcb9.png)



