### PR TITLE
Mock batch update mutation

### DIFF
--- a/lib/meadow_web/schema/schema.ex
+++ b/lib/meadow_web/schema/schema.ex
@@ -11,6 +11,7 @@ defmodule MeadowWeb.Schema do
   alias Meadow.Ingest
 
   import_types(__MODULE__.AccountTypes)
+  import_types(__MODULE__.Data.BatchTypes)
   import_types(__MODULE__.IngestTypes)
   import_types(__MODULE__.Data.CollectionTypes)
   import_types(__MODULE__.Data.ControlledTermTypes)
@@ -30,6 +31,7 @@ defmodule MeadowWeb.Schema do
 
   mutation do
     import_fields(:account_mutations)
+    import_fields(:batch_mutations)
     import_fields(:ingest_mutations)
     import_fields(:collection_mutations)
     import_fields(:work_mutations)

--- a/lib/meadow_web/schema/types/data/batch_types.ex
+++ b/lib/meadow_web/schema/types/data/batch_types.ex
@@ -1,0 +1,30 @@
+defmodule MeadowWeb.Schema.Data.BatchTypes do
+  @moduledoc """
+  Absinthe Schema for Batch Update Functionality
+
+  """
+  use Absinthe.Schema.Notation
+  alias MeadowWeb.Schema.Middleware
+
+  object :batch_mutations do
+    @desc "Start a batch update operation"
+    field :batch_update, :message do
+      arg(:query, non_null(:string))
+      arg(:delete, non_null(:batch_update_input))
+      middleware(Middleware.Authenticate)
+
+      resolve(fn _, _ ->
+        {:ok, %{message: "Batch started"}}
+      end)
+    end
+  end
+
+  object :message do
+    field :message, :string
+  end
+
+  @desc "Input fields for batch update opereations"
+  input_object :batch_update_input do
+    import_fields(:controlled_fields_input)
+  end
+end

--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -108,6 +108,19 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     field :ingest_sheet, :ingest_sheet, resolve: dataloader(Data)
   end
 
+  @desc "`controlled_fields` represents all controlled descriptive metadata fields on a work."
+  object :controlled_fields do
+    field :contributor, list_of(:controlled_metadata_entry)
+    field :creator, list_of(:controlled_metadata_entry)
+    field :genre, list_of(:controlled_metadata_entry)
+    field :language, list_of(:controlled_metadata_entry)
+    field :location, list_of(:controlled_metadata_entry)
+    field :related_url, list_of(:related_url_entry)
+    field :style_period, list_of(:controlled_metadata_entry)
+    field :subject, list_of(:controlled_metadata_entry)
+    field :technique, list_of(:controlled_metadata_entry)
+  end
+
   @desc "`uncontrolled_descriptive_fields` represents all uncontrolled descriptive metadata fields."
   object :uncontrolled_descriptive_fields do
     field :abstract, list_of(:string)
@@ -142,18 +155,11 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
   object :work_descriptive_metadata do
     field :ark, :string
     field :citation, list_of(:string)
-    field :contributor, list_of(:controlled_metadata_entry)
-    field :creator, list_of(:controlled_metadata_entry)
-    field :genre, list_of(:controlled_metadata_entry)
-    field :language, list_of(:controlled_metadata_entry)
     field :license, :coded_term
-    field :location, list_of(:controlled_metadata_entry)
     field :rights_statement, :coded_term
     field :related_url, list_of(:related_url_entry)
-    field :style_period, list_of(:controlled_metadata_entry)
-    field :subject, list_of(:controlled_metadata_entry)
-    field :technique, list_of(:controlled_metadata_entry)
     import_fields(:uncontrolled_descriptive_fields)
+    import_fields(:controlled_fields)
   end
 
   object :uncontrolled_administrative_fields do
@@ -208,19 +214,23 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
 
   @desc "Input fields for works descriptive metadata"
   input_object :work_descriptive_metadata_input do
+    field :license, :coded_term_input
+    field :rights_statement, :coded_term_input
+    field :related_url, list_of(:related_url_entry_input)
+    import_fields(:controlled_fields_input)
+    import_fields(:uncontrolled_descriptive_fields)
+  end
+
+  @desc "`controlled_fields_input` controlled fields that can be updated on a work object"
+  input_object :controlled_fields_input do
     field :contributor, list_of(:controlled_metadata_entry_input)
     field :creator, list_of(:controlled_metadata_entry_input)
     field :genre, list_of(:controlled_metadata_entry_input)
     field :language, list_of(:controlled_metadata_entry_input)
-    field :license, :coded_term_input
     field :location, list_of(:controlled_metadata_entry_input)
-    field :rights_statement, :coded_term_input
-    field :related_url, list_of(:related_url_entry_input)
     field :subject, list_of(:controlled_metadata_entry_input)
     field :style_period, list_of(:controlled_metadata_entry_input)
     field :technique, list_of(:controlled_metadata_entry_input)
-
-    import_fields(:uncontrolled_descriptive_fields)
   end
 
   @desc "Filters for the list of works"

--- a/test/gql/BatchUpdate.gql
+++ b/test/gql/BatchUpdate.gql
@@ -1,0 +1,5 @@
+mutation($query: String!, $delete: BatchUpdateInput!) {
+  batchUpdate(query: $query, delete: $delete) {
+    message
+  }
+}

--- a/test/meadow_web/schema/mutation/batch_update_test.exs
+++ b/test/meadow_web/schema/mutation/batch_update_test.exs
@@ -1,0 +1,29 @@
+defmodule MeadowWeb.Schema.Mutation.BatchUpdateTest do
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+
+  load_gql(MeadowWeb.Schema, "test/gql/BatchUpdate.gql")
+
+  test "should be a valid mutation" do
+    result =
+      query_gql(
+        variables: %{
+          "query" => "{\"based_near.label.keyword\": \"England--London\"}",
+          "delete" => %{
+            "contributor" => [
+              %{
+                "term" => "http => //reemoveme",
+                "role" => %{"id" => "aut", "scheme" => "MARC_RELATOR"}
+              }
+            ]
+          }
+        },
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+
+    response = get_in(query_data, [:data, "batchUpdate", "message"])
+    assert response == "Batch started"
+  end
+end


### PR DESCRIPTION
- Define mutation for `batchUpdate` in the GraphQL schema
- Returns a "batch started" message but this is only meant to be a temporary mocking sort of thing. No actual functionality implemented. 

<img width="926" alt="Screen Shot 2020-07-29 at 4 17 21 PM" src="https://user-images.githubusercontent.com/6372022/88857419-dfad7d80-d1bb-11ea-96b2-4d8dfb6c7ef6.png">



<img width="1313" alt="Screen Shot 2020-07-29 at 4 56 57 PM" src="https://user-images.githubusercontent.com/6372022/88857819-91e54500-d1bc-11ea-919e-2e9331ba9ab7.png">

