### PR TITLE
Update Search page with more facet items

### DIFF
--- a/assets/js/services/reactive-search.js
+++ b/assets/js/services/reactive-search.js
@@ -24,10 +24,39 @@ const defaultListItemValues = {
 export const FACET_SENSORS = [
   {
     ...defaultListItemValues,
+    componentId: "FacetContributor",
+    dataField: "descriptiveMetadata.contributor.displayFacet",
+    title: "Contributor",
+  },
+  {
+    ...defaultListItemValues,
     componentId: "FacetCollection",
     dataField: "collection.id",
-    showSearch: true,
     title: "Collection",
+  },
+  {
+    ...defaultListItemValues,
+    componentId: "FacetGenre",
+    dataField: "descriptiveMetadata.genre.displayFacet",
+    title: "Genre",
+  },
+  {
+    ...defaultListItemValues,
+    componentId: "FacetLanguage",
+    dataField: "descriptiveMetadata.language.displayFacet",
+    title: "Language",
+  },
+  {
+    ...defaultListItemValues,
+    componentId: "FacetLicense",
+    dataField: "descriptiveMetadata.license.label.keyword",
+    title: "License",
+  },
+  {
+    ...defaultListItemValues,
+    componentId: "FacetLocation",
+    dataField: "descriptiveMetadata.location.displayFacet",
+    title: "Location",
   },
   {
     ...defaultListItemValues,
@@ -49,8 +78,14 @@ export const FACET_SENSORS = [
   },
   {
     ...defaultListItemValues,
+    componentId: "FacetRightsStatement",
+    dataField: "descriptiveMetadata.rightsStatement.label.keyword",
+    title: "Rights Statement",
+  },
+  {
+    ...defaultListItemValues,
     componentId: "FacetVisibility",
-    dataField: "visibility.id",
+    dataField: "visibility.label.keyword",
     title: "Visibility",
   },
 ];


### PR DESCRIPTION
Just adds some more faceted items to the Search page so we can further test out pulling Elasticsearch aggregate info out of the user's most recent query.

![image](https://user-images.githubusercontent.com/3020266/88720701-e61ff480-d0ea-11ea-9ea6-ae6792cacf1e.png)
