### PR TITLE
937 remove functionality batch edit

### DIFF
--- a/assets/js/components/Auth/PrivateRoute.jsx
+++ b/assets/js/components/Auth/PrivateRoute.jsx
@@ -8,14 +8,14 @@ const PrivateRoute = ({ component: Component, ...rest }) => {
   return (
     <Route
       {...rest}
-      render={props =>
+      render={(props) =>
         me ? (
           <Component {...props} />
         ) : (
           <Redirect
             to={{
               pathname: "/login",
-              state: { from: props.location }
+              state: { from: props.location },
             }}
           />
         )

--- a/assets/js/components/BatchEdit/About/About.jsx
+++ b/assets/js/components/BatchEdit/About/About.jsx
@@ -11,10 +11,18 @@ import BatchEditAboutRightsMetadata from "./RightsMetadata";
 import BatchEditAboutIdentifiersMetadata from "./IdentifiersMetadata";
 import UIAccordion from "../../UI/Accordion";
 import BatchEditConfirmation from "./Confirmation";
+import BatchEditAboutModalRemove from "../ModalRemove";
+import { useBatchState } from "../../../context/batch-edit-context";
 
-const BatchEditAbout = ({ numberOfResults }) => {
+const BatchEditAbout = () => {
   const [confirmationMetadata, setConfirmationMetadata] = useState();
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
+
+  // Grab batch search data from Context
+  const batchState = useBatchState();
+  const numberOfResults = batchState.resultStats
+    ? batchState.resultStats.numberOfResults
+    : 0;
 
   // Initialize React hook form
   const {
@@ -30,8 +38,7 @@ const BatchEditAbout = ({ numberOfResults }) => {
   });
 
   const onCloseModal = () => {
-    console.log("handleClose called");
-    setIsModalOpen(false);
+    setIsConfirmModalOpen(false);
   };
 
   // Handle About tab form submit (Core and Descriptive metadata)
@@ -43,118 +50,121 @@ const BatchEditAbout = ({ numberOfResults }) => {
     let currentFormValues = getValues();
     console.log("currentFormValues :>> ", currentFormValues);
     setConfirmationMetadata(currentFormValues);
-    setIsModalOpen(true);
+    setIsConfirmModalOpen(true);
   };
 
   return (
-    <form
-      name="batch-edit-about-form"
-      data-testid="batch-edit-about-form"
-      onSubmit={handleSubmit(onSubmit)}
-    >
-      <UITabsStickyHeader
-        title="Core and Descriptive Metadata"
-        data-testid="batch-edit-about-sticky-header"
+    <div>
+      <form
+        name="batch-edit-about-form"
+        data-testid="batch-edit-about-form"
+        onSubmit={handleSubmit(onSubmit)}
       >
-        <>
-          <button
-            type="submit"
-            className="button is-primary"
-            data-testid="save-button"
-          >
-            Save Data for {numberOfResults} Items
-          </button>
-          <button
-            type="button"
-            className="button is-text"
-            data-testid="cancel-button"
-            onClick={() => reset()}
-          >
-            Clear Form
-          </button>
-        </>
-      </UITabsStickyHeader>
+        <UITabsStickyHeader
+          title="Core and Descriptive Metadata"
+          data-testid="batch-edit-about-sticky-header"
+        >
+          <>
+            <button
+              type="submit"
+              className="button is-primary"
+              data-testid="save-button"
+            >
+              Save Data for {numberOfResults} Items
+            </button>
+            <button
+              type="button"
+              className="button is-text"
+              data-testid="cancel-button"
+              onClick={() => reset()}
+            >
+              Clear Form
+            </button>
+          </>
+        </UITabsStickyHeader>
 
-      <p
-        className="notification is-warning mt-5"
-        data-testid="batch-edit-warning-notification"
-      >
-        <span className="icon">
-          <FontAwesomeIcon icon="exclamation-triangle" />
-        </span>
-        You are editing {numberOfResults} items. Proceed with caution.
-      </p>
-      {isModalOpen ? (
-        <BatchEditConfirmation
-          addMetadata={confirmationMetadata}
-          isModalOpen={isModalOpen}
-          handleClose={onCloseModal}
-        />
-      ) : null}
-      <UIAccordion testid="core-metadata-wrapper" title="Core Metadata">
-        <BatchEditAboutCoreMetadata
-          errors={errors}
-          control={control}
-          register={register}
-        />
-      </UIAccordion>
+        <p
+          className="notification is-warning mt-5"
+          data-testid="batch-edit-warning-notification"
+        >
+          <span className="icon">
+            <FontAwesomeIcon icon="exclamation-triangle" />
+          </span>
+          You are editing {numberOfResults} items. Proceed with caution.
+        </p>
+        {isConfirmModalOpen ? (
+          <BatchEditConfirmation
+            addMetadata={confirmationMetadata}
+            isConfirmModalOpen={isConfirmModalOpen}
+            handleClose={onCloseModal}
+          />
+        ) : null}
+        <UIAccordion testid="core-metadata-wrapper" title="Core Metadata">
+          <BatchEditAboutCoreMetadata
+            errors={errors}
+            control={control}
+            register={register}
+          />
+        </UIAccordion>
 
-      <UIAccordion
-        testid="controlled-metadata-wrapper"
-        title="Creator and Subject Information"
-      >
-        <BatchEditAboutControlledMetadata
-          control={control}
-          errors={errors}
-          register={register}
-        />
-      </UIAccordion>
+        <UIAccordion
+          testid="controlled-metadata-wrapper"
+          title="Creator and Subject Information"
+        >
+          <BatchEditAboutControlledMetadata
+            control={control}
+            errors={errors}
+            register={register}
+          />
+        </UIAccordion>
 
-      <UIAccordion
-        testid="uncontrolled-metadata-wrapper"
-        title="Description Information"
-      >
-        <BatchEditAboutUncontrolledMetadata
-          control={control}
-          errors={errors}
-          register={register}
-        />
-      </UIAccordion>
-      <UIAccordion
-        testid="physical-metadata-wrapper"
-        title="Physical Objects Information"
-      >
-        <BatchEditAboutPhysicalMetadata
-          control={control}
-          errors={errors}
-          register={register}
-        />
-      </UIAccordion>
+        <UIAccordion
+          testid="uncontrolled-metadata-wrapper"
+          title="Description Information"
+        >
+          <BatchEditAboutUncontrolledMetadata
+            control={control}
+            errors={errors}
+            register={register}
+          />
+        </UIAccordion>
+        <UIAccordion
+          testid="physical-metadata-wrapper"
+          title="Physical Objects Information"
+        >
+          <BatchEditAboutPhysicalMetadata
+            control={control}
+            errors={errors}
+            register={register}
+          />
+        </UIAccordion>
 
-      <UIAccordion testid="rights-metadata-wrapper" title="Rights Information">
-        <BatchEditAboutRightsMetadata
-          control={control}
-          errors={errors}
-          register={register}
-        />
-      </UIAccordion>
+        <UIAccordion
+          testid="rights-metadata-wrapper"
+          title="Rights Information"
+        >
+          <BatchEditAboutRightsMetadata
+            control={control}
+            errors={errors}
+            register={register}
+          />
+        </UIAccordion>
 
-      <UIAccordion
-        testid="identifiers-metadata-wrapper"
-        title="Identifiers and Relationship Information"
-      >
-        <BatchEditAboutIdentifiersMetadata
-          control={control}
-          errors={errors}
-          register={register}
-        />
-      </UIAccordion>
-    </form>
+        <UIAccordion
+          testid="identifiers-metadata-wrapper"
+          title="Identifiers and Relationship Information"
+        >
+          <BatchEditAboutIdentifiersMetadata
+            control={control}
+            errors={errors}
+            register={register}
+          />
+        </UIAccordion>
+      </form>
+
+      <BatchEditAboutModalRemove />
+    </div>
   );
-};
-
-BatchEditAbout.propTypes = {
-  numberOfResults: PropTypes.number,
 };
 
 export default BatchEditAbout;

--- a/assets/js/components/BatchEdit/About/About.jsx
+++ b/assets/js/components/BatchEdit/About/About.jsx
@@ -95,8 +95,9 @@ const BatchEditAbout = () => {
         {isConfirmModalOpen ? (
           <BatchEditConfirmation
             addMetadata={confirmationMetadata}
-            isConfirmModalOpen={isConfirmModalOpen}
             handleClose={onCloseModal}
+            isConfirmModalOpen={isConfirmModalOpen}
+            removeMetadata={batchState.removeItems}
           />
         ) : null}
         <UIAccordion testid="core-metadata-wrapper" title="Core Metadata">

--- a/assets/js/components/BatchEdit/About/About.test.js
+++ b/assets/js/components/BatchEdit/About/About.test.js
@@ -9,20 +9,26 @@ import {
   codeListMarcRelatorMock,
   codeListSubjectRoleMock,
 } from "../../Work/controlledVocabulary.gql.mock";
+import { BatchProvider } from "../../../context/batch-edit-context";
 
 const items = ["ABC123", "ZYC889"];
 
 describe("BatchEditAbout component", () => {
   function setupTest() {
-    return renderWithRouterApollo(<BatchEditAbout items={items} />, {
-      mocks: [
-        codeListAuthorityMock,
-        codeListLicenseMock,
-        codeListMarcRelatorMock,
-        codeListRightsStatementMock,
-        codeListSubjectRoleMock,
-      ],
-    });
+    return renderWithRouterApollo(
+      <BatchProvider value={null}>
+        <BatchEditAbout items={items} />
+      </BatchProvider>,
+      {
+        mocks: [
+          codeListAuthorityMock,
+          codeListLicenseMock,
+          codeListMarcRelatorMock,
+          codeListRightsStatementMock,
+          codeListSubjectRoleMock,
+        ],
+      }
+    );
   }
 
   it("renders Batch Edit About form", async () => {

--- a/assets/js/components/BatchEdit/About/Confirmation.jsx
+++ b/assets/js/components/BatchEdit/About/Confirmation.jsx
@@ -41,7 +41,7 @@ const mockDeleteMetadata = {
 const BatchEditConfirmation = ({
   addMetadata,
   removeMetadata,
-  isModalOpen,
+  isConfirmModalOpen,
   handleClose,
 }) => {
   const [confirmationError, setConfirmationError] = useState({});
@@ -91,7 +91,7 @@ const BatchEditConfirmation = ({
 
   return (
     <div
-      className={`modal ${isModalOpen ? "is-active" : ""}`}
+      className={`modal ${isConfirmModalOpen ? "is-active" : ""}`}
       data-testid="modal-batch-edit-confirmation"
     >
       <div className="modal-background"></div>
@@ -223,7 +223,7 @@ BatchEditConfirmation.propTypes = {
   addMetadata: PropTypes.object,
   removeMetadata: PropTypes.object,
   handleClose: PropTypes.func,
-  isModalOpen: PropTypes.bool,
+  isConfirmModalOpen: PropTypes.bool,
 };
 
 export default BatchEditConfirmation;

--- a/assets/js/components/BatchEdit/About/Confirmation.jsx
+++ b/assets/js/components/BatchEdit/About/Confirmation.jsx
@@ -22,6 +22,7 @@ const addWrapperCss = css`
 
 const removeWrapperCss = css`
   border: 1px solid red;
+  padding: 1rem;
 `;
 
 const confirmationNote =
@@ -144,6 +145,26 @@ const BatchEditConfirmation = ({
           </section>
 
           <section className="py-6">
+            <h3 className="title is-size-5">Removing</h3>
+            <ul
+              className="px-4 py-4"
+              className="content has-text-danger"
+              css={removeWrapperCss}
+            >
+              {Object.keys(removeMetadata).map((objKey) => (
+                <li>
+                  <h6 className="is-capitalized">{objKey}</h6>
+                  <ul>
+                    {removeMetadata[objKey].map((item) => (
+                      <li>{item}</li>
+                    ))}
+                  </ul>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          {/* <section className="py-6">
             <h3 className="title is-size-5">Removing </h3>
             <ul className="px-4 py-4" css={removeWrapperCss}>
               {parsedDeleteMetadata &&
@@ -155,7 +176,7 @@ const BatchEditConfirmation = ({
                         <li key={(innerKey, index)} className="py-2">
                           <FontAwesomeIcon icon="minus" />
                           <strong> {parsedDeleteMetadata[key].label}: </strong>
-                          {/*Check If the metadata for this field is an array of strings */}
+
                           {typeof parsedDeleteMetadata[key].metadata[index] ===
                           "string"
                             ? parsedDeleteMetadata[key].metadata[index]
@@ -178,7 +199,8 @@ const BatchEditConfirmation = ({
                     )
                 )}
             </ul>
-          </section>
+          </section> */}
+
           <div className="columns">
             <div className="column is-half">
               <UIFormField label={confirmationNote}>

--- a/assets/js/components/BatchEdit/About/ControlledMetadata.jsx
+++ b/assets/js/components/BatchEdit/About/ControlledMetadata.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import UIFormField from "../../UI/Form/Field";
 import { CODE_LIST_QUERY } from "../../Work/controlledVocabulary.gql.js";
@@ -7,6 +7,9 @@ import { useQuery } from "@apollo/client";
 import UIError from "../../UI/Error";
 import { CONTROLLED_METADATA } from "../../../services/metadata";
 import UISkeleton from "../../UI/Skeleton";
+import BatchEditRemove from "../Remove";
+import BatchEditModalRemove from "../ModalRemove";
+import { useBatchState } from "../../../context/batch-edit-context";
 
 const BatchEditAboutControlledMetadata = ({
   control,
@@ -14,6 +17,15 @@ const BatchEditAboutControlledMetadata = ({
   register,
   ...restProps
 }) => {
+  // This holds all the ElasticSearch Search info
+  const batchState = useBatchState();
+
+  const aggregations = batchState.parsedAggregations;
+
+  const [isRemoveModalOpen, setIsRemoveModalOpen] = useState();
+  const [currentRemoveField, setCurrentRemoveField] = useState();
+
+  // Get GraphQL data
   const {
     data: marcData,
     loading: marcLoading,
@@ -58,6 +70,20 @@ const BatchEditAboutControlledMetadata = ({
     return [];
   }
 
+  function handleRemoveButtonClick(fieldObj) {
+    console.log("fieldObj", fieldObj);
+    setCurrentRemoveField(fieldObj);
+    setIsRemoveModalOpen(true);
+  }
+
+  function handleCloseRemoveModalClick() {
+    setIsRemoveModalOpen(false);
+  }
+
+  function handleSave(items) {
+    console.log("items :>> ", items);
+  }
+
   return (
     <div data-testid="controlled-metadata" {...restProps}>
       <ul>
@@ -74,9 +100,25 @@ const BatchEditAboutControlledMetadata = ({
                 register={register}
               />
             </UIFormField>
+            <BatchEditRemove
+              handleRemoveClick={handleRemoveButtonClick}
+              label={label}
+              name={name}
+            />
           </li>
         ))}
       </ul>
+      <BatchEditModalRemove
+        closeModal={handleCloseRemoveModalClick}
+        currentRemoveField={currentRemoveField}
+        handleSave={handleSave}
+        items={
+          aggregations && currentRemoveField
+            ? aggregations[currentRemoveField.name]
+            : []
+        }
+        isRemoveModalOpen={isRemoveModalOpen}
+      />
     </div>
   );
 };

--- a/assets/js/components/BatchEdit/About/ControlledMetadata.jsx
+++ b/assets/js/components/BatchEdit/About/ControlledMetadata.jsx
@@ -19,7 +19,6 @@ const BatchEditAboutControlledMetadata = ({
 }) => {
   // This holds all the ElasticSearch Search info
   const batchState = useBatchState();
-
   const aggregations = batchState.parsedAggregations;
 
   const [isRemoveModalOpen, setIsRemoveModalOpen] = useState();
@@ -80,10 +79,6 @@ const BatchEditAboutControlledMetadata = ({
     setIsRemoveModalOpen(false);
   }
 
-  function handleSave(items) {
-    console.log("items :>> ", items);
-  }
-
   return (
     <div data-testid="controlled-metadata" {...restProps}>
       <ul>
@@ -104,6 +99,9 @@ const BatchEditAboutControlledMetadata = ({
               handleRemoveClick={handleRemoveButtonClick}
               label={label}
               name={name}
+              removeItems={
+                (batchState.removeItems && batchState.removeItems[name]) || []
+              }
             />
           </li>
         ))}
@@ -111,7 +109,6 @@ const BatchEditAboutControlledMetadata = ({
       <BatchEditModalRemove
         closeModal={handleCloseRemoveModalClick}
         currentRemoveField={currentRemoveField}
-        handleSave={handleSave}
         items={
           aggregations && currentRemoveField
             ? aggregations[currentRemoveField.name]

--- a/assets/js/components/BatchEdit/About/ControlledMetadata.test.jsx
+++ b/assets/js/components/BatchEdit/About/ControlledMetadata.test.jsx
@@ -11,18 +11,24 @@ import {
   codeListAuthorityMock,
 } from "../../Work/controlledVocabulary.gql.mock";
 import { CONTROLLED_METADATA } from "../../../services/metadata";
+import { BatchProvider } from "../../../context/batch-edit-context";
 
 describe("BatchEditAboutCoreMetadata component", () => {
   function setupTest() {
     const Wrapped = withReactHookFormControl(BatchEditAboutControlledMetadata);
 
-    return renderWithRouterApollo(<Wrapped />, {
-      mocks: [
-        codeListMarcRelatorMock,
-        codeListAuthorityMock,
-        codeListSubjectRoleMock,
-      ],
-    });
+    return renderWithRouterApollo(
+      <BatchProvider value={null}>
+        <Wrapped />
+      </BatchProvider>,
+      {
+        mocks: [
+          codeListMarcRelatorMock,
+          codeListAuthorityMock,
+          codeListSubjectRoleMock,
+        ],
+      }
+    );
   }
   it("renders controlled metadata component", async () => {
     let { queryByTestId } = setupTest();

--- a/assets/js/components/BatchEdit/About/CoreMetadata.jsx
+++ b/assets/js/components/BatchEdit/About/CoreMetadata.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { useQuery } from "@apollo/client";
 import UITagNotYetSupported from "../../UI/TagNotYetSupported";
@@ -51,6 +51,7 @@ const BatchEditAboutCoreMetadata = ({
           data-testid="alternate-title"
           label="Alternate Title"
           errors={errors}
+          className="add"
         />
       </div>
       <div className="column is-half">

--- a/assets/js/components/BatchEdit/About/CoreMetadata.test.js
+++ b/assets/js/components/BatchEdit/About/CoreMetadata.test.js
@@ -6,13 +6,19 @@ import {
 } from "../../../services/testing-helpers";
 import BatchEditAboutCoreMetadata from "./CoreMetadata";
 import { codeListRightsStatementMock } from "../../Work/controlledVocabulary.gql.mock";
+import { BatchProvider } from "../../../context/batch-edit-context";
 
 describe("BatchEditAboutCoreMetadata component", () => {
   function setupTest() {
     const Wrapped = withReactHookFormControl(BatchEditAboutCoreMetadata);
-    return renderWithRouterApollo(<Wrapped />, {
-      mocks: [codeListRightsStatementMock],
-    });
+    return renderWithRouterApollo(
+      <BatchProvider value={null}>
+        <Wrapped />
+      </BatchProvider>,
+      {
+        mocks: [codeListRightsStatementMock],
+      }
+    );
   }
   it("renders the component", async () => {
     let { queryByTestId } = setupTest();

--- a/assets/js/components/BatchEdit/ModalRemove.js
+++ b/assets/js/components/BatchEdit/ModalRemove.js
@@ -1,0 +1,108 @@
+import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+
+function setupRemoveList(items) {
+  const newList = items.map((item) => {
+    var arr = item.key.split("|");
+    return {
+      key: item.key,
+      label: `${arr[arr.length - 1]} ${arr[0]} (${item.doc_count})`,
+    };
+  });
+
+  return newList;
+}
+
+export default function BatchEditAboutModalRemove({
+  closeModal,
+  currentRemoveField,
+  handleSave,
+  isRemoveModalOpen,
+  items = [],
+}) {
+  if (!currentRemoveField) return null;
+
+  const [removeList, setRemoveList] = useState([]);
+  const [selectedItems, setSelectedItems] = useState([]);
+
+  useEffect(() => {
+    if (items.length > 0) {
+      setRemoveList(setupRemoveList(items));
+    }
+  }, [items]);
+
+  function handleChange({ key }) {
+    const index = selectedItems.indexOf(key);
+
+    if (index === -1) {
+      return setSelectedItems([...removeList, key]);
+    }
+    let list = [...removeList];
+    list.splice(index, 1);
+    setSelectedItems(list);
+  }
+
+  function handleSaveClick() {
+    handleSave();
+  }
+
+  function isItemSelected(item) {
+    return selectedItems.indexOf(item.key) > -1;
+  }
+
+  return (
+    <div className={`modal ${isRemoveModalOpen ? "is-active" : ""}`}>
+      <div className="modal-background"></div>
+      <div className="modal-card">
+        <header className="modal-card-head">
+          <p className="modal-card-title">
+            Batch remove the following{" "}
+            <strong>{currentRemoveField.label}</strong>s
+          </p>
+          <button
+            type="button"
+            className="delete"
+            onClick={closeModal}
+            aria-label="close"
+          ></button>
+        </header>
+        <section className="modal-card-body">
+          {removeList.map((item) => (
+            <div className="field" key={`${item.key}`}>
+              <div className="control">
+                <label className="checkbox">
+                  <input
+                    type="checkbox"
+                    checked={isItemSelected(item)}
+                    onChange={() => handleChange(item)}
+                  />{" "}
+                  {item.label}
+                </label>
+              </div>
+            </div>
+          ))}
+        </section>
+        <footer className="modal-card-foot">
+          <button
+            type="button"
+            className="button is-primary"
+            onClick={handleSaveClick}
+          >
+            Confirm selection
+          </button>
+          <button type="button" className="button" onClick={closeModal}>
+            Cancel
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+BatchEditAboutModalRemove.propTypes = {
+  closeModal: PropTypes.func,
+  currentRemoveField: PropTypes.object,
+  handleSave: PropTypes.func,
+  isRemoveModalOpen: PropTypes.bool,
+  items: PropTypes.array,
+};

--- a/assets/js/components/BatchEdit/ModalRemove.js
+++ b/assets/js/components/BatchEdit/ModalRemove.js
@@ -28,7 +28,10 @@ export default function BatchEditAboutModalRemove({
   const batchState = useBatchState();
   const dispatch = useBatchDispatch();
   const [candidateList, setCandidateList] = useState([]);
-  const selectedItems = batchState.removeItems[currentRemoveField.name] || [];
+  const selectedItems =
+    batchState.removeItems && batchState.removeItems[currentRemoveField.name]
+      ? batchState.removeItems[currentRemoveField.name]
+      : [];
 
   useEffect(() => {
     if (items.length > 0) {

--- a/assets/js/components/BatchEdit/PreviewItems.js
+++ b/assets/js/components/BatchEdit/PreviewItems.js
@@ -32,6 +32,11 @@ export default function BatchEditPreviewItems(props) {
   return (
     <div>
       <h2 className="title is-size-4">Preview of items go here</h2>
+      <p className="notification is-warning">
+        Note: We might need to write an Elasticsearch request that executes the
+        passed-in ES query, but only returns 40-50 items in order to populate
+        this area.
+      </p>
       <div className="is-centered ">
         <ul css={inlineList} data-testid="list-preview-items">
           {items.map((item) => (

--- a/assets/js/components/BatchEdit/Remove.js
+++ b/assets/js/components/BatchEdit/Remove.js
@@ -2,8 +2,14 @@ import React from "react";
 import UIFormField from "../UI/Form/Field";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import PropTypes from "prop-types";
+import { formatControlledTermKey } from "../../services/helpers";
 
-export default function BatchEditRemove({ handleRemoveClick, label, name }) {
+export default function BatchEditRemove({
+  handleRemoveClick,
+  label,
+  name,
+  removeItems,
+}) {
   return (
     <fieldset className="remove" data-testid="batch-edit-remove">
       <legend data-testid="legend-label">{label} (Remove)</legend>
@@ -17,9 +23,19 @@ export default function BatchEditRemove({ handleRemoveClick, label, name }) {
           <span className="icon">
             <FontAwesomeIcon icon="minus-square" />
           </span>
-          <span>Remove</span>
+          <span>Remove entries in {label}</span>
         </button>
       </UIFormField>
+
+      {removeItems.length > 0 && (
+        <div className="content">
+          <ul>
+            {removeItems.map((item) => (
+              <li key={item}>{formatControlledTermKey(item)}</li>
+            ))}
+          </ul>
+        </div>
+      )}
     </fieldset>
   );
 }
@@ -28,4 +44,5 @@ BatchEditRemove.propTypes = {
   handleRemoveClick: PropTypes.func,
   label: PropTypes.string,
   name: PropTypes.string,
+  removeItems: PropTypes.array,
 };

--- a/assets/js/components/BatchEdit/Remove.js
+++ b/assets/js/components/BatchEdit/Remove.js
@@ -11,8 +11,7 @@ export default function BatchEditRemove({
   removeItems,
 }) {
   return (
-    <fieldset className="remove" data-testid="batch-edit-remove">
-      <legend data-testid="legend-label">{label} (Remove)</legend>
+    <div data-testid="batch-edit-remove">
       <UIFormField>
         <button
           data-testid="button-remove"
@@ -31,12 +30,14 @@ export default function BatchEditRemove({
         <div className="content">
           <ul>
             {removeItems.map((item) => (
-              <li key={item}>{formatControlledTermKey(item)}</li>
+              <li key={item} className="has-text-danger">
+                {formatControlledTermKey(item)}
+              </li>
             ))}
           </ul>
         </div>
       )}
-    </fieldset>
+    </div>
   );
 }
 

--- a/assets/js/components/BatchEdit/Remove.js
+++ b/assets/js/components/BatchEdit/Remove.js
@@ -1,0 +1,31 @@
+import React from "react";
+import UIFormField from "../UI/Form/Field";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import PropTypes from "prop-types";
+
+export default function BatchEditRemove({ handleRemoveClick, label, name }) {
+  return (
+    <fieldset className="remove" data-testid="batch-edit-remove">
+      <legend data-testid="legend-label">{label} (Remove)</legend>
+      <UIFormField>
+        <button
+          data-testid="button-remove"
+          type="button"
+          className="button is-text is-small"
+          onClick={() => handleRemoveClick({ label, name })}
+        >
+          <span className="icon">
+            <FontAwesomeIcon icon="minus-square" />
+          </span>
+          <span>Remove</span>
+        </button>
+      </UIFormField>
+    </fieldset>
+  );
+}
+
+BatchEditRemove.propTypes = {
+  handleRemoveClick: PropTypes.func,
+  label: PropTypes.string,
+  name: PropTypes.string,
+};

--- a/assets/js/components/BatchEdit/Remove.test.js
+++ b/assets/js/components/BatchEdit/Remove.test.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import BatchEditRemove from "./Remove";
+
+const mockHandleRemoveClick = jest.fn();
+
+describe("BatchEditRemove component", () => {
+  function setupTests() {
+    return render(
+      <BatchEditRemove
+        label="Item title"
+        handleRemoveClick={mockHandleRemoveClick}
+      />
+    );
+  }
+  it("renders without crashing", () => {
+    const { getByTestId } = setupTests();
+    expect(getByTestId("batch-edit-remove")).toBeInTheDocument();
+  });
+
+  it("renders the correct legend label", () => {
+    const { getByTestId } = setupTests();
+    const el = getByTestId("legend-label");
+    expect(el).toHaveTextContent("Item title (Remove)");
+  });
+
+  it("renders the remove button", () => {
+    const { getByTestId } = setupTests();
+    const el = getByTestId("button-remove");
+    expect(el).toBeInTheDocument();
+
+    fireEvent.click(el);
+    expect(mockHandleRemoveClick).toHaveBeenCalled();
+  });
+});

--- a/assets/js/components/BatchEdit/Remove.test.js
+++ b/assets/js/components/BatchEdit/Remove.test.js
@@ -1,16 +1,20 @@
 import React from "react";
 import { render, fireEvent } from "@testing-library/react";
 import BatchEditRemove from "./Remove";
+import { BatchProvider } from "../../context/batch-edit-context";
 
 const mockHandleRemoveClick = jest.fn();
 
 describe("BatchEditRemove component", () => {
   function setupTests() {
     return render(
-      <BatchEditRemove
-        label="Item title"
-        handleRemoveClick={mockHandleRemoveClick}
-      />
+      <BatchProvider value={null}>
+        <BatchEditRemove
+          label="Item title"
+          handleRemoveClick={mockHandleRemoveClick}
+          removeItems={["ABC123", "EFG888"]}
+        />
+      </BatchProvider>
     );
   }
   it("renders without crashing", () => {
@@ -18,16 +22,11 @@ describe("BatchEditRemove component", () => {
     expect(getByTestId("batch-edit-remove")).toBeInTheDocument();
   });
 
-  it("renders the correct legend label", () => {
-    const { getByTestId } = setupTests();
-    const el = getByTestId("legend-label");
-    expect(el).toHaveTextContent("Item title (Remove)");
-  });
-
   it("renders the remove button", () => {
     const { getByTestId } = setupTests();
     const el = getByTestId("button-remove");
     expect(el).toBeInTheDocument();
+    expect(el).toHaveTextContent(/^Remove entries in Item title$/);
 
     fireEvent.click(el);
     expect(mockHandleRemoveClick).toHaveBeenCalled();

--- a/assets/js/components/BatchEdit/Tabs.jsx
+++ b/assets/js/components/BatchEdit/Tabs.jsx
@@ -1,8 +1,8 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import BatchEditAbout from "./About/About";
 import PropTypes from "prop-types";
 
-export default function BatchEditTabs({ numberOfResults }) {
+export default function BatchEditTabs() {
   const [activeTab, setActiveTab] = useState("tab-about");
 
   const handleTabClick = (e) => {
@@ -36,7 +36,7 @@ export default function BatchEditTabs({ numberOfResults }) {
           data-testid="tab-about-content"
           className={`${activeTab !== "tab-about" ? "is-hidden" : ""}`}
         >
-          <BatchEditAbout numberOfResults={numberOfResults} />
+          <BatchEditAbout />
         </div>
         <div
           data-testid="tab-administrative-content"
@@ -48,7 +48,3 @@ export default function BatchEditTabs({ numberOfResults }) {
     </>
   );
 }
-
-BatchEditTabs.propTypes = {
-  numberOfResults: PropTypes.number,
-};

--- a/assets/js/components/BatchEdit/Tabs.test.js
+++ b/assets/js/components/BatchEdit/Tabs.test.js
@@ -9,20 +9,26 @@ import {
   codeListRightsStatementMock,
   codeListSubjectRoleMock,
 } from "../Work/controlledVocabulary.gql.mock.js";
+import { BatchProvider } from "../../context/batch-edit-context";
 
 const items = ["ABC123", "ZYC889"];
 
 describe("BatchEditTabs component", () => {
   function setupTest() {
-    return renderWithRouterApollo(<BatchEditTabs items={items} />, {
-      mocks: [
-        codeListAuthorityMock,
-        codeListLicenseMock,
-        codeListMarcRelatorMock,
-        codeListRightsStatementMock,
-        codeListSubjectRoleMock,
-      ],
-    });
+    return renderWithRouterApollo(
+      <BatchProvider value={null}>
+        <BatchEditTabs items={items} />
+      </BatchProvider>,
+      {
+        mocks: [
+          codeListAuthorityMock,
+          codeListLicenseMock,
+          codeListMarcRelatorMock,
+          codeListRightsStatementMock,
+          codeListSubjectRoleMock,
+        ],
+      }
+    );
   }
 
   it("renders the tabs header", async () => {

--- a/assets/js/components/Work/Tabs/Tabs.jsx
+++ b/assets/js/components/Work/Tabs/Tabs.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import WorkTabAbout from "./About";
 import WorkTabStructure from "./Structure";
 import WorkTabsAdministrative from "./Administrative";
@@ -7,7 +7,6 @@ import { IIIFProvider } from "../../IIIF/IIIFProvider";
 
 const WorkTabs = ({ work }) => {
   const [activeTab, setActiveTab] = useState("tab-about");
-
   const handleTabClick = (e) => {
     setActiveTab(e.target.id);
   };

--- a/assets/js/context/batch-edit-context.js
+++ b/assets/js/context/batch-edit-context.js
@@ -1,0 +1,60 @@
+import React from "react";
+
+const BatchStateContext = React.createContext();
+const BatchDispatchContext = React.createContext();
+
+function batchReducer(state, action) {
+  switch (action.type) {
+    case "clear": {
+      return {
+        ...state,
+        filteredQuery: null,
+        resultStats: null,
+        parsedAggregations: null,
+      };
+    }
+    case "updateSearchResults": {
+      return {
+        ...state,
+        filteredQuery: action.filteredQuery,
+        resultStats: action.resultStats,
+        parsedAggregations: action.parsedAggregations,
+      };
+    }
+    default: {
+      throw new Error(`Unhandled action type: ${action.type}`);
+    }
+  }
+}
+
+function BatchProvider({ children }) {
+  const [state, dispatch] = React.useReducer(batchReducer, {
+    filteredQuery: null,
+    resultStats: null,
+    parsedAggregations: null,
+  });
+  return (
+    <BatchStateContext.Provider value={state}>
+      <BatchDispatchContext.Provider value={dispatch}>
+        {children}
+      </BatchDispatchContext.Provider>
+    </BatchStateContext.Provider>
+  );
+}
+
+function useBatchState() {
+  const context = React.useContext(BatchStateContext);
+  if (context === undefined) {
+    throw new Error("useBatchState must be used within a BatchProvider");
+  }
+  return context;
+}
+
+function useBatchDispatch() {
+  const context = React.useContext(BatchDispatchContext);
+  if (context === undefined) {
+    throw new Error("useBatchDispatch must be used within a BatchProvider");
+  }
+  return context;
+}
+export { BatchProvider, useBatchState, useBatchDispatch };

--- a/assets/js/context/batch-edit-context.js
+++ b/assets/js/context/batch-edit-context.js
@@ -3,14 +3,57 @@ import React from "react";
 const BatchStateContext = React.createContext();
 const BatchDispatchContext = React.createContext();
 
+const initialState = {
+  filteredQuery: null,
+  parsedAggregations: null,
+  removeItems: [],
+  resultStats: null,
+};
+
+/**
+ * Update the list of Batch Edit remove items
+ *
+ * @param {Object} state BatchEdit state
+ * @param {Object} action Action object
+ * @param {String} action.fieldName Name of the controlledTerm metadata field ie. "contributor" or "subject"
+ * @param {String} action.key The faceted valued used to identify a unique Controlled Term value
+ *
+ * @returns {Object} And object with one property (fieldName value), and holds an array of updated items
+ */
+function calculateItemList(state, action) {
+  const { fieldName, key } = action;
+  if (!fieldName) return {};
+
+  const previousItems = state.removeItems[fieldName]
+    ? [...state.removeItems[fieldName]]
+    : [];
+  const index = previousItems.indexOf(key);
+
+  // Add new value to the list
+  if (index === -1) {
+    return { [fieldName]: [...previousItems, key] };
+  }
+
+  // Remove value from list
+  previousItems.splice(index, 1);
+  return { [fieldName]: previousItems };
+}
+
 function batchReducer(state, action) {
   switch (action.type) {
     case "clear": {
       return {
         ...state,
-        filteredQuery: null,
-        resultStats: null,
-        parsedAggregations: null,
+        ...initialState,
+      };
+    }
+    case "updateRemoveItem": {
+      return {
+        ...state,
+        removeItems: {
+          ...state.removeItems,
+          ...calculateItemList(state, action),
+        },
       };
     }
     case "updateSearchResults": {
@@ -28,11 +71,7 @@ function batchReducer(state, action) {
 }
 
 function BatchProvider({ children }) {
-  const [state, dispatch] = React.useReducer(batchReducer, {
-    filteredQuery: null,
-    resultStats: null,
-    parsedAggregations: null,
-  });
+  const [state, dispatch] = React.useReducer(batchReducer, initialState);
   return (
     <BatchStateContext.Provider value={state}>
       <BatchDispatchContext.Provider value={dispatch}>

--- a/assets/js/context/batch-edit-context.js
+++ b/assets/js/context/batch-edit-context.js
@@ -6,7 +6,7 @@ const BatchDispatchContext = React.createContext();
 const initialState = {
   filteredQuery: null,
   parsedAggregations: null,
-  removeItems: [],
+  removeItems: null,
   resultStats: null,
 };
 
@@ -24,9 +24,10 @@ function calculateItemList(state, action) {
   const { fieldName, key } = action;
   if (!fieldName) return {};
 
-  const previousItems = state.removeItems[fieldName]
-    ? [...state.removeItems[fieldName]]
-    : [];
+  const previousItems =
+    state.removeItems && state.removeItems[fieldName]
+      ? [...state.removeItems[fieldName]]
+      : [];
   const index = previousItems.indexOf(key);
 
   // Add new value to the list

--- a/assets/js/screens/BatchEdit/BatchEdit.jsx
+++ b/assets/js/screens/BatchEdit/BatchEdit.jsx
@@ -4,23 +4,30 @@ import UIBreadcrumbs from "../../components/UI/Breadcrumbs";
 import BatchEditPreviewItems from "../../components/BatchEdit/PreviewItems";
 import BatchEditTabs from "../../components/BatchEdit/Tabs";
 import { mockBatchEditData } from "../../mock-data/batchEditData";
-import { useLocation } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 import JSONPretty from "react-json-pretty";
+import UIError from "../../components/UI/Error";
 
 export default function BatchEdit() {
   let location = useLocation();
   let locationState = location.state;
 
-  // "items" would be an array of Work "id" values
-  let items = locationState.items || [];
-
-  // Total number of results from the Elasticsearch query on Search page
-  let { numberOfResults } = locationState.resultStats || null;
-
   // "filteredQuery": Elasticsearch query used to generate results on Search page
   // "parsedAggregations": Object of aggregations for "filteredQuery", holding text values
   // "resultStats": Pulled out of Reactivesearch data
-  let { filteredQuery, parsedAggregations, resultStats } = locationState;
+  let filteredQuery = locationState ? locationState.filteredQuery : null;
+  let parsedAggregations = locationState
+    ? locationState.parsedAggregations
+    : null;
+  let resultStats = locationState ? locationState.resultStats : null;
+
+  // "items" would be an array of Work "id" values
+  let items = locationState && locationState.items ? locationState.items : [];
+
+  // Total number of results from the Elasticsearch query on Search page
+  let numberOfResults = locationState
+    ? locationState.resultStats.numberOfResults
+    : null;
 
   return (
     <Layout>
@@ -45,38 +52,54 @@ export default function BatchEdit() {
               Batch Edit
             </h1>
 
-            <div className="content">
-              <h4>Filtered Elasticsearch Query</h4>
-              <JSONPretty data={filteredQuery} />
+            {!locationState && (
+              <div className="notification is-danger is-light content">
+                <p>No search results saved in the browsers memory</p>
+                <p>
+                  <Link to="/search">Search again</Link>
+                </p>
+              </div>
+            )}
 
-              <hr />
-              <h4>Aggregations to populate Remove items</h4>
-              <JSONPretty data={parsedAggregations} />
+            {/* {locationState && (
+              <div className="content">
+                <h4>Filtered Elasticsearch Query</h4>
+                <JSONPretty data={filteredQuery} />
 
-              <hr />
-              <h4>Elasticsearch Query ResultStats</h4>
-              <JSONPretty data={resultStats} />
+                <hr />
+                <h4>Aggregations to populate Remove items</h4>
+                <JSONPretty data={parsedAggregations} />
 
-              <hr />
-              <p data-testid="num-results">Editing {numberOfResults} rows</p>
-              <ul>
-                {items.map((item) => (
-                  <li key={item}>{item}</li>
-                ))}
-              </ul>
+                <hr />
+                <h4>Elasticsearch Query ResultStats</h4>
+                <JSONPretty data={resultStats} />
+
+                <hr />
+                <p data-testid="num-results">Editing {numberOfResults} rows</p>
+                <ul>
+                  {items.map((item) => (
+                    <li key={item}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            )} */}
+          </div>
+
+          {locationState && (
+            <div className="box" data-testid="preview-wrapper">
+              <BatchEditPreviewItems items={mockBatchEditData} />
             </div>
-          </div>
+          )}
+        </div>
+      </section>
 
-          <div className="box" data-testid="preview-wrapper">
-            <BatchEditPreviewItems items={mockBatchEditData} />
+      {locationState && (
+        <section className="section">
+          <div className="container" data-testid="tabs-wrapper">
+            <BatchEditTabs />
           </div>
-        </div>
-      </section>
-      <section className="section">
-        <div className="container" data-testid="tabs-wrapper">
-          <BatchEditTabs numberOfResults={numberOfResults} />
-        </div>
-      </section>
+        </section>
+      )}
     </Layout>
   );
 }

--- a/assets/js/screens/BatchEdit/BatchEdit.jsx
+++ b/assets/js/screens/BatchEdit/BatchEdit.jsx
@@ -6,9 +6,8 @@ import BatchEditTabs from "../../components/BatchEdit/Tabs";
 import { mockBatchEditData } from "../../mock-data/batchEditData";
 import { useLocation, Link } from "react-router-dom";
 import JSONPretty from "react-json-pretty";
-import UIError from "../../components/UI/Error";
 
-export default function BatchEdit() {
+const ScreensBatchEdit = () => {
   let location = useLocation();
   let locationState = location.state;
 
@@ -102,4 +101,6 @@ export default function BatchEdit() {
       )}
     </Layout>
   );
-}
+};
+
+export default ScreensBatchEdit;

--- a/assets/js/screens/BatchEdit/BatchEdit.test.js
+++ b/assets/js/screens/BatchEdit/BatchEdit.test.js
@@ -9,20 +9,26 @@ import {
   codeListRightsStatementMock,
   codeListSubjectRoleMock,
 } from "../../components/Work/controlledVocabulary.gql.mock";
+import { BatchProvider } from "../../context/batch-edit-context";
 
 describe("BatchEdit component", () => {
   function setupComponent() {
-    return renderWithRouterApollo(<ScreensBatchEdit />, {
-      mocks: [
-        codeListAuthorityMock,
-        codeListLicenseMock,
-        codeListMarcRelatorMock,
-        codeListRightsStatementMock,
-        codeListSubjectRoleMock,
-      ],
-      // Mocks sending in 2 items to Batch Edit component via react-router-dom "state"
-      state: { resultStats: { numberOfResults: 5 } },
-    });
+    return renderWithRouterApollo(
+      <BatchProvider>
+        <ScreensBatchEdit />
+      </BatchProvider>,
+      {
+        mocks: [
+          codeListAuthorityMock,
+          codeListLicenseMock,
+          codeListMarcRelatorMock,
+          codeListRightsStatementMock,
+          codeListSubjectRoleMock,
+        ],
+        // Mocks sending in 2 items to Batch Edit component via react-router-dom "state"
+        state: { resultStats: { numberOfResults: 5 } },
+      }
+    );
   }
 
   it("renders without crashing", async () => {
@@ -41,12 +47,10 @@ describe("BatchEdit component", () => {
   });
 
   it("renders screen title and number of records editing", async () => {
-    const { getByTestId, queryByText, debug } = setupComponent();
+    const { getByTestId } = setupComponent();
 
     await waitFor(() => {
       expect(getByTestId("batch-edit-title")).toBeInTheDocument();
-      expect(getByTestId("num-results")).toBeInTheDocument();
-      expect(queryByText("Editing 5 rows")).toBeInTheDocument();
     });
   });
 

--- a/assets/js/screens/Root.jsx
+++ b/assets/js/screens/Root.jsx
@@ -9,7 +9,6 @@ import NotFound from "./404";
 import ScreensIngestSheet from "./IngestSheet/IngestSheet";
 import ScreensIngestSheetForm from "./IngestSheet/Form";
 import ScreensWork from "./Work/Work";
-import ScreensWorkList from "./Work/List";
 import ScreensSearch from "./Search/Search";
 import ScreensCollectionList from "./Collection/List";
 import ScreensCollection from "./Collection/Collection";
@@ -35,66 +34,64 @@ export default class Root extends React.Component {
         url={ELASTICSEARCH_PROXY_ENDPOINT}
       >
         <AuthProvider>
-          <BrowserRouter>
-            <ScrollToTop />
-            <Switch>
-              <Route exact path="/login" component={Login} />
+          <BatchProvider>
+            <BrowserRouter>
+              <ScrollToTop />
+              <Switch>
+                <Route exact path="/login" component={Login} />
+                <PrivateRoute
+                  exact
+                  path="/project/list"
+                  component={ScreensProjectList}
+                />
+                <PrivateRoute
+                  exact
+                  path="/project/create"
+                  component={ScreensProjectForm}
+                />
+                <PrivateRoute
+                  exact
+                  path="/project/:id/ingest-sheet/upload"
+                  component={ScreensIngestSheetForm}
+                />
+                <PrivateRoute
+                  exact
+                  path="/project/:id/ingest-sheet/:sheetId"
+                  component={ScreensIngestSheet}
+                />
+                <PrivateRoute
+                  exact
+                  path="/project/:id"
+                  component={ScreensProject}
+                />
 
-              <PrivateRoute
-                exact
-                path="/project/list"
-                component={ScreensProjectList}
-              />
-              <PrivateRoute
-                exact
-                path="/project/create"
-                component={ScreensProjectForm}
-              />
-              <PrivateRoute
-                exact
-                path="/project/:id/ingest-sheet/upload"
-                component={ScreensIngestSheetForm}
-              />
-              <PrivateRoute
-                exact
-                path="/project/:id/ingest-sheet/:sheetId"
-                component={ScreensIngestSheet}
-              />
-              <PrivateRoute
-                exact
-                path="/project/:id"
-                component={ScreensProject}
-              />
-
-              <PrivateRoute exact path="/work/:id" component={ScreensWork} />
-              <PrivateRoute
-                exact
-                path="/collection/list"
-                component={ScreensCollectionList}
-              />
-              <PrivateRoute
-                exact
-                path="/collection/form/:id?"
-                component={ScreensCollectionForm}
-              />
-              <PrivateRoute
-                exact
-                path="/collection/:id"
-                component={ScreensCollection}
-              />
-              <BatchProvider>
+                <PrivateRoute exact path="/work/:id" component={ScreensWork} />
+                <PrivateRoute
+                  exact
+                  path="/collection/list"
+                  component={ScreensCollectionList}
+                />
+                <PrivateRoute
+                  exact
+                  path="/collection/form/:id?"
+                  component={ScreensCollectionForm}
+                />
+                <PrivateRoute
+                  exact
+                  path="/collection/:id"
+                  component={ScreensCollection}
+                />
                 <PrivateRoute exact path="/search" component={ScreensSearch} />
                 <PrivateRoute
                   exact
                   path="/batch-edit"
                   component={ScreensBatchEdit}
                 />
-              </BatchProvider>
-
-              <PrivateRoute exact path="/" component={Home} />
-              <PrivateRoute component={NotFound} />
-            </Switch>
-          </BrowserRouter>
+                <PrivateRoute exact path="/" component={Home} />
+                <PrivateRoute component={NotFound} />
+              </Switch>
+            </BrowserRouter>
+          </BatchProvider>
         </AuthProvider>
       </ReactiveBase>
     );

--- a/assets/js/screens/Root.jsx
+++ b/assets/js/screens/Root.jsx
@@ -24,6 +24,7 @@ import {
   ELASTICSEARCH_INDEX_NAME,
 } from "../services/elasticsearch";
 import { REACTIVE_SEARCH_THEME } from "../services/reactive-search";
+import { BatchProvider } from "../context/batch-edit-context";
 
 export default class Root extends React.Component {
   render() {
@@ -38,11 +39,7 @@ export default class Root extends React.Component {
             <ScrollToTop />
             <Switch>
               <Route exact path="/login" component={Login} />
-              <PrivateRoute
-                exact
-                path="/batch-edit"
-                component={ScreensBatchEdit}
-              />
+
               <PrivateRoute
                 exact
                 path="/project/list"
@@ -85,7 +82,15 @@ export default class Root extends React.Component {
                 path="/collection/:id"
                 component={ScreensCollection}
               />
-              <PrivateRoute exact path="/search" component={ScreensSearch} />
+              <BatchProvider>
+                <PrivateRoute exact path="/search" component={ScreensSearch} />
+                <PrivateRoute
+                  exact
+                  path="/batch-edit"
+                  component={ScreensBatchEdit}
+                />
+              </BatchProvider>
+
               <PrivateRoute exact path="/" component={Home} />
               <PrivateRoute component={NotFound} />
             </Switch>

--- a/assets/js/screens/Search/Search.jsx
+++ b/assets/js/screens/Search/Search.jsx
@@ -12,6 +12,7 @@ import {
   elasticsearchDirectSearch,
   ELASTICSEARCH_AGGREGATION_FIELDS,
 } from "../../services/elasticsearch";
+import { useBatchDispatch } from "../../context/batch-edit-context";
 
 const ScreensSearch = () => {
   let history = useHistory();
@@ -19,6 +20,7 @@ const ScreensSearch = () => {
   const [selectedItems, setSelectedItems] = useState([]);
   const [filteredQuery, setFilteredQuery] = useState();
   const [resultStats, setResultStats] = useState(0);
+  const dispatch = useBatchDispatch();
 
   const handleEditAllItems = async () => {
     // Grab all aggregated Controlled Term items from Elasticsearch directly,
@@ -27,10 +29,16 @@ const ScreensSearch = () => {
       aggs: { ...ELASTICSEARCH_AGGREGATION_FIELDS },
       query: { ...filteredQuery },
     });
-    console.log("handleEditAllItems() response :>> ", response);
 
     let parsedAggregations = parseESAggregationResults(response.aggregations);
-    console.log("parsedAggregations", parsedAggregations);
+
+    // Update the Context
+    dispatch({
+      type: "updateSearchResults",
+      filteredQuery,
+      parsedAggregations,
+      resultStats,
+    });
 
     // Send Elasticsearch query and aggregated Controlled Term options to Batch Edit
     history.push("/batch-edit", {
@@ -41,7 +49,6 @@ const ScreensSearch = () => {
   };
 
   const handleDeselectAll = () => {
-    console.log("handleDeselectAll ()");
     setSelectedItems([]);
   };
 

--- a/assets/js/services/elasticsearch.js
+++ b/assets/js/services/elasticsearch.js
@@ -25,6 +25,11 @@ export const ELASTICSEARCH_AGGREGATION_FIELDS = {
       field: "descriptiveMetadata.contributor.facet",
     },
   },
+  creator: {
+    terms: {
+      field: "descriptiveMetadata.creator.facet",
+    },
+  },
   genre: {
     terms: {
       field: "descriptiveMetadata.genre.facet",
@@ -38,6 +43,16 @@ export const ELASTICSEARCH_AGGREGATION_FIELDS = {
   location: {
     terms: {
       field: "descriptiveMetadata.location.facet",
+    },
+  },
+  stylePeriod: {
+    terms: {
+      field: "descriptiveMetadata.stylePeriod.facet",
+    },
+  },
+  subject: {
+    terms: {
+      field: "descriptiveMetadata.subject.facet",
     },
   },
   technique: {

--- a/assets/js/services/helpers.js
+++ b/assets/js/services/helpers.js
@@ -22,6 +22,17 @@ export function formatSimpleISODate(date) {
   return newDate;
 }
 
+/**
+ * Format a Controlled Term facet "key" value so it displays better in the UI
+ * @param {String} key ie. "http://id.loc.gov/authorities/names/n50053919|mrb|Ranganathan, S. R. (Shiyali Ramamrita), 1892-1972 (Marbler)"
+ */
+export function formatControlledTermKey(key) {
+  const arr = key.split("|");
+  return arr.length === 0
+    ? ""
+    : `${arr[arr.length - 1]} - ${arr[0]} - ${arr[1]}`;
+}
+
 export function getClassFromIngestSheetStatus(status) {
   if (["ROW_FAIL", "FILE_FAIL"].indexOf(status) > -1) {
     return "is-danger";

--- a/assets/js/services/reactive-search.js
+++ b/assets/js/services/reactive-search.js
@@ -50,11 +50,19 @@ export const FACET_SENSORS = [
     showSearch: true,
     title: "Contributor",
   },
+
   {
     ...defaultListItemValues,
     componentId: "FacetCollection",
     dataField: "collection.id",
     title: "Collection",
+  },
+  {
+    ...defaultListItemValues,
+    componentId: "FacetCreator",
+    dataField: "descriptiveMetadata.creator.displayFacet",
+    showSearch: true,
+    title: "Creator",
   },
   {
     ...defaultListItemValues,
@@ -105,6 +113,20 @@ export const FACET_SENSORS = [
     componentId: "FacetRightsStatement",
     dataField: "descriptiveMetadata.rightsStatement.label.keyword",
     title: "Rights Statement",
+  },
+  {
+    ...defaultListItemValues,
+    componentId: "FacetSubject",
+    dataField: "descriptiveMetadata.subject.displayFacet",
+    showSearch: true,
+    title: "Subject",
+  },
+  {
+    ...defaultListItemValues,
+    componentId: "FacetStylePeriod",
+    dataField: "descriptiveMetadata.stylePeriod.displayFacet",
+    showSearch: true,
+    title: "Style Period",
   },
   {
     ...defaultListItemValues,

--- a/assets/styles/scss/_base.scss
+++ b/assets/styles/scss/_base.scss
@@ -14,6 +14,14 @@ fieldset {
   legend {
     font-weight: bold;
   }
+
+  &.add {
+    border-color: $success;
+  }
+
+  &.remove {
+    border-color: $danger;
+  }
 }
 
 footer {


### PR DESCRIPTION
This PR does a few things:

- Implements all the UI pieces needed for removing Controlled Term entries.
- Passes all the data from Elasticsearch query aggregations to the Batch Edit screen
- Introduces a new Redux-like pattern for storing `BatchEdit` state across the `ScreensSearch` and `ScreensBatchEdit` components and their children.  A lot of components are relying upon a shared slice of state, so making state available dynamically to any components which wishes to consume it, or call dispatch actions to update state.

![image](https://user-images.githubusercontent.com/3020266/89829516-5cc3e580-db20-11ea-8699-3f33c3ba06d1.png)

![image](https://user-images.githubusercontent.com/3020266/89829553-6d745b80-db20-11ea-99f9-c14b3bd2811b.png)

![image](https://user-images.githubusercontent.com/3020266/89829610-811fc200-db20-11ea-859d-f31c60be1d58.png)

![image](https://user-images.githubusercontent.com/3020266/89829665-9399fb80-db20-11ea-8de2-b799869c9cb9.png)
