### PR TITLE
Ingest speed and reliability improvements

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -85,7 +85,7 @@ config :honeybadger,
 
 config :sequins,
   prefix: "meadow",
-  supervisor_opts: [max_restarts: 360]
+  supervisor_opts: [max_restarts: 2048]
 
 config :ueberauth, Ueberauth,
   providers: [

--- a/lib/meadow/pipeline/actions/generate_file_set_digests.ex
+++ b/lib/meadow/pipeline/actions/generate_file_set_digests.ex
@@ -43,6 +43,10 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigests do
       ActionStates.set_state!(file_set, __MODULE__, "ok")
       :ok
     rescue
+      Meadow.Utils.Stream.Timeout ->
+        ActionStates.set_state!(file_set, __MODULE__, "pending")
+        :retry
+
       e ->
         ActionStates.set_state!(file_set, __MODULE__, "error", Exception.message(e))
         {:error, Exception.message(e)}

--- a/lib/meadow/utils/stream.ex
+++ b/lib/meadow/utils/stream.ex
@@ -2,39 +2,20 @@ defmodule Meadow.Utils.Stream do
   @moduledoc """
   Functions to provide chunk streams from http:// and s3:// URLs
   """
+
+  defmodule Timeout do
+    defexception [:message]
+  end
+
+  require Logger
+
   def stream_from("s3://" <> _ = url), do: url |> presigned_url_for() |> stream_from()
 
   def stream_from(url) do
     Elixir.Stream.resource(
-      fn ->
-        HTTPoison.get!(
-          url,
-          %{},
-          stream_to: self(),
-          async: :once
-        )
-      end,
-      fn %HTTPoison.AsyncResponse{id: id} = resp ->
-        receive do
-          %HTTPoison.AsyncStatus{id: ^id} ->
-            HTTPoison.stream_next(resp)
-            {[], resp}
-
-          %HTTPoison.AsyncHeaders{id: ^id} ->
-            HTTPoison.stream_next(resp)
-            {[], resp}
-
-          %HTTPoison.AsyncChunk{id: ^id, chunk: chunk} ->
-            HTTPoison.stream_next(resp)
-            {[chunk], resp}
-
-          %HTTPoison.AsyncEnd{id: ^id} ->
-            {:halt, resp}
-        end
-      end,
-      fn %HTTPoison.AsyncResponse{id: id} ->
-        :hackney.stop_async(id)
-      end
+      fn -> async_stream_start(url) end,
+      &async_stream_next/1,
+      &async_stream_after/1
     )
   end
 
@@ -47,4 +28,40 @@ defmodule Meadow.Utils.Stream do
       result
     end
   end
+
+  defp async_stream_start(url), do: HTTPoison.get!(url, %{}, stream_to: self(), async: :once)
+
+  defp async_stream_next(%HTTPoison.AsyncResponse{id: id} = resp) do
+    receive do
+      %HTTPoison.AsyncStatus{id: ^id} ->
+        HTTPoison.stream_next(resp)
+        {[], resp}
+
+      %HTTPoison.AsyncHeaders{id: ^id} ->
+        HTTPoison.stream_next(resp)
+        {[], resp}
+
+      %HTTPoison.AsyncChunk{id: ^id, chunk: chunk} ->
+        HTTPoison.stream_next(resp)
+        {[chunk], resp}
+
+      %HTTPoison.AsyncEnd{id: ^id} ->
+        {:halt, resp}
+
+      {:EXIT, _pid, :normal} ->
+        {[], resp}
+
+      other ->
+        Logger.warn("Unexpected message received from #{inspect(resp)}: #{inspect(other)}")
+        {[], resp}
+    after
+      5_000 ->
+        with msg <- "No message received from #{inspect(resp)} in 5 seconds." do
+          Logger.warn(msg)
+          raise __MODULE__.Timeout, message: msg
+        end
+    end
+  end
+
+  defp async_stream_after(%HTTPoison.AsyncResponse{id: id}), do: :hackney.stop_async(id)
 end


### PR DESCRIPTION
* Add a `retry` status to the pipeline
* Use timeout / retry to avoid stream lockups in `GenerateFileSetDigests`