### PR TITLE
Add two layers of caching (DB and ETS) for controlled term fetches

### DIFF
--- a/lib/meadow/data/controlled_terms.ex
+++ b/lib/meadow/data/controlled_terms.ex
@@ -1,0 +1,168 @@
+defmodule Meadow.Data.ControlledTerms do
+  @moduledoc """
+  Caching context for Controlled Terms
+  """
+
+  import Ecto.Query
+
+  alias Meadow.Data.Schemas.ControlledTermCache
+  alias Meadow.Repo
+
+  @type cache_status :: :db | :memory | :miss
+  @type controlled_term :: %{id: binary(), label: binary()}
+  @type fetch_result :: {{:ok, cache_status()}, controlled_term()}
+
+  @doc """
+  Returns a cached term, fetching and storing it if necessary.
+
+  ## Examples
+
+      # Cache miss
+      iex> fetch("http://id.loc.gov/authorities/names/n50034776")
+      {{:ok, :miss},
+        %{
+          id: "http://id.loc.gov/authorities/names/n50034776",
+          label: "Carver, George Washington, 1864?-1943"
+        }}
+
+      # Found in DB cache
+      iex> fetch("http://id.loc.gov/authorities/names/n50034776")
+      {{:ok, :db},
+        %{
+          id: "http://id.loc.gov/authorities/names/n50034776",
+          label: "Carver, George Washington, 1864?-1943"
+        }}
+
+      # Found in ETS cache
+      iex> fetch("http://id.loc.gov/authorities/names/n50034776")
+      {{:ok, :memory},
+        %{
+          id: "http://id.loc.gov/authorities/names/n50034776",
+          label: "Carver, George Washington, 1864?-1943"
+        }}
+
+      # Error
+      iex> fetch("invalid_id")
+      {:error, :unknown_authority}
+  """
+  @spec fetch(id :: binary()) :: fetch_result() | {:error, any()}
+  def fetch(id), do: ets_fetch(id)
+
+  @doc """
+  Like fetch/1, but raises on error
+
+  ## Examples
+
+      iex> fetch!("http://id.loc.gov/authorities/names/n50034776")
+      %{
+        id: "http://id.loc.gov/authorities/names/n50034776",
+        label: "Carver, George Washington, 1864?-1943"
+      }
+
+      # Error
+      iex> fetch!("invalid_id")
+      ** (RuntimeError) Error fetching controlled term `invalid_id': unknown_authority
+  """
+  @spec fetch!(id :: binary()) :: controlled_term()
+  def fetch!(id) do
+    case fetch(id) do
+      {{:ok, _}, term} -> term
+      {:error, error} -> raise "Error fetching controlled term `#{id}': #{error}"
+    end
+  end
+
+  @doc """
+  Clears the entire cache
+  """
+  @spec clear!() :: :ok | {:error, any()}
+  def clear! do
+    Cachex.clear!(Meadow.Cache.ControlledTerms)
+    Repo.delete_all(ControlledTermCache)
+  end
+
+  @doc """
+  Clears a single ID from the cache
+  """
+  @spec clear!(id :: binary()) :: :ok | {:error, any()}
+  def clear!(id) do
+    Cachex.del!(Meadow.Cache.ControlledTerms, id)
+
+    from(e in ControlledTermCache, where: e.id == ^id)
+    |> Repo.delete_all()
+  end
+
+  @doc """
+  Deletes values from the cache based on age in seconds and (optional) ID prefix
+
+  ## Examples
+
+      # Clear all entries older than 24 hours
+      iex> clear!(86_400)
+      :ok
+
+      # Clear all LCNAF entries older than 24 hours
+      iex> clear!(86_400, "http://id.loc.gov/authorities/names/")
+      :ok
+  """
+  @spec expire!(age_in_seconds :: integer(), prefix :: binary()) :: :ok | {:error, any()}
+  def expire!(age_in_seconds, prefix \\ "") do
+    Cachex.clear!(Meadow.Cache.ControlledTerms)
+
+    with timestamp <- NaiveDateTime.utc_now() |> NaiveDateTime.add(-age_in_seconds) do
+      from(e in ControlledTermCache,
+        where: e.updated_at < ^timestamp,
+        where: like(e.id, ^(prefix <> "%"))
+      )
+      |> Repo.delete_all()
+    end
+  end
+
+  defp ets_fetch(id) do
+    case Cachex.get!(Meadow.Cache.ControlledTerms, id) do
+      nil ->
+        case db_fetch(id) do
+          {{:ok, _}, term} = result ->
+            ets_store(term)
+            result
+
+          other ->
+            other
+        end
+
+      term ->
+        {{:ok, :memory}, term}
+    end
+  end
+
+  defp ets_store(term),
+    do: Cachex.put!(Meadow.Cache.ControlledTerms, term.id, term)
+
+  defp db_fetch(id) do
+    case Repo.get(ControlledTermCache, id) do
+      nil ->
+        case cache(id) do
+          {:ok, term} -> {{:ok, :miss}, term}
+          other -> other
+        end
+
+      %ControlledTermCache{id: id, label: label} ->
+        {{:ok, :db}, %{id: id, label: label}}
+    end
+  end
+
+  defp cache(id) do
+    Cachex.del!(Meadow.Cache.ControlledTerms, id)
+
+    case Authoritex.fetch(id) do
+      {:ok, %{id: id, label: label}} ->
+        %ControlledTermCache{id: id}
+        |> ControlledTermCache.changeset(%{label: label})
+        |> Repo.insert_or_update()
+
+        {:ok, %{id: id, label: label}}
+
+      other ->
+        other
+    end
+  end
+end

