### PR TITLE
Refactor Application child specs

### DIFF
--- a/lib/meadow/application.ex
+++ b/lib/meadow/application.ex
@@ -4,11 +4,9 @@ defmodule Meadow.Application do
   @moduledoc false
 
   use Application
+  alias Meadow.Application.Children
   alias Meadow.Config
   alias Meadow.Pipeline
-  alias Meadow.Utils
-
-  require Cachex.Spec
 
   def start(_type, _args) do
     # List all child processes to be supervised
@@ -22,25 +20,12 @@ defmodule Meadow.Application do
       Meadow.Repo,
       MeadowWeb.Endpoint,
       {Absinthe.Subscription, MeadowWeb.Endpoint},
-      {Registry, keys: :unique, name: Meadow.TaskRegistry},
-      cache_spec(:global_cache, Meadow.Cache),
-      cache_spec(
-        :controlled_term_cache,
-        Meadow.Cache.ControlledTerms,
-        expiration: Cachex.Spec.expiration(default: :timer.hours(6)),
-        stats: true
-      ),
-      cache_spec(
-        :user_cache,
-        Meadow.Cache.Users,
-        expiration: Cachex.Spec.expiration(default: :timer.minutes(20)),
-        stats: true
-      )
+      {Registry, keys: :unique, name: Meadow.TaskRegistry}
     ]
 
-    children = base_children ++ environment_specific_children(Config.environment())
+    children = base_children ++ Children.specs()
 
-    unless Meadow.Config.environment?(:test), do: Pipeline.start()
+    unless Config.environment?(:test), do: Pipeline.start()
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
@@ -53,36 +38,5 @@ defmodule Meadow.Application do
   def config_change(changed, _new, removed) do
     MeadowWeb.Endpoint.config_change(changed, removed)
     :ok
-  end
-
-  defp cache_spec(id, name, args \\ []) do
-    %{
-      id: id,
-      start: {Cachex, :start_link, [name, args]},
-      type: :supervisor
-    }
-  end
-
-  def environment_specific_children(:dev) do
-    [
-      {Meadow.Data.IndexWorker, interval: Config.index_interval()},
-      Meadow.IIIF.ManifestListener,
-      {Plug.Cowboy, scheme: :http, plug: Utils.ArkClient.MockServer, options: [port: 3943]},
-      cache_spec(:ark_storage, Utils.ArkClient.MockServer.Cache)
-    ]
-  end
-
-  def environment_specific_children(:test) do
-    [
-      {Plug.Cowboy, scheme: :http, plug: Utils.ArkClient.MockServer, options: [port: 3944]},
-      cache_spec(:ark_storage, Utils.ArkClient.MockServer.Cache)
-    ]
-  end
-
-  def environment_specific_children(:prod) do
-    [
-      {Meadow.Data.IndexWorker, interval: Config.index_interval()},
-      Meadow.IIIF.ManifestListener
-    ]
   end
 end

--- a/lib/meadow/application/caches.ex
+++ b/lib/meadow/application/caches.ex
@@ -1,0 +1,38 @@
+defmodule Meadow.Application.Caches do
+  @moduledoc """
+  Cache specs for Meadow.Application
+  """
+  require Cachex.Spec
+
+  def specs do
+    [
+      cache_spec(:global_cache, Meadow.Cache),
+      cache_spec(
+        :controlled_term_cache,
+        Meadow.Cache.ControlledTerms,
+        expiration: Cachex.Spec.expiration(default: :timer.hours(6)),
+        stats: true
+      ),
+      cache_spec(
+        :user_cache,
+        Meadow.Cache.Users,
+        expiration: Cachex.Spec.expiration(default: :timer.minutes(20)),
+        stats: true
+      )
+    ]
+  end
+
+  def specs(:prod), do: specs()
+
+  def specs(_) do
+    [cache_spec(:ark_storage, Meadow.Utils.ArkClient.MockServer.Cache) | specs()]
+  end
+
+  defp cache_spec(id, name, args \\ []) do
+    %{
+      id: id,
+      start: {Cachex, :start_link, [name, args]},
+      type: :supervisor
+    }
+  end
+end

--- a/lib/meadow/application/children.ex
+++ b/lib/meadow/application/children.ex
@@ -1,0 +1,54 @@
+defmodule Meadow.Application.Children do
+  @moduledoc """
+  Child specs for Meadow.Application
+  """
+  alias Meadow.Application.Caches
+  alias Meadow.Config
+  alias Meadow.Utils.ArkClient
+  require Logger
+
+  def specs do
+    (Caches.specs(Config.environment()) ++
+       specs(Config.environment()))
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp specs(:dev) do
+    [
+      {Meadow.Data.IndexWorker, interval: Config.index_interval()},
+      Meadow.IIIF.ManifestListener,
+      mock_ark_server(3943)
+    ]
+  end
+
+  defp specs(:test) do
+    [mock_ark_server(3944)]
+  end
+
+  defp specs(:prod) do
+    [
+      {Meadow.Data.IndexWorker, interval: Config.index_interval()},
+      Meadow.IIIF.ManifestListener
+    ]
+  end
+
+  defp mock_ark_server(port) do
+    plug = ArkClient.MockServer
+
+    case :gen_tcp.connect('localhost', port, [], 50) do
+      {:ok, _} ->
+        "Skipping launch of #{inspect(plug)}. Port #{port} already in use."
+        |> Logger.info()
+
+        nil
+
+      {:error, _} ->
+        cowboy_version = Application.spec(:cowboy)[:vsn]
+
+        "Running #{inspect(plug)} with cowboy #{cowboy_version} at 0.0.0.0:#{port} (http)"
+        |> Logger.info()
+
+        {Plug.Cowboy, scheme: :http, plug: plug, options: [port: port]}
+    end
+  end
+end


### PR DESCRIPTION
* Create separate modules (`Children` and `Caches`) for maintainability
* Don't start mock ARK server if the port is already in use