### PR TITLE
Cascade work visibility changes to fileSet in Elasticsearch index

### DIFF
--- a/priv/repo/migrations/20200507123625_create_dependency_triggers.exs
+++ b/priv/repo/migrations/20200507123625_create_dependency_triggers.exs
@@ -4,7 +4,7 @@ defmodule Meadow.Repo.Migrations.CreateDependencyTriggers do
   def up do
     create_dependency_trigger(:ingest_sheets, :works, [:name])
     create_dependency_trigger(:collections, :works, [:name])
-    create_dependency_trigger(:works, :file_sets, [:published])
+    create_dependency_trigger(:works, :file_sets, [:published, :visibility])
 
     create_dependency_trigger(
       :works,


### PR DESCRIPTION
- Requires `ecto.reset` or `devstack down -v` in dev environment