--- a/lib/meadow/data/schemas/controlled_term_cache.ex
+++ b/lib/meadow/data/schemas/controlled_term_cache.ex
@@ -1,0 +1,20 @@
+defmodule Meadow.Data.Schemas.ControlledTermCache do
+  @moduledoc """
+  Schema for Controlled Term Cache
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+  @primary_key {:id, :string, autogenerate: false}
+
+  schema "controlled_term_cache" do
+    field :label, :string
+    timestamps()
+  end
+
+  @doc false
+  def changeset(entry, attrs) do
+    entry
+    |> cast(attrs, [:id, :label])
+    |> validate_required([:id, :label])
+  end
+end

--- a/lib/meadow/data/schemas/types/controlled_term.ex
+++ b/lib/meadow/data/schemas/types/controlled_term.ex
@@ -4,6 +4,7 @@ defmodule Meadow.Data.Types.ControlledTerm do
   """
 
   use Ecto.Type
+  alias Meadow.Data.ControlledTerms
 
   def embed_as(:json), do: :dump
 
@@ -24,8 +25,8 @@ defmodule Meadow.Data.Types.ControlledTerm do
 
   defp validate_uri(uri) do
     # replace with real lookup/cache call
-    case Authoritex.fetch(uri) do
-      {:ok, %{label: label}} ->
+    case ControlledTerms.fetch(uri) do
+      {{:ok, _}, %{label: label}} ->
         {:ok, %{id: uri, label: label}}
 
       {:error, error} ->

--- a/lib/meadow_web/resolvers/authorities_search.ex
+++ b/lib/meadow_web/resolvers/authorities_search.ex
@@ -1,11 +1,16 @@
 defmodule MeadowWeb.Resolvers.Data.AuthoritiesSearch do
   @moduledoc "GraphQL Resolvers for authority searching"
 
+  alias Meadow.Data.ControlledTerms
+
   def search(%{authority: code, query: query}, _) do
     Authoritex.search(code, query)
   end
 
   def fetch_label(%{id: id}, _) do
-    Authoritex.fetch(id)
+    case ControlledTerms.fetch(id) do
+      {{:ok, _}, term} -> {:ok, term}
+      other -> other
+    end
   end
 end

