### PR TITLE
Change data type of collection description column

### DIFF
--- a/priv/repo/migrations/20190911151155_create_collections.exs
+++ b/priv/repo/migrations/20190911151155_create_collections.exs
@@ -4,7 +4,7 @@ defmodule Meadow.Repo.Migrations.CreateCollections do
   def change do
     create table("collections") do
       add(:title, :string)
-      add(:description, :string)
+      add(:description, :text)
       add(:keywords, {:array, :string}, default: [])
       add(:finding_aid_url, :text)
       add(:admin_email, :text)


### PR DESCRIPTION
- Changes data type of collection description column in the migration from `:string` to `:text` so collections can have descriptions longer than 255 characters.

**Requires `down -v`**