### PR TITLE
Centralize authority mocking with a common set of entries

### DIFF
--- a/test/meadow/data/controlled_terms_test.exs
+++ b/test/meadow/data/controlled_terms_test.exs
@@ -1,34 +1,12 @@
 defmodule Meadow.Data.ControlledTermsTest do
+  use Meadow.AuthorityCase
   use Meadow.DataCase
 
-  alias Authoritex.Mock
   alias Meadow.Data.ControlledTerms
   alias Meadow.Data.Schemas.ControlledTermCache
   alias Meadow.Repo
 
-  @data [
-    %{
-      id: "mock1:result1",
-      label: "First Result",
-      qualified_label: "First Result (1)",
-      hint: "(1)"
-    },
-    %{
-      id: "mock1:result2",
-      label: "Second Result",
-      qualified_label: "Second Result (2)",
-      hint: "(2)"
-    },
-    %{
-      id: "mock2:result3",
-      label: "Third Result",
-      qualified_label: "Third Result (3)",
-      hint: "(3)"
-    }
-  ]
-
   setup do
-    Mock.set_data(@data)
     ControlledTerms.clear!()
     :ok
   end

--- a/test/meadow/data/schemas/controlled_metadata_entry_test.exs
+++ b/test/meadow/data/schemas/controlled_metadata_entry_test.exs
@@ -1,14 +1,14 @@
 defmodule Meadow.Data.Schemas.ControlledMetadataEntryTest do
   @moduledoc false
+  use Meadow.AuthorityCase
   use Meadow.DataCase
 
-  alias Authoritex.Mock
   alias Meadow.Data.Schemas.ControlledMetadataEntry
 
   @valid_attrs %{
     object_id: Ecto.UUID.generate(),
     role: %{id: "aut", scheme: "marc_relator"},
-    term: %{id: "mock:result1"}
+    term: %{id: "mock1:result1"}
   }
 
   @invalid_attrs %{
@@ -18,19 +18,6 @@ defmodule Meadow.Data.Schemas.ControlledMetadataEntryTest do
   }
 
   describe "changeset" do
-    setup do
-      Mock.set_data([
-        %{
-          id: "mock:result1",
-          label: "First Result",
-          qualified_label: "First Result (1)",
-          hint: "(1)"
-        }
-      ])
-
-      :ok
-    end
-
     test "with valid attributes is successful" do
       changeset = %ControlledMetadataEntry{} |> ControlledMetadataEntry.changeset(@valid_attrs)
       assert changeset.valid?

--- a/test/meadow/data/schemas/types/controlled_term_test.exs
+++ b/test/meadow/data/schemas/types/controlled_term_test.exs
@@ -1,8 +1,8 @@
 defmodule Meadow.Data.Types.ControlledTermTest do
   @moduledoc false
+  use Meadow.AuthorityCase
   use Meadow.DataCase
 
-  alias Authoritex.Mock
   alias Meadow.Data.Types.ControlledTerm
 
   @controlled_term %{
@@ -10,21 +10,7 @@ defmodule Meadow.Data.Types.ControlledTermTest do
     label: "Border Collie Trust Great Britain"
   }
 
-  @data [
-    %{
-      id: "http://id.loc.gov/authorities/names/nb2015010626",
-      label: "Border Collie Trust Great Britain",
-      qualified_label: "Border Collie Trust Great Britain",
-      hint: "Border Collie Trust Great Britain"
-    }
-  ]
-
   describe "FetchControlledTermLabel.gql" do
-    setup do
-      Mock.set_data(@data)
-      :ok
-    end
-
     test "cast function" do
       assert {:ok, @controlled_term} == ControlledTerm.cast(@controlled_term)
       assert {:ok, @controlled_term} == ControlledTerm.cast(@controlled_term.id)

--- a/test/meadow/data/works_test.exs
+++ b/test/meadow/data/works_test.exs
@@ -1,7 +1,7 @@
 defmodule Meadow.Data.WorksTest do
+  use Meadow.AuthorityCase
   use Meadow.DataCase
 
-  alias Authoritex.Mock
   alias Meadow.Data.Schemas.Work
   alias Meadow.Data.{FileSets, Works}
   alias Meadow.Repo
@@ -189,37 +189,13 @@ defmodule Meadow.Data.WorksTest do
       accession_number: "12345",
       descriptive_metadata: %{title: "Test"}
     }
