### PR TITLE
Replace the ActionState based progress system

### DIFF
--- a/lib/meadow/data/action_states.ex
+++ b/lib/meadow/data/action_states.ex
@@ -4,8 +4,9 @@ defmodule Meadow.Data.ActionStates do
   """
 
   import Ecto.Query, warn: false
+  import Meadow.Utils.Atoms
+
   alias Meadow.Data.Schemas.ActionState
-  alias Meadow.Ingest.Progress
   alias Meadow.Repo
 
   def latest_outcome(object_id) do
@@ -62,7 +63,7 @@ defmodule Meadow.Data.ActionStates do
   def get_latest_state(object_id, action) do
     from(
       a in states(object_id),
-      where: a.action == ^ActionState.atom_to_string(action),
+      where: a.action == ^atom_to_string(action),
       limit: 1
     )
     |> Repo.one()
@@ -135,8 +136,6 @@ defmodule Meadow.Data.ActionStates do
       action_update: state.object_id,
       action_updates: :all
     )
-
-    Progress.send_notification(state)
 
     state
   end

--- a/lib/meadow/data/schemas/action_state.ex
+++ b/lib/meadow/data/schemas/action_state.ex
@@ -3,10 +3,10 @@ defmodule Meadow.Data.Schemas.ActionState do
   ActionStates keep track of actions performed on Works and FileSets
   """
   use Ecto.Schema
+  use Meadow.Constants
 
   import Ecto.Changeset
-
-  use Meadow.Constants
+  import Meadow.Utils.Atoms
 
   @primary_key {:id, Ecto.UUID, autogenerate: false, read_after_writes: true}
   @foreign_key_type Ecto.UUID
@@ -26,14 +26,6 @@ defmodule Meadow.Data.Schemas.ActionState do
     |> cast_type(attrs[:object_type])
     |> cast(attrs, [:object_id, :outcome, :notes])
     |> validate_required([:object_id, :action, :outcome])
-  end
-
-  def atom_to_string(action) do
-    cond do
-      is_binary(action) -> action
-      is_atom(action) && Code.ensure_loaded?(action) -> Module.split(action) |> Enum.join(".")
-      true -> inspect(action)
-    end
   end
 
   defp cast_action(change, action) do

--- a/lib/meadow/ingest/progress.ex
+++ b/lib/meadow/ingest/progress.ex
@@ -2,9 +2,12 @@ defmodule Meadow.Ingest.Progress do
   @moduledoc """
   Translate action state notifications into ingest sheet progress notifications
   """
-  alias Meadow.Data.Works
-  alias Meadow.Ingest
-  alias Meadow.Ingest.Sheets
+  alias Meadow.Ingest.Schemas.{Progress, Row, Sheet}
+  alias Meadow.Pipeline
+  alias Meadow.Repo
+
+  import Ecto.Query
+  import Meadow.Utils.Atoms
 
   defstruct sheet_id: nil,
             total_file_sets: 0,
@@ -13,49 +16,177 @@ defmodule Meadow.Ingest.Progress do
             completed_actions: 0,
             percent_complete: 0
 
-  def send_notification(%{object_id: file_set_id, object_type: "Meadow.Data.Schemas.FileSet"}) do
-    case Ingest.ingest_sheet_for_file_set(file_set_id) do
-      nil ->
-        :noop
+  @doc """
+  Retrieve all progress entries for an ingest sheet
+  """
+  def get_entries(sheet) do
+    progress_entries(sheet)
+    |> Repo.all()
+  end
 
