### PR TITLE
Update indexing to support front end faceting needs

### DIFF
--- a/lib/meadow/data/schemas/work_descriptive_metadata.ex
+++ b/lib/meadow/data/schemas/work_descriptive_metadata.ex
@@ -118,7 +118,15 @@ defmodule Meadow.Data.Schemas.WorkDescriptiveMetadata do
     def encode_field([field | []]), do: [encode_field(field)]
     def encode_field([field | fields]), do: [encode_field(field) | encode_field(fields)]
 
-    def encode_field(%ControlledMetadataEntry{} = field), do: Map.from_struct(field)
+    def encode_field(%ControlledMetadataEntry{role: nil} = field) do
+      Map.from_struct(field)
+      |> Map.put(:display_facet, field.term.label)
+    end
+
+    def encode_field(%ControlledMetadataEntry{} = field) do
+      Map.from_struct(field)
+      |> Map.put(:display_facet, "#{field.term.label} (#{field.role.label})")
+    end
 
     def encode_field(field), do: field
   end

--- a/priv/elasticsearch/meadow.json
+++ b/priv/elasticsearch/meadow.json
@@ -8,25 +8,14 @@
         "full_analyzer": {
           "type": "custom",
           "tokenizer": "standard",
-          "char_filter": [
-            "html_strip"
-          ],
-          "filter": [
-            "lowercase",
-            "asciifolding"
-          ]
+          "char_filter": ["html_strip"],
+          "filter": ["lowercase", "asciifolding"]
         },
         "stopword_analyzer": {
           "type": "custom",
           "tokenizer": "standard",
-          "char_filter": [
-            "html_strip"
-          ],
-          "filter": [
-            "lowercase",
-            "asciifolding",
-            "english_stop"
-          ]
+          "char_filter": ["html_strip"],
+          "filter": ["lowercase", "asciifolding", "english_stop"]
         }
       },
       "filter": {
@@ -62,7 +51,7 @@
       "dynamic_templates": [
         {
           "facets": {
-            "match": "*_facet",
+            "match": "*facet",
             "mapping": { "type": "keyword" }
           }
         },

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -127,8 +127,8 @@ defmodule Meadow.TestHelpers do
             %{
               project_name: [Faker.Lorem.sentence(3)],
               project_desc: [Faker.Lorem.sentence()],
-              project_proposer: [Faker.Name.name()],
-              project_manager: [Faker.Name.name()],
+              project_proposer: [Faker.Person.name()],
+              project_manager: [Faker.Person.name()],
               project_task_number: [Faker.Code.issn()],
               project_cycle: Faker.Lorem.word()
             },


### PR DESCRIPTION
Indexes `display_facet` for controlled fields to give Fen (and potentially internal Meadow) the role concatenated with the label to use/display in facets.

<img width="535" alt="Screen Shot 2020-07-28 at 10 46 48 AM" src="https://user-images.githubusercontent.com/6372022/88689378-025a6c00-d0c0-11ea-909c-56369ff6f14e.png">
