### PR TITLE
Sign Elasticsearch requests for shared links

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -87,6 +87,9 @@ config :meadow,
       "https://devbox.library.northwestern.edu:9001/dev-pyramids/public/"
     )
 
+config :elastix,
+  custom_headers: {Meadow.Utils.AWS, :add_aws_signature, ["us-east-1", "fake", "fake"]}
+
 config :ex_aws,
   access_key_id: "fake",
   secret_access_key: "fake"

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -9,6 +9,15 @@ get_required_var = fn var ->
   System.get_env(var) || raise "environment variable #{var} is missing."
 end
 
+config :elastix,
+  custom_headers:
+    {Meadow.Utils.AWS, :add_aws_signature,
+     [
+       get_required_var.("AWS_REGION"),
+       get_required_var.("ELASTICSEARCH_KEY"),
+       get_required_var.("ELASTICSEARCH_SECRET")
+     ]}
+
 config :exldap, :settings,
   server: get_required_var.("LDAP_SERVER"),
   base: "DC=library,DC=northwestern,DC=edu",

--- a/lib/meadow/utils/aws.ex
+++ b/lib/meadow/utils/aws.ex
@@ -1,0 +1,28 @@
+defmodule Meadow.Utils.AWS do
+  @moduledoc """
+  Utility functions for AWS requests
+  """
+
+  def add_aws_signature(request, region, access_key, secret) do
+    request.headers ++ generate_aws_signature(request, region, access_key, secret)
+  end
+
+  defp generate_aws_signature(request, region, access_key, secret) do
+    signed_request =
+      Sigaws.sign_req(
+        request.url,
+        method: request.method |> to_string() |> String.upcase(),
+        headers: request.headers,
+        body: request.body,
+        service: "es",
+        region: region,
+        access_key: access_key,
+        secret: secret
+      )
+
+    case signed_request do
+      {:ok, headers, _} -> headers |> Enum.into([])
+      other -> other
+    end
+  end
+end


### PR DESCRIPTION
Add code to cryptographically sign requests to AWS Elasticsearch when using the `Elastix` module