-      sheet ->
-        Absinthe.Subscription.publish(
-          MeadowWeb.Endpoint,
-          pipeline_progress(sheet),
-          ingest_progress: sheet.id
-        )
+  @doc """
+  Retrieve a progress entry by ingest sheet row ID and action name
+  """
+  def get_entry(%Row{} = row, action), do: get_entry(row.id, action)
+
+  def get_entry(row_id, action) do
+    action = atom_to_string(action)
+
+    from(p in Progress, where: p.row_id == ^row_id and p.action == ^action)
+    |> Repo.one()
+  end
+
+  @doc """
+  Initialize progress entries for a given ingest sheet row, including
+  an additional entry if the row creates a new work
+  """
+  def initialize_entry(%Row{} = row, include_work), do: initialize_entry(row.id, include_work)
+
+  def initialize_entry(row_id, include_work) do
+    row_actions(include_work)
+    |> Enum.each(fn action -> update_entry(row_id, action, "pending") end)
+  end
+
+  def initialize_entries(entries) do
+    timestamp = DateTime.utc_now()
+
+    entries
+    |> Enum.chunk_every(500)
+    |> Enum.each(&initialize_chunk(&1, timestamp))
+  end
+
+  defp initialize_chunk(chunk, timestamp) do
+    new_entries =
+      Enum.flat_map(chunk, fn {row_id, include_work} ->
+        row_actions(include_work)
+        |> Enum.map(fn action ->
+          %{
+            row_id: row_id,
+            action: atom_to_string(action),
+            status: "pending",
+            inserted_at: timestamp,
+            updated_at: timestamp
+          }
+        end)
+      end)
+
+    Repo.insert_all(Progress, new_entries)
+  end
+
+  @doc """
+  Update the status of a progress entry for a given ingest sheet row and action
+  """
+  def update_entry(%Row{} = row, action, status), do: update_entry(row.id, action, status)
+
+  def update_entry(row_id, action, status) do
+    progress =
+      case get_entry(row_id, action) do
+        nil -> %Progress{row_id: row_id, action: atom_to_string(action)}
+        row -> row
+      end
+      |> Progress.changeset(%{status: status})
+      |> Repo.insert_or_update!()
+
+    send_notification(progress)
+
+    progress
+  end
+
+  @doc """
+  Get the total number of actions for an ingest sheet
+  """
+  def action_count(sheet) do
+    sheet
+    |> progress_entries()
+    |> Repo.aggregate(:count)
+  end
+
+  @doc """
+  Get the number of completed actions for an ingest sheet
+  """
+  def completed_count(sheet) do
+    from([entry: p] in progress_entries(sheet), where: p.status in ["ok", "error"])
+    |> Repo.aggregate(:count)
+  end
+
+  @doc """
+  Get the total number of file sets for an ingest sheet
+  """
+  def file_set_count(sheet) do
+    from([entry: p] in progress_entries(sheet),
+      where: p.action == "Meadow.Pipeline.Actions.FileSetComplete"
+    )
+    |> Repo.aggregate(:count)
+  end
+
+  @doc """
+  Get the number of completed file sets for an ingest sheet
+  """
+  def completed_file_set_count(sheet) do
+    from([entry: p] in progress_entries(sheet),
+      where:
+        p.action == "Meadow.Pipeline.Actions.FileSetComplete" and
+          p.status in ["ok", "error"]
+    )
+    |> Repo.aggregate(:count)
+  end
+
+  defp row_actions(include_work) do
+    if include_work do
+      ["CreateWork" | Pipeline.actions()]
+    else
+      Pipeline.actions()
     end
   end
 
-  def send_notification(%{object_id: work_id, object_type: "Meadow.Data.Schemas.Work"}) do
-    with work <- Works.with_sheet(work_id) do
-      Absinthe.Subscription.publish(
-        MeadowWeb.Endpoint,
-        pipeline_progress(work.ingest_sheet),
-        ingest_progress: work.ingest_sheet_id
-      )
-    end
+  defp progress_entries(%Sheet{} = sheet), do: progress_entries(sheet.id)
+
+  defp progress_entries(sheet_id) do
+    from p in Progress,
+      as: :entry,
+      join: r in Row,
+      as: :row,
+      on: r.id == p.row_id,
+      where: r.sheet_id == ^sheet_id
   end
 
-  def send_notification(_), do: :noop
+  @doc """
+  Get the total progress report for an ingest sheet
+  """
+  def pipeline_progress(%Sheet{} = sheet), do: pipeline_progress(sheet.id)
 
-  def pipeline_progress(ingest_sheet) do
-    case Sheets.total_action_count(ingest_sheet) do
+  def pipeline_progress(sheet_id) do
+    case action_count(sheet_id) do
       0 ->
-        %__MODULE__{sheet_id: ingest_sheet.id}
+        %__MODULE__{sheet_id: sheet_id}
 
       action_count ->
