### PR TITLE
Bundle vendor JS into it's own chunk in webpack

### DIFF
--- a/assets/.babelrc
+++ b/assets/.babelrc
@@ -1,7 +1,8 @@
 {
   "presets": [
     [
-      "@babel/preset-env", {
+      "@babel/preset-env",
+      {
         "targets": {
           "node": "current"
         }
@@ -12,6 +13,7 @@
   "plugins": [
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-object-rest-spread",
-    "@babel/plugin-transform-async-to-generator"
+    "@babel/plugin-transform-async-to-generator",
+    "syntax-dynamic-import"
   ]
 }

--- a/assets/js/screens/Root.jsx
+++ b/assets/js/screens/Root.jsx
@@ -37,6 +37,7 @@ export default class Root extends React.Component {
           <BatchProvider>
             <BrowserRouter>
               <ScrollToTop />
+
               <Switch>
                 <Route exact path="/login" component={Login} />
                 <PrivateRoute

--- a/assets/package.json
+++ b/assets/package.json
@@ -57,6 +57,7 @@
     "@testing-library/react": "^10.4.9",
     "axios": "^0.20.0",
     "babel-loader": "^8.1.0",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "copy-webpack-plugin": "^6.1.0",
     "coveralls": "^3.1.0",
     "css-loader": "^4.2.2",

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -1,8 +1,5 @@
 @charset "utf-8";
 
-// Get access to Bulma variables
-// @import "bulma/sass/utilities/initial-variables";
-
 // Custom variables go before importing Bulma
 @import "~@nulib/admin-react-components/dist/public/styles/variables";
 @import "~@nulib/admin-react-components/dist/public/styles/fonts";

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -11,12 +11,19 @@ module.exports = (env, options) => ({
       new TerserPlugin({ cache: true, parallel: true, sourceMap: false }),
       new OptimizeCSSAssetsPlugin({}),
     ],
+    splitChunks: {
+      chunks: "all",
+    },
   },
   entry: {
     app: "./js/app.jsx",
   },
   output: {
-    filename: "app.js",
+    //filename: "app.js",
+    // `filename` provides a template for naming your bundles (remember to use `[name]`)
+    filename: "[name].bundle.js",
+    // `chunkFilename` provides a template for naming code-split bundles (optional)
+    chunkFilename: "[name].bundle.js",
     path: path.resolve(__dirname, "../priv/static/js"),
   },
   module: {
@@ -37,7 +44,6 @@ module.exports = (env, options) => ({
         test: /\.(sa|sc|c)ss$/,
         use: [
           MiniCssExtractPlugin.loader,
-          // "style-loader",
           { loader: "css-loader", options: {} },
           { loader: "sass-loader", options: {} },
         ],

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -2278,6 +2278,11 @@ babel-plugin-react-svg@^3.0.3:
   resolved "https://registry.yarnpkg.com/babel-plugin-react-svg/-/babel-plugin-react-svg-3.0.3.tgz#7da46a0bd8319f49ac85523d259f145ce5d78321"
   integrity sha512-Pst1RWjUIiV0Ykv1ODSeceCBsFOP2Y4dusjq7/XkjuzJdvS9CjpkPMUIoO4MLlvp5PiLCeMlsOC7faEUA0gm3Q==
 
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
+  integrity sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=
+
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"

--- a/lib/meadow_web/templates/layout/app.html.eex
+++ b/lib/meadow_web/templates/layout/app.html.eex
@@ -9,6 +9,7 @@
   </head>
   <body>
     <%= @inner_content %>
-    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
+    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/vendors~app.bundle.js") %>"></script>
+    <script type="text/javascript" src="<%= Routes.static_path(@conn, "/js/app.bundle.js") %>"></script>
   </body>
 </html>


### PR DESCRIPTION
Partial PR that breaks down the Vendor JS into it's own chunk.

![image](https://user-images.githubusercontent.com/3020266/92968892-8636a080-f441-11ea-8928-4aa6dcddd797.png)


Next steps would be to implement:

- Route based code-splitting using `React.lazy` or `import()`
- Break down the vendor JS into smaller chunks, and dynamically have the `lib/meadow_web/templates/layout/app.html.eex` read all entries.
- Break down the compiled CSS into chunks and make it dynamically read in a dev, live-reloading environment.