### PR TITLE
Include the target index in the shared link

### DIFF
--- a/lib/meadow/data/shared_links.ex
+++ b/lib/meadow/data/shared_links.ex
@@ -28,13 +28,20 @@ defmodule Meadow.Data.SharedLinks do
     expires = DateTime.utc_now() |> DateTime.add(ttl, :millisecond)
     link = %__MODULE__{shared_link_id: Ecto.UUID.generate(), expires: expires, work_id: work_id}
 
+    document = %{
+      shared_link_id: link.shared_link_id,
+      target_id: link.work_id,
+      expires: link.expires,
+      target_index: "meadow"
+    }
+
     result =
       Elastix.Document.index(
         elasticsearch_url(),
         @index,
         @type_name,
         link.shared_link_id,
-        link
+        document
       )
 
     Elastix.Index.refresh(elasticsearch_url(), @index)


### PR DESCRIPTION
In order to keep the proxy agnostic and ignorant of the shape of our data, I added a `target_index` property to shared links and also changed `work_id` to `target_id`. It's still `work_id` in Meadow, but it indexes it as `target_id` to give the proxy the most flexibility down the road (and for its internal tests).