-        completed_action_count = Sheets.completed_action_count(ingest_sheet)
+        completed_action_count = completed_count(sheet_id)
         percent_complete = round(completed_action_count / action_count * 10_000) / 100
 
         %__MODULE__{
-          sheet_id: ingest_sheet.id,
-          total_file_sets: Sheets.file_set_count(ingest_sheet),
-          completed_file_sets: Sheets.completed_file_set_count(ingest_sheet),
+          sheet_id: sheet_id,
+          total_file_sets: file_set_count(sheet_id),
+          completed_file_sets: completed_file_set_count(sheet_id),
           total_actions: action_count,
           completed_actions: completed_action_count,
           percent_complete: percent_complete
         }
     end
   end
+
+  @doc """
+  Send a progress report notification every time a progress record changes
+  """
+  def send_notification(%Progress{} = record) do
+    with sheet_id <- record |> Repo.preload(:row) |> Map.get(:row) |> Map.get(:sheet_id) do
+      Absinthe.Subscription.publish(
+        MeadowWeb.Endpoint,
+        pipeline_progress(sheet_id),
+        ingest_progress: sheet_id
+      )
+    end
+  end
+
+  def send_notification(_), do: :noop
 end

--- a/lib/meadow/ingest/rows.ex
+++ b/lib/meadow/ingest/rows.ex
@@ -9,6 +9,14 @@ defmodule Meadow.Ingest.Rows do
   """
 
   @doc """
+  Gets a row by ingest sheet and row number
+  """
+  def get_row(sheet_id, row_num) do
+    from(r in Row, where: r.sheet_id == ^sheet_id and r.row == ^row_num)
+    |> Repo.one()
+  end
+
+  @doc """
   Changes the validation state of a Row
   """
   def change_ingest_sheet_row_validation_state(

--- a/lib/meadow/ingest/schemas/progress.ex
+++ b/lib/meadow/ingest/schemas/progress.ex
@@ -1,0 +1,25 @@
+defmodule Meadow.Ingest.Schemas.Progress do
+  @moduledoc """
+  This modeule defines the Ecto.Schema
+  and Ecto.Changeset for Meadow.Ingest.Schemas.Progress
+
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  @foreign_key_type Ecto.UUID
+  @timestamps_opts [type: :utc_datetime_usec]
+  schema "ingest_progress" do
+    belongs_to :row, Meadow.Ingest.Schemas.Row, primary_key: true
+    field :action, :string, primary_key: true
+    field :status, :string
+    timestamps()
+  end
+
+  def changeset(record, attrs \\ %{}) do
+    record
+    |> cast(attrs, [:row_id, :action, :status])
+    |> validate_required([:row_id, :action, :status])
+  end
+end

--- a/lib/meadow/ingest/sheets.ex
+++ b/lib/meadow/ingest/sheets.ex
@@ -329,41 +329,6 @@ defmodule Meadow.Ingest.Sheets do
     |> Repo.one()
   end
 
-  def completed_file_set_count(%Sheet{} = ingest_sheet),
-    do: completed_file_set_count(ingest_sheet.id)
-
-  def completed_file_set_count(sheet_id) do
-    from([entry: a] in file_set_action_states(sheet_id),
-      where: a.outcome in ["ok", "error"],
-      where: a.object_type == "Meadow.Data.Schemas.FileSet",
-      where: a.action == "Meadow.Pipeline.Actions.FileSetComplete",
-      select: count(a.id)
-    )
-    |> Repo.one()
-  end
-
-  def total_action_count(%Sheet{} = ingest_sheet), do: total_action_count(ingest_sheet.id)
-
-  def total_action_count(sheet_id) do
-    from([entry: a] in file_set_action_states(sheet_id),
-      where: a.object_type == "Meadow.Data.Schemas.FileSet",
-      select: count(a.id)
-    )
-    |> Repo.one()
-  end
-
-  def completed_action_count(%Sheet{} = ingest_sheet),
-    do: completed_action_count(ingest_sheet.id)
-
-  def completed_action_count(sheet_id) do
-    from([entry: a] in file_set_action_states(sheet_id),
-      where: a.object_type == "Meadow.Data.Schemas.FileSet",
-      where: a.outcome in ["ok", "error"],
-      select: count(a.id)
-    )
-    |> Repo.one()
-  end
-
   def ingest_errors(%Sheet{} = ingest_sheet), do: ingest_errors(ingest_sheet.id)
 
   def ingest_errors(sheet_id) do

