### PR TITLE
SetCurrentUser plug lookup user from cache first

### DIFF
--- a/lib/meadow/application.ex
+++ b/lib/meadow/application.ex
@@ -28,6 +28,12 @@ defmodule Meadow.Application do
         Meadow.Cache.ControlledTerms,
         expiration: Cachex.Spec.expiration(default: :timer.hours(6)),
         stats: true
+      ),
+      cache_spec(
+        :user_cache,
+        Meadow.Cache.Users,
+        expiration: Cachex.Spec.expiration(default: :timer.minutes(20)),
+        stats: true
       )
     ]
 

--- a/lib/meadow_web/controllers/auth_controller.ex
+++ b/lib/meadow_web/controllers/auth_controller.ex
@@ -21,6 +21,8 @@ defmodule MeadowWeb.AuthController do
 
     case Accounts.authorize_user_login(uid) do
       {:ok, user} ->
+        Cachex.put!(Meadow.Cache.Users, uid, user)
+
         conn
         |> put_session(:current_user, user)
         |> configure_session(renew: true)
@@ -33,6 +35,13 @@ defmodule MeadowWeb.AuthController do
   end
 
   def logout(conn, _params) do
+    current_user =
+      conn
+      |> fetch_session
+      |> get_session(:current_user)
+
+    Cachex.del!(Meadow.Cache.Users, current_user.username)
+
     conn
     |> delete_session(:current_user)
     |> Plug.Conn.assign(:current_user, nil)

--- a/lib/meadow_web/plugs/set_current_user.ex
+++ b/lib/meadow_web/plugs/set_current_user.ex
@@ -29,6 +29,18 @@ defmodule MeadowWeb.Plugs.SetCurrentUser do
   end
 
   defp refresh_user(%{username: username}) do
+    case Cachex.get!(Meadow.Cache.Users, username) do
+      nil ->
+        refresh_user_ldap(username)
+
+      user ->
+        user
+    end
+  end
+
+  defp refresh_user(_), do: nil
+
+  defp refresh_user_ldap(username) do
     case Accounts.authorize_user_login(username) do
       {:ok, user} ->
         user
@@ -37,6 +49,4 @@ defmodule MeadowWeb.Plugs.SetCurrentUser do
         nil
     end
   end
-
-  defp refresh_user(_), do: nil
 end

--- a/test/meadow_web/controllers/auth_controller_test.exs
+++ b/test/meadow_web/controllers/auth_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule MeadowWeb.AuthControllerTest do
   use MeadowWeb.ConnCase, async: true
 
+  alias MeadowWeb.Plugs.SetCurrentUser
+
   test "GET /auth/nusso redirects to SSO url with a callback url", %{conn: conn} do
     assert get(conn, "/auth/nusso")
            |> redirected_to(302)
@@ -18,5 +20,25 @@ defmodule MeadowWeb.AuthControllerTest do
     conn = get(conn, "/auth/nusso/callback")
 
     assert "/project/list" == redirected_to(conn, 302)
+  end
+
+  describe "/auth/logout" do
+    setup do
+      user = user_fixture("TestAdmins")
+      {:ok, %{user: user}}
+    end
+
+    test "GET /auth/logout removes user from cache", %{user: user} do
+      conn =
+        build_conn()
+        |> auth_user(user)
+        |> SetCurrentUser.call(nil)
+
+      Cachex.put!(Meadow.Cache.Users, user.username, user)
+
+      get(conn, "/auth/logout")
+
+      assert Cachex.get!(Meadow.Cache.Users, user.username) == nil
+    end
   end
 end


### PR DESCRIPTION
- Store user/role information in an ETS cache with an ttl of 20 minutes in order to prevent LDAP timeouts that are occurring with user lookup on every GraphQL request. 