### PR TITLE
End to end coded term implementation.

### DIFF
--- a/assets/js/client.js
+++ b/assets/js/client.js
@@ -14,7 +14,7 @@ import { typeDefs, resolvers } from "./client-local";
 // connection from the Phoenix app's GraphQL API endpoint URL.
 const httpLink = new HttpLink({
   uri: "/api/graphql",
-  fetch
+  fetch,
 });
 
 // Create a WebSocket link that sends GraphQL subscriptions over
@@ -29,7 +29,7 @@ const absintheSocketLink = createAbsintheSocketLink(
 // If it's a subscription, send it over the WebSocket link.
 // Otherwise, if it's a query or mutation, send it over the HTTP link.
 const link = new ApolloLink.split(
-  operation => hasSubscription(operation.query),
+  (operation) => hasSubscription(operation.query),
   absintheSocketLink,
   httpLink
 );
@@ -39,7 +39,7 @@ const client = new ApolloClient({
   link: link,
   cache: new InMemoryCache(),
   typeDefs,
-  resolvers
+  resolvers,
 });
 
 export default client;

--- a/assets/js/components/IngestSheet/ingestSheet.gql.js
+++ b/assets/js/components/IngestSheet/ingestSheet.gql.js
@@ -223,11 +223,11 @@ export const INGEST_SHEET_WORKS = gql`
       published
       representativeImage
       updatedAt
-      workType @client {
+      workType {
         id
         label
       }
-      visibility @client {
+      visibility {
         id
         label
       }

--- a/assets/js/components/Search/Results.jsx
+++ b/assets/js/components/Search/Results.jsx
@@ -13,7 +13,7 @@ const SearchResults = ({ handleSelectItem }) => {
   const getWorkItem = (res) => {
     return {
       id: res._id,
-      title: res.title,
+      title: res.descriptive_metadata.title,
       updatedAt: res.modified_date,
       representativeImage: res.representative_file_set,
       manifestUrl: res.iiif_manifest,

--- a/assets/js/components/UI/CodedTerm/Item.jsx
+++ b/assets/js/components/UI/CodedTerm/Item.jsx
@@ -2,6 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 
 const UICodedTermItem = ({ item = {} }) => {
+  if (!item) return null;
+
   if (!item.id) return null;
 
   return <p>{item.label}</p>;

--- a/assets/js/components/Work/Tabs/About.jsx
+++ b/assets/js/components/Work/Tabs/About.jsx
@@ -133,6 +133,10 @@ const WorkTabsAbout = ({ work }) => {
         identifier,
         keywords,
         legacyIdentifier,
+        license: {
+          id: data.license,
+          scheme: "LICENSE",
+        },
         notes,
         physicalDescriptionMaterial,
         physicalDescriptionSize,
@@ -148,6 +152,7 @@ const WorkTabsAbout = ({ work }) => {
         description,
         rightsStatement: {
           id: data.rightsStatement,
+          scheme: "RIGHTS_STATEMENT",
         },
         title,
       },

--- a/assets/js/components/Work/Tabs/About/CoreMetadata.jsx
+++ b/assets/js/components/Work/Tabs/About/CoreMetadata.jsx
@@ -23,6 +23,13 @@ const WorkTabsAboutCoreMetadata = ({
   } = useQuery(CODE_LIST_QUERY, {
     variables: { scheme: "RIGHTS_STATEMENT" },
   });
+  const {
+    loading: licenseLoading,
+    error: licenseError,
+    data: licenseData,
+  } = useQuery(CODE_LIST_QUERY, {
+    variables: { scheme: "LICENSE" },
+  });
 
   return showCoreMetadata ? (
     <div className="columns is-multiline">
@@ -64,7 +71,7 @@ const WorkTabsAboutCoreMetadata = ({
       </div>
 
       <div className="column is-half">
-        <UIFormField label="Rights Statement" notLive mocked>
+        <UIFormField label="Rights Statement">
           {isEditing ? (
             <UIFormSelect
               register={register}
@@ -73,7 +80,11 @@ const WorkTabsAboutCoreMetadata = ({
               options={
                 rightsStatementsData ? rightsStatementsData.codeList : []
               }
-              defaultValue={descriptiveMetadata.rightsStatement.id}
+              defaultValue={
+                descriptiveMetadata.rightsStatement
+                  ? descriptiveMetadata.rightsStatement.id
+                  : ""
+              }
               errors={errors}
             />
           ) : (
@@ -104,9 +115,20 @@ const WorkTabsAboutCoreMetadata = ({
       </div>
       <div className="column is-half">
         {/* License */}
-        <UIFormField label="License" mocked notLive>
+        <UIFormField label="License">
           {isEditing ? (
-            <p>Form elements go here</p>
+            <UIFormSelect
+              register={register}
+              name="license"
+              label="License"
+              options={licenseData ? licenseData.codeList : []}
+              defaultValue={
+                descriptiveMetadata.licenseStatement
+                  ? descriptiveMetadata.licenseStatement.id
+                  : ""
+              }
+              errors={errors}
+            />
           ) : (
             <UICodedTermItem item={descriptiveMetadata.license} />
           )}

--- a/assets/js/components/Work/Tabs/About/DescriptiveMetadata.jsx
+++ b/assets/js/components/Work/Tabs/About/DescriptiveMetadata.jsx
@@ -77,7 +77,7 @@ const WorkTabsAboutDescriptiveMetadata = ({
       <ul>
         {DESCRIPTIVE_METADATA.controlledTerms.map(({ label, name }) => (
           <li key={name} className="mb-5">
-            <UIFormField label={label} mocked notLive>
+            <UIFormField label={label}>
               {isEditing ? (
                 <UIFormControlledTermArray
                   codeLists={codeLists}

--- a/assets/js/components/Work/Tabs/Administrative.jsx
+++ b/assets/js/components/Work/Tabs/Administrative.jsx
@@ -96,8 +96,11 @@ const WorkTabsAdministrative = ({ work }) => {
     } = data;
     let workUpdateInput = {
       administrativeMetadata: {
-        preservationLevel: { id: preservationLevel },
-        status: { id: status },
+        preservationLevel: {
+          id: preservationLevel,
+          scheme: "PRESERVATION_LEVEL",
+        },
+        status: { id: status, scheme: "STATUS" },
         // TODO: Should these be field arrays or singular values?
         // projectName,
         // projectDesc,
@@ -107,7 +110,7 @@ const WorkTabsAdministrative = ({ work }) => {
         // projectCycle,
       },
       collectionId: collection,
-      visibility: { id: visibility },
+      visibility: { id: visibility, scheme: "VISIBILITY" },
     };
 
     updateWork({
@@ -191,7 +194,7 @@ const WorkTabsAdministrative = ({ work }) => {
               )}
             </UIFormField>
 
-            <UIFormField label="Preservation Level" mocked notLive>
+            <UIFormField label="Preservation Level">
               {isEditing ? (
                 <UIFormSelect
                   register={register}
@@ -210,7 +213,7 @@ const WorkTabsAdministrative = ({ work }) => {
               )}
             </UIFormField>
 
-            <UIFormField label="Status" mocked notLive>
+            <UIFormField label="Status">
               {isEditing ? (
                 <UIFormSelect
                   register={register}
@@ -229,7 +232,7 @@ const WorkTabsAdministrative = ({ work }) => {
               <p>Nothing yet</p>
             </UIFormField>
 
-            <UIFormField label="Visibility" mocked notLive>
+            <UIFormField label="Visibility">
               {isEditing ? (
                 <UIFormSelect
                   register={register}

--- a/assets/js/components/Work/work.gql.js
+++ b/assets/js/components/Work/work.gql.js
@@ -6,11 +6,11 @@ export const GET_WORK = gql`
       id
       accessionNumber
       administrativeMetadata {
-        preservationLevel @client {
+        preservationLevel {
           id
           label
         }
-        status @client {
+        status {
           id
           label
         }
@@ -80,7 +80,7 @@ export const GET_WORK = gql`
             label
           }
         }
-        license @client {
+        license {
           id
           label
         }
@@ -90,7 +90,7 @@ export const GET_WORK = gql`
             label
           }
         }
-        rightsStatement @client {
+        rightsStatement {
           id
           label
         }
@@ -144,11 +144,11 @@ export const GET_WORK = gql`
         name
       }
       updatedAt
-      visibility @client {
+      visibility {
         id
         label
       }
-      workType @client {
+      workType {
         id
         label
       }
@@ -190,11 +190,11 @@ export const GET_WORKS = gql`
       published
       representativeImage
       updatedAt
-      workType @client {
+      workType {
         id
         label
       }
-      visibility @client {
+      visibility {
         id
         label
       }
@@ -216,11 +216,11 @@ export const UPDATE_WORK = gql`
     updateWork(id: $id, work: $work) {
       id
       administrativeMetadata {
-        preservationLevel @client {
+        preservationLevel {
           id
           label
         }
-        status @client {
+        status {
           id
           label
         }
@@ -261,7 +261,7 @@ export const UPDATE_WORK = gql`
             label
           }
         }
-        license @client {
+        license {
           id
           label
         }
@@ -271,7 +271,7 @@ export const UPDATE_WORK = gql`
             label
           }
         }
-        rightsStatement @client {
+        rightsStatement {
           id
           label
         }

--- a/lib/meadow/data/schemas/collection.ex
+++ b/lib/meadow/data/schemas/collection.ex
@@ -53,7 +53,7 @@ defmodule Meadow.Data.Schemas.Collection do
     def encode(collection) do
       %{
         model: %{application: "Meadow", name: "Collection"},
-        title: collection.name,
+        name: collection.name,
         published: collection.published,
         create_date: collection.inserted_at,
         modified_date: collection.updated_at,

--- a/lib/meadow/data/schemas/file_set.ex
+++ b/lib/meadow/data/schemas/file_set.ex
@@ -57,7 +57,11 @@ defmodule Meadow.Data.Schemas.FileSet do
         description: file_set.metadata.description,
         create_date: file_set.inserted_at,
         modified_date: file_set.updated_at,
-        visibility: "open",
+        visibility:
+          case file_set.work.visibility do
+            nil -> %{}
+            visibility -> visibility.id
+          end,
         work_id: file_set.work.id
       }
     end

--- a/lib/meadow/data/schemas/work_administrative_metadata.ex
+++ b/lib/meadow/data/schemas/work_administrative_metadata.ex
@@ -5,15 +5,18 @@ defmodule Meadow.Data.Schemas.WorkAdministrativeMetadata do
 
   import Ecto.Changeset
   use Ecto.Schema
+  alias Meadow.Data.Types
 
   @timestamps_opts [type: :utc_datetime_usec]
   embedded_schema do
+    field :preservation_level, Types.CodedTerm
     field :project_name, {:array, :string}, default: []
     field :project_desc, {:array, :string}, default: []
     field :project_proposer, {:array, :string}, default: []
     field :project_manager, {:array, :string}, default: []
     field :project_task_number, {:array, :string}, default: []
     field :project_cycle, :string
+    field :status, Types.CodedTerm
 
     timestamps()
   end
@@ -21,12 +24,14 @@ defmodule Meadow.Data.Schemas.WorkAdministrativeMetadata do
   def changeset(metadata, params) do
     metadata
     |> cast(params, [
+      :preservation_level,
       :project_name,
       :project_desc,
       :project_proposer,
       :project_manager,
       :project_task_number,
       :project_cycle,
+      :status
     ])
 
     # The following are marked as required on the metadata
@@ -48,11 +53,14 @@ defmodule Meadow.Data.Schemas.WorkAdministrativeMetadata do
     def routing(_), do: false
 
     def encode(md) do
-      Source.field_names()
-      |> Enum.map(fn field_name ->
-        {field_name, md |> Map.get(field_name)}
-      end)
-      |> Enum.into(%{})
+      %{
+        administrative_metadata:
+          Source.field_names()
+          |> Enum.map(fn field_name ->
+            {field_name, md |> Map.get(field_name)}
+          end)
+          |> Enum.into(%{})
+      }
     end
   end
 end

--- a/lib/meadow/ingest/sheets_to_works.ex
+++ b/lib/meadow/ingest/sheets_to_works.ex
@@ -46,8 +46,6 @@ defmodule Meadow.Ingest.SheetsToWorks do
 
     attrs = %{
       accession_number: accession_number,
-      published: false,
-      ingest_sheet_id: ingest_sheet.id,
       file_sets:
         file_set_rows
         |> Enum.map(fn row ->
@@ -64,7 +62,11 @@ defmodule Meadow.Ingest.SheetsToWorks do
               label: Path.basename(file_path)
             }
           }
-        end)
+        end),
+      ingest_sheet_id: ingest_sheet.id,
+      published: false,
+      visibility: %{id: "RESTRICTED", scheme: "visibility"},
+      work_type: %{id: "IMAGE", scheme: "work_type"}
     }
 
     case Works.ensure_create_work(attrs) do

--- a/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
+++ b/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
@@ -9,7 +9,7 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
   alias MeadowWeb.Schema.Middleware
 
   object :controlled_term_queries do
-    @desc "NOT YET IMPLEMENTED. Get values from a code list table (for use in dropdowns, etc)"
+    @desc "Get values from a code list table (for use in dropdowns, etc)"
     field :code_list, list_of(:coded_term) do
       arg(:scheme, non_null(:code_list_scheme))
       middleware(Middleware.Authenticate)
@@ -68,7 +68,7 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
     field :scheme, :code_list_scheme
   end
 
-  @desc "NOT YET IMPLEMENTED Controlled Vocab input, id required, label is looked up on the backend. Provide role for compound vocabs"
+  @desc "Controlled Vocab input, id required, label is looked up on the backend. Provide role for compound vocabs"
   input_object :controlled_metadata_entry_input do
     field :term, non_null(:id)
     field :role, :coded_term_input

--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -147,10 +147,8 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     field :creator, list_of(:controlled_metadata_entry)
     field :genre, list_of(:controlled_metadata_entry)
     field :language, list_of(:controlled_metadata_entry)
-    @desc "NOT YET IMPLEMENTED"
     field :license, :coded_term
     field :location, list_of(:controlled_metadata_entry)
-    @desc "NOT YET IMPLEMENTED"
     field :rights_statement, :coded_term
     field :style_period, list_of(:controlled_metadata_entry)
     field :subject, list_of(:controlled_metadata_entry)
@@ -169,9 +167,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
 
   @desc "`work_administrative_metadata` represents all administrative metadata associated with a work object. It is stored in a single json field."
   object :work_administrative_metadata do
-    @desc "NOT YET IMPLEMENTED"
     field :preservation_level, :coded_term
-    @desc "NOT YET IMPLEMENTED"
     field :status, :coded_term
 
     import_fields(:uncontrolled_administrative_fields)
@@ -204,9 +200,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
 
   @desc "Input fields for works administrative metadata"
   input_object :work_administrative_metadata_input do
-    @desc "NOT YET IMPLEMENTED"
     field :preservation_level, :coded_term_input
-    @desc "NOT YET IMPLEMENTED"
     field :status, :coded_term_input
 
     import_fields(:uncontrolled_administrative_fields)
@@ -218,10 +212,8 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     field :creator, list_of(:controlled_metadata_entry_input)
     field :genre, list_of(:controlled_metadata_entry_input)
     field :language, list_of(:controlled_metadata_entry_input)
-    @desc "NOT YET IMPLEMENTED"
     field :license, :coded_term_input
     field :location, list_of(:controlled_metadata_entry_input)
-    @desc "NOT YET IMPLEMENTED"
     field :rights_statement, :coded_term_input
     field :subject, list_of(:controlled_metadata_entry_input)
     field :style_period, list_of(:controlled_metadata_entry_input)

--- a/priv/repo/migrations/20190911151157_create_works.exs
+++ b/priv/repo/migrations/20190911151157_create_works.exs
@@ -9,8 +9,8 @@ defmodule Meadow.Repo.Migrations.CreateWorks do
       add(:descriptive_metadata, :map, default: %{})
       add(:administrative_metadata, :map, default: %{})
       add(:published, :boolean)
-      add(:visibility, :string)
-      add(:work_type, :string)
+      add(:visibility, :map)
+      add(:work_type, :map)
       timestamps()
     end
 

--- a/test/meadow/data/indexer_test.exs
+++ b/test/meadow/data/indexer_test.exs
@@ -43,14 +43,14 @@ defmodule Meadow.Data.IndexerTest do
         %{collection: collection, works: [work | _]} = indexable_data()
 
         Indexer.synchronize_index()
-        assert indexed_doc(collection.id) |> get_in(["title"]) == collection.name
-        assert indexed_doc(work.id) |> get_in(["collection", "title"]) == collection.name
+        assert indexed_doc(collection.id) |> get_in(["name"]) == collection.name
+        assert indexed_doc(work.id) |> get_in(["collection", "name"]) == collection.name
 
         {:ok, collection} = collection |> Collections.update_collection(%{name: "New Name"})
 
         Indexer.synchronize_index()
-        assert indexed_doc(collection.id) |> get_in(["title"]) == "New Name"
-        assert indexed_doc(work.id) |> get_in(["collection", "title"]) == "New Name"
+        assert indexed_doc(collection.id) |> get_in(["name"]) == "New Name"
+        assert indexed_doc(work.id) |> get_in(["collection", "name"]) == "New Name"
       end)
     end
 
@@ -104,7 +104,7 @@ defmodule Meadow.Data.IndexerTest do
 
         with doc <- indexed_doc(work.id) do
           assert doc |> get_in(["collection"]) == %{}
-          assert doc |> get_in(["project"]) == %{"id" => project.id, "name" => project.title}
+          assert doc |> get_in(["project"]) == %{"id" => project.id, "title" => project.title}
 
           assert doc |> get_in(["sheet"]) == %{
                    "id" => ingest_sheet.id,
@@ -148,7 +148,7 @@ defmodule Meadow.Data.IndexerTest do
         with doc <- indexed_doc(work.id) do
           assert doc |> get_in(["project"]) == %{
                    "id" => project.id,
-                   "name" => project.title
+                   "title" => project.title
                  }
         end
 
@@ -158,7 +158,7 @@ defmodule Meadow.Data.IndexerTest do
         with doc <- indexed_doc(work.id) do
           assert doc |> get_in(["project"]) == %{
                    "id" => project.id,
-                   "name" => "New Name"
+                   "title" => "New Name"
                  }
         end
       end)
@@ -181,7 +181,7 @@ defmodule Meadow.Data.IndexerTest do
       [header, doc] = subject |> Indexer.encode!(:index) |> decode_njson()
       assert header |> get_in(["index", "_id"]) == subject.id
       assert doc |> get_in(["model", "application"]) == "Meadow"
-      assert doc |> get_in(["title"]) == subject.name
+      assert doc |> get_in(["name"]) == subject.name
     end
 
     test "work encoding", %{work: subject} do
@@ -190,11 +190,12 @@ defmodule Meadow.Data.IndexerTest do
       assert doc |> get_in(["model", "application"]) == "Meadow"
 
       with metadata <- subject.descriptive_metadata do
-        assert doc |> get_in(["title"]) == metadata.title
+        assert doc |> get_in(["descriptive_metadata", "title"]) ==
+                 metadata.title
       end
 
       with metadata <- subject.administrative_metadata do
-        assert doc |> get_in(["project_name"]) == metadata.project_name
+        assert doc |> get_in(["administrative_metadata", "project_name"]) == metadata.project_name
       end
     end
 

--- a/test/meadow_web/schema/mutation/create_work_test.exs
+++ b/test/meadow_web/schema/mutation/create_work_test.exs
@@ -27,8 +27,8 @@ defmodule MeadowWeb.Schema.Mutation.CreateWorkTest do
               ]
             },
             "administrativeMetadata" => %{},
-            "workType" => %{"id" => "IMAGE"},
-            "visibility" => %{"id" => "OPEN"}
+            "workType" => %{"id" => "IMAGE", "scheme" => "WORK_TYPE"},
+            "visibility" => %{"id" => "OPEN", "scheme" => "VISIBILITY"}
           },
           context: gql_context()
         )

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -120,8 +120,8 @@ defmodule Meadow.TestHelpers do
     attrs =
       Enum.into(attrs, %{
         accession_number: attrs[:accession_number] || Faker.String.base64(),
-        visibility: attrs[:visibility] || Faker.Util.pick(@visibility),
-        work_type: attrs[:work_type] || Faker.Util.pick(@work_types),
+        visibility: attrs[:visibility] || %{id: "OPEN", scheme: "visibility"},
+        work_type: attrs[:work_type] || %{id: "IMAGE", scheme: "work_type"},
         administrative_metadata:
           attrs[:administrative_metadata] ||
             %{


### PR DESCRIPTION
Editing and saving works with coded terms now works from UI
 - rights statement
 - license
 - visibility
 - work type (saving only not editable)
 - preservation level 
 - status

Updated Elasticsearch indexing structure to more closely resemble GraphQL structure

**_Database changes so staging data will need to be reset on deploy and dev environments will require a `devstack down -v`_**

Changes: 
- Updated API and front end components.
- Indexing coded terms for file sets and works.
- Removes "Not Live" and "Mock" on properties and NOT IMPLEMENTED documentation and descriptions
- Updated Ecto changesets for works and file sets

We broke out a separate issue to remove Apollo client mocking artifacts, the tests seemed to have a dependency on them and we weren't sure why: https://github.com/nulib/repodev_planning_and_docs/issues/898
