### PR TITLE
Update shared link to point to Fen staging url

### DIFF
--- a/assets/js/components/Work/SharedLinkNotification.jsx
+++ b/assets/js/components/Work/SharedLinkNotification.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import moment from "moment";
 
 export default function WorkSharedLinkNotification({ linkData }) {
-  const linkUrl = `http://digital-collections.rdc-staging.library.northwestern.edu/shared/${linkData.sharedLinkId}`;
+  const linkUrl = `http://fen.rdc-staging.library.northwestern.edu/shared/${linkData.sharedLinkId}`;
 
   return (
     <div


### PR DESCRIPTION
This will now point to the real Fen staging URL, for the demo.