--- a/priv/repo/migrations/20200708160406_create_controlled_term_cache.exs
+++ b/priv/repo/migrations/20200708160406_create_controlled_term_cache.exs
@@ -1,0 +1,12 @@
+defmodule Meadow.Repo.Migrations.CreateControlledTermCache do
+  use Ecto.Migration
+
+  def change do
+    create table(:controlled_term_cache, primary_key: false) do
+      add :id, :string, primary_key: true
+      add :label, :string
+
+      timestamps()
+    end
+  end
+end

--- a/test/meadow/data/controlled_terms_test.exs
+++ b/test/meadow/data/controlled_terms_test.exs
@@ -1,0 +1,148 @@
+defmodule Meadow.Data.ControlledTermsTest do
+  use Meadow.DataCase
+
+  alias Authoritex.Mock
+  alias Meadow.Data.ControlledTerms
+  alias Meadow.Data.Schemas.ControlledTermCache
+  alias Meadow.Repo
+
+  @data [
+    %{
+      id: "mock1:result1",
+      label: "First Result",
+      qualified_label: "First Result (1)",
+      hint: "(1)"
+    },
+    %{
+      id: "mock1:result2",
+      label: "Second Result",
+      qualified_label: "Second Result (2)",
+      hint: "(2)"
+    },
+    %{
+      id: "mock2:result3",
+      label: "Third Result",
+      qualified_label: "Third Result (3)",
+      hint: "(3)"
+    }
+  ]
+
+  setup do
+    Mock.set_data(@data)
+    ControlledTerms.clear!()
+    :ok
+  end
+
+  describe "fetch/1" do
+    test "cache miss" do
+      assert {{:ok, :miss}, term} = ControlledTerms.fetch("mock1:result1")
+      assert term == %{id: "mock1:result1", label: "First Result"}
+    end
+
+    test "memory cache hit" do
+      assert {{:ok, :miss}, term} = ControlledTerms.fetch("mock1:result1")
+      assert {{:ok, :memory}, term} = ControlledTerms.fetch("mock1:result1")
+      assert term == %{id: "mock1:result1", label: "First Result"}
+    end
+
+    test "db cache hit" do
+      assert {{:ok, :miss}, term} = ControlledTerms.fetch("mock1:result1")
+      Cachex.clear!(Meadow.Cache.ControlledTerms)
+      assert {{:ok, :db}, term} = ControlledTerms.fetch("mock1:result1")
+      assert term == %{id: "mock1:result1", label: "First Result"}
+    end
+
+    test "invalid term" do
+      assert {:error, 404} == ControlledTerms.fetch("mock0:result0")
+    end
+  end
+
+  describe "fetch!/1" do
+    test "cache miss" do
+      assert term = ControlledTerms.fetch!("mock1:result1")
+      assert term == %{id: "mock1:result1", label: "First Result"}
+    end
+
+    test "memory cache hit" do
+      assert term = ControlledTerms.fetch!("mock1:result1")
+      assert term = ControlledTerms.fetch!("mock1:result1")
+      assert term == %{id: "mock1:result1", label: "First Result"}
+    end
+
+    test "db cache hit" do
+      assert term = ControlledTerms.fetch!("mock1:result1")
+      Cachex.clear!(Meadow.Cache.ControlledTerms)
+      assert term = ControlledTerms.fetch!("mock1:result1")
+      assert term == %{id: "mock1:result1", label: "First Result"}
+    end
+
+    test "invalid term" do
+      assert_raise(RuntimeError, fn -> ControlledTerms.fetch!("mock0:result0") end)
+    end
+  end
+
+  describe "clear!" do
+    setup do
+      ControlledTerms.fetch("mock1:result1")
+      ControlledTerms.fetch("mock1:result2")
+      ControlledTerms.fetch("mock2:result3")
+      :ok
+    end
+
+    test "clear!/0" do
+      assert {3, nil} == ControlledTerms.clear!()
+      assert {{:ok, :miss}, _} = ControlledTerms.fetch("mock1:result1")
+      assert {{:ok, :miss}, _} = ControlledTerms.fetch("mock1:result2")
+      assert {{:ok, :miss}, _} = ControlledTerms.fetch("mock2:result3")
+    end
+
+    test "clear!/1" do
+      assert {1, nil} == ControlledTerms.clear!("mock1:result2")
+      assert {{:ok, :memory}, _} = ControlledTerms.fetch("mock1:result1")
+      assert {{:ok, :miss}, _} = ControlledTerms.fetch("mock1:result2")
+      assert {{:ok, :memory}, _} = ControlledTerms.fetch("mock2:result3")
+    end
+  end
+
+  describe "expire/2" do
+    setup do
+      naive_secs_ago = fn s ->
+        NaiveDateTime.utc_now()
+        |> NaiveDateTime.add(-s)
+        |> NaiveDateTime.truncate(:second)
+      end
+
+      ControlledTerms.fetch("mock1:result1")
+      ControlledTerms.fetch("mock1:result2")
+      ControlledTerms.fetch("mock2:result3")
+
+      %ControlledTermCache{id: "mock1:result1"}
+      |> Ecto.Changeset.change(%{updated_at: naive_secs_ago.(300)})
+      |> Repo.update!()
+
+      %ControlledTermCache{id: "mock1:result2"}
+      |> Ecto.Changeset.change(%{updated_at: naive_secs_ago.(600)})
+      |> Repo.update!()
+
+      %ControlledTermCache{id: "mock2:result3"}
+      |> Ecto.Changeset.change(%{updated_at: naive_secs_ago.(600)})
+      |> Repo.update!()
+
+      :ok
+    end
+
+    test "expire on age" do
+      assert {2, nil} == ControlledTerms.expire!(500)
+      assert {{:ok, :db}, _} = ControlledTerms.fetch("mock1:result1")
+      assert {{:ok, :miss}, _} = ControlledTerms.fetch("mock1:result2")
+      assert {{:ok, :miss}, _} = ControlledTerms.fetch("mock2:result3")
+    end
+
+    test "expire on age and prefix" do
+      assert {2, nil} == ControlledTerms.expire!(200, "mock1:")
+      assert {{:ok, :miss}, _} = ControlledTerms.fetch("mock1:result1")
+      assert {{:ok, :miss}, _} = ControlledTerms.fetch("mock1:result2")
+      assert {{:ok, :db}, _} = ControlledTerms.fetch("mock2:result3")
+    end
+  end
+end

