### PR TITLE
updateProject mutation in GraphQL API

### DIFF
--- a/lib/meadow_web/resolvers/ingest.ex
+++ b/lib/meadow_web/resolvers/ingest.ex
@@ -34,6 +34,17 @@ defmodule MeadowWeb.Resolvers.Ingest do
     end
   end
 
+  def update_project(_, args, _) do
+    case Projects.create_project(args) do
+      {:error, changeset} ->
+        {:error,
+         message: "Could not update project", details: ChangesetErrors.error_details(changeset)}
+
+      {:ok, project} ->
+        {:ok, project}
+    end
+  end
+
   def delete_project(_, args, _) do
     project = Projects.get_project!(args[:project_id])
 

--- a/lib/meadow_web/schema/types/ingest_types.ex
+++ b/lib/meadow_web/schema/types/ingest_types.ex
@@ -86,6 +86,14 @@ defmodule MeadowWeb.Schema.IngestTypes do
       resolve(&Resolvers.Ingest.create_project/3)
     end
 
+    @desc "Create a new Ingest Project"
+    field :update_project, :project do
+      arg(:id, non_null(:id))
+      arg(:title, :string)
+      middleware(Middleware.Authenticate)
+      resolve(&Resolvers.Ingest.update_project/3)
+    end
+
     @desc "Create a new Ingest Sheet for a Project"
     field :create_ingest_sheet, :ingest_sheet do
       arg(:title, non_null(:string))

--- a/test/gql/UpdateProject.gql
+++ b/test/gql/UpdateProject.gql
@@ -1,0 +1,7 @@
+mutation($id: ID!, $title: String!) {
+  updateProject(id: $id, title: $title) {
+    id
+    title
+    folder
+  }
+}

--- a/test/meadow_web/schema/mutation/update_project_test.exs
+++ b/test/meadow_web/schema/mutation/update_project_test.exs
@@ -1,0 +1,26 @@
+defmodule MeadowWeb.Schema.Mutation.UpdateProjectTest do
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+
+  load_gql(MeadowWeb.Schema, "test/gql/UpdateProject.gql")
+
+  describe "updateProject mutation" do
+    test "should allow the title to be updated" do
+      project = project_fixture()
+
+      result =
+        query_gql(
+          variables: %{
+            "id" => project.id,
+            "title" => "The New Title"
+          },
+          context: gql_context()
+        )
+
+      assert {:ok, query_data} = result
+
+      title = get_in(query_data, [:data, "updateProject", "title"])
+      assert title == "The New Title"
+    end
+  end
+end


### PR DESCRIPTION
- Adds an `updateProject` mutation to the GraphQL api through which you can update a project's title.