--- a/lib/meadow/pipeline/actions/common.ex
+++ b/lib/meadow/pipeline/actions/common.ex
@@ -1,0 +1,34 @@
+defmodule Meadow.Pipeline.Actions.Common do
+  @moduledoc """
+  Shared functions for Meadow pipeline actions
+  """
+  defmacro __using__(_) do
+    quote do
+      alias Meadow.Data.ActionStates
+      alias Meadow.Ingest.{Progress, Rows}
+
+      def process(data, attrs) do
+        with complete <- ActionStates.ok?(data.file_set_id, __MODULE__) do
+          result = process(data, attrs, complete)
+          unless complete, do: update_progress(attrs, result)
+          result
+        end
+      end
+
+      defp process(%{file_set_id: file_set_id}, _, true) do
+        Logger.warn("Skipping #{__MODULE__} for #{file_set_id} – already complete")
+        :ok
+      end
+
+      def update_progress(attrs, {status, _, _}, _), do: update_progress(attrs, status)
+      def update_progress(attrs, {status, _}, _), do: update_progress(attrs, status)
+
+      def update_progress(%{ingest_sheet: sheet_id, ingest_sheet_row: row_num}, status) do
+        Rows.get_row(sheet_id, row_num)
+        |> Progress.update_entry(__MODULE__, to_string(status))
+      end
+
+      def update_progress(_, _), do: :noop
+    end
+  end
+end

--- a/lib/meadow/pipeline/actions/copy_file_to_preservation.ex
+++ b/lib/meadow/pipeline/actions/copy_file_to_preservation.ex
@@ -12,18 +12,11 @@ defmodule Meadow.Pipeline.Actions.CopyFileToPreservation do
   alias Meadow.Utils.Pairtree
   alias Sequins.Pipeline.Action
   use Action
+  use Meadow.Pipeline.Actions.Common
   require Logger
   import SweetXml, only: [sigil_x: 2]
 
   @actiondoc "Copy File to Preservation"
-
-  def process(data, attrs),
-    do: process(data, attrs, ActionStates.ok?(data.file_set_id, __MODULE__))
-
-  defp process(%{file_set_id: file_set_id}, _, true) do
-    Logger.warn("Skipping #{__MODULE__} for #{file_set_id} – already complete")
-    :ok
-  end
 
   defp process(data, attributes, _) do
     file_set = FileSets.get_file_set!(data.file_set_id)

--- a/lib/meadow/pipeline/actions/create_pyramid_tiff.ex
+++ b/lib/meadow/pipeline/actions/create_pyramid_tiff.ex
@@ -6,16 +6,9 @@ defmodule Meadow.Pipeline.Actions.CreatePyramidTiff do
   alias Meadow.Utils.Pairtree
   alias Sequins.Pipeline.Action
   use Action
+  use Meadow.Pipeline.Actions.Common
 
   @timeout 30_000
-
-  def process(data, attrs),
-    do: process(data, attrs, ActionStates.ok?(data.file_set_id, __MODULE__))
-
-  defp process(%{file_set_id: file_set_id}, _, true) do
-    Logger.warn("Skipping #{__MODULE__} for #{file_set_id} – already complete")
-    :ok
-  end
 
   defp process(%{file_set_id: file_set_id}, _, _) do
     Logger.info("Beginning #{__MODULE__} for FileSet #{file_set_id}")

--- a/lib/meadow/pipeline/actions/file_set_complete.ex
+++ b/lib/meadow/pipeline/actions/file_set_complete.ex
@@ -4,16 +4,9 @@ defmodule Meadow.Pipeline.Actions.FileSetComplete do
   alias Meadow.Data.{ActionStates, Schemas.FileSet}
   alias Sequins.Pipeline.Action
   use Action
+  use Meadow.Pipeline.Actions.Common
 
   @actiondoc "Completed Processing FileSet"
-
-  def process(data, attrs),
-    do: process(data, attrs, ActionStates.ok?(data.file_set_id, __MODULE__))
-
-  defp process(%{file_set_id: file_set_id}, _, true) do
-    Logger.warn("Skipping #{__MODULE__} for #{file_set_id} – already complete")
-    :ok
-  end
 
   defp process(%{file_set_id: file_set_id}, _, _) do
     Logger.info("Ingest pipeline complete for FileSet #{file_set_id}")

--- a/lib/meadow/pipeline/actions/generate_file_set_digests.ex
+++ b/lib/meadow/pipeline/actions/generate_file_set_digests.ex
@@ -10,18 +10,11 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigests do
   alias Meadow.Utils
   alias Sequins.Pipeline.Action
   use Action
