### PR TITLE
Related URL and label backend functionality

### DIFF
--- a/assets/js/components/Work/Tabs/About.jsx
+++ b/assets/js/components/Work/Tabs/About.jsx
@@ -68,7 +68,6 @@ const WorkTabsAbout = ({ work }) => {
       physicalDescriptionSize: descriptiveMetadata.physicalDescriptionSize,
       provenance: descriptiveMetadata.provenance,
       publisher: descriptiveMetadata.publisher,
-      relatedUrl: descriptiveMetadata.relatedUrl,
       relatedMaterial: descriptiveMetadata.relatedMaterial,
       rightsHolder: descriptiveMetadata.rightsHolder,
       scopeAndContents: descriptiveMetadata.scopeAndContents,
@@ -123,7 +122,6 @@ const WorkTabsAbout = ({ work }) => {
       physicalDescriptionSize = [],
       provenance = [],
       publisher = [],
-      relatedUrl = [],
       relatedMaterial = [],
       rightsHolder = [],
       scopeAndContents = [],
@@ -159,7 +157,6 @@ const WorkTabsAbout = ({ work }) => {
         physicalDescriptionSize,
         provenance,
         publisher,
-        relatedUrl,
         relatedMaterial,
         rightsHolder,
         rightsStatement: data.rightsStatement

--- a/assets/js/components/Work/work.gql.js
+++ b/assets/js/components/Work/work.gql.js
@@ -83,7 +83,13 @@ export const GET_WORK = gql`
         physicalDescriptionSize
         provenance
         publisher
-        relatedUrl
+        relatedUrl {
+          url
+          label {
+            id
+            label
+          }
+        }
         relatedMaterial
         rightsHolder
         rightsStatement {

--- a/assets/js/services/metadata.js
+++ b/assets/js/services/metadata.js
@@ -63,7 +63,6 @@ export const DESCRIPTIVE_METADATA = {
     },
     { name: "provenance", label: "Provenance" },
     { name: "publisher", label: "Publisher" },
-    { name: "relatedUrl", label: "Related URL" },
     { name: "relatedMaterial", label: "Related Material" },
     { name: "rightsHolder", label: "Rights Holder" },
     { name: "scopeAndContents", label: "Scope and Content" },

--- a/lib/meadow/data/schemas/related_url_entry.ex
+++ b/lib/meadow/data/schemas/related_url_entry.ex
@@ -1,0 +1,21 @@
+defmodule Meadow.Data.Schemas.RelatedURLEntry do
+  @moduledoc """
+  Schema for Related URL
+  """
+
+  import Ecto.Changeset
+  use Ecto.Schema
+  alias Meadow.Data.Types
+
+  @primary_key false
+  embedded_schema do
+    field :url, :string
+    field :label, Types.CodedTerm
+  end
+
+  def changeset(metadata, params) do
+    metadata
+    |> cast(params, [:url, :label])
+    |> validate_required([:url, :label])
+  end
+end

--- a/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
+++ b/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
@@ -68,6 +68,12 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
     field :scheme, :code_list_scheme
   end
 
+  @desc "RelatedURLEntry"
+  object :related_url_entry do
+    field :url, :string
+    field :label, :coded_term
+  end
+
   @desc "Controlled Vocab input, id required, label is looked up on the backend. Provide role for compound vocabs"
   input_object :controlled_metadata_entry_input do
     field :term, non_null(:id)
@@ -80,6 +86,12 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
     field :scheme, :code_list_scheme
   end
 
+  @desc "Related URL input"
+  input_object :related_url_entry_input do
+    field :url, :string
+    field :label, :coded_term_input
+  end
+
   @desc "Schemes for code list table. (Ex: Subjects, MARC relators, prevervation levels, etc)"
   enum :code_list_scheme do
     value(:authority, as: "authority", description: "Authority")
@@ -87,6 +99,7 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
     value(:marc_relator, as: "marc_relator", description: "MARC Relator")
     value(:preservation_level, as: "preservation_level", description: "Preservation Level")
     value(:rights_statement, as: "rights_statement", description: "Rights Statement")
+    value(:related_url, as: "related_url", description: "Related URL")
     value(:subject_role, as: "subject_role", description: "Subject Role")
     value(:status, as: "status", description: "Status")
     value(:visibility, as: "visibility", description: "Visibility")

--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -129,7 +129,6 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     field :physical_description_size, list_of(:string)
     field :provenance, list_of(:string)
     field :publisher, list_of(:string)
-    field :related_url, list_of(:string)
     field :related_material, list_of(:string)
     field :rights_holder, list_of(:string)
     field :scope_and_contents, list_of(:string)
@@ -150,6 +149,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     field :license, :coded_term
     field :location, list_of(:controlled_metadata_entry)
     field :rights_statement, :coded_term
+    field :related_url, list_of(:related_url_entry)
     field :style_period, list_of(:controlled_metadata_entry)
     field :subject, list_of(:controlled_metadata_entry)
     field :technique, list_of(:controlled_metadata_entry)
@@ -215,6 +215,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     field :license, :coded_term_input
     field :location, list_of(:controlled_metadata_entry_input)
     field :rights_statement, :coded_term_input
+    field :related_url, list_of(:related_url_entry_input)
     field :subject, list_of(:controlled_metadata_entry_input)
     field :style_period, list_of(:controlled_metadata_entry_input)
     field :technique, list_of(:controlled_metadata_entry_input)

--- a/priv/elasticsearch/meadow.json
+++ b/priv/elasticsearch/meadow.json
@@ -137,6 +137,7 @@
         {
           "labels": {
             "path_match": "*.label",
+            "path_unmatch": "descriptiveMetadata.relatedUrl.label",
             "mapping": {
               "type": "text",
               "analyzer": "full_analyzer",

--- a/priv/repo/seeds/coded_terms/related_url.json
+++ b/priv/repo/seeds/coded_terms/related_url.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "RESEARCH_GUIDE",
+    "label": "Research Guide"
+  },
+  {
+    "id": "HATHI_TRUST_DIGITAL_LIBRARY",
+    "label": "Hathi Trust Digital Library"
+  },
+  {
+    "id": "FINDING_AID",
+    "label": "Finding Aid"
+  },
+  {
+    "id": "RELATED_INFORMATION",
+    "label": "Related Information"
+  }
+]

--- a/test/gql/WorkDescriptiveMetadataFields.frag.gql
+++ b/test/gql/WorkDescriptiveMetadataFields.frag.gql
@@ -45,6 +45,13 @@ fragment WorkDescriptiveMetadataFields on Work {
       id
       label
     }
+    relatedUrl {
+      url
+      label {
+        id
+        label
+      }
+    }
     stylePeriod {
       term {
         id

--- a/test/meadow/data/coded_terms_test.exs
+++ b/test/meadow/data/coded_terms_test.exs
@@ -8,6 +8,7 @@ defmodule Meadow.Data.CodedTermsTest do
     "license",
     "marc_relator",
     "preservation_level",
+    "related_url",
     "rights_statement",
     "status",
     "subject_role",

--- a/test/meadow/data/works_test.exs
+++ b/test/meadow/data/works_test.exs
@@ -338,4 +338,32 @@ defmodule Meadow.Data.WorksTest do
       end
     end
   end
+
+  describe "works with related url entries" do
+    test "create_work/1 with valid related url fields creates a work" do
+      attrs = %{
+        accession_number: "12345",
+        descriptive_metadata: %{
+          title: "Test",
+          related_url: [
+            %{
+              url: "http://rightsstatements.org/vocab/NoC-US/1.0/",
+              label: %{id: "FINDING_AID", scheme: "related_url"}
+            }
+          ]
+        }
+      }
+
+      assert {:ok, %Work{} = work} = Works.create_work(attrs)
+
+      assert length(work.descriptive_metadata.related_url) == 1
+
+      with value <- List.first(work.descriptive_metadata.related_url) do
+        assert value.url ==
+                 "http://rightsstatements.org/vocab/NoC-US/1.0/"
+
+        assert value.label.label == "Finding Aid"
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Backend for storing `related_url` property as uri/label pair (with label as a controlled term)
 - updates the Meadow seed to add related urls to the coded terms table
 - adds related url to work object in GraphQL api
 - removes front end code for plain text related url field.


<img width="403" alt="Screen Shot 2020-07-29 at 8 08 33 AM" src="https://user-images.githubusercontent.com/6372022/88806760-73f4f180-d176-11ea-95ed-c3eda2cbc2c9.png">

**Reviewers and after merge** - you'll need to do a `devstack down -v` or (otherwise reset your database and index)
