### PR TITLE
Update Search and BatchEdit screens to use the newly indexed facet pr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,20 @@ In dev mode, the IIIF Server is available at: `http://localhost:8183/iiif/2`
 - In dev mode, Elasticsearch is available at: `http://localhost:9201`
 - In dev mode, Kibana (if started) is available at: `http://localhost:5602/`
 
+To force an Elasticsearch re-index, and not wait for the 2-minute cycle to kick in when updating a Meadow item:
+
+Run the interactive shell in a terminal tab
+
+```
+iex -S mix
+```
+
+And force a re-index:
+
+```
+Meadow.Data.Indexer.reindex_all!
+```
+
 ### LDAP
 
 The development LDAP is available at `localhost` port `390`

--- a/assets/js/screens/Search/Search.jsx
+++ b/assets/js/screens/Search/Search.jsx
@@ -8,9 +8,9 @@ import { useHistory } from "react-router-dom";
 import SearchActionRow from "../../components/Search/ActionRow";
 import UIResultsDisplaySwitcher from "../../components/UI/ResultsDisplaySwitcher";
 import {
-  getAggregationTextValues,
+  parseESAggregationResults,
   elasticsearchDirectSearch,
-  ELASTICSEARCH_AGGS,
+  ELASTICSEARCH_AGGREGATION_FIELDS,
 } from "../../services/elasticsearch";
 
 const ScreensSearch = () => {
@@ -24,12 +24,12 @@ const ScreensSearch = () => {
     // Grab all aggregated Controlled Term items from Elasticsearch directly,
     // to populate the "Remove" items in Batch Edit
     let response = await elasticsearchDirectSearch({
-      aggs: { ...ELASTICSEARCH_AGGS },
+      aggs: { ...ELASTICSEARCH_AGGREGATION_FIELDS },
       query: { ...filteredQuery },
     });
     console.log("handleEditAllItems() response :>> ", response);
 
-    let parsedAggregations = getAggregationTextValues(response.aggregations);
+    let parsedAggregations = parseESAggregationResults(response.aggregations);
     console.log("parsedAggregations", parsedAggregations);
 
     // Send Elasticsearch query and aggregated Controlled Term options to Batch Edit

--- a/assets/js/services/elasticsearch.js
+++ b/assets/js/services/elasticsearch.js
@@ -19,30 +19,30 @@ export const ELASTICSEARCH_FIELDS_TO_SEARCH = [
   "accessionNumber",
 ];
 
-export const ELASTICSEARCH_AGGS = {
+export const ELASTICSEARCH_AGGREGATION_FIELDS = {
   contributor: {
     terms: {
-      field: "descriptiveMetadata.contributor.displayFacet",
+      field: "descriptiveMetadata.contributor.facet",
     },
   },
   genre: {
     terms: {
-      field: "descriptiveMetadata.genre.displayFacet",
+      field: "descriptiveMetadata.genre.facet",
     },
   },
   language: {
     terms: {
-      field: "descriptiveMetadata.language.displayFacet",
+      field: "descriptiveMetadata.language.facet",
     },
   },
   location: {
     terms: {
-      field: "descriptiveMetadata.location.displayFacet",
+      field: "descriptiveMetadata.location.facet",
     },
   },
   technique: {
     terms: {
-      field: "descriptiveMetadata.technique.displayFacet",
+      field: "descriptiveMetadata.technique.facet",
     },
   },
 };
@@ -52,18 +52,14 @@ export const ELASTICSEARCH_AGGS = {
  * @param {object} aggregations Value returned from the Elasticsearch direct query
  * @returns {object}
  */
-export function getAggregationTextValues(aggregations) {
-  let parsedAggregations = {};
+export function parseESAggregationResults(aggregations) {
+  let returnObj = {};
 
-  for (const prop in aggregations) {
-    let buckets = aggregations[prop].buckets;
-
-    // Pull out the aggregation text value we'll want to display to the user
-    parsedAggregations[prop] =
-      buckets.length > 0 ? buckets.map((bucket) => bucket.key) : [];
+  for (const property in aggregations) {
+    returnObj[property] = [...aggregations[property].buckets];
   }
 
-  return parsedAggregations;
+  return returnObj;
 }
 
 /**

--- a/assets/js/services/reactive-search.js
+++ b/assets/js/services/reactive-search.js
@@ -1,12 +1,31 @@
 import React from "react";
 
+/**
+ * Helper function to parse out text presented to the user in Facet labels
+ *
+ * This assumes that the label text is the last item in the pipe ("|") delimited indexed field "facet"
+ *
+ * @param {String} label Default facet label
+ * @param {Number} count Default facet count
+ * @returns {Object} A React component
+ */
+function renderAggregationFacetLabel(label, count) {
+  let facetSplitArray = label.split("|");
+  return (
+    <span>
+      <span>{facetSplitArray[facetSplitArray.length - 1]}</span>
+      <span>{count}</span>
+    </span>
+  );
+}
+
 export const REACTIVE_SEARCH_THEME = {
   typography: {
     fontFamily: "Akkurat Pro Regular",
   },
 };
 
-// https://docs.appbase.io/docs/reactivesearch/v3/theming/classnameinjection/
+// Documention: https://docs.appbase.io/docs/reactivesearch/v3/theming/classnameinjection/
 const facetClasses = {
   checkbox: "facet-checkbox",
   label: "facet-item-label",


### PR DESCRIPTION
…operty in addition to facetLabel

Partial PR which uses the new `facet` index item in addition to `facetLabel`.  The Batch Edit screen now receives an object with the full `facet` value, plus counts to help user distinguish what's used most often.

Also snuck in a piece of documentation on how to force an Elasticsearch re-index when developing so we don't have to wait for the 2-minute cycle every time we make an update to a record.

![image](https://user-images.githubusercontent.com/3020266/88969183-11831a80-d276-11ea-834e-92d5dce29a3d.png)

![image](https://user-images.githubusercontent.com/3020266/88969609-baca1080-d276-11ea-9660-66bba25cd272.png)


![image](https://user-images.githubusercontent.com/3020266/88969222-1ea00980-d276-11ea-9f83-16ceecef5aa4.png)