+  use Meadow.Pipeline.Actions.Common
   require Logger
 
   @actiondoc "Generate Digests for FileSet"
   @hashes [:sha256]
-
-  def process(data, attrs),
-    do: process(data, attrs, ActionStates.ok?(data.file_set_id, __MODULE__))
-
-  defp process(%{file_set_id: file_set_id}, _, true) do
-    Logger.warn("Skipping #{__MODULE__} for #{file_set_id} – already complete")
-    :ok
-  end
 
   defp process(%{file_set_id: file_set_id}, _attributes, _) do
     file_set = FileSets.get_file_set!(file_set_id)

--- a/lib/meadow/pipeline/actions/ingest_file_set.ex
+++ b/lib/meadow/pipeline/actions/ingest_file_set.ex
@@ -4,16 +4,9 @@ defmodule Meadow.Pipeline.Actions.IngestFileSet do
   alias Meadow.Data.{ActionStates, FileSet}
   alias Sequins.Pipeline.Action
   use Action
+  use Meadow.Pipeline.Actions.Common
 
   @actiondoc "Start Ingesting a FileSet"
-
-  def process(data, attrs),
-    do: process(data, attrs, ActionStates.ok?(data.file_set_id, __MODULE__))
-
-  defp process(%{file_set_id: file_set_id}, _, true) do
-    Logger.warn("Skipping #{__MODULE__} for #{file_set_id} – already complete")
-    :ok
-  end
 
   defp process(%{file_set_id: file_set_id}, _, _) do
     Logger.info("Beginning ingest pipeline for FileSet #{file_set_id}")

--- a/lib/meadow/utils/atoms.ex
+++ b/lib/meadow/utils/atoms.ex
@@ -1,0 +1,16 @@
+defmodule Meadow.Utils.Atoms do
+  @moduledoc """
+  Functions for dealing with atoms
+  """
+
+  @doc """
+  Convert a value to a string wiht special handling for module names
+  """
+  def atom_to_string(v) do
+    cond do
+      is_binary(v) -> v
+      is_atom(v) && Code.ensure_loaded?(v) -> Module.split(v) |> Enum.join(".")
+      true -> inspect(v)
+    end
+  end
+end

--- a/priv/repo/migrations/20200909201754_create_ingest_progress.exs
+++ b/priv/repo/migrations/20200909201754_create_ingest_progress.exs
@@ -1,0 +1,15 @@
+defmodule Meadow.Repo.Migrations.CreateIngestProgress do
+  use Ecto.Migration
+
+  def change do
+    create table(:ingest_progress, primary_key: false) do
+      add :row_id, references("ingest_sheet_rows", on_delete: :delete_all),
+        null: false,
+        primary_key: true
+
+      add :action, :string, primary_key: true
+      add :status, :string
+      timestamps()
+    end
+  end
+end

