### PR TITLE
Create facet by id for batch remove modal

### DIFF
--- a/lib/meadow/data/schemas/work_descriptive_metadata.ex
+++ b/lib/meadow/data/schemas/work_descriptive_metadata.ex
@@ -116,11 +116,16 @@ defmodule Meadow.Data.Schemas.WorkDescriptiveMetadata do
     def encode_field(%ControlledMetadataEntry{role: nil} = field) do
       Map.from_struct(field)
       |> Map.put(:displayFacet, field.term.label)
+      |> Map.put(:facet, "#{field.term.id}|#{field.term.label}")
     end
 
     def encode_field(%ControlledMetadataEntry{} = field) do
       Map.from_struct(field)
       |> Map.put(:displayFacet, "#{field.term.label} (#{field.role.label})")
+      |> Map.put(
+        :facet,
+        "#{field.term.id}|#{field.role.id}|#{field.term.label} (#{field.role.label})"
+      )
     end
 
     def encode_field(%RelatedURLEntry{} = field), do: Map.from_struct(field)

--- a/priv/elasticsearch/meadow.json
+++ b/priv/elasticsearch/meadow.json
@@ -51,7 +51,7 @@
       "dynamic_templates": [
         {
           "facets": {
-            "match": ".*Facet|facet",
+            "match": ".*Facet|^facet",
             "match_pattern": "regex",
             "mapping": { "type": "keyword" }
           }


### PR DESCRIPTION
Indexes `facet` for controlled fields that will provide term id (+ role id) info to the front end to populate the remove modal

<img width="725" alt="Screen Shot 2020-07-29 at 2 47 43 PM" src="https://user-images.githubusercontent.com/6372022/88847210-59d60600-d1ac-11ea-8558-99d24f1cecde.png">


<img width="550" alt="Screen Shot 2020-07-29 at 3 02 27 PM" src="https://user-images.githubusercontent.com/6372022/88847356-8b4ed180-d1ac-11ea-8f86-0897f274c016.png">