-    @data [
-      %{
-        id: "mock:result1",
-        label: "First Result",
-        qualified_label: "First Result (1)",
-        hint: "(1)"
-      },
-      %{
-        id: "mock:result2",
-        label: "Second Result",
-        qualified_label: "Second Result (2)",
-        hint: "(2)"
-      },
-      %{
-        id: "mock:result3",
-        label: "Third Result",
-        qualified_label: "Third Result (3)",
-        hint: "(3)"
-      }
-    ]
-    setup do
-      Mock.set_data(@data)
-      :ok
-    end
 
     test "create_work/1 with valid controlled entries creates a work" do
       attrs =
         Map.put(@valid, :descriptive_metadata, %{
-          contributor: [%{term: "mock:result1", role: %{id: "aut", scheme: "marc_relator"}}],
-          subject: [%{term: "mock:result2", role: %{id: "TOPICAL", scheme: "subject_role"}}],
-          genre: [%{term: "mock:result3"}]
+          contributor: [%{term: "mock1:result1", role: %{id: "aut", scheme: "marc_relator"}}],
+          subject: [%{term: "mock1:result2", role: %{id: "TOPICAL", scheme: "subject_role"}}],
+          genre: [%{term: "mock2:result3"}]
         })
 
       assert {:ok, %Work{} = work} = Works.create_work(attrs)
@@ -249,10 +225,10 @@ defmodule Meadow.Data.WorksTest do
     test "update_work/2 with valid controlled entries updates a work" do
       attrs =
         Map.put(@valid, :descriptive_metadata, %{
-          contributor: [%{term: "mock:result1", role: %{id: "aut", scheme: "marc_relator"}}],
+          contributor: [%{term: "mock1:result1", role: %{id: "aut", scheme: "marc_relator"}}],
           subject: [
-            %{term: "mock:result1", role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}},
-            %{term: "mock:result2", role: %{id: "TOPICAL", scheme: "subject_role"}}
+            %{term: "mock1:result1", role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}},
+            %{term: "mock1:result2", role: %{id: "TOPICAL", scheme: "subject_role"}}
           ]
         })
 
@@ -267,9 +243,9 @@ defmodule Meadow.Data.WorksTest do
       assert {:ok, %Work{} = work} =
                Works.update_work(work, %{
                  descriptive_metadata: %{
-                   genre: [%{term: "mock:result2"}],
+                   genre: [%{term: "mock1:result2"}],
                    subject: [
-                     %{term: "mock:result3", role: %{id: "TOPICAL", scheme: "subject_role"}}
+                     %{term: "mock2:result3", role: %{id: "TOPICAL", scheme: "subject_role"}}
                    ]
                  }
                })

--- a/test/meadow_web/schema/mutation/create_work_test.exs
+++ b/test/meadow_web/schema/mutation/create_work_test.exs
@@ -1,26 +1,11 @@
 defmodule MeadowWeb.Schema.Mutation.CreateWorkTest do
+  use Meadow.AuthorityCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
-
-  alias Authoritex.Mock
 
   load_gql(MeadowWeb.Schema, "test/gql/CreateWork.gql")
 
   describe "CreateWork mutation" do
-    @data [
-      %{
-        id: "mock:result1",
-        label: "First Result",
-        qualified_label: "First Result (1)",
-        hint: "(1)"
-      }
-    ]
-
-    setup do
-      Mock.set_data(@data)
-      :ok
-    end
-
     test "should be a valid mutation" do
       result =
         query_gql(
@@ -31,13 +16,13 @@ defmodule MeadowWeb.Schema.Mutation.CreateWorkTest do
               "title" => "Something",
               "contributor" => [
                 %{
-                  "term" => "mock:result1",
+                  "term" => "mock1:result1",
                   "role" => %{"id" => "aut", "scheme" => "MARC_RELATOR"}
                 }
               ],
               "stylePeriod" => [
                 %{
-                  "term" => "mock:result1"
+                  "term" => "mock1:result1"
                 }
               ]
             },

--- a/test/meadow_web/schema/query/controlled_types/authorities_search_test.exs
+++ b/test/meadow_web/schema/query/controlled_types/authorities_search_test.exs
@@ -1,32 +1,11 @@
 defmodule MeadowWeb.Schema.Query.AuthoritiesSearchTest do