--- a/test/meadow/ingest/progress_test.exs
+++ b/test/meadow/ingest/progress_test.exs
@@ -1,0 +1,101 @@
+defmodule Meadow.Ingest.ProgressTest do
+  use Meadow.DataCase
+  use Meadow.IngestCase
+
+  alias Meadow.Ingest.{Progress, Rows}
+  alias Meadow.Pipeline.Actions
+
+  @bad_sheet_id "deadface-c0de-feed-cafe-addedbadbeef"
+
+  describe "Meadow.Ingest.Progress" do
+    setup %{ingest_sheet: sheet} do
+      with rows <- Rows.list_ingest_sheet_rows(sheet: sheet) do
+        rows
+        |> Enum.with_index()
+        |> Enum.map(fn {row, index} -> {row.id, rem(index, 4) == 0} end)
+        |> Progress.initialize_entries()
+
+        {:ok, %{rows: rows}}
+      end
+    end
+
+    test "get/2", %{rows: [row | _]} do
+      assert Progress.get_entry(row, "CreateWork") |> Map.get(:status) == "pending"
+      assert Progress.get_entry(row.id, "CreateWork") |> Map.get(:status) == "pending"
+    end
+
+    test "update_entry/3", %{rows: [row | _]} do
+      Progress.update_entry(row, "CreateWork", "ok")
+      assert Progress.get_entry(row, "CreateWork") |> Map.get(:status) == "ok"
+
+      Progress.update_entry(row, Actions.IngestFileSet, "ok")
+      assert Progress.get_entry(row.id, Actions.IngestFileSet) |> Map.get(:status) == "ok"
+    end
+
+    test "action_count/1", %{ingest_sheet: sheet} do
+      assert Progress.action_count(sheet) == 37
+      assert Progress.action_count(@bad_sheet_id) == 0
+    end
+
+    test "completed_count/1", %{ingest_sheet: sheet, rows: [row | _]} do
+      assert Progress.completed_count(sheet) == 0
+      Progress.update_entry(row, "CreateWork", "ok")
+      Progress.update_entry(row, Actions.IngestFileSet, "ok")
+      assert Progress.completed_count(sheet) == 2
+    end
+
+    test "file_set_count/1", %{ingest_sheet: sheet} do
+      assert Progress.file_set_count(sheet) == 7
+    end
+
+    test "completed_file_set_count/1", %{ingest_sheet: sheet, rows: [row | _]} do
+      assert Progress.completed_file_set_count(sheet) == 0
+      Progress.update_entry(row, Actions.FileSetComplete, "ok")
+      assert Progress.completed_file_set_count(sheet) == 1
+    end
+
+    test "pipeline_progress/1", %{ingest_sheet: sheet} do
+      with progress <- Progress.pipeline_progress(sheet) do
+        assert progress.sheet_id == sheet.id
+        assert progress.total_file_sets == 7
+        assert progress.completed_file_sets == 0
+        assert progress.total_actions == 37
+        assert progress.completed_actions == 0
+        assert progress.percent_complete == 0.0
+      end
+
+      Progress.get_entries(sheet)
+      |> Enum.take(20)
+      |> Enum.each(fn entry -> Progress.update_entry(entry.row_id, entry.action, "ok") end)
+
+      with progress <- Progress.pipeline_progress(sheet) do
+        assert progress.completed_file_sets == 4
+        assert progress.completed_actions == 20
+        assert_in_delta(progress.percent_complete, 54.0, 0.10)
+      end
+
+      Progress.get_entries(sheet)
+      |> Enum.each(fn entry -> Progress.update_entry(entry.row_id, entry.action, "ok") end)
+
+      with progress <- Progress.pipeline_progress(sheet) do
+        assert progress.completed_file_sets == 7
+        assert progress.completed_actions == 37
+        assert progress.percent_complete == 100.0
+      end
+
+      with progress <- Progress.pipeline_progress(@bad_sheet_id) do
+        assert progress.sheet_id == @bad_sheet_id
+        assert progress.total_file_sets == 0
+        assert progress.completed_file_sets == 0
+        assert progress.total_actions == 0
+        assert progress.completed_actions == 0
+        assert progress.percent_complete == 0.0
+      end
+    end
+  end
+
+  # pipeline_progress(%Sheet{} = sheet), do: pipeline_progress(sheet.id)
+  # pipeline_progress(sheet_id) do
+  # send_notification(%Progress{} = record) do
+  # send_notification(_), do: :noop
+end

--- a/test/meadow_web/schema/subscription/ingest_progress_test.exs
+++ b/test/meadow_web/schema/subscription/ingest_progress_test.exs
@@ -1,29 +1,24 @@
 defmodule MeadowWeb.Schema.Subscription.IngestProgressTest do
   use Meadow.IngestCase
   use MeadowWeb.SubscriptionCase, async: true
-  alias Meadow.Data.ActionStates
-  alias Meadow.Ingest.Actions.GenerateFileSetDigests
-  alias Meadow.Ingest.{Sheets, Status}
+  alias Meadow.Ingest.{Progress, Sheets, SheetsToWorks}
   alias Meadow.Pipeline
+  alias Meadow.Pipeline.Actions.GenerateFileSetDigests
 
+  @work_count 2
   @file_set_count 7
   @action_count length(Pipeline.actions())
-  @pct_factor 100 / (@file_set_count * @action_count)
+  @pct_factor 100 / (@file_set_count * @action_count + @work_count)
 
   load_gql(MeadowWeb.Schema, "test/gql/IngestProgress.gql")
 
   setup %{socket: socket, ingest_sheet: sheet} do
