### PR TITLE
Update Batch Edit preview items and Elastic search mocks in tests

### DIFF
--- a/assets/js/components/BatchEdit/PreviewItems.js
+++ b/assets/js/components/BatchEdit/PreviewItems.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
 
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
@@ -7,7 +8,7 @@ import { css, jsx } from "@emotion/core";
 const inlineList = css`
   white-space: nowrap;
   overflow: auto;
-  scrollbar-color: #4e2a84 #ccc;
+  scrollbar-color: #999 #ccc;
   scrollbar-width: thin;
   ::-webkit-scrollbar {
     height: 0.5rem;
@@ -16,56 +17,60 @@ const inlineList = css`
   ::-webkit-scrollbar-track {
     border-radius: 1rem;
   }
-
   ::-webkit-scrollbar-thumb {
-    background: #4e2a84;
+    background: #999;
     border-radius: 1rem;
   }
 `;
 
-const inlineListElem = css`
-  display: inline-block;
+const previewItem = css`
+  opacity: 1;
+  transition: 0.3s;
+
+  &:hover {
+    opacity: 0.75;
+  }
 `;
 
-export default function BatchEditPreviewItems(props) {
-  const { items } = props;
+export default function BatchEditPreviewItems({ items = [] }) {
   return (
     <div>
-      <h2 className="title is-size-4">Preview of items go here</h2>
-      <p className="notification is-warning">
-        Note: We might need to write an Elasticsearch request that executes the
-        passed-in ES query, but only returns 40-50 items in order to populate
-        this area.
+      <p className="mb-2">
+        <strong>Items preview</strong>
       </p>
       <div className="is-centered ">
         <ul css={inlineList} data-testid="list-preview-items">
-          {items.map((item) => (
-            <li key={item.id} className="mr-4 mb-4" css={inlineListElem}>
-              <Link to={`/work/${item.id}`} target="_blank">
+          {items.map(({ id, representativeFileSet }) => (
+            <li
+              key={id}
+              className="mr-4 mb-4 is-inline-block"
+              css={previewItem}
+            >
+              <Link to={`/work/${id}`} target="_blank" className="hvr-grow">
                 <figure>
                   <img
                     data-testid="image-preview"
                     src={
-                      item.representativeImage
-                        ? `${item.representativeImage}/square/256,256/0/default.jpg`
-                        : "https://bulma.io/images/placeholders/256x256.png"
+                      representativeFileSet.url
+                        ? `${representativeFileSet.url}/square/128,128/0/default.jpg`
+                        : "https://bulma.io/images/placeholders/128x128.png"
                     }
                   />
-                  <h2 className="subtitle" style={{ textAlign: "center" }}>
-                    {item.descriptiveMetadata.title}
-                  </h2>
                 </figure>
               </Link>
             </li>
           ))}
-          <li key={1} css={inlineListElem}>
-            <h3 className="subtitle is-size-5">
-              ... This is a preview of works selected for batch edit.
-              <br /> Displayed here are a few items from your selection.
-            </h3>
-          </li>
         </ul>
       </div>
     </div>
   );
 }
+
+BatchEditPreviewItems.propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      representativeFileSet: PropTypes.object,
+    })
+  ),
+};

