### PR TITLE
Validate coded term input through GraphQL

### DIFF
--- a/assets/js/client-local.js
+++ b/assets/js/client-local.js
@@ -133,7 +133,7 @@ const mockLicense = () => {
 const mockStatus = () => {
   return {
     id: "IN PROGRESS",
-    label: "In Progresss",
+    label: "In Progress",
     __typename: "CodedTerm",
   };
 };

--- a/assets/js/components/Work/Tabs/About.jsx
+++ b/assets/js/components/Work/Tabs/About.jsx
@@ -148,10 +148,12 @@ const WorkTabsAbout = ({ work }) => {
         identifier,
         keywords,
         legacyIdentifier,
-        license: {
-          id: data.license,
-          scheme: "LICENSE",
-        },
+        license: data.license
+          ? {
+              id: data.license,
+              scheme: "LICENSE",
+            }
+          : {},
         notes,
         physicalDescriptionMaterial,
         physicalDescriptionSize,
@@ -160,10 +162,12 @@ const WorkTabsAbout = ({ work }) => {
         relatedUrl,
         relatedMaterial,
         rightsHolder,
-        rightsStatement: {
-          id: data.rightsStatement,
-          scheme: "RIGHTS_STATEMENT",
-        },
+        rightsStatement: data.rightsStatement
+          ? {
+              id: data.rightsStatement,
+              scheme: "RIGHTS_STATEMENT",
+            }
+          : {},
         scopeAndContents,
         series,
         source,

--- a/assets/js/components/Work/Tabs/About/CoreMetadata.jsx
+++ b/assets/js/components/Work/Tabs/About/CoreMetadata.jsx
@@ -39,7 +39,6 @@ const WorkTabsAboutCoreMetadata = ({
           {isEditing ? (
             <UIInput
               register={register}
-              required
               name="title"
               label="Title"
               data-testid="title"
@@ -57,7 +56,6 @@ const WorkTabsAboutCoreMetadata = ({
           {isEditing ? (
             <UIFormTextarea
               register={register}
-              required
               name="description"
               label="Description"
               data-testid="description"
@@ -86,7 +84,6 @@ const WorkTabsAboutCoreMetadata = ({
                   ? descriptiveMetadata.rightsStatement.id
                   : ""
               }
-              required
               errors={errors}
             />
           ) : (
@@ -130,7 +127,6 @@ const WorkTabsAboutCoreMetadata = ({
                   ? descriptiveMetadata.license.id
                   : ""
               }
-              required
               errors={errors}
             />
           ) : (

--- a/assets/js/components/Work/Tabs/Administrative.jsx
+++ b/assets/js/components/Work/Tabs/Administrative.jsx
@@ -96,11 +96,13 @@ const WorkTabsAdministrative = ({ work }) => {
     } = data;
     let workUpdateInput = {
       administrativeMetadata: {
-        preservationLevel: {
-          id: preservationLevel,
-          scheme: "PRESERVATION_LEVEL",
-        },
-        status: { id: status, scheme: "STATUS" },
+        preservationLevel: preservationLevel
+          ? {
+              id: preservationLevel,
+              scheme: "PRESERVATION_LEVEL",
+            }
+          : {},
+        status: status ? { id: status, scheme: "STATUS" } : {},
         // TODO: Should these be field arrays or singular values?
         // projectName,
         // projectDesc,
@@ -110,7 +112,7 @@ const WorkTabsAdministrative = ({ work }) => {
         // projectCycle,
       },
       collectionId: collection,
-      visibility: { id: visibility, scheme: "VISIBILITY" },
+      visibility: visibility ? { id: visibility, scheme: "VISIBILITY" } : {},
     };
 
     updateWork({
@@ -176,7 +178,6 @@ const WorkTabsAdministrative = ({ work }) => {
               {isEditing ? (
                 <UIFormSelect
                   register={register}
-                  required
                   name="collection"
                   label="Collection"
                   showHelper={true}
@@ -205,7 +206,6 @@ const WorkTabsAdministrative = ({ work }) => {
                   options={preservationLevelsData.codeList}
                   defaultValue={preservationLevel ? preservationLevel.id : ""}
                   errors={errors}
-                  required
                 />
               ) : (
                 <p>
@@ -226,7 +226,6 @@ const WorkTabsAdministrative = ({ work }) => {
                   options={statusData.codeList}
                   defaultValue={status ? status.id : ""}
                   errors={errors}
-                  required
                 />
               ) : (
                 <p>{status ? status.label : "None selected"}</p>
@@ -241,7 +240,6 @@ const WorkTabsAdministrative = ({ work }) => {
               {isEditing ? (
                 <UIFormSelect
                   register={register}
-                  required
                   name="visibility"
                   label="Visibility"
                   showHelper={true}

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -2557,7 +2557,7 @@ cacache@^12.0.2:
     unique-filename "^1.1.1"
     y18n "^4.0.0"
 
-cacache@^15.0.5:
+cacache@^15.0.4, cacache@^15.0.5:
   version "15.0.5"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-15.0.5.tgz#69162833da29170d6732334643c60e005f5f17d0"
   integrity sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==
@@ -6401,7 +6401,7 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
+p-limit@^3.0.1, p-limit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.0.2.tgz#1664e010af3cadc681baafd3e2a437be7b0fb5fe"
   integrity sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==

--- a/lib/meadow/data/schemas/types/coded_term.ex
+++ b/lib/meadow/data/schemas/types/coded_term.ex
@@ -24,13 +24,15 @@ defmodule Meadow.Data.Types.CodedTerm do
 
   defp retrieve_term(nil), do: {:ok, nil}
 
+  defp retrieve_term(%{id: "", scheme: _scheme}), do: {:error, message: "id cannot be blank"}
+
   defp retrieve_term(%{"id" => id, "scheme" => scheme}),
     do: retrieve_term(%{id: id, scheme: scheme})
 
   defp retrieve_term(%{id: id, scheme: scheme}) do
     case CodedTerms.get_coded_term(id, scheme) do
       nil ->
-        nil
+        {:error, message: "#{id} is invalid coded term for scheme #{String.upcase(scheme)}"}
 
       %Schemas.CodedTerm{id: id, scheme: scheme, label: label} ->
         {:ok, %{id: id, scheme: scheme, label: label}}
@@ -40,5 +42,7 @@ defmodule Meadow.Data.Types.CodedTerm do
     end
   end
 
-  defp retrieve_term(_), do: :error
+  defp retrieve_term(%{}), do: {:ok, nil}
+
+  defp retrieve_term(_), do: {:error, message: "Invalid coded term type"}
 end

--- a/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
+++ b/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
@@ -76,7 +76,7 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
 
   @desc "Input for code lookup in code list table. Provide id and scheme"
   input_object :coded_term_input do
-    field :id, non_null(:id)
+    field :id, :id
     field :scheme, :code_list_scheme
   end
 

--- a/priv/repo/seeds/coded_terms/status.json
+++ b/priv/repo/seeds/coded_terms/status.json
@@ -5,7 +5,7 @@
   },
   {
     "id": "IN PROGRESS",
-    "label": "In Progresss"
+    "label": "In Progress"
   },
   {
     "id": "STARTED",

--- a/test/meadow/data/coded_terms_test.exs
+++ b/test/meadow/data/coded_terms_test.exs
@@ -3,9 +3,17 @@ defmodule Meadow.Data.CodedTermsTest do
   alias Meadow.Data.CodedTerms
   import Assertions
 
-  @schemes ["authority", "license", "marc_relator", "preservation_level",
-            "rights_statement", "status", "subject_role", "visibility",
-            "work_type"]
+  @schemes [
+    "authority",
+    "license",
+    "marc_relator",
+    "preservation_level",
+    "rights_statement",
+    "status",
+    "subject_role",
+    "visibility",
+    "work_type"
+  ]
 
   describe "CodedTerms context" do
     test "lists schemes" do
@@ -14,8 +22,14 @@ defmodule Meadow.Data.CodedTermsTest do
 
     test "lists terms within a scheme" do
       with results <- CodedTerms.list_coded_terms("work_type") do
-        assert_lists_equal(results |> Enum.map(&(&1.id)), ["AUDIO", "DOCUMENT", "IMAGE", "VIDEO"])
-        assert_lists_equal(results |> Enum.map(&(&1.label)), ["Audio", "Document", "Image", "Video"])
+        assert_lists_equal(results |> Enum.map(& &1.id), ["AUDIO", "DOCUMENT", "IMAGE", "VIDEO"])
+
+        assert_lists_equal(results |> Enum.map(& &1.label), [
+          "Audio",
+          "Document",
+          "Image",
+          "Video"
+        ])
       end
     end
 

--- a/test/meadow/data/schemas/types/coded_term_test.exs
+++ b/test/meadow/data/schemas/types/coded_term_test.exs
@@ -1,0 +1,49 @@
+defmodule Meadow.Data.Types.CodedTermTest do
+  @moduledoc false
+  use Meadow.AuthorityCase
+  use Meadow.DataCase
+
+  alias Meadow.Data.Types.CodedTerm
+
+  @coded_term_db_type %{
+    id: "http://rightsstatements.org/vocab/CNE/1.0/",
+    scheme: "rights_statement"
+  }
+
+  @coded_term_custom_type %{
+    id: "http://rightsstatements.org/vocab/CNE/1.0/",
+    scheme: "rights_statement",
+    label: "Copyright Not Evaluated"
+  }
+
+  describe "Meadow.Data.Types.CodedTerm" do
+    test "cast function" do
+      assert {:ok, @coded_term_custom_type} == CodedTerm.cast(@coded_term_db_type)
+      assert CodedTerm.cast(1234) == {:error, [message: "Invalid coded term type"]}
+
+      assert {:error, [message: "totallywrong is invalid coded term for scheme RIGHTS_STATEMENT"]} ==
+               CodedTerm.cast(%{id: "totallywrong", scheme: "rights_statement"})
+
+      assert {:error,
+              [
+                message:
+                  "http://rightsstatements.org/vocab/CNE/1.0/ is invalid coded term for scheme LICENSE"
+              ]} ==
+               CodedTerm.cast(%{
+                 id: "http://rightsstatements.org/vocab/CNE/1.0/",
+                 scheme: "license"
+               })
+    end
+
+    test "dump function" do
+      assert CodedTerm.dump(@coded_term_custom_type) == {:ok, @coded_term_db_type}
+      assert CodedTerm.dump(134_524) == :error
+    end
+
+    test "load function" do
+      assert CodedTerm.load(@coded_term_db_type) == {:ok, @coded_term_custom_type}
+
+      assert CodedTerm.load(1234) == {:error, [message: "Invalid coded term type"]}
+    end
+  end
+end

--- a/test/meadow/data/schemas/types/controlled_term_test.exs
+++ b/test/meadow/data/schemas/types/controlled_term_test.exs
@@ -10,7 +10,7 @@ defmodule Meadow.Data.Types.ControlledTermTest do
     label: "Border Collie Trust Great Britain"
   }
 
-  describe "FetchControlledTermLabel.gql" do
+  describe "Meadow.Data.Types.ControlledTerm" do
     test "cast function" do
       assert {:ok, @controlled_term} == ControlledTerm.cast(@controlled_term)
       assert {:ok, @controlled_term} == ControlledTerm.cast(@controlled_term.id)


### PR DESCRIPTION
- Validate coded term input through the GraphQL API. 
- Provide helpful error messages if input fails validation
- Add Elixir tests for `CodedTerm` type
- Removed `required` from form input properties
- Updates to front end coded term UI to support API changes
- Removes extra s from 'In Progress' in Status seed data

Closes https://github.com/nulib/repodev_planning_and_docs/issues/935