### PR TITLE
Task to generate descriptive metadata for works

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,30 +1,54 @@
 alias Meadow.Repo
-alias Meadow.{Accounts, Ingest}
+
+alias Meadow.{
+  Accounts,
+  Constants,
+  Data,
+  ElasticsearchCluster,
+  ElasticsearchDiffStore,
+  ElasticsearchStore,
+  IIIF,
+  Ingest,
+  Pipeline,
+  Utils
+}
+
 alias Meadow.Accounts.Users
 alias Meadow.Accounts.Schemas.User
 
 alias Meadow.Data.{
   ActionStates,
+  CodedTerms,
   Collections,
+  ControlledTerms,
   FileSets,
+  Indexer,
+  IndexTimes,
   Works
 }
 
 alias Meadow.Data.Schemas.{
   ActionState,
+  CodedTerm,
   Collection,
+  ControlledMetadataEntry,
+  ControlledTermCache,
+  Field,
   FileSet,
-  Work
+  FileSetMetadata,
+  IndexTime,
+  Value,
+  Work,
+  WorkAdministrativeMetadata,
+  WorkDescriptiveMetadata
 }
 
-alias Meadow.Ingest.{Sheets, Projects}
-alias Meadow.Ingest.Projects.Bucket
+alias Meadow.Ingest.{Projects, Sheets, SheetsToWorks}
 
 alias Meadow.Ingest.Schemas.{
   Project,
-  Sheet,
   Row,
-  Validator,
+  Sheet,
   Status
 }
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -110,6 +110,8 @@ config :ex_aws,
   ],
   region: aws_region
 
+config :httpoison_retry, wait: 50
+
 import_config "sequins.exs"
 
 # Import environment specific config. This must remain at the bottom

--- a/lib/meadow/data/controlled_terms.ex
+++ b/lib/meadow/data/controlled_terms.ex
@@ -117,6 +117,12 @@ defmodule Meadow.Data.ControlledTerms do
     end
   end
 
+  def cache!(%{id: id, label: label}) do
+    %ControlledTermCache{id: id}
+    |> ControlledTermCache.changeset(%{label: label})
+    |> Repo.insert(on_conflict: :replace_all, conflict_target: :id)
+  end
+
   defp ets_fetch(id) do
     case Cachex.get!(Meadow.Cache.ControlledTerms, id) do
       nil ->