--- a/test/meadow_web/schema/query/controlled_types/fetch_controlled_term_label_test.exs
+++ b/test/meadow_web/schema/query/controlled_types/fetch_controlled_term_label_test.exs
@@ -30,5 +30,12 @@ defmodule MeadowWeb.Schema.Query.FetchControlledTermLabelTest do
         assert(result == %{"label" => "First Result"})
       end
     end
+
+    test "Query an invalid ID" do
+      result = query_gql(variables: %{"id" => "mock:result0"}, context: gql_context())
+
+      assert {:ok, %{errors: [error]}} = result
+      assert error.message == "404"
+    end
   end
 end


### PR DESCRIPTION
This PR:
- Creates a backend cache for controlled terms via a new `Meadow.Data.ControlledTerms` context. The `fetch/1` and `fetch!/1` functions check an in-memory ETS cache first, then the database, then fetches the label from its source authority as a last resort
- `fetch/1` includes information about where in the cache the value was found (`:memory`, `:db`, or `:miss`) in the success type
- Updates `Meadow.Data.Schemas.Types.ControlledTerm` and `MeadowWeb.Resolvers.Data.AuthoritiesSearch` to use the caching context
- Includes functions for clearing by ID, clearing the entire cache, and expiring entries based on age and ID prefix
- *Note: Creates a new table; requires migration*
