### PR TITLE
Expose metadata property info through the GraphQL API

### DIFF
--- a/lib/meadow/data/fields.ex
+++ b/lib/meadow/data/fields.ex
@@ -1,0 +1,28 @@
+defmodule Meadow.Data.Fields do
+  @moduledoc """
+  The Fields context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Meadow.Data.Schemas.Field
+  alias Meadow.Repo
+
+  @doc """
+  Returns the list of Field information.
+
+  ## Examples
+
+      iex> Fields.describe()
+      [%field{}, ...]
+
+  """
+  def describe(id) do
+    Field
+    |> Repo.get!(id)
+  end
+
+  def describe do
+    Field
+    |> Repo.all()
+  end
+end

--- a/lib/meadow/data/schemas/field.ex
+++ b/lib/meadow/data/schemas/field.ex
@@ -18,6 +18,8 @@ defmodule Meadow.Data.Schemas.Field do
     field :label, :string
     field :repeating, :boolean, default: false
     field :required, :boolean, default: false
+    field :role, :string
+    field :scheme, :string
     field :metadata_class, MetadataClassEnum
 
     timestamps()

--- a/lib/meadow_web/resolvers/fields.ex
+++ b/lib/meadow_web/resolvers/fields.ex
@@ -1,0 +1,14 @@
+defmodule MeadowWeb.Resolvers.Fields do
+  @moduledoc """
+  Absinthe resolver for Fields queries
+  """
+  alias Meadow.Data.Fields
+
+  def describe(_, %{id: id}, _) do
+    {:ok, Fields.describe(id)}
+  end
+
+  def describe(_, _, _) do
+    {:ok, Fields.describe()}
+  end
+end

--- a/lib/meadow_web/schema/schema.ex
+++ b/lib/meadow_web/schema/schema.ex
@@ -17,16 +17,18 @@ defmodule MeadowWeb.Schema do
   import_types(__MODULE__.Data.ControlledTermTypes)
   import_types(__MODULE__.Data.WorkTypes)
   import_types(__MODULE__.Data.FileSetTypes)
+  import_types(__MODULE__.Data.FieldTypes)
   import_types(__MODULE__.HelperTypes)
 
   query do
     import_fields(:account_queries)
     import_fields(:collection_queries)
     import_fields(:controlled_term_queries)
-    import_fields(:ingest_queries)
-    import_fields(:work_queries)
+    import_fields(:field_queries)
     import_fields(:file_set_queries)
     import_fields(:helper_queries)
+    import_fields(:ingest_queries)
+    import_fields(:work_queries)
   end
 
   mutation do

--- a/lib/meadow_web/schema/types/data/field_types.ex
+++ b/lib/meadow_web/schema/types/data/field_types.ex
@@ -1,0 +1,33 @@
+defmodule MeadowWeb.Schema.Data.FieldTypes do
+  @moduledoc """
+  Absinthe Schema for field (metadata properties) queries
+
+  """
+  use Absinthe.Schema.Notation
+  alias MeadowWeb.Resolvers
+  alias MeadowWeb.Schema.Middleware
+
+  object :field_queries do
+    @desc "Describes the metadata properties on works"
+    field :describe_fields, list_of(:field_info) do
+      middleware(Middleware.Authenticate)
+      resolve(&Resolvers.Fields.describe/3)
+    end
+
+    field :describe_field, :field_info do
+      arg(:id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      resolve(&Resolvers.Fields.describe/3)
+    end
+  end
+
+  object :field_info do
+    field :id, :string
+    field :label, :string
+    field :metadata_class, :string
+    field :repeating, :boolean
+    field :required, :boolean
+    field :role, :code_list_scheme
+    field :scheme, :code_list_scheme
+  end
+end

--- a/priv/repo/migrations/20200504191838_create_fields.exs
+++ b/priv/repo/migrations/20200504191838_create_fields.exs
@@ -5,10 +5,11 @@ defmodule Meadow.Repo.Migrations.CreateFields do
     create table(:fields, primary_key: false) do
       add :id, :string, primary_key: true
       add :label, :string
+      add :metadata_class, :string
       add :repeating, :boolean, default: false, null: false
       add :required, :boolean, default: false, null: false
-      add :metadata_class, :string
-
+      add :role, :string
+      add :scheme, :string
       timestamps()
     end
   end

--- a/priv/repo/seeds/fields.json
+++ b/priv/repo/seeds/fields.json
@@ -1,100 +1,461 @@
 [
   {
-    "metadata_class": "administrative",
-    "id": "preservation_level",
-    "label": "Preservation Level",
-    "required": true,
-    "repeating": false
-  },
-  {
-    "metadata_class": "core",
-    "id": "resource_type",
-    "label": "Resource Type",
-    "required": true,
-    "repeating": false
-  },
-  {
-    "metadata_class": "core",
-    "id": "status",
-    "label": "Status",
-    "required": true,
-    "repeating": false
-  },
-  {
-    "metadata_class": "core",
-    "id": "visibility",
-    "label": "Visibility",
-    "required": true,
-    "repeating": false
+    "metadata_class": "descriptive",
+    "id": "abstract",
+    "label": "Abstract",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
   },
   {
     "metadata_class": "descriptive",
-    "id": "based_near",
-    "label": "Location (Place of Publication)",
+    "id": "accession_number",
+    "label": "Accession Number",
+    "required": true,
+    "repeating": false,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "alternate_title",
+    "label": "Alternate Title",
     "required": false,
-    "repeating": true
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "ark",
+    "label": "ARK",
+    "required": false,
+    "repeating": false,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "box_name",
+    "label": "Box Name",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "box_number",
+    "label": "Box Number",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "call_number",
+    "label": "Call Number",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "caption",
+    "label": "Caption",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "catalog_key",
+    "label": "Catalog Key",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "citation",
+    "label": "Citation",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
   },
   {
     "metadata_class": "descriptive",
     "id": "contributor",
     "label": "Contributor",
     "required": false,
-    "repeating": true
+    "repeating": true,
+    "role": "marc_relator",
+    "scheme": null
   },
   {
     "metadata_class": "descriptive",
     "id": "creator",
     "label": "Creator",
     "required": false,
-    "repeating": true
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "date_created",
+    "label": "Date Created",
+    "required": true,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "description",
+    "label": "Description",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "folder_name",
+    "label": "Folder Name",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "folder_number",
+    "label": "Folder Number",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
   },
   {
     "metadata_class": "descriptive",
     "id": "genre",
     "label": "Genre",
     "required": false,
-    "repeating": true
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "identifier",
+    "label": "Identifier",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "keyword",
+    "label": "Keyword",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
   },
   {
     "metadata_class": "descriptive",
     "id": "language",
     "label": "Language",
     "required": false,
-    "repeating": true
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "legacy_identifier",
+    "label": "Legacy Identifier",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
   },
   {
     "metadata_class": "descriptive",
     "id": "license",
     "label": "License",
     "required": true,
-    "repeating": false
+    "repeating": false,
+    "scheme": "license",
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "based_near",
+    "label": "Location (Place of Publication)",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "notes",
+    "label": "Notes",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "nul_use_statement",
+    "label": "NUL Use Statement",
+    "required": true,
+    "repeating": false,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "physical_description_material",
+    "label": "Physical Description Material",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "physical_description_size",
+    "label": "Physical Description Size",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "administrative",
+    "id": "preservation_level",
+    "label": "Preservation Level",
+    "required": true,
+    "repeating": false,
+    "scheme": "preservation_level",
+    "role": null
+  },
+  {
+    "metadata_class": "administrative",
+    "id": "project_name",
+    "label": "Project Name",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "administrative",
+    "id": "project_desc",
+    "label": "Project Description",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "administrative",
+    "id": "project_proposer",
+    "label": "Project Proposer / Requestor Name",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "administrative",
+    "id": "project_manager",
+    "label": "Project Manager",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "administrative",
+    "id": "project_task_number",
+    "label": "Project Task Number",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "administrative",
+    "id": "project_cycle",
+    "label": "Project Cycle",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "provenance",
+    "label": "Provenance",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "published",
+    "label": "Published",
+    "required": true,
+    "repeating": false,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "publisher",
+    "label": "Publisher",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "related_url",
+    "label": "Related URL",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "related_materials",
+    "label": "Related Materials",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "rights_holder",
+    "label": "Rights Holder",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
   },
   {
     "metadata_class": "descriptive",
     "id": "rights_statement",
     "label": "Rights Statement",
     "required": true,
-    "repeating": false
+    "repeating": false,
+    "scheme": "rights_statement",
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "scope_and_contents",
+    "label": "Scope and Contents",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "series",
+    "label": "Series",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "source",
+    "label": "Source",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "administrative",
+    "id": "status",
+    "label": "Status",
+    "required": true,
+    "repeating": false,
+    "scheme": "status",
+    "role": null
   },
   {
     "metadata_class": "descriptive",
     "id": "style_period",
     "label": "Style Period",
     "required": false,
-    "repeating": true
+    "repeating": true,
+    "scheme": null,
+    "role": null
   },
   {
     "metadata_class": "descriptive",
     "id": "subject",
     "label": "Subject",
     "required": false,
-    "repeating": true
+    "repeating": true,
+    "role": "subject_role",
+    "scheme": null
+  },
+  {
+    "metadata_class": "descriptive",
+    "id": "table_of_contents",
+    "label": "Table of Contents",
+    "required": false,
+    "repeating": true,
+    "scheme": null,
+    "role": null
   },
   {
     "metadata_class": "descriptive",
     "id": "technique",
     "label": "Technique",
     "required": false,
-    "repeating": true
+    "repeating": true,
+    "scheme": null,
+    "role": null
+  },
+  {
+    "metadata_class": "core",
+    "id": "visibility",
+    "label": "Visibility",
+    "required": true,
+    "repeating": false,
+    "scheme": "visibility",
+    "role": null
+  },
+  {
+    "metadata_class": "core",
+    "id": "work_type",
+    "label": "Work Type",
+    "required": true,
+    "repeating": false,
+    "scheme": "work_type",
+    "role": null
   }
 ]

--- a/test/gql/DescribeField.gql
+++ b/test/gql/DescribeField.gql
@@ -1,0 +1,7 @@
+#import "./MetadataFields.frag.gql"
+
+query DescribeField($id: ID!) {
+  describeField(id: $id) {
+    ...MetadataFields
+  }
+}

--- a/test/gql/DescribeFields.gql
+++ b/test/gql/DescribeFields.gql
@@ -1,0 +1,7 @@
+#import "./MetadataFields.frag.gql"
+
+query DescribeFields {
+  describeFields {
+    ...MetadataFields
+  }
+}

--- a/test/gql/MetadataFields.frag.gql
+++ b/test/gql/MetadataFields.frag.gql
@@ -1,0 +1,9 @@
+fragment MetadataFields on FieldInfo {
+  id
+  label
+  role
+  scheme
+  metadataClass
+  repeating
+  required
+}

--- a/test/meadow/data/fields_test.exs
+++ b/test/meadow/data/fields_test.exs
@@ -1,0 +1,16 @@
+defmodule Meadow.Data.FieldsTest do
+  use Meadow.DataCase
+
+  alias Meadow.Data.Fields
+
+  describe "queries" do
+    test "describe/0 returns all fields" do
+      assert length(Fields.describe()) > 1
+    end
+
+    test "describe/1 fetches the field info by id" do
+      subject = Fields.describe("subject")
+      assert subject.label == "Subject"
+    end
+  end
+end

--- a/test/meadow_web/schema/query/describe_fields_test.exs
+++ b/test/meadow_web/schema/query/describe_fields_test.exs
@@ -1,0 +1,42 @@
+defmodule MeadowWeb.Schema.Query.DescribeFieldsTest do
+  defmodule All do
+    use MeadowWeb.ConnCase, async: true
+    use Wormwood.GQLCase
+    load_gql(MeadowWeb.Schema, "test/gql/DescribeFields.gql")
+
+    test "describeFields query is a valid query" do
+      assert {:ok, %{data: query_data}} = query_gql(context: gql_context())
+      assert length(get_in(query_data, ["describeFields"])) > 0
+    end
+  end
+
+  defmodule ByID do
+    use MeadowWeb.ConnCase, async: true
+    use Wormwood.GQLCase
+    load_gql(MeadowWeb.Schema, "test/gql/DescribeField.gql")
+
+    test "describeField query returns field info for an id" do
+      result =
+        query_gql(
+          variables: %{"id" => "contributor"},
+          context: gql_context()
+        )
+
+      assert {:ok, query_data} = result
+
+      assert query_data == %{
+               data: %{
+                 "describeField" => %{
+                   "id" => "contributor",
+                   "label" => "Contributor",
+                   "metadataClass" => "descriptive",
+                   "repeating" => true,
+                   "required" => false,
+                   "role" => "MARC_RELATOR",
+                   "scheme" => nil
+                 }
+               }
+             }
+    end
+  end
+end


### PR DESCRIPTION
Expose metadata property info through the API:

Ex: 
Retrieve all fields:

```query{
  describeFields {
    id
    label
    metadataClass
    repeating
    required
    role
    scheme
  }
}
```

Or, get one field by id: (this will also allow you to retrieve roles (for contributor and subject) and schemes (for coded terms that need to send a scheme with a value)

Ex:

```
query{
  describeField(id: "contributor") {
    id
    label
    metadataClass
    repeating
    required
    role
    scheme
  }
}


{
  "data": {
    "describeField": {
      "id": "contributor",
      "label": "Contributor",
      "metadataClass": "descriptive",
      "repeating": true,
      "required": false,
      "role": "MARC_RELATOR",
      "scheme": null
    }
  }
}
```

```
query{
  describeField(id: "rights_statement") {
    id
    label
    metadataClass
    repeating
    required
    role
    scheme
  }
}

{
  "data": {
    "describeField": {
      "id": "rights_statement",
      "label": "Rights Statement",
      "metadataClass": "descriptive",
      "repeating": false,
      "required": true,
      "role": null,
      "scheme": "RIGHTS_STATEMENT"
    }
  }
}
```



** will require a `down -v`