--- a/lib/meadow/utils/metadata_generator.ex
+++ b/lib/meadow/utils/metadata_generator.ex
@@ -1,0 +1,186 @@
+defmodule Meadow.Utils.MetadataGenerator do
+  @moduledoc """
+  Generate random descriptive metadata for works
+  """
+
+  alias Meadow.Data.{CodedTerms, ControlledTerms}
+  alias Meadow.Data.Works
+
+  @values %{
+    contributor: [
+      %{
+        id: "http://id.loc.gov/authorities/names/no2011087251",
+        label: "Valim, Jose"
+      },
+      %{
+        id: "http://id.loc.gov/authorities/names/n85153068",
+        label: "Mandela, Nelson, 1918-2013"
+      },
+      %{
+        id: "http://id.loc.gov/authorities/names/n79091588",
+        label: "Dewey, Melvil, 1851-1931"
+      },
+      %{
+        id: "http://id.loc.gov/authorities/names/n83175996",
+        label: "Hopper, Grace Murray"
+      },
+      %{
+        id: "http://id.loc.gov/authorities/names/n78030997",
+        label: "Lovelace, Ada King, Countess of, 1815-1852"
+      },
+      %{
+        id: "http://id.loc.gov/authorities/names/n50053919",
+        label: "Ranganathan, S. R. (Shiyali Ramamrita), 1892-1972"
+      }
+    ],
+    creator: [
+      %{id: "http://vocab.getty.edu/ulan/500030701", label: "Kahlo, Frida"},
+      %{id: "http://vocab.getty.edu/ulan/500029268", label: "Pei, I. M."},
+      %{id: "http://vocab.getty.edu/ulan/500018219", label: "Curtis, Edward S."},
+      %{id: "http://vocab.getty.edu/ulan/500115207", label: "Muybridge, Eadweard"},
+      %{id: "http://vocab.getty.edu/ulan/500102192", label: "Claudel, Camille"},
+      %{
+        id: "http://vocab.getty.edu/ulan/500445403",
+        label: "Aberdare, Henry Bruce, 2nd Baron"
+      }
+    ],
+    genre: [
+      %{id: "http://vocab.getty.edu/aat/300386217", label: "genre artists"},
+      %{id: "http://vocab.getty.edu/aat/300139140", label: "genre pictures"},
+      %{id: "http://vocab.getty.edu/aat/300266117", label: "genre painters"},
+      %{id: "http://vocab.getty.edu/aat/300056462", label: "art genres"},
+      %{
+        id: "http://vocab.getty.edu/aat/300185712",
+        label: "object genres (object classifications)"
+      },
+      %{id: "http://vocab.getty.edu/aat/300026031", label: "document genres"}
+    ],
+    language: [
+      %{id: "http://id.loc.gov/vocabulary/languages/cha", label: "Chamorro"},
+      %{id: "http://id.loc.gov/vocabulary/languages/div", label: "Divehi"},
+      %{id: "http://id.loc.gov/vocabulary/languages/lin", label: "Lingala"},
+      %{id: "http://id.loc.gov/vocabulary/languages/bug", label: "Bugis"},
+      %{id: "http://id.loc.gov/vocabulary/languages/nia", label: "Nias"},
+      %{id: "http://id.loc.gov/vocabulary/languages/kor", label: "Korean"}
+    ],
+    location: [
+      %{id: "https://sws.geonames.org/3598132", label: "Guatemala City"},
+      %{id: "https://sws.geonames.org/3530597", label: "Mexico City"},
+      %{id: "https://sws.geonames.org/3703443", label: "Panama City"},
+      %{id: "https://sws.geonames.org/3582677", label: "Belize City"},
+      %{id: "https://sws.geonames.org/2347283", label: "Benin City"},
+      %{id: "https://sws.geonames.org/292932", label: "Ajman"}
+    ],
+    style_period: [
+      %{id: "http://vocab.getty.edu/aat/300312140", label: "White Style"},
+      %{id: "http://vocab.getty.edu/aat/300375728", label: "Glasgow style"},
+      %{id: "http://vocab.getty.edu/aat/300378903", label: "Style Guimard"},
+      %{id: "http://vocab.getty.edu/aat/300375737", label: "Yachting Style"},
+      %{
+        id: "http://vocab.getty.edu/aat/300375743",
+        label: "Modern Style (Art Nouveau )"
+      },
+      %{id: "http://vocab.getty.edu/aat/300378910", label: "Quaint Style"}
+    ],
+    subject: [
+      %{
+        id: "http://id.loc.gov/authorities/subjects/sh2002006395",
+        label: "Library"
+      },
+      %{
+        id: "http://id.loc.gov/authorities/subjects/sh85070610",
+        label: "John Cotton Dana Library Public Relations Award"
+      },
+      %{
+        id: "http://id.loc.gov/authorities/subjects/sh85076710",
+        label: "Library pages"
+      },
+      %{
+        id: "http://id.loc.gov/authorities/subjects/sh85076671",
+        label: "Library catalogs and users"
+      },
+      %{
+        id: "http://id.loc.gov/authorities/subjects/sh91004067",
+        label: "Library materials budgets"
+      },
+      %{
+        id: "http://id.loc.gov/authorities/subjects/sh85076678",
+        label: "Library cooperation"
+      }
+    ],
+    technique: [
+      %{id: "http://vocab.getty.edu/aat/300265034", label: "Six's Technique"},
+      %{id: "http://vocab.getty.edu/aat/300400619", label: "Levallois technique"},
+      %{
+        id: "http://vocab.getty.edu/aat/300435429",
+        label: "materials/technique description"
+      },
+      %{id: "http://vocab.getty.edu/aat/300053376", label: "soak-stain technique"},
+      %{
+        id: "http://vocab.getty.edu/aat/300438611",
+        label: "micro hot table technique"
+      },
+      %{id: "http://vocab.getty.edu/aat/300410254", label: "sarga (technique)"}
+    ]
+  }
+
+  def prewarm_cache do
+    Enum.each(@values, fn {_field, value} ->
+      Enum.each(value, fn term -> ControlledTerms.cache!(term) end)
+    end)
+  end
+
+  @spec generate_descriptive_metadata_for(
+          maybe_improper_list(
+            maybe_improper_list(maybe_improper_list(any, [] | map) | map, [] | map)
+            | Meadow.Data.Schemas.Work.t(),
+            [] | Meadow.Data.Schemas.Work.t()
+          )
+          | Meadow.Data.Schemas.Work.t()
+        ) :: any
+  def generate_descriptive_metadata_for([]), do: []
+
+  def generate_descriptive_metadata_for([work | works]) do
+    [generate_descriptive_metadata_for(work) | generate_descriptive_metadata_for(works)]
+  end
+
+  def generate_descriptive_metadata_for(work) do
+    md = %{
+      title: Faker.Lorem.sentence(),
+      contributor: random_number_of(:contributor),
+      creator: random_number_of(:creator),
+      genre: random_number_of(:genre),
+      language: random_number_of(:language),
+      location: random_number_of(:location),
+      style_period: random_number_of(:style_period),
+      subject: random_number_of(:subject),
+      technique: random_number_of(:technique)
+    }
+
+    work |> Works.update_work(%{descriptive_metadata: md})
+  end
+
+  defp random_number_of(field) do
+    min = if field == :creator, do: 1, else: 0
+
+    with pool <- @values[field] do
+      0..Enum.random(min..5)
+      |> Enum.map(fn _ ->
+        with value <- Enum.random(pool) do
+          case field do
+            :contributor -> %{role: random_role("marc_relator"), term: %{id: value.id}}
+            :subject -> %{role: random_role("subject_role"), term: %{id: value.id}}
+            _ -> %{role: nil, term: %{id: value.id}}
+          end
+        end
+      end)
+    end
+    |> Enum.uniq()
+  end
+
+  defp random_role(scheme) do
+    with id <- CodedTerms.list_coded_terms(scheme) |> Enum.random() |> Map.get(:id) do
+      %{id: id, scheme: scheme}
+    end
+  end
+end