-    sheet = create_works(sheet)
-    file_sets = file_sets_for(sheet)
-
-    file_sets
-    |> Enum.each(fn file_set ->
-      ActionStates.initialize_states(file_set, Pipeline.actions())
-    end)
+    groups = SheetsToWorks.initialize_progress(sheet)
 
     {:ok,
      ingest_sheet: sheet,
-     file_sets: file_sets,
+     work_rows: groups |> Enum.map(fn {_, [row | _]} -> row end),
+     file_set_rows: groups |> Enum.flat_map(fn {_, rows} -> rows end),
      ref: subscribe_gql(socket, variables: %{"sheetId" => sheet.id, context: gql_context()})}
   end
 
@@ -31,33 +26,49 @@ defmodule MeadowWeb.Schema.Subscription.IngestProgressTest do
     assert_reply ref, :ok, %{subscriptionId: subscription_id}
   end
 
-  test "receive data", %{ref: ref, file_sets: file_sets, ingest_sheet: sheet} do
+  test "receive data", %{ref: ref, ingest_sheet: sheet, work_rows: [first_row | _]} do
     assert_reply ref, :ok, %{subscriptionId: subscription_id}
 
-    List.first(file_sets)
-    |> ActionStates.set_state!(GenerateFileSetDigests, "ok")
+    Progress.update_entry(first_row, "CreateWork", "ok")
 
     assert_push "subscription:data", %{
       result: %{data: %{"ingestProgress" => %{"percentComplete" => pct}}}
     }
 
-    assert_in_delta(pct, @pct_factor, 0.10)
+    Progress.update_entry(first_row, GenerateFileSetDigests, "ok")
+
+    assert_push "subscription:data", %{
+      result: %{data: %{"ingestProgress" => %{"percentComplete" => pct}}}
+    }
+
+    assert_in_delta(pct, @pct_factor * 2, 0.10)
     sheet = Sheets.get_ingest_sheet!(sheet.id)
     refute(sheet.status == "completed")
   end
 
-  test "complete sheet", %{ref: ref, file_sets: file_sets, ingest_sheet: sheet} do
+  test "complete sheet", %{
+    ref: ref,
+    ingest_sheet: sheet,
+    work_rows: work_rows,
+    file_set_rows: file_set_rows
+  } do
     assert_reply ref, :ok, %{subscriptionId: subscription_id}
 
-    file_sets
-    |> Enum.with_index()
-    |> Enum.each(fn {file_set, row} ->
-      Status.change(sheet.id, row, "ok")
-      ActionStates.initialize_states(file_set, Pipeline.actions(), "ok")
+    work_rows
+    |> Enum.each(fn row ->
+      Progress.update_entry(row, "CreateWork", "ok")
+      assert_push "subscription:data", _
     end)
 
-    Range.new(1, 28)
-    |> Enum.each(fn i ->
+    file_set_rows
+    |> Enum.flat_map(fn row ->
+      Pipeline.actions()
+      |> Enum.map(fn action -> {row, action} end)
+    end)
+    |> Enum.with_index(3)
+    |> Enum.each(fn {{row, action}, i} ->
+      Progress.update_entry(row, action, "ok")
+
       assert_push "subscription:data", %{
         result: %{data: %{"ingestProgress" => %{"percentComplete" => pct}}}
       }
@@ -65,7 +76,6 @@ defmodule MeadowWeb.Schema.Subscription.IngestProgressTest do
       assert_in_delta(pct, i * @pct_factor, 0.10)
     end)
 
-    sheet = Sheets.get_ingest_sheet!(sheet.id)
-    assert(sheet.status == "completed")
+    assert Progress.pipeline_progress(sheet) |> Map.get(:percent_complete) == 100
   end
 end


### PR DESCRIPTION
This PR replaces the progress reporting/notification system with one that is faster, more accurate, and more reliable, without changing the external interface (including the GraphQL API). It replaces the calculations that relied on the loose coupling between `ActionState`, `Row`, and `FileSet` (via accession number) with a new table that contains one row + action per entry. In other words, the number of `ingest_progress` rows associated with a sheet is the same as the number of actions (including work creation) that need to completed before the sheet is fully ingested. Each action updates the relevant progress entry as it runs.

The following animation shows two ingests running through the UI – one with 30 file sets, and one with 2,041. The animation is sped up 4x, but you can see how much less jittery and more reliable the progress bar is, especially during the initial work creation phase. The entire run took 15 minutes in realtime.

![ingest](https://user-images.githubusercontent.com/196872/92817953-c425bd00-f38c-11ea-907f-5b6479f69f4e.gif)