### PR TITLE
Remove mockedData for clientside

### DIFF
--- a/assets/js/client.js
+++ b/assets/js/client.js
@@ -8,7 +8,6 @@ import { hasSubscription } from "@jumpn/utils-graphql";
 import * as AbsintheSocket from "@absinthe/socket";
 import { createAbsintheSocketLink } from "@absinthe/socket-apollo-link";
 import { Socket as PhoenixSocket } from "phoenix";
-import { typeDefs, resolvers } from "./client-local";
 
 // Create an HTTP link that fetches GraphQL results over an HTTP
 // connection from the Phoenix app's GraphQL API endpoint URL.
@@ -38,8 +37,6 @@ const link = new ApolloLink.split(
 const client = new ApolloClient({
   link: link,
   cache: new InMemoryCache(),
-  typeDefs,
-  resolvers,
 });
 
 export default client;


### PR DESCRIPTION
Removed mockedData from regular usage. It is needed for test cases mocks.