### PR TITLE
CamelCase Elasticsearch fields, indexing updates

### DIFF
--- a/assets/js/components/Search/Results.jsx
+++ b/assets/js/components/Search/Results.jsx
@@ -13,15 +13,15 @@ const SearchResults = ({ handleSelectItem }) => {
   const getWorkItem = (res) => {
     return {
       id: res._id,
-      title: res.descriptive_metadata.title,
+      title: res.descriptiveMetadata.title,
       updatedAt: res.modified_date,
-      representativeImage: res.representative_file_set,
-      manifestUrl: res.iiif_manifest,
+      representativeImage: res.representativeFileSet,
+      manifestUrl: res.iiifManifest,
       published: res.published,
-      visibility: res.visibility_term,
-      fileSets: res.file_sets.length,
-      accessionNumber: res.accession_number,
-      workType: res.work_type,
+      visibility: res.visibility,
+      fileSets: res.fileSets.length,
+      accessionNumber: res.accessionNumber,
+      workType: res.workType,
     };
   };
 

--- a/assets/js/components/Work/CardItem.jsx
+++ b/assets/js/components/Work/CardItem.jsx
@@ -22,7 +22,7 @@ const WorkCardItem = ({
           <Link to={`/work/${id}`}>
             <img
               src={
-                representativeImage.file_set_id
+                representativeImage.fileSetId
                   ? `${representativeImage.url}/square/500,500/0/default.jpg`
                   : `${representativeImage}/full/1280,960/0/default.jpg`
               }

--- a/assets/js/components/Work/ListItem.jsx
+++ b/assets/js/components/Work/ListItem.jsx
@@ -23,7 +23,7 @@ const WorkListItem = ({
             <Link to={`/work/${id}`}>
               <img
                 src={
-                  representativeImage.file_set_id
+                  representativeImage.fileSetId
                     ? `${representativeImage.url}/square/500,500/0/default.jpg`
                     : `${representativeImage}/full/1280,960/0/default.jpg`
                 }

--- a/assets/js/screens/Work/List.jsx
+++ b/assets/js/screens/Work/List.jsx
@@ -14,14 +14,14 @@ const ScreensWorkList = () => {
     return {
       id: res._id,
       title: res.title,
-      updatedAt: res.modified_date,
-      representativeImage: res.representative_file_set,
-      manifestUrl: res.iiif_manifest,
+      updatedAt: res.modifiedDate,
+      representativeImage: res.representativeFileSet,
+      manifestUrl: res.iiifManifest,
       published: res.published,
-      visibility: res.visibility_term,
-      fileSets: res.file_sets.length,
-      accessionNumber: res.accession_number,
-      workType: res.work_type,
+      visibility: res.visibility,
+      fileSets: res.fileSets.length,
+      accessionNumber: res.accessionNumber,
+      workType: res.workType,
     };
   };
 

--- a/lib/meadow/data/indexer.ex
+++ b/lib/meadow/data/indexer.ex
@@ -13,7 +13,7 @@ defmodule Meadow.Data.Indexer do
   @index :meadow
 
   def synchronize_index do
-    [:deleted, Work, FileSet, Collection]
+    [:deleted, FileSet, Work, Collection]
     |> Enum.each(&synchronize_schema/1)
 
     Elasticsearch.Index.refresh(Cluster, to_string(@index))

--- a/lib/meadow/data/schemas/collection.ex
+++ b/lib/meadow/data/schemas/collection.ex
@@ -13,20 +13,20 @@ defmodule Meadow.Data.Schemas.Collection do
   @foreign_key_type Ecto.UUID
   @timestamps_opts [type: :utc_datetime_usec]
   schema "collections" do
-    field :name, :string
-    field :description, :string
-    field :keywords, {:array, :string}, default: []
-    field :featured, :boolean
-    field :finding_aid_url, :string
-    field :admin_email, :string
-    field :published, :boolean, default: false
+    field(:name, :string)
+    field(:description, :string)
+    field(:keywords, {:array, :string}, default: [])
+    field(:featured, :boolean)
+    field(:finding_aid_url, :string)
+    field(:admin_email, :string)
+    field(:published, :boolean, default: false)
 
     timestamps()
 
-    belongs_to :representative_work, Work, on_replace: :nilify
-    has_many :works, Work
+    belongs_to(:representative_work, Work, on_replace: :nilify)
+    has_many(:works, Work)
 
-    field :representative_image, :string, virtual: true
+    field(:representative_image, :string, virtual: true)
   end
 
   def changeset(collection, params \\ %{}) do
@@ -52,24 +52,27 @@ defmodule Meadow.Data.Schemas.Collection do
 
     def encode(collection) do
       %{
+        createDate: collection.inserted_at,
+        description: collection.description,
+        featured: collection.featured,
+        findingAidUrl: collection.finding_aid_url,
+        keywords: collection.keywords,
         model: %{application: "Meadow", name: "Collection"},
-        name: collection.name,
+        modifiedDate: collection.updated_at,
         published: collection.published,
-        create_date: collection.inserted_at,
-        modified_date: collection.updated_at,
-        visibility: "open",
-        visibility_term: %{id: "open", label: "Public"},
-        representative_image:
+        representativeImage:
           case collection.representative_work do
             nil ->
               %{}
 
             work ->
               %{
-                work_id: work.id,
+                workId: work.id,
                 url: work.representative_image
               }
-          end
+          end,
+        name: collection.name,
+        visibility: %{id: "OPEN", label: "Public", scheme: "visibility"}
       }
     end
   end

--- a/lib/meadow/data/schemas/file_set.ex
+++ b/lib/meadow/data/schemas/file_set.ex
@@ -52,18 +52,19 @@ defmodule Meadow.Data.Schemas.FileSet do
 
     def encode(file_set) do
       %{
-        model: %{application: "Meadow", name: "FileSet"},
-        label: file_set.metadata.label,
+        createDate: file_set.inserted_at,
         description: file_set.metadata.description,
-        create_date: file_set.inserted_at,
-        modified_date: file_set.updated_at,
-        visibility:
-          case file_set.work.visibility do
-            nil -> %{}
-            visibility -> visibility.id
-          end,
-        work_id: file_set.work.id
+        label: file_set.metadata.label,
+        model: %{application: "Meadow", name: "FileSet"},
+        modifiedDate: file_set.updated_at,
+        visibility: format(file_set.work.visibility),
+        workId: file_set.work.id
       }
     end
+
+    defp format(%{id: id, name: name}), do: %{id: id, name: name}
+    defp format(%{id: id, title: title}), do: %{id: id, title: title}
+    defp format(%{id: _id, label: _label, scheme: _scheme} = field), do: field
+    defp format(_), do: %{}
   end
 end

--- a/lib/meadow/data/schemas/work.ex
+++ b/lib/meadow/data/schemas/work.ex
@@ -103,43 +103,38 @@ defmodule Meadow.Data.Schemas.Work do
 
     def encode(work) do
       %{
-        model: %{application: "Meadow", name: "Image"},
-        id: work.id,
-        accession_number: work.accession_number,
-        published: work.published,
+        accessionNumber: work.accession_number,
         collection: format(work.collection),
-        file_sets:
+        createDate: work.inserted_at,
+        fileSets:
           work.file_sets
           |> Enum.map(fn file_set ->
             %{
               id: file_set.id,
-              accession_number: file_set.accession_number,
+              accessionNumber: file_set.accession_number,
               label: file_set.metadata.label
             }
           end),
-        create_date: work.inserted_at,
-        iiif_manifest: IIIF.manifest_id(work.id),
-        modified_date: work.updated_at,
-        visibility_term: format(work.visibility),
-        visibility:
-          case work.visibility do
-            nil -> %{}
-            visibility -> visibility.id
-          end,
-        work_type: format(work.work_type),
+        id: work.id,
+        iiifManifest: IIIF.manifest_id(work.id),
+        model: %{application: "Meadow", name: "Image"},
+        modifiedDate: work.updated_at,
         project: format(work.project),
-        sheet: format(work.ingest_sheet),
-        representative_file_set:
+        published: work.published,
+        representativeFileSet:
           case work.representative_file_set_id do
             nil ->
               %{}
 
             representative_file_set_id ->
               %{
-                file_set_id: representative_file_set_id,
+                fileSetId: representative_file_set_id,
                 url: work.representative_image
               }
-          end
+          end,
+        sheet: format(work.ingest_sheet),
+        visibility: format(work.visibility),
+        workType: format(work.work_type)
       }
       |> Map.merge(AdministrativeMetadataDocument.encode(work.administrative_metadata))
       |> Map.merge(DescriptiveMetadataDocument.encode(work.descriptive_metadata))

--- a/lib/meadow/data/schemas/work_administrative_metadata.ex
+++ b/lib/meadow/data/schemas/work_administrative_metadata.ex
@@ -54,10 +54,10 @@ defmodule Meadow.Data.Schemas.WorkAdministrativeMetadata do
 
     def encode(md) do
       %{
-        administrative_metadata:
+        administrativeMetadata:
           Source.field_names()
           |> Enum.map(fn field_name ->
-            {field_name, md |> Map.get(field_name)}
+            {Inflex.camelize(field_name, :lower), md |> Map.get(field_name)}
           end)
           |> Enum.into(%{})
       }

--- a/lib/meadow/data/schemas/work_descriptive_metadata.ex
+++ b/lib/meadow/data/schemas/work_descriptive_metadata.ex
@@ -106,10 +106,10 @@ defmodule Meadow.Data.Schemas.WorkDescriptiveMetadata do
 
     def encode(md) do
       %{
-        descriptive_metadata:
+        descriptiveMetadata:
           Source.field_names()
           |> Enum.map(fn field_name ->
-            {field_name, encode_field(Map.get(md, field_name))}
+            {Inflex.camelize(field_name, :lower), encode_field(Map.get(md, field_name))}
           end)
           |> Enum.into(%{})
       }

--- a/test/meadow/data/indexer_test.exs
+++ b/test/meadow/data/indexer_test.exs
@@ -62,7 +62,7 @@ defmodule Meadow.Data.IndexerTest do
 
         Indexer.synchronize_index()
 
-        assert indexed_doc(collection.id) |> get_in(["representative_image", "work_id"]) ==
+        assert indexed_doc(collection.id) |> get_in(["representativeImage", "workId"]) ==
                  work.id
 
         file_set = file_set_fixture(%{work_id: work.id})
@@ -72,10 +72,10 @@ defmodule Meadow.Data.IndexerTest do
         Indexer.synchronize_index()
 
         assert indexed_doc(work.id)
-               |> get_in(["representative_file_set", "file_set_id"]) == file_set.id
+               |> get_in(["representativeFileSet", "fileSetId"]) == file_set.id
 
         assert indexed_doc(collection.id)
-               |> get_in(["representative_image", "url"]) == work.representative_image
+               |> get_in(["representativeImage", "url"]) == work.representative_image
       end)
     end
 
@@ -171,7 +171,8 @@ defmodule Meadow.Data.IndexerTest do
         {:ok,
          %{
            collection: collection,
-           work: List.first(works) |> Repo.preload([:collection, :ingest_sheet, :project]),
+           work:
+             List.first(works) |> Repo.preload([:collection, :file_sets, :ingest_sheet, :project]),
            file_set: List.first(file_sets) |> Repo.preload(:work)
          }}
       end
@@ -188,14 +189,15 @@ defmodule Meadow.Data.IndexerTest do
       [header, doc] = subject |> Indexer.encode!(:index) |> decode_njson()
       assert header |> get_in(["index", "_id"]) == subject.id
       assert doc |> get_in(["model", "application"]) == "Meadow"
+      assert doc |> get_in(["fileSets"]) |> length == 2
 
       with metadata <- subject.descriptive_metadata do
-        assert doc |> get_in(["descriptive_metadata", "title"]) ==
+        assert doc |> get_in(["descriptiveMetadata", "title"]) ==
                  metadata.title
       end
 
       with metadata <- subject.administrative_metadata do
-        assert doc |> get_in(["administrative_metadata", "project_name"]) == metadata.project_name
+        assert doc |> get_in(["administrativeMetadata", "projectName"]) == metadata.project_name
       end
     end
 

--- a/test/support/index_case.ex
+++ b/test/support/index_case.ex
@@ -82,7 +82,7 @@ defmodule Meadow.IndexCase do
         %{
           count: length(works) + length(file_sets) + 1,
           collection: collection,
-          works: works,
+          works: Works.list_works(),
           file_sets: file_sets
         }
       end


### PR DESCRIPTION
- CamelCase Elasticsearch fields to match GraphQL API
- Nests `administrativeMetadata` and `descriptiveMetadata` under Elasticsearch work documents.

**Run `devstack down -v` to avoid issues with previously indexed Elasticsearch documents**

**Reset data or clear index on staging**