+  use Meadow.AuthorityCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 
-  alias Authoritex.Mock
-
   load_gql(MeadowWeb.Schema, "test/gql/AuthoritiesSearch.gql")
 
-  @data [
-    %{
-      id: "mock:result1",
-      label: "First Result",
-      qualified_label: "First Result (1)",
-      hint: "(1)"
-    },
-    %{
-      id: "mock:result2",
-      label: "Second Result",
-      qualified_label: "Second Result (2)",
-      hint: "(2)"
-    }
-  ]
-
   describe "AuthoritiesSearch.gql" do
-    setup do
-      Mock.set_data(@data)
-      :ok
-    end
-
     test "Is a valid query" do
       result =
         query_gql(variables: %{"authority" => "mock", "query" => "test"}, context: gql_context())
@@ -36,7 +15,7 @@ defmodule MeadowWeb.Schema.Query.AuthoritiesSearchTest do
       with result <- get_in(query_data, ["authoritiesSearch"]) do
         assert result
                |> Enum.member?(%{
-                 "id" => "mock:result2",
+                 "id" => "mock1:result2",
                  "label" => "Second Result",
                  "hint" => "(2)"
                })

--- a/test/meadow_web/schema/query/controlled_types/fetch_controlled_term_label_test.exs
+++ b/test/meadow_web/schema/query/controlled_types/fetch_controlled_term_label_test.exs
@@ -1,28 +1,13 @@
 defmodule MeadowWeb.Schema.Query.FetchControlledTermLabelTest do
+  use Meadow.AuthorityCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 
-  alias Authoritex.Mock
-
   load_gql(MeadowWeb.Schema, "test/gql/FetchControlledTermLabel.gql")
 
-  @data [
-    %{
-      id: "mock:result1",
-      label: "First Result",
-      qualified_label: "First Result (1)",
-      hint: "(1)"
-    }
-  ]
-
   describe "FetchControlledTermLabel.gql" do
-    setup do
-      Mock.set_data(@data)
-      :ok
-    end
-
     test "Is a valid query" do
-      result = query_gql(variables: %{"id" => "mock:result1"}, context: gql_context())
+      result = query_gql(variables: %{"id" => "mock1:result1"}, context: gql_context())
 
       assert {:ok, %{data: query_data}} = result
 
@@ -32,7 +17,7 @@ defmodule MeadowWeb.Schema.Query.FetchControlledTermLabelTest do
     end
 
     test "Query an invalid ID" do
-      result = query_gql(variables: %{"id" => "mock:result0"}, context: gql_context())
+      result = query_gql(variables: %{"id" => "mock0:result0"}, context: gql_context())
 
       assert {:ok, %{errors: [error]}} = result
       assert error.message == "404"

--- a/test/support/authority_case.ex
+++ b/test/support/authority_case.ex
@@ -1,0 +1,44 @@
+defmodule Meadow.AuthorityCase do
+  @moduledoc """
+  Defines a common set of mock entries and setup for tests involving
+  Authoritex.
+  """
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      alias Authoritex.Mock
+
+      setup do
+        Mock.set_data([
+          %{
+            id: "mock1:result1",
+            label: "First Result",
+            qualified_label: "First Result (1)",
+            hint: "(1)"
+          },
+          %{
+            id: "mock1:result2",
+            label: "Second Result",
+            qualified_label: "Second Result (2)",
+            hint: "(2)"
+          },
+          %{
+            id: "mock2:result3",
+            label: "Third Result",
+            qualified_label: "Third Result (3)",
+            hint: "(3)"
+          },
+          %{
+            id: "http://id.loc.gov/authorities/names/nb2015010626",
+            label: "Border Collie Trust Great Britain",
+            qualified_label: "Border Collie Trust Great Britain",
+            hint: "Border Collie Trust Great Britain"
+          }
+        ])
+
+        :ok
+      end
+    end
+  end
+end


### PR DESCRIPTION
This occurred to me while I was finalizing #932, but it felt like a separate piece of work so I held it off until now. Creating a case template for authorities with a common mock dataset will decrease the repetition and redundancy involved in writing tests that search and fetch from `Authoritex`, and make maintenance much easier if the `Authoritex.Mock` interface changes in a future version.