--- a/lib/mix/tasks/seed_data.ex
+++ b/lib/mix/tasks/seed_data.ex
@@ -17,7 +17,9 @@ defmodule Mix.Tasks.Meadow.SeedData do
   use Mix.Task
 
   alias Meadow.{Config, Repo}
+  alias Meadow.Data.Indexer
   alias Meadow.Ingest.{Progress, Projects, Rows, Sheets, SheetsToWorks, Validator}
+  alias Meadow.Utils.MetadataGenerator
 
   require Logger
 
@@ -79,6 +81,12 @@ defmodule Mix.Tasks.Meadow.SeedData do
 
       Logger.info("Ingest sheet sent to pipeline. Waiting for ingest to complete.")
       wait_for_completion(sheet)
+
+      sheet
+      |> Sheets.list_ingest_sheet_works()
+      |> MetadataGenerator.generate_descriptive_metadata_for()
+
+      Indexer.synchronize_index()
     end
   end
 

--- a/test/meadow/utils/metadata_generator_test.exs
+++ b/test/meadow/utils/metadata_generator_test.exs
@@ -1,0 +1,19 @@
+defmodule Meadow.Utils.MetadataGeneratorTest do
+  use ExUnit.Case
+  use Meadow.DataCase
+
+  alias Meadow.Utils.MetadataGenerator
+
+  describe "Meadow.Utils.MetadataGenerator" do
+    test "`generate_descriptive_metadata_for/1`" do
+      work = work_fixture()
+
+      assert Enum.empty?(work.descriptive_metadata.creator)
+
+      MetadataGenerator.prewarm_cache()
+      [{:ok, work}] = MetadataGenerator.generate_descriptive_metadata_for([work])
+
+      refute Enum.empty?(work.descriptive_metadata.creator)
+    end
+  end
+end


### PR DESCRIPTION
- Now when you run the meadow `mix meadow.seed_data` task to generate works, it will add descriptiveMetadata (title and controlled terms).
- It will also reindex 

<img width="1447" alt="Screen Shot 2020-07-31 at 11 58 19 AM" src="https://user-images.githubusercontent.com/6372022/89059239-726a2b80-d326-11ea-969d-b6750d24b18e.png">