--- a/assets/js/components/BatchEdit/PreviewItems.js
+++ b/assets/js/components/BatchEdit/PreviewItems.js
@@ -46,7 +46,7 @@ export default function BatchEditPreviewItems({ items = [] }) {
               className="mr-4 mb-4 is-inline-block"
               css={previewItem}
             >
-              <Link to={`/work/${id}`} target="_blank" className="hvr-grow">
+              <Link to={`/work/${id}`} target="_blank" className="hvr-shrink">
                 <figure>
                   <img
                     data-testid="image-preview"

--- a/assets/js/components/BatchEdit/PreviewItems.test.js
+++ b/assets/js/components/BatchEdit/PreviewItems.test.js
@@ -1,57 +1,52 @@
 import React from "react";
 import BatchEditPreviewItems from "./PreviewItems";
 import { renderWithRouter } from "../../services/testing-helpers";
-import { mockBatchEditData } from "../../mock-data/batchEditData";
+import { batchEditPreviewItems } from "../../mock-data/batch-edit-preview-items";
 
 describe("Batch-edit preview items component", () => {
   function setUpTests() {
     return renderWithRouter(
-      <BatchEditPreviewItems items={mockBatchEditData} />
+      <BatchEditPreviewItems items={batchEditPreviewItems} />
     );
   }
   it("renders the list", () => {
     const { getByTestId, debug } = setUpTests();
     expect(getByTestId("list-preview-items")).toBeInTheDocument();
   });
+
   it("renders all items passed to list", () => {
     const { getByTestId, debug } = setUpTests();
     const el = getByTestId("list-preview-items");
     expect(el).toBeInTheDocument();
     //+1 for the last hint element
     expect(el.querySelectorAll("li")).toHaveLength(
-      mockBatchEditData.length + 1
+      batchEditPreviewItems.length
     );
   });
+
   it("renders correct data for list elements", () => {
     const { getByTestId } = setUpTests();
     const el = getByTestId("list-preview-items");
 
     const anchorEls = el.querySelectorAll("a");
     const imageEls = el.querySelectorAll("img");
-    const headerEls = el.querySelectorAll("h2");
-
-    // Renders a header with correct title
-    expect(headerEls[2].innerHTML).toEqual(
-      mockBatchEditData[2].descriptiveMetadata.title
-    );
-    expect(headerEls[7].innerHTML).toEqual(
-      mockBatchEditData[7].descriptiveMetadata.title
-    );
 
     // Renders correct anchor tags
     expect(anchorEls[2].getAttribute("href")).toEqual(
-      "/work/" + mockBatchEditData[2].id
+      "/work/" + batchEditPreviewItems[2].id
     );
     expect(anchorEls[9].getAttribute("href")).toEqual(
-      "/work/" + mockBatchEditData[9].id
+      "/work/" + batchEditPreviewItems[9].id
     );
 
-    //Renders default image
-    expect(imageEls[0].getAttribute("src")).toEqual(
-      mockBatchEditData[0].representativeImage
-        ? mockBatchEditData[0].representativeImage +
-            "/square/256,256/0/default.jpg"
-        : "https://bulma.io/images/placeholders/256x256.png"
+    //Renders correct image
+    expect(imageEls[0].getAttribute("src")).toContain(
+      `${batchEditPreviewItems[0].representativeFileSet.url}/square/128,128/0/default.jpg`
+    );
+
+    // Renders default image
+    expect(imageEls[2].getAttribute("src")).toContain(
+      `https://bulma.io/images/placeholders/128x128.png`
     );
   });
 });

--- a/assets/js/components/Collection/ListRow.jsx
+++ b/assets/js/components/Collection/ListRow.jsx
@@ -16,7 +16,7 @@ const CollectionListRow = ({ collection, onOpenModal }) => {
       <article className="media">
         <figure className="media-left">
           <p className="image is-128x128">
-            <Link to={`/collection/${id}`} className="hvr-grow">
+            <Link to={`/collection/${id}`} className="hvr-shrink">
               <img
                 src={
                   representativeWork

--- a/assets/js/components/Collection/ListRow.jsx
+++ b/assets/js/components/Collection/ListRow.jsx
@@ -16,13 +16,15 @@ const CollectionListRow = ({ collection, onOpenModal }) => {
       <article className="media">
         <figure className="media-left">
           <p className="image is-128x128">
-            <img
-              src={
-                representativeWork
-                  ? `${representativeWork.representativeImage}/square/500,500/0/default.jpg`
-                  : "/images/480x480.png"
-              }
-            />
+            <Link to={`/collection/${id}`} className="hvr-grow">
+              <img
+                src={
+                  representativeWork
+                    ? `${representativeWork.representativeImage}/square/500,500/0/default.jpg`
+                    : "/images/480x480.png"
+                }
+              />
+            </Link>
           </p>
         </figure>
         <div className="media-content">

--- a/assets/js/components/UI/SearchBar.test.js
+++ b/assets/js/components/UI/SearchBar.test.js
@@ -2,6 +2,8 @@ import React from "react";
 import { render } from "@testing-library/react";
 import UISearchBar from "./SearchBar";
 
+jest.mock("../../services/elasticsearch");
+
 describe("UISearchBar component", () => {
   it("renders without crashing", () => {
     expect(render(<UISearchBar />));

--- a/assets/js/components/Work/CardItem.jsx
+++ b/assets/js/components/Work/CardItem.jsx
@@ -16,7 +16,7 @@ const WorkCardItem = ({
     <div className="card " data-testid="ui-workcard">
       <div className="card-image">
         <figure className="image is-3by3">
-          <Link to={`/work/${id}`}>
+          <Link to={`/work/${id}`} className="hvr-grow">
             <img
               src={
                 representativeImage.fileSetId
@@ -30,12 +30,12 @@ const WorkCardItem = ({
         </figure>
       </div>
       <div className="card-content">
-        <h2
-          className="subtitle"
+        <p
+          className="mb-2"
           dangerouslySetInnerHTML={{
             __html: title ? title : "Untitled",
           }}
-        ></h2>
+        ></p>
         {collectionName && <strong>{collectionName}</strong>}
         <div className="content">
           <p>

--- a/assets/js/components/Work/CardItem.jsx
+++ b/assets/js/components/Work/CardItem.jsx
@@ -16,7 +16,7 @@ const WorkCardItem = ({
     <div className="card " data-testid="ui-workcard">
       <div className="card-image">
         <figure className="image is-3by3">
-          <Link to={`/work/${id}`} className="hvr-grow">
+          <Link to={`/work/${id}`} className="hvr-shrink">
             <img
               src={
                 representativeImage.fileSetId

--- a/assets/js/components/Work/ListItem.jsx
+++ b/assets/js/components/Work/ListItem.jsx
@@ -20,7 +20,7 @@ const WorkListItem = ({
       <article className="media" data-testid="ui-worklist-item">
         <figure className="media-left">
           <p className="image is-128x128">
-            <Link to={`/work/${id}`} className="hvr-grow">
+            <Link to={`/work/${id}`} className="hvr-shrink">
               <img
                 src={
                   representativeImage.fileSetId

--- a/assets/js/components/Work/ListItem.jsx
+++ b/assets/js/components/Work/ListItem.jsx
@@ -20,7 +20,7 @@ const WorkListItem = ({
       <article className="media" data-testid="ui-worklist-item">
         <figure className="media-left">
           <p className="image is-128x128">
-            <Link to={`/work/${id}`}>
+            <Link to={`/work/${id}`} className="hvr-grow">
               <img
                 src={
                   representativeImage.fileSetId
@@ -34,60 +34,31 @@ const WorkListItem = ({
           </p>
         </figure>
         <div className="media-content">
-          <div className="level">
-            <div className="level-left">
-              <div className="level-item">
-                <h3 className="title is-size-4">
-                  <Link
-                    to={`/work/${id}`}
-                    dangerouslySetInnerHTML={{
-                      __html: title ? title : "Untitled",
-                    }}
-                  ></Link>{" "}
-                </h3>
-              </div>
-              <div className="level-item">
-                <span className="tag">{workType.label.toUpperCase()}</span>
-              </div>
-              {visibility && (
-                <div className="level-item">
-                  <span
-                    data-testid="tag-visibility"
-                    className={`tag ${setVisibilityClass(visibility.id)}`}
-                  >
-                    {visibility.label.toUpperCase()}
-                  </span>
-                </div>
-              )}
-
-              {published && (
-                <div className="level-item">
-                  <span
-                    data-testid="result-item-published"
-                    className="tag is-success"
-                  >
-                    PUBLISHED
-                  </span>
-                </div>
-              )}
-
-              <div className="level-item">
-                <a
-                  href={manifestUrl}
-                  target="_blank"
-                  className="card-footer-item"
-                >
-                  <figure className="image is-32x32">
-                    <img
-                      src="/images/IIIF-logo.png"
-                      alt="IIIF logo"
-                      title="View IIIF manifest"
-                    />
-                  </figure>
-                </a>
-              </div>
-            </div>
-          </div>
+          <h3 className="title is-size-5">
+            <Link
+              to={`/work/${id}`}
+              dangerouslySetInnerHTML={{
+                __html: title ? title : "Untitled",
+              }}
+            ></Link>{" "}
+          </h3>
+          <span className="tag">{workType.label.toUpperCase()}</span>
+          {visibility && (
+            <span
+              data-testid="tag-visibility"
+              className={`tag ${setVisibilityClass(visibility.id)}`}
+            >
+              {visibility.label.toUpperCase()}
+            </span>
+          )}
+          {published && (
+            <span
+              data-testid="result-item-published"
+              className="tag is-success"
+            >
+              PUBLISHED
+            </span>
+          )}
 
           <div className="content ">
             <table className="table">

--- a/assets/js/mock-data/batch-edit-preview-items.js
+++ b/assets/js/mock-data/batch-edit-preview-items.js
@@ -1,0 +1,97 @@
+export const batchEditPreviewItems = [
+  {
+    id: "d2b38ab9-0d67-469f-8bef-75ec4410a4fb",
+    representativeFileSet: {
+      fileSetId: "aaa3a5f9-bd03-4ce2-8f83-d6845acdf6a7",
+      url:
+        "https://devbox.library.northwestern.edu:8183/iiif/2/aaa3a5f9-bd03-4ce2-8f83-d6845acdf6a7",
+    },
+  },
+  {
+    id: "ddf5b536-640f-416d-8907-543fc6d6d251",
+    representativeFileSet: {
+      fileSetId: "80db3ee8-50a8-4150-99a2-76284809ae7c",
+      url:
+        "https://devbox.library.northwestern.edu:8183/iiif/2/80db3ee8-50a8-4150-99a2-76284809ae7c",
+    },
+  },
+  {
+    id: "b5bc0523-cb1c-46bc-a093-efef415aa4fe",
+    representativeFileSet: {
+      fileSetId: "",
+      url: "",
+    },
+  },
+  {
+    id: "558ee91a-7f0b-43bd-bfce-c078818677ca",
+    representativeFileSet: {
+      fileSetId: "00a74a6a-a8e0-4770-bdba-3db666358b13",
+      url:
+        "https://devbox.library.northwestern.edu:8183/iiif/2/00a74a6a-a8e0-4770-bdba-3db666358b13",
+    },
+  },
+  {
+    id: "42328462-b12b-4502-8262-40fef1f6c27a",
+    representativeFileSet: {
+      fileSetId: "9a6973d6-ee70-4010-a53d-3a0aaaa981b6",
+      url:
+        "https://devbox.library.northwestern.edu:8183/iiif/2/9a6973d6-ee70-4010-a53d-3a0aaaa981b6",
+    },
+  },
+  {
+    id: "898e3791-f37a-4845-9bb3-b6fc6819764f",
+    representativeFileSet: {
+      fileSetId: "375415f5-b95a-48d7-b8ee-95303d290c6c",
+      url:
+        "https://devbox.library.northwestern.edu:8183/iiif/2/375415f5-b95a-48d7-b8ee-95303d290c6c",
+    },
+  },
+  {
+    id: "38a67524-bde4-4be6-88dc-23b73c816d4d",
+    representativeFileSet: {
+      fileSetId: "19cc5f46-e084-4d6a-9d75-c520c1808a6c",
+      url:
+        "https://devbox.library.northwestern.edu:8183/iiif/2/19cc5f46-e084-4d6a-9d75-c520c1808a6c",
+    },
+  },
+  {
+    id: "4a15bf76-9b78-4758-be80-734ad59f3651",
+    representativeFileSet: {
+      fileSetId: "85524694-1a8d-4d8e-b1c4-94187f859929",
+      url:
+        "https://devbox.library.northwestern.edu:8183/iiif/2/85524694-1a8d-4d8e-b1c4-94187f859929",
+    },
+  },
+  {
+    id: "555875ce-61c9-472a-96ec-40dfe61e0fb0",
+    representativeFileSet: {
+      fileSetId: "2de5ba57-088b-4ed8-8e38-53a9ee640665",
+      url:
+        "https://devbox.library.northwestern.edu:8183/iiif/2/2de5ba57-088b-4ed8-8e38-53a9ee640665",
+    },
+  },
+  {
+    id: "fcf26554-21dc-4e88-af5e-09b700301c32",
+    representativeFileSet: {
+      fileSetId: "352f59b2-a686-40b8-be4f-793c8bcfcdf2",
+      url:
+        "https://devbox.library.northwestern.edu:8183/iiif/2/352f59b2-a686-40b8-be4f-793c8bcfcdf2",
+    },
+  },
+  {
+    id: "773d6d42-b4f2-4740-bb27-ecf7d4759881",
+    representativeFileSet: {
+      fileSetId: "478b3981-4e66-4001-a068-95079a7070b6",
+      url:
+        "https://devbox.library.northwestern.edu:8183/iiif/2/478b3981-4e66-4001-a068-95079a7070b6",
+    },
+  },
+  {
+    id: "ad8b5bfc-053f-4aba-a90e-2d894d0167c7",
+    representativeFileSet: {
+      fileSetId: "98e62096-7465-43fb-9cd1-c59c7c7f2306",
+      url:
+        "https://devbox.library.northwestern.edu:8183/iiif/2/98e62096-7465-43fb-9cd1-c59c7c7f2306",
+    },
+  },
+];

--- a/assets/js/mock-data/elasticsearch-response.js
+++ b/assets/js/mock-data/elasticsearch-response.js
@@ -1,0 +1,810 @@
+export const elasticSearchResponse = {
+  _shards: {
+    failed: 0,
+    skipped: 0,
+    successful: 5,
+    total: 5,
+  },
+  hits: {
+    hits: [
+      {
+        _id: "7465d7fb-5e66-4cc5-bd5b-6b913c508856",
+        _index: "meadow-1597438000026988",
+        _score: 3.428854,
+        _source: {
+          accessionNumber: "Voyager:2586736",
+          administrativeMetadata: {
+            preservationLevel: null,
+            projectCycle: null,
+            projectDesc: [],
+            projectManager: [],
+            projectName: [],
+            projectProposer: [],
+            projectTaskNumber: [],
+            status: null,
+          },
+          collection: {},
+          createDate: "2020-08-04T18:06:57.486892Z",
+          descriptiveMetadata: {
+            source: [],
+            title:
+              "Et molestiae dolor ut ad quaerat blanditiis occaecati minima?",
+            scopeAndContents: [],
+            notes: [],
+            folderName: [],
+            license: null,
+            rightsHolder: [],
+            genre: [
+              {
+                displayFacet: "art genres",
+                facet: "http://vocab.getty.edu/aat/300056462||art genres|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/aat/300056462",
+                  label: "art genres",
+                },
+              },
+              {
+                displayFacet: "genre pictures",
+                facet: "http://vocab.getty.edu/aat/300139140||genre pictures|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/aat/300139140",
+                  label: "genre pictures",
+                },
+              },
+            ],
+            catalogKey: [],
+            legacyIdentifier: [],
+            alternateTitle: [],
+            contributor: [
+              {
+                displayFacet: "Mandela, Nelson, 1918-2013 (Marbler)",
+                facet:
+                  "http://id.loc.gov/authorities/names/n85153068|mrb|Mandela, Nelson, 1918-2013 (Marbler)",
+                role: {
+                  id: "mrb",
+                  label: "Marbler",
+                  scheme: "marc_relator",
+                },
+                term: {
+                  id: "http://id.loc.gov/authorities/names/n85153068",
+                  label: "Mandela, Nelson, 1918-2013",
+                },
+              },
+              {
+                displayFacet: "United States (Architect)",
+                facet:
+                  "http://id.worldcat.org/fast/1204155|arc|United States (Architect)",
+                role: {
+                  id: "arc",
+                  label: "Architect",
+                  scheme: "marc_relator",
+                },
+                term: {
+                  id: "http://id.worldcat.org/fast/1204155",
+                  label: "United States",
+                },
+              },
+            ],
+            caption: [],
+            boxName: [],
+            physicalDescriptionMaterial: [],
+            rightsStatement: null,
+            series: [],
+            tableOfContents: [],
+            location: [
+              {
+                displayFacet: "Belize City",
+                facet: "https://sws.geonames.org/3582677||Belize City|",
+                role: null,
+                term: {
+                  id: "https://sws.geonames.org/3582677",
+                  label: "Belize City",
+                },
+              },
+              {
+                displayFacet: "Panama City",
+                facet: "https://sws.geonames.org/3703443||Panama City|",
+                role: null,
+                term: {
+                  id: "https://sws.geonames.org/3703443",
+                  label: "Panama City",
+                },
+              },
+              {
+                displayFacet: "Ajman",
+                facet: "https://sws.geonames.org/292932||Ajman|",
+                role: null,
+                term: {
+                  id: "https://sws.geonames.org/292932",
+                  label: "Ajman",
+                },
+              },
+              {
+                displayFacet: "Guatemala City",
+                facet: "https://sws.geonames.org/3598132||Guatemala City|",
+                role: null,
+                term: {
+                  id: "https://sws.geonames.org/3598132",
+                  label: "Guatemala City",
+                },
+              },
+            ],
+            identifier: [],
+            creator: [
+              {
+                displayFacet: "Claudel, Camille",
+                facet:
+                  "http://vocab.getty.edu/ulan/500102192||Claudel, Camille|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/ulan/500102192",
+                  label: "Claudel, Camille",
+                },
+              },
+              {
+                displayFacet: "Kahlo, Frida",
+                facet: "http://vocab.getty.edu/ulan/500030701||Kahlo, Frida|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/ulan/500030701",
+                  label: "Kahlo, Frida",
+                },
+              },
+              {
+                displayFacet: "Aberdare, Henry Bruce, 2nd Baron",
+                facet:
+                  "http://vocab.getty.edu/ulan/500445403||Aberdare, Henry Bruce, 2nd Baron|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/ulan/500445403",
+                  label: "Aberdare, Henry Bruce, 2nd Baron",
+                },
+              },
+            ],
+            relatedMaterial: [],
+            ark: null,
+            relatedUrl: [],
+            provenance: [],
+            folderNumber: [],
+            keywords: [],
+            description: [""],
+            language: [
+              {
+                displayFacet: "Lingala",
+                facet: "http://id.loc.gov/vocabulary/languages/lin||Lingala|",
+                role: null,
+                term: {
+                  id: "http://id.loc.gov/vocabulary/languages/lin",
+                  label: "Lingala",
+                },
+              },
+              {
+                displayFacet: "Divehi",
+                facet: "http://id.loc.gov/vocabulary/languages/div||Divehi|",
+                role: null,
+                term: {
+                  id: "http://id.loc.gov/vocabulary/languages/div",
+                  label: "Divehi",
+                },
+              },
+              {
+                displayFacet: "Bugis",
+                facet: "http://id.loc.gov/vocabulary/languages/bug||Bugis|",
+                role: null,
+                term: {
+                  id: "http://id.loc.gov/vocabulary/languages/bug",
+                  label: "Bugis",
+                },
+              },
+              {
+                displayFacet: "Nias",
+                facet: "http://id.loc.gov/vocabulary/languages/nia||Nias|",
+                role: null,
+                term: {
+                  id: "http://id.loc.gov/vocabulary/languages/nia",
+                  label: "Nias",
+                },
+              },
+            ],
+            stylePeriod: [
+              {
+                displayFacet: "Glasgow style",
+                facet: "http://vocab.getty.edu/aat/300375728||Glasgow style|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/aat/300375728",
+                  label: "Glasgow style",
+                },
+              },
+              {
+                displayFacet: "Yachting Style",
+                facet: "http://vocab.getty.edu/aat/300375737||Yachting Style|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/aat/300375737",
+                  label: "Yachting Style",
+                },
+              },
+              {
+                displayFacet: "White Style",
+                facet: "http://vocab.getty.edu/aat/300312140||White Style|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/aat/300312140",
+                  label: "White Style",
+                },
+              },
+              {
+                displayFacet: "Style Guimard",
+                facet: "http://vocab.getty.edu/aat/300378903||Style Guimard|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/aat/300378903",
+                  label: "Style Guimard",
+                },
+              },
+            ],
+            publisher: [],
+            technique: [
+              {
+                displayFacet: "Six's Technique",
+                facet: "http://vocab.getty.edu/aat/300265034||Six's Technique|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/aat/300265034",
+                  label: "Six's Technique",
+                },
+              },
+              {
+                displayFacet: "Levallois technique",
+                facet:
+                  "http://vocab.getty.edu/aat/300400619||Levallois technique|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/aat/300400619",
+                  label: "Levallois technique",
+                },
+              },
+            ],
+            abstract: [],
+            citation: [],
+            physicalDescriptionSize: [],
+            boxNumber: [],
+            subject: [
+              {
+                displayFacet: "Library catalogs and users (Geographical)",
+                facet:
+                  "http://id.loc.gov/authorities/subjects/sh85076671|GEOGRAPHICAL|Library catalogs and users (Geographical)",
+                role: {
+                  id: "GEOGRAPHICAL",
+                  label: "Geographical",
+                  scheme: "subject_role",
+                },
+                term: {
+                  id: "http://id.loc.gov/authorities/subjects/sh85076671",
+                  label: "Library catalogs and users",
+                },
+              },
+              {
+                displayFacet: "Library pages (Geographical)",
+                facet:
+                  "http://id.loc.gov/authorities/subjects/sh85076710|GEOGRAPHICAL|Library pages (Geographical)",
+                role: {
+                  id: "GEOGRAPHICAL",
+                  label: "Geographical",
+                  scheme: "subject_role",
+                },
+                term: {
+                  id: "http://id.loc.gov/authorities/subjects/sh85076710",
+                  label: "Library pages",
+                },
+              },
+            ],
+            nulUseStatement: null,
+            callNumber: [],
+          },
+          fileSets: [
+            {
+              accessionNumber: "Voyager:2586736_FILE_0",
+              id: "1ce2a17f-b275-4cc1-adfb-e05d884ad0c7",
+              label: "inu-dil-e4456fe4-711a-4bcf-974e-debf6aad70c2.jpg",
+            },
+          ],
+          id: "7465d7fb-5e66-4cc5-bd5b-6b913c508856",
+          iiifManifest:
+            "https://devbox.library.northwestern.edu:9001/dev-pyramids/public/74/65/d7/fb/-5/e6/6-/4c/c5/-b/d5/b-/6b/91/3c/50/88/56-manifest.json",
+          model: {
+            application: "Meadow",
+            name: "Image",
+          },
+          modifiedDate: "2020-08-13T14:16:53.100008Z",
+          project: {
+            id: "5245c9cc-5a32-453e-b862-e83726c046be",
+            title: "Seed Data Project",
+          },
+          published: false,
+          representativeFileSet: {
+            fileSetId: "1ce2a17f-b275-4cc1-adfb-e05d884ad0c7",
+            url:
+              "https://devbox.library.northwestern.edu:8183/iiif/2/1ce2a17f-b275-4cc1-adfb-e05d884ad0c7",
+          },
+          sheet: {
+            id: "c8b870c0-84c2-47f6-b8c4-23566b7dea52",
+            title: "wwii_posters.csv",
+          },
+          visibility: {
+            id: "RESTRICTED",
+            label: "Private",
+            scheme: "visibility",
+          },
+          workType: {
+            id: "IMAGE",
+            label: "Image",
+            scheme: "work_type",
+          },
+        },
+        _type: "_doc",
+      },
+      {
+        _id: "bd7c21c1-590a-4edb-a0ac-54e6932b51ed",
+        _index: "meadow-1597438000026988",
+        _score: 3.1108823,
+        _source: {
+          accessionNumber: "BFMF_B21_F04_037",
+          administrativeMetadata: {
+            preservationLevel: null,
+            projectCycle: null,
+            projectDesc: [],
+            projectManager: [],
+            projectName: [],
+            projectProposer: [],
+            projectTaskNumber: [],
+            status: null,
+          },
+          collection: {},
+          createDate: "2020-08-04T18:25:04.716518Z",
+          descriptiveMetadata: {
+            source: [],
+            title: "Fugit eaque voluptatibus impedit est at sit.",
+            scopeAndContents: [],
+            notes: [],
+            folderName: [],
+            license: null,
+            rightsHolder: [],
+            genre: [
+              {
+                displayFacet: "document genres",
+                facet: "http://vocab.getty.edu/aat/300026031||document genres|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/aat/300026031",
+                  label: "document genres",
+                },
+              },
+              {
+                displayFacet: "genre painters",
+                facet: "http://vocab.getty.edu/aat/300266117||genre painters|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/aat/300266117",
+                  label: "genre painters",
+                },
+              },
+            ],
+            catalogKey: [],
+            legacyIdentifier: [],
+            alternateTitle: [],
+            contributor: [
+              {
+                displayFacet: "Mandela, Nelson, 1918-2013 (Storyteller)",
+                facet:
+                  "http://id.loc.gov/authorities/names/n85153068|stl|Mandela, Nelson, 1918-2013 (Storyteller)",
+                role: {
+                  id: "stl",
+                  label: "Storyteller",
+                  scheme: "marc_relator",
+                },
+                term: {
+                  id: "http://id.loc.gov/authorities/names/n85153068",
+                  label: "Mandela, Nelson, 1918-2013",
+                },
+              },
+              {
+                displayFacet:
+                  "Ranganathan, S. R. (Shiyali Ramamrita), 1892-1972 (Publisher)",
+                facet:
+                  "http://id.loc.gov/authorities/names/n50053919|pbl|Ranganathan, S. R. (Shiyali Ramamrita), 1892-1972 (Publisher)",
+                role: {
+                  id: "pbl",
+                  label: "Publisher",
+                  scheme: "marc_relator",
+                },
+                term: {
+                  id: "http://id.loc.gov/authorities/names/n50053919",
+                  label: "Ranganathan, S. R. (Shiyali Ramamrita), 1892-1972",
+                },
+              },
+              {
+                displayFacet: "Dewey, Melvil, 1851-1931 (Storyteller)",
+                facet:
+                  "http://id.loc.gov/authorities/names/n79091588|stl|Dewey, Melvil, 1851-1931 (Storyteller)",
+                role: {
+                  id: "stl",
+                  label: "Storyteller",
+                  scheme: "marc_relator",
+                },
+                term: {
+                  id: "http://id.loc.gov/authorities/names/n79091588",
+                  label: "Dewey, Melvil, 1851-1931",
+                },
+              },
+              {
+                displayFacet: "Mandela, Nelson, 1918-2013 (Marbler)",
+                facet:
+                  "http://id.loc.gov/authorities/names/n85153068|mrb|Mandela, Nelson, 1918-2013 (Marbler)",
+                role: {
+                  id: "mrb",
+                  label: "Marbler",
+                  scheme: "marc_relator",
+                },
+                term: {
+                  id: "http://id.loc.gov/authorities/names/n85153068",
+                  label: "Mandela, Nelson, 1918-2013",
+                },
+              },
+            ],
+            caption: [],
+            boxName: [],
+            physicalDescriptionMaterial: [],
+            rightsStatement: null,
+            series: [],
+            tableOfContents: [],
+            location: [
+              {
+                displayFacet: "Benin City",
+                facet: "https://sws.geonames.org/2347283||Benin City|",
+                role: null,
+                term: {
+                  id: "https://sws.geonames.org/2347283",
+                  label: "Benin City",
+                },
+              },
+              {
+                displayFacet: "Ajman",
+                facet: "https://sws.geonames.org/292932||Ajman|",
+                role: null,
+                term: {
+                  id: "https://sws.geonames.org/292932",
+                  label: "Ajman",
+                },
+              },
+              {
+                displayFacet: "Mexico City",
+                facet: "https://sws.geonames.org/3530597||Mexico City|",
+                role: null,
+                term: {
+                  id: "https://sws.geonames.org/3530597",
+                  label: "Mexico City",
+                },
+              },
+              {
+                displayFacet: "Panama City",
+                facet: "https://sws.geonames.org/3703443||Panama City|",
+                role: null,
+                term: {
+                  id: "https://sws.geonames.org/3703443",
+                  label: "Panama City",
+                },
+              },
+            ],
+            identifier: [],
+            creator: [
+              {
+                displayFacet: "Kahlo, Frida",
+                facet: "http://vocab.getty.edu/ulan/500030701||Kahlo, Frida|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/ulan/500030701",
+                  label: "Kahlo, Frida",
+                },
+              },
+              {
+                displayFacet: "Muybridge, Eadweard",
+                facet:
+                  "http://vocab.getty.edu/ulan/500115207||Muybridge, Eadweard|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/ulan/500115207",
+                  label: "Muybridge, Eadweard",
+                },
+              },
+            ],
+            relatedMaterial: [],
+            ark: null,
+            relatedUrl: [],
+            provenance: [],
+            folderNumber: [],
+            keywords: [],
+            description: [],
+            language: [
+              {
+                displayFacet: "Korean",
+                facet: "http://id.loc.gov/vocabulary/languages/kor||Korean|",
+                role: null,
+                term: {
+                  id: "http://id.loc.gov/vocabulary/languages/kor",
+                  label: "Korean",
+                },
+              },
+              {
+                displayFacet: "Nias",
+                facet: "http://id.loc.gov/vocabulary/languages/nia||Nias|",
+                role: null,
+                term: {
+                  id: "http://id.loc.gov/vocabulary/languages/nia",
+                  label: "Nias",
+                },
+              },
+            ],
+            stylePeriod: [
+              {
+                displayFacet: "Quaint Style",
+                facet: "http://vocab.getty.edu/aat/300378910||Quaint Style|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/aat/300378910",
+                  label: "Quaint Style",
+                },
+              },
+              {
+                displayFacet: "Style Guimard",
+                facet: "http://vocab.getty.edu/aat/300378903||Style Guimard|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/aat/300378903",
+                  label: "Style Guimard",
+                },
+              },
+              {
+                displayFacet: "Glasgow style",
+                facet: "http://vocab.getty.edu/aat/300375728||Glasgow style|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/aat/300375728",
+                  label: "Glasgow style",
+                },
+              },
+              {
+                displayFacet: "Modern Style (Art Nouveau )",
+                facet:
+                  "http://vocab.getty.edu/aat/300375743||Modern Style (Art Nouveau )|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/aat/300375743",
+                  label: "Modern Style (Art Nouveau )",
+                },
+              },
+              {
+                displayFacet: "White Style",
+                facet: "http://vocab.getty.edu/aat/300312140||White Style|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/aat/300312140",
+                  label: "White Style",
+                },
+              },
+            ],
+            publisher: [],
+            technique: [
+              {
+                displayFacet: "Levallois technique",
+                facet:
+                  "http://vocab.getty.edu/aat/300400619||Levallois technique|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/aat/300400619",
+                  label: "Levallois technique",
+                },
+              },
+              {
+                displayFacet: "sarga (technique)",
+                facet:
+                  "http://vocab.getty.edu/aat/300410254||sarga (technique)|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/aat/300410254",
+                  label: "sarga (technique)",
+                },
+              },
+              {
+                displayFacet: "Six's Technique",
+                facet: "http://vocab.getty.edu/aat/300265034||Six's Technique|",
+                role: null,
+                term: {
+                  id: "http://vocab.getty.edu/aat/300265034",
+                  label: "Six's Technique",
+                },
+              },
+            ],
+            abstract: [],
+            citation: [],
+            physicalDescriptionSize: [],
+            boxNumber: [],
+            subject: [
+              {
+                displayFacet: "Library catalogs and users (Geographical)",
+                facet:
+                  "http://id.loc.gov/authorities/subjects/sh85076671|GEOGRAPHICAL|Library catalogs and users (Geographical)",
+                role: {
+                  id: "GEOGRAPHICAL",
+                  label: "Geographical",
+                  scheme: "subject_role",
+                },
+                term: {
+                  id: "http://id.loc.gov/authorities/subjects/sh85076671",
+                  label: "Library catalogs and users",
+                },
+              },
+              {
+                displayFacet: "Library cooperation (Geographical)",
+                facet:
+                  "http://id.loc.gov/authorities/subjects/sh85076678|GEOGRAPHICAL|Library cooperation (Geographical)",
+                role: {
+                  id: "GEOGRAPHICAL",
+                  label: "Geographical",
+                  scheme: "subject_role",
+                },
+                term: {
+                  id: "http://id.loc.gov/authorities/subjects/sh85076678",
+                  label: "Library cooperation",
+                },
+              },
+              {
+                displayFacet:
+                  "John Cotton Dana Library Public Relations Award (Geographical)",
+                facet:
+                  "http://id.loc.gov/authorities/subjects/sh85070610|GEOGRAPHICAL|John Cotton Dana Library Public Relations Award (Geographical)",
+                role: {
+                  id: "GEOGRAPHICAL",
+                  label: "Geographical",
+                  scheme: "subject_role",
+                },
+                term: {
+                  id: "http://id.loc.gov/authorities/subjects/sh85070610",
+                  label: "John Cotton Dana Library Public Relations Award",
+                },
+              },
+              {
+                displayFacet: "Library pages (Topical)",
+                facet:
+                  "http://id.loc.gov/authorities/subjects/sh85076710|TOPICAL|Library pages (Topical)",
+                role: {
+                  id: "TOPICAL",
+                  label: "Topical",
+                  scheme: "subject_role",
+                },
+                term: {
+                  id: "http://id.loc.gov/authorities/subjects/sh85076710",
+                  label: "Library pages",
+                },
+              },
+            ],
+            nulUseStatement: null,
+            callNumber: [],
+          },
+          fileSets: [
+            {
+              accessionNumber: "BFMF_B21_F04_037_FILE_10",
+              id: "8ca8b91c-756e-4538-b60f-036d66f1b897",
+              label: "BFMF_B21_F04_037_p014.jpg",
+            },
+            {
+              accessionNumber: "BFMF_B21_F04_037_FILE_0",
+              id: "e064fb2d-20c3-4fff-8773-f4e1aeae0162",
+              label: "BFMF_B21_F04_037_p008.jpg",
+            },
+            {
+              accessionNumber: "BFMF_B21_F04_037_FILE_8",
+              id: "7ba5595e-0905-4252-aa03-5d99d329ed6d",
+              label: "BFMF_B21_F04_037_p006.jpg",
+            },
+            {
+              accessionNumber: "BFMF_B21_F04_037_FILE_11",
+              id: "69857a28-7abb-4bfb-b145-eb7d25148d64",
+              label: "BFMF_B21_F04_037_p002.jpg",
+            },
+            {
+              accessionNumber: "BFMF_B21_F04_037_FILE_12",
+              id: "30aa4ef2-4179-4f77-a87b-fdb34a95cbac",
+              label: "BFMF_B21_F04_037_p011.jpg",
+            },
+            {
+              accessionNumber: "BFMF_B21_F04_037_FILE_1",
+              id: "dfe7465a-fbbc-47c9-8bba-9f8564b48797",
+              label: "BFMF_B21_F04_037_p004.jpg",
+            },
+            {
+              accessionNumber: "BFMF_B21_F04_037_FILE_9",
+              id: "a4c2050e-3bdf-42d8-937f-10d9b62e453a",
+              label: "BFMF_B21_F04_037_p001.jpg",
+            },
+            {
+              accessionNumber: "BFMF_B21_F04_037_FILE_3",
+              id: "19c38218-059b-4724-b3f2-d5f16537c1d5",
+              label: "BFMF_B21_F04_037_p009.jpg",
+            },
+            {
+              accessionNumber: "BFMF_B21_F04_037_FILE_13",
+              id: "21484f56-6ba6-40d8-8a2a-c0f51a6ae085",
+              label: "BFMF_B21_F04_037_p007.jpg",
+            },
+            {
+              accessionNumber: "BFMF_B21_F04_037_FILE_7",
+              id: "ec55148f-49ef-438b-97c0-21e31602ffbb",
+              label: "BFMF_B21_F04_037_p003.jpg",
+            },
+            {
+              accessionNumber: "BFMF_B21_F04_037_FILE_2",
+              id: "6c84a029-c5b0-4af8-b664-5a118b603314",
+              label: "BFMF_B21_F04_037_p010.jpg",
+            },
+            {
+              accessionNumber: "BFMF_B21_F04_037_FILE_5",
+              id: "cfc69948-3008-49fa-9678-65719d5d4386",
+              label: "BFMF_B21_F04_037_p005.jpg",
+            },
+            {
+              accessionNumber: "BFMF_B21_F04_037_FILE_6",
+              id: "df91fdc3-d178-412b-91af-f8d59ae4f93f",
+              label: "BFMF_B21_F04_037_p012.jpg",
+            },
+            {
+              accessionNumber: "BFMF_B21_F04_037_FILE_4",
+              id: "999d30e0-d98c-4c24-b991-f3f75299cab1",
+              label: "BFMF_B21_F04_037_p013.jpg",
+            },
+          ],
+          id: "bd7c21c1-590a-4edb-a0ac-54e6932b51ed",
+          iiifManifest:
+            "https://devbox.library.northwestern.edu:9001/dev-pyramids/public/bd/7c/21/c1/-5/90/a-/4e/db/-a/0a/c-/54/e6/93/2b/51/ed-manifest.json",
+          model: {
+            application: "Meadow",
+            name: "Image",
+          },
+          modifiedDate: "2020-08-04T18:44:38.132574Z",
+          project: {
+            id: "5245c9cc-5a32-453e-b862-e83726c046be",
+            title: "Seed Data Project",
+          },
+          published: false,
+          representativeFileSet: {
+            fileSetId: "e064fb2d-20c3-4fff-8773-f4e1aeae0162",
+            url:
+              "https://devbox.library.northwestern.edu:8183/iiif/2/e064fb2d-20c3-4fff-8773-f4e1aeae0162",
+          },
+          sheet: {
+            id: "f731ee5e-a92d-46a4-8fd1-65db645d13bc",
+            title: "berkeley.csv",
+          },
+          visibility: {
+            id: "RESTRICTED",
+            label: "Private",
+            scheme: "visibility",
+          },
+          workType: {
+            id: "IMAGE",
+            label: "Image",
+            scheme: "work_type",
+          },
+        },
+        _type: "_doc",
+      },
+    ],
+    max_score: 3.428854,
+    total: 7,
+  },
+  timed_out: false,
+  took: 4,
+};

--- a/assets/js/screens/BatchEdit/BatchEdit.jsx
+++ b/assets/js/screens/BatchEdit/BatchEdit.jsx
@@ -1,16 +1,41 @@
-import React from "react";
+import React, { useEffect, useState, Suspense } from "react";
 import Layout from "../Layout";
 import UIBreadcrumbs from "../../components/UI/Breadcrumbs";
 import BatchEditPreviewItems from "../../components/BatchEdit/PreviewItems";
 import BatchEditTabs from "../../components/BatchEdit/Tabs";
-import { mockBatchEditData } from "../../mock-data/batchEditData";
 import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useBatchState } from "../../context/batch-edit-context";
+import { elasticsearchDirectSearch } from "../../services/elasticsearch";
+import UISkeleton from "../../components/UI/Skeleton";
 
 const ScreensBatchEdit = () => {
   const batchState = useBatchState();
   const isActiveSearch = batchState.filteredQuery && batchState.resultStats;
+  const [previewItems, setPreviewItems] = useState([]);
+  const [isLoadingPreviewItems, setIsLoadingPreviewItems] = useState(true);
+
+  useEffect(() => {
+    async function getResultItems() {
+      let resultItems = [];
+      let results = await elasticsearchDirectSearch({
+        size: 25,
+        ...batchState.filteredQuery,
+      });
+
+      if (results.hits.hits.length > 0) {
+        resultItems = results.hits.hits.map((hit) => {
+          return {
+            id: hit._source.id,
+            representativeFileSet: hit._source.representativeFileSet,
+          };
+        });
+      }
+      setIsLoadingPreviewItems(false);
+      setPreviewItems(resultItems);
+    }
+    getResultItems();
+  }, []);
 
   return (
     <Layout>
@@ -35,6 +60,16 @@ const ScreensBatchEdit = () => {
               Batch Edit
             </h1>
 
+            {isActiveSearch && (
+              <div data-testid="preview-wrapper">
+                {isLoadingPreviewItems ? (
+                  <UISkeleton rows={5} />
+                ) : (
+                  <BatchEditPreviewItems items={previewItems} />
+                )}
+              </div>
+            )}
+
             {!isActiveSearch && (
               <div className="notification content">
                 <p>
@@ -49,12 +84,6 @@ const ScreensBatchEdit = () => {
               </div>
             )}
           </div>
-
-          {isActiveSearch && (
-            <div className="box" data-testid="preview-wrapper">
-              <BatchEditPreviewItems items={mockBatchEditData} />
-            </div>
-          )}
         </div>
       </section>
 

--- a/assets/js/screens/BatchEdit/BatchEdit.test.js
+++ b/assets/js/screens/BatchEdit/BatchEdit.test.js
@@ -12,6 +12,8 @@ import {
 } from "../../components/Work/controlledVocabulary.gql.mock";
 import { BatchProvider } from "../../context/batch-edit-context";
 
+jest.mock("../../services/elasticsearch");
+
 describe("BatchEdit component", () => {
   function setupComponent() {
     setupCachedCodeListsLocalStorage();
@@ -38,7 +40,6 @@ describe("BatchEdit component", () => {
           codeListRelatedUrlMock,
           codeListRightsStatementMock,
         ],
-        // Mocks sending in 2 items to Batch Edit component via react-router-dom "state"
         // NOTE: We're not using this in the component anymore, but keeping it in for a pattern to
         // reference in the future.
         state: { resultStats: { numberOfResults: 5 } },

--- a/assets/js/screens/Collection/Collection.test.js
+++ b/assets/js/screens/Collection/Collection.test.js
@@ -13,6 +13,8 @@ import {
   MOCK_COLLECTION_ID,
 } from "../../components/Collection/collection.gql.mock";
 
+jest.mock("../../services/elasticsearch");
+
 /**
  * Helper function to render the component for testing
  * @param {Array} mocks All the mocks needed to run each spec

--- a/assets/js/screens/Collection/Form.test.js
+++ b/assets/js/screens/Collection/Form.test.js
@@ -6,6 +6,8 @@ import { waitFor } from "@testing-library/react";
 import { getCollectionMock } from "../../components/Collection/collection.gql.mock";
 const mocks = [getCollectionMock];
 
+jest.mock("../../services/elasticsearch");
+
 function setupTests() {
   return renderWithRouterApollo(
     <Route path="/collection/form/:id" component={ScreensCollectionForm} />,

--- a/assets/js/screens/Collection/List.test.js
+++ b/assets/js/screens/Collection/List.test.js
@@ -6,6 +6,8 @@ import { waitFor } from "@testing-library/react";
 import { getCollectionsMock } from "../../components/Collection/collection.gql.mock";
 const mocks = [getCollectionsMock];
 
+jest.mock("../../services/elasticsearch");
+
 function setupTests() {
   return renderWithRouterApollo(
     <Route path="/collection/list/" component={ScreensCollectionList} />,

--- a/assets/js/screens/Home/Home.test.jsx
+++ b/assets/js/screens/Home/Home.test.jsx
@@ -5,6 +5,8 @@ import "@testing-library/jest-dom/extend-expect";
 import HomePage from "./Home";
 import { renderWithRouter } from "../../services/testing-helpers";
 
+jest.mock("../../services/elasticsearch");
+
 afterEach(cleanup);
 
 test.skip("Home page component renders", () => {

--- a/assets/js/screens/IngestSheet/Form.test.jsx
+++ b/assets/js/screens/IngestSheet/Form.test.jsx
@@ -4,11 +4,13 @@ import ScreensIngestSheetForm from "./Form";
 import "@testing-library/jest-dom/extend-expect";
 import { renderWithRouter } from "../../services/testing-helpers";
 
+jest.mock("../../services/elasticsearch");
+
 afterEach(cleanup);
 
 xtest("ScreensIngestSheet upload form component renders", () => {
   const { container } = renderWithRouter(<ScreensIngestSheetForm />, {
-    route: "/project/01DESDW646M02M8S8R9B4Y98W9/ingest-sheet/upload"
+    route: "/project/01DESDW646M02M8S8R9B4Y98W9/ingest-sheet/upload",
   });
 
   expect(container).toBeTruthy();

--- a/assets/js/screens/Project/List.test.jsx
+++ b/assets/js/screens/Project/List.test.jsx
@@ -4,6 +4,8 @@ import { renderWithRouterApollo } from "../../services/testing-helpers";
 import { getProjectsMock } from "../../components/Project/project.gql.mock";
 const mocks = [getProjectsMock];
 
+jest.mock("../../services/elasticsearch");
+
 it("renders a create new project button", async () => {
   const { findByTestId } = renderWithRouterApollo(<ScreensProjectList />, {
     mocks,

--- a/assets/js/screens/Project/Project.test.js
+++ b/assets/js/screens/Project/Project.test.js
@@ -7,6 +7,8 @@ import {
   ingestSheetUpdatesMock,
 } from "../../components/Project/project.gql.mock";
 
+jest.mock("../../services/elasticsearch");
+
 const MOCK_PROJECT_TITLE = "Mock project title";
 const mocks = [getProjectMock, ingestSheetUpdatesMock];
 

--- a/assets/js/screens/Work/Work.test.jsx
+++ b/assets/js/screens/Work/Work.test.jsx
@@ -17,6 +17,8 @@ function setupMatchTests() {
   );
 }
 
+jest.mock("../../services/elasticsearch");
+
 // TODO: Figure out why the getWorkMock is not working.
 
 xit("renders without crashing", () => {

--- a/assets/js/services/__mocks__/elasticsearch.js
+++ b/assets/js/services/__mocks__/elasticsearch.js
@@ -1,0 +1,7 @@
+import { elasticSearchResponse } from "../../mock-data/elasticsearch-response";
+
+export async function elasticsearchDirectSearch(body) {
+  return new Promise((resolve, reject) => {
+    process.nextTick(() => resolve(elasticSearchResponse));
+  });
+}

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -16,3 +16,4 @@
 @import "./scss/base";
 @import "./scss/reactivesearch";
 @import "./scss/skeleton";
+@import "./scss//hover";

--- a/assets/styles/scss/_hover.scss
+++ b/assets/styles/scss/_hover.scss
@@ -1,0 +1,17 @@
+/* Grow */
+.hvr-grow {
+  display: inline-block;
+  vertical-align: middle;
+  transform: translateZ(0);
+  box-shadow: 0 0 1px rgba(0, 0, 0, 0);
+  backface-visibility: hidden;
+  -moz-osx-font-smoothing: grayscale;
+  transition-duration: 0.3s;
+  transition-property: transform;
+}
+
+.hvr-grow:hover,
+.hvr-grow:focus,
+.hvr-grow:active {
+  transform: scale(1.1);
+}

--- a/assets/styles/scss/_hover.scss
+++ b/assets/styles/scss/_hover.scss
@@ -15,3 +15,21 @@
 .hvr-grow:active {
   transform: scale(1.1);
 }
+
+.hvr-shrink {
+  display: inline-block;
+  vertical-align: middle;
+  -webkit-transform: perspective(1px) translateZ(0);
+  transform: perspective(1px) translateZ(0);
+  box-shadow: 0 0 1px rgba(0, 0, 0, 0);
+  -webkit-transition-duration: 0.3s;
+  transition-duration: 0.3s;
+  -webkit-transition-property: transform;
+  transition-property: transform;
+}
+.hvr-shrink:hover,
+.hvr-shrink:focus,
+.hvr-shrink:active {
+  -webkit-transform: scale(0.9);
+  transform: scale(0.9);
+}


### PR DESCRIPTION
This PR does a few things...
- Makes the Preview Items live in Batch Edit
- Introduces `hover.css` package styles to images to give some life to image hovers (these could be any effect...just picked one for now)
- Mocks ElasticSearch direct query in unit tests, though need to find a way in the future to configure this mock globally so every test doesn't require the `jest.mock` function
- Slight UI cleanup updates to Card and List view

![image](https://user-images.githubusercontent.com/3020266/90553073-66b99a00-e159-11ea-9829-d047c64e3d81.png)

![image](https://user-images.githubusercontent.com/3020266/90553386-ea738680-e159-11ea-853d-fa7b54b69e51.png)

![image](https://user-images.githubusercontent.com/3020266/90553430-fa8b6600-e159-11ea-86a8-9f1dfc3944b0.png)
