### PR TITLE
Implement batch update backend and API (delete only)

### DIFF
--- a/lib/meadow/batches.ex
+++ b/lib/meadow/batches.ex
@@ -1,0 +1,82 @@
+defmodule Meadow.Batches do
+  @moduledoc """
+  Meadow batch context
+  """
+
+  import Ecto.Query, warn: false
+  alias Meadow.Data.{ControlledTerms, Indexer, Works}
+
+  @controlled_fields ~w(contributor creator genre language location style_period subject technique)a
+
+  def batch_update(query, delete) do
+    Meadow.Repo.transaction(
+      fn ->
+        process_updates(query, delete)
+        Indexer.synchronize_index()
+      end,
+      timeout: :infinity
+    )
+  end
+
+  defp apply_delete([], _), do: []
+
+  defp apply_delete([work | works], delete),
+    do: [apply_delete(work, delete) | apply_delete(works, delete)]
+
+  defp apply_delete(work, delete) do
+    with descriptive_metadata <- Map.from_struct(work.descriptive_metadata) do
+      new_descriptive_metadata =
+        Enum.reduce(@controlled_fields, descriptive_metadata, fn field, result ->
+          apply_delete(result, field, delete)
+        end)
+
+      Works.update_work(work, %{descriptive_metadata: new_descriptive_metadata})
+    end
+  end
+
+  defp apply_delete(metadata, field, delete) do
+    values = delete |> Map.get(field, [])
+
+    new_value =
+      metadata
+      |> Map.get(field, [])
+      |> Enum.reject(fn existing_value ->
+        Enum.any?(values, fn delete_value ->
+          ControlledTerms.terms_equal?(existing_value, delete_value)
+        end)
+      end)
+      |> Enum.map(&Map.from_struct/1)
+
+    Map.put(metadata, field, new_value)
+  end
+
+  defp process_updates({:ok, %{"hits" => %{"hits" => []}}}, _) do
+    {:ok, :noop}
+  end
+
+  defp process_updates({:ok, %{"_scroll_id" => scroll_id, "hits" => hits}}, delete) do
+    hits
+    |> Map.get("hits")
+    |> Enum.map(&Map.get(&1, "_id"))
+    |> Works.get_works()
+    |> apply_delete(delete)
+
+    Meadow.ElasticsearchCluster
+    |> Elasticsearch.post(
+      "/_search/scroll",
+      Jason.encode!(%{scroll: "1m", scroll_id: scroll_id})
+    )
+    |> process_updates(delete)
+  end
+
+  defp process_updates(query, delete) do
+    query =
+      Jason.decode!(query)
+      |> Map.put("_source", "")
+      |> Jason.encode!()
+
+    Meadow.ElasticsearchCluster
+    |> Elasticsearch.post("/meadow/_search?scroll=10m", query)
+    |> process_updates(delete)
+  end
+end

--- a/lib/meadow/data/works.ex
+++ b/lib/meadow/data/works.ex
@@ -88,6 +88,11 @@ defmodule Meadow.Data.Works do
     |> add_representative_image()
   end
 
+  def get_works(id_list) do
+    from(w in Work, where: w.id in ^id_list)
+    |> Repo.all()
+  end
+
   @doc """
   Gets a work by accession_number
 

--- a/lib/meadow/utils/metadata_generator.ex
+++ b/lib/meadow/utils/metadata_generator.ex
@@ -3,7 +3,7 @@ defmodule Meadow.Utils.MetadataGenerator do
   Generate random descriptive metadata for works
   """
 
-  alias Meadow.Data.{CodedTerms, ControlledTerms}
+  alias Meadow.Data.ControlledTerms
   alias Meadow.Data.Works
 
   @values %{
@@ -124,6 +124,11 @@ defmodule Meadow.Utils.MetadataGenerator do
     ]
   }
 
+  @roles %{
+    "marc_relator" => ~w(aut lil mrb pbl stl vac),
+    "subject_role" => ~w(GEOGRAPHICAL TOPICAL)
+  }
+
   def prewarm_cache do
     Enum.each(@values, fn {_field, value} ->
       Enum.each(value, fn term -> ControlledTerms.cache!(term) end)
@@ -179,7 +184,7 @@ defmodule Meadow.Utils.MetadataGenerator do
   end
 
   defp random_role(scheme) do
-    with id <- CodedTerms.list_coded_terms(scheme) |> Enum.random() |> Map.get(:id) do
+    with id <- @roles |> Map.get(scheme) |> Enum.random() do
       %{id: id, scheme: scheme}
     end
   end

--- a/lib/meadow_web/resolvers/batches.ex
+++ b/lib/meadow_web/resolvers/batches.ex
@@ -1,0 +1,15 @@
+defmodule MeadowWeb.Resolvers.Data.Batches do
+  @moduledoc """
+  Absinthe resolver for Batch update related functionality
+  """
+  alias Meadow.Batches
+
+  def update(_, %{query: query, delete: delete}, _) do
+    {_response, _pid} =
+      Meadow.Async.run_once("batch_update", fn ->
+        Batches.batch_update(query, delete)
+      end)
+
+    {:ok, %{message: "Batch started"}}
+  end
+end

--- a/lib/meadow_web/schema/types/data/batch_types.ex
+++ b/lib/meadow_web/schema/types/data/batch_types.ex
@@ -4,6 +4,7 @@ defmodule MeadowWeb.Schema.Data.BatchTypes do
 
   """
   use Absinthe.Schema.Notation
+  alias MeadowWeb.Resolvers.Data.Batches
   alias MeadowWeb.Schema.Middleware
 
   object :batch_mutations do
@@ -12,10 +13,7 @@ defmodule MeadowWeb.Schema.Data.BatchTypes do
       arg(:query, non_null(:string))
       arg(:delete, non_null(:batch_update_input))
       middleware(Middleware.Authenticate)
-
-      resolve(fn _, _ ->
-        {:ok, %{message: "Batch started"}}
-      end)
+      resolve(&Batches.update/3)
     end
   end
 

--- a/lib/mix/tasks/seed_data.ex
+++ b/lib/mix/tasks/seed_data.ex
@@ -82,10 +82,12 @@ defmodule Mix.Tasks.Meadow.SeedData do
       Logger.info("Ingest sheet sent to pipeline. Waiting for ingest to complete.")
       wait_for_completion(sheet)
 
-      sheet
-      |> Sheets.list_ingest_sheet_works()
-      |> MetadataGenerator.generate_descriptive_metadata_for()
+      with works <- Sheets.list_ingest_sheet_works(sheet) do
+        Logger.info("Generating random descriptive metadata for #{length(works)} works.")
+        MetadataGenerator.generate_descriptive_metadata_for(works)
+      end
 
+      Logger.info("Synchronizing Elasticsearch index.")
       Indexer.synchronize_index()
     end
   end

--- a/test/meadow/batches_test.exs
+++ b/test/meadow/batches_test.exs
@@ -1,0 +1,94 @@
+defmodule Meadow.BatchesTest do
+  use Meadow.DataCase
+  use Meadow.IndexCase
+  alias Meadow.Batches
+  alias Meadow.Data.{Indexer, Works}
+  alias Meadow.Utils.MetadataGenerator
+
+  describe "Meadow.BatchesTest" do
+    setup do
+      MetadataGenerator.prewarm_cache()
+
+      works = [
+        work_fixture(%{
+          descriptive_metadata: %{
+            title: "Work 1",
+            contributor: [
+              %{
+                role: %{scheme: "marc_relator", id: "aut"},
+                term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+              }
+            ],
+            genre: [
+              %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}},
+              %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
+            ]
+          }
+        }),
+        work_fixture(%{
+          descriptive_metadata: %{
+            title: "Work 2",
+            contributor: [
+              %{
+                role: %{scheme: "marc_relator", id: "aut"},
+                term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+              },
+              %{
+                role: %{scheme: "marc_relator", id: "col"},
+                term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+              }
+            ],
+            genre: [
+              %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
+            ]
+          }
+        }),
+        work_fixture(%{
+          descriptive_metadata: %{
+            title: "Work 3",
+            contributor: [
+              %{
+                role: %{scheme: "marc_relator", id: "aut"},
+                term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+              },
+              %{
+                role: %{scheme: "marc_relator", id: "aut"},
+                term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+              }
+            ],
+            genre: [
+              %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
+            ]
+          }
+        })
+      ]
+
+      Indexer.reindex_all!()
+      {:ok, %{works: works}}
+    end
+
+    test "batch_update/2" do
+      query = ~s'{"query":{"term":{"workType.id": "IMAGE"}}}'
+
+      delete = %{
+        contributor: [
+          %{
+            role: %{scheme: "marc_relator", id: "aut"},
+            term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+          }
+        ],
+        genre: [
+          %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
+        ]
+      }
+
+      assert {:ok, _result} = Batches.batch_update(query, delete)
+
+      assert List.first(Works.get_works_by_title("Work 1")).descriptive_metadata.genre
+             |> length() == 1
+
+      assert List.first(Works.get_works_by_title("Work 2")).descriptive_metadata.contributor
+             |> length() == 1
+    end
+  end
+end

--- a/test/meadow/data/controlled_terms_test.exs
+++ b/test/meadow/data/controlled_terms_test.exs
@@ -6,6 +6,8 @@ defmodule Meadow.Data.ControlledTermsTest do
   alias Meadow.Data.Schemas.ControlledTermCache
   alias Meadow.Repo
 
+  doctest Meadow.Data.ControlledTerms, import: true, only: [{:terms_equal?, 2}]
+
   setup do
     ControlledTerms.clear!()
     :ok

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -10,6 +10,7 @@ defmodule Meadow.TestHelpers do
   alias Meadow.Data.Works
   alias Meadow.Ingest.Validator
   alias Meadow.Ingest.Schemas.{Project, Sheet}
+  alias Meadow.Utils.MetadataGenerator
 
   alias Meadow.Repo
 
@@ -24,6 +25,8 @@ defmodule Meadow.TestHelpers do
     :noAccess => ~w[aup9261 aup6836 aui9865 auj5680 auq9679],
     :unknown => ~w[unknownUser]
   }
+
+  def prewarm_controlled_term_cache, do: MetadataGenerator.prewarm_cache()
 
   def test_users(category \\ :access), do: @test_users |> Map.get(category)
   def random_user(category \\ :access), do: category |> test_users |> Enum.random()


### PR DESCRIPTION
* Wires up actual functionality behind the batchUpdate mutation in the GraphQL API
* Returns a `Batch started` message, but updates continue asynchronously in the background
  * Status/completion updates are in [another issue](https://github.com/nulib/repodev_planning_and_docs/issues/952)
  * Watch your Elixir output log for when the updates stop

Example mutation:
```gql
mutation ($query: String!, $delete: BatchUpdateInput!) {
  batchUpdate(query: $query, delete: $delete) {
    message
  }
}
```

Example variables (adjust values for your actual dataset):
```json
{
  "query": "{\"query\":{\"term\":{\"workType.id\": \"IMAGE\"}}}",
  "delete": {
    "contributor": [
      {
        "role": {"scheme": "MARC_RELATOR", "id": "aut"}, 
        "term": "http://id.loc.gov/authorities/names/n79091588"
      }
    ],
    "genre": [{"term": "http://vocab.getty.edu/aat/300026031"}]
  }
}
```