### PR TITLE
Backend controlled term batch add functionality

### DIFF
--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -6547,13 +6547,8 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-phoenix@^1.4.0:
+phoenix@^1.4.0, "phoenix@file:../deps/phoenix":
   version "1.5.4"
-  resolved "https://registry.yarnpkg.com/phoenix/-/phoenix-1.5.4.tgz#d42bb537f03f55076b4e7a6757fe29318a8439f0"
-  integrity sha512-mTxseCKWDgrBQRIriqzvxL+QH5xruu6KQPqFdDx0jrdu/nqWCo914MLihVksn7SV2Bol3T+e/VtovJgC5UZT+w==
-
-"phoenix@file:../deps/phoenix":
-  version "1.5.3"
 
 "phoenix_html@file:../deps/phoenix_html":
   version "2.14.2"

--- a/lib/meadow/batches.ex
+++ b/lib/meadow/batches.ex
@@ -5,71 +5,95 @@ defmodule Meadow.Batches do
 
   import Ecto.Query, warn: false
   alias Meadow.Data.{ControlledTerms, Indexer, Works}
+  alias Meadow.Utils.StructMap
 
   @controlled_fields ~w(contributor creator genre language location style_period subject technique)a
 
-  def batch_update(query, delete) do
+  def batch_update(query, delete, add) do
     Meadow.Repo.transaction(
       fn ->
-        process_updates(query, delete)
+        process_updates(query, delete, add)
         Indexer.synchronize_index()
       end,
       timeout: :infinity
     )
   end
 
-  defp apply_delete([], _), do: []
+  defp apply_changes([], _delete, _add), do: []
 
-  defp apply_delete([work | works], delete),
-    do: [apply_delete(work, delete) | apply_delete(works, delete)]
+  defp apply_changes([work | works], delete, add),
+    do: [apply_changes(work, delete, add) | apply_changes(works, delete, add)]
 
-  defp apply_delete(work, delete) do
+  defp apply_changes(work, delete, add) do
     with descriptive_metadata <- Map.from_struct(work.descriptive_metadata) do
       new_descriptive_metadata =
         Enum.reduce(@controlled_fields, descriptive_metadata, fn field, result ->
-          apply_delete(result, field, delete)
+          apply_changes(result, field, delete, add)
         end)
 
       Works.update_work(work, %{descriptive_metadata: new_descriptive_metadata})
     end
   end
 
-  defp apply_delete(metadata, field, delete) do
-    values = delete |> Map.get(field, [])
+  defp apply_changes(metadata, field, delete, add) do
+    new_value = apply_deletes(metadata, field, delete)
+    values_to_add = apply_adds(new_value, field, add)
 
-    new_value =
-      metadata
-      |> Map.get(field, [])
-      |> Enum.reject(fn existing_value ->
-        Enum.any?(values, fn delete_value ->
-          ControlledTerms.terms_equal?(existing_value, delete_value)
-        end)
-      end)
-      |> Enum.map(&Map.from_struct/1)
-
-    Map.put(metadata, field, new_value)
+    metadata
+    |> Map.put(field, new_value ++ values_to_add)
+    |> StructMap.deep_struct_to_map()
   end
 
-  defp process_updates({:ok, %{"hits" => %{"hits" => []}}}, _) do
+  defp apply_deletes(metadata, field, delete) when map_size(delete) == 0 do
+    metadata
+    |> Map.get(field, [])
+  end
+
+  defp apply_deletes(metadata, field, delete) do
+    values_to_delete = delete |> Map.get(field, [])
+
+    metadata
+    |> Map.get(field, [])
+    |> Enum.reject(fn existing_value ->
+      Enum.any?(values_to_delete, fn delete_value ->
+        ControlledTerms.terms_equal?(existing_value, delete_value)
+      end)
+    end)
+  end
+
+  defp apply_adds(metadata, _field, add) when map_size(add) == 0, do: metadata
+
+  defp apply_adds(metadata, field, add) do
+    add
+    |> Map.get(:descriptive_metadata, %{})
+    |> Map.get(field, [])
+    |> Enum.reject(fn add_value ->
+      Enum.any?(metadata, fn existing_value ->
+        ControlledTerms.terms_equal?(existing_value, add_value)
+      end)
+    end)
+  end
+
+  defp process_updates({:ok, %{"hits" => %{"hits" => []}}}, _delete, _add) do
     {:ok, :noop}
   end
 
-  defp process_updates({:ok, %{"_scroll_id" => scroll_id, "hits" => hits}}, delete) do
+  defp process_updates({:ok, %{"_scroll_id" => scroll_id, "hits" => hits}}, delete, add) do
     hits
     |> Map.get("hits")
     |> Enum.map(&Map.get(&1, "_id"))
     |> Works.get_works()
-    |> apply_delete(delete)
+    |> apply_changes(delete, add)
 
     Meadow.ElasticsearchCluster
     |> Elasticsearch.post(
       "/_search/scroll",
       Jason.encode!(%{scroll: "1m", scroll_id: scroll_id})
     )
-    |> process_updates(delete)
+    |> process_updates(delete, add)
   end
 
-  defp process_updates(query, delete) do
+  defp process_updates(query, delete, add) do
     query =
       Jason.decode!(query)
       |> Map.put("_source", "")
@@ -77,6 +101,6 @@ defmodule Meadow.Batches do
 
     Meadow.ElasticsearchCluster
     |> Elasticsearch.post("/meadow/_search?scroll=10m", query)
-    |> process_updates(delete)
+    |> process_updates(delete, add)
   end
 end

--- a/lib/meadow/utils/struct_map.ex
+++ b/lib/meadow/utils/struct_map.ex
@@ -1,0 +1,32 @@
+defmodule Meadow.Utils.StructMap do
+  @moduledoc """
+  Deep-convert structs to maps
+  """
+
+  @doc """
+  Deep-convert a struct to a map
+  """
+
+  def deep_struct_to_map(arg) when is_struct(arg) do
+    Map.from_struct(arg) |> deep_struct_to_map()
+  end
+
+  def deep_struct_to_map(arg) when is_list(arg) do
+    Enum.map(arg, &deep_struct_to_map/1)
+  end
+
+  def deep_struct_to_map(arg) when is_map(arg) do
+    arg
+    |> Enum.map(fn {key, value} -> {key, deep_struct_to_map(value)} end)
+    |> Enum.into(%{})
+  end
+
+  def deep_struct_to_map(arg) when is_tuple(arg) do
+    arg
+    |> Tuple.to_list()
+    |> deep_struct_to_map()
+    |> List.to_tuple()
+  end
+
+  def deep_struct_to_map(arg), do: arg
+end

--- a/lib/meadow_web/resolvers/batches.ex
+++ b/lib/meadow_web/resolvers/batches.ex
@@ -4,10 +4,15 @@ defmodule MeadowWeb.Resolvers.Data.Batches do
   """
   alias Meadow.Batches
 
-  def update(_, %{query: query, delete: delete}, _) do
+  def update(_, %{query: _query, delete: delete, add: add}, _)
+      when map_size(delete) == 0 and map_size(add) == 0 do
+    {:ok, %{message: "No updates specified"}}
+  end
+
+  def update(_, %{query: query, delete: delete, add: add}, _) do
     {_response, _pid} =
       Meadow.Async.run_once("batch_update", fn ->
-        Batches.batch_update(query, delete)
+        Batches.batch_update(query, delete, add)
       end)
 
     {:ok, %{message: "Batch started"}}

--- a/lib/meadow_web/schema/types/data/batch_types.ex
+++ b/lib/meadow_web/schema/types/data/batch_types.ex
@@ -11,7 +11,8 @@ defmodule MeadowWeb.Schema.Data.BatchTypes do
     @desc "Start a batch update operation"
     field :batch_update, :message do
       arg(:query, non_null(:string))
-      arg(:delete, non_null(:batch_update_input))
+      arg(:delete, :batch_delete_input, default_value: %{})
+      arg(:add, :batch_add_input, default_value: %{})
       middleware(Middleware.Authenticate)
       resolve(&Batches.update/3)
     end
@@ -21,8 +22,18 @@ defmodule MeadowWeb.Schema.Data.BatchTypes do
     field :message, :string
   end
 
-  @desc "Input fields for batch update opereations"
-  input_object :batch_update_input do
+  @desc "Input fields for batch add operations"
+  input_object :batch_add_input do
+    field :descriptive_metadata, :batch_add_descriptive_metadata_input
+  end
+
+  @desc "Input fields for batch delete operations"
+  input_object :batch_delete_input do
+    import_fields(:controlled_fields_input)
+  end
+
+  @desc "Descriptive metadata input fields for batch add operations"
+  input_object :batch_add_descriptive_metadata_input do
     import_fields(:controlled_fields_input)
   end
 end

--- a/test/gql/BatchUpdate.gql
+++ b/test/gql/BatchUpdate.gql
@@ -1,5 +1,5 @@
-mutation($query: String!, $delete: BatchUpdateInput!) {
-  batchUpdate(query: $query, delete: $delete) {
+mutation($query: String!, $delete: BatchDeleteInput, $add: BatchAddInput) {
+  batchUpdate(query: $query, delete: $delete, add: $add) {
     message
   }
 }

--- a/test/meadow/batches_test.exs
+++ b/test/meadow/batches_test.exs
@@ -82,12 +82,23 @@ defmodule Meadow.BatchesTest do
         ]
       }
 
-      assert {:ok, _result} = Batches.batch_update(query, delete)
+      add = %{
+        descriptive_metadata: %{
+          style_period: [
+            %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
+          ]
+        }
+      }
+
+      assert {:ok, _result} = Batches.batch_update(query, delete, add)
 
       assert List.first(Works.get_works_by_title("Work 1")).descriptive_metadata.genre
              |> length() == 1
 
       assert List.first(Works.get_works_by_title("Work 2")).descriptive_metadata.contributor
+             |> length() == 1
+
+      assert List.first(Works.get_works_by_title("Work 2")).descriptive_metadata.style_period
              |> length() == 1
     end
   end

--- a/test/meadow/utils/struct_map_test.exs
+++ b/test/meadow/utils/struct_map_test.exs
@@ -1,0 +1,55 @@
+defmodule Meadow.Utils.StructMapTest do
+  use ExUnit.Case
+  alias Meadow.Utils.StructMap
+
+  defstruct struct: nil,
+            map: nil,
+            list: nil,
+            boolean: nil,
+            number: nil,
+            string: nil,
+            atom: nil,
+            tuple: nil
+
+  describe "Meadow.Utils.StructMap" do
+    test "deep_struct_to_map/1" do
+      inner_struct = %__MODULE__{struct: nil, map: %{a: 1, b: 2}, list: [1, 2, 3]}
+
+      inner_map = %{
+        struct: nil,
+        map: %{a: 1, b: 2},
+        list: [1, 2, 3],
+        atom: nil,
+        boolean: nil,
+        number: nil,
+        string: nil,
+        tuple: nil
+      }
+
+      input = %__MODULE__{
+        struct: inner_struct,
+        map: %{struct: inner_struct, scalar: "Scalar"},
+        list: [inner_struct, "Scalar"],
+        boolean: true,
+        number: 1234,
+        string: "String",
+        atom: :atom,
+        tuple: {inner_struct, 2, 3}
+      }
+
+      assert StructMap.deep_struct_to_map(input) == %{
+               struct: inner_map,
+               map: %{
+                 struct: inner_map,
+                 scalar: "Scalar"
+               },
+               list: [inner_map, "Scalar"],
+               boolean: true,
+               number: 1234,
+               string: "String",
+               atom: :atom,
+               tuple: {inner_map, 2, 3}
+             }
+    end
+  end
+end

--- a/test/meadow_web/schema/mutation/batch_update_test.exs
+++ b/test/meadow_web/schema/mutation/batch_update_test.exs
@@ -44,6 +44,16 @@ defmodule MeadowWeb.Schema.Mutation.BatchUpdateTest do
             "genre" => [
               %{"term" => "http://vocab.getty.edu/aat/300139140"}
             ]
+          },
+          "add" => %{
+            "descriptive_metadata" => %{
+              "contributor" => [
+                %{
+                  "role" => %{"scheme" => "MARC_RELATOR", "id" => "pbl"},
+                  "term" => "http://id.loc.gov/authorities/names/n50053919"
+                }
+              ]
+            }
           }
         },
         context: gql_context()
@@ -53,5 +63,45 @@ defmodule MeadowWeb.Schema.Mutation.BatchUpdateTest do
 
     response = get_in(query_data, [:data, "batchUpdate", "message"])
     assert response == "Batch started"
+  end
+
+  test "adds only should be a valid mutation" do
+    result =
+      query_gql(
+        variables: %{
+          "query" => ~s'{"query":{"term":{"workType.id": "IMAGE"}}}',
+          "add" => %{
+            "descriptive_metadata" => %{
+              "contributor" => [
+                %{
+                  "role" => %{"scheme" => "MARC_RELATOR", "id" => "pbl"},
+                  "term" => "http://id.loc.gov/authorities/names/n50053919"
+                }
+              ]
+            }
+          }
+        },
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+
+    response = get_in(query_data, [:data, "batchUpdate", "message"])
+    assert response == "Batch started"
+  end
+
+  test "no updates should not be a valid mutation" do
+    result =
+      query_gql(
+        variables: %{
+          "query" => ~s'{"query":{"term":{"workType.id": "IMAGE"}}}'
+        },
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+
+    response = get_in(query_data, [:data, "batchUpdate", "message"])
+    assert response == "No updates specified"
   end
 end


### PR DESCRIPTION
- Adds functionality to the `batchUpdate` mutation to add **controlled terms (only)**
- Mutation kicks of the process but does not wait for it to finish. (In this iteration we just return a "batch started" message - but the data will actually be updated in the background.)



Sample graphQL query with one add and one delete (if you want to test this in the GraphQL playground, you'll need to adjust the delete to a value your data contains):

```
mutation {
  batchUpdate(
    query: "{\"query\":{\"term\":{\"workType.id\": \"IMAGE\"}}}"
    delete: {
      contributor: [
        {
          term: "http://id.loc.gov/authorities/names/no2011087251"
          role: { id: "aut", scheme: MARC_RELATOR }
        }
      ]
    }
    add: {
      descriptiveMetadata: {
        contributor: [
          {
            term: "http://id.loc.gov/authorities/names/no2011087251"
            role: { id: "pbl", scheme: MARC_RELATOR }
          }
        ]
      }
    }
  ) {
    message
  }
}

```