### PR TITLE
Use Cachex for coded term lookup

### DIFF
--- a/lib/meadow/application/caches.ex
+++ b/lib/meadow/application/caches.ex
@@ -8,6 +8,12 @@ defmodule Meadow.Application.Caches do
     [
       cache_spec(:global_cache, Meadow.Cache),
       cache_spec(
+        :coded_term_cache,
+        Meadow.Cache.CodedTerms,
+        expiration: Cachex.Spec.expiration(default: :timer.hours(6)),
+        stats: true
+      ),
+      cache_spec(
         :controlled_term_cache,
         Meadow.Cache.ControlledTerms,
         expiration: Cachex.Spec.expiration(default: :timer.hours(6)),

--- a/lib/meadow/data/schemas/types/coded_term.ex
+++ b/lib/meadow/data/schemas/types/coded_term.ex
@@ -34,7 +34,7 @@ defmodule Meadow.Data.Types.CodedTerm do
       nil ->
         {:error, message: "#{id} is invalid coded term for scheme #{String.upcase(scheme)}"}
 
-      %Schemas.CodedTerm{id: id, scheme: scheme, label: label} ->
+      {{:ok, _}, %{id: id, scheme: scheme, label: label}} ->
         {:ok, %{id: id, scheme: scheme, label: label}}
 
       other ->

--- a/lib/meadow_web/resolvers/controlled_vocabulary.ex
+++ b/lib/meadow_web/resolvers/controlled_vocabulary.ex
@@ -8,6 +8,12 @@ defmodule MeadowWeb.Resolvers.Data.ControlledVocabulary do
   end
 
   def fetch_coded_term_label(_, %{id: id, scheme: scheme}, _) do
-    {:ok, CodedTerms.get_coded_term(id, scheme)}
+    case CodedTerms.get_coded_term(id, scheme) do
+      nil ->
+        {:error, message: "#{id} is invalid coded term for scheme #{String.upcase(scheme)}"}
+
+      {{:ok, _}, term} ->
+        {:ok, term}
+    end
   end
 end

--- a/test/meadow/data/coded_terms_test.exs
+++ b/test/meadow/data/coded_terms_test.exs
@@ -39,7 +39,7 @@ defmodule Meadow.Data.CodedTermsTest do
     end
 
     test "fetches a term by scheme and id" do
-      with result <- CodedTerms.get_coded_term("cmp", "marc_relator") do
+      with {{:ok, _}, result} <- CodedTerms.get_coded_term("cmp", "marc_relator") do
         assert result.id == "cmp"
         assert result.label == "Composer"
       end
@@ -51,6 +51,21 @@ defmodule Meadow.Data.CodedTermsTest do
 
     test "returns nil for an unknown scheme" do
       assert CodedTerms.get_coded_term("cmp", "nope_still_not_here") |> is_nil()
+    end
+  end
+
+  describe "get_coded_term/2" do
+    test "cache miss" do
+      assert {{:ok, :db}, term} = CodedTerms.get_coded_term("cpl", "marc_relator")
+    end
+
+    test "cache hit" do
+      assert {{:ok, :db}, term} = CodedTerms.get_coded_term("ive", "marc_relator")
+      assert {{:ok, :memory}, term} = CodedTerms.get_coded_term("ive", "marc_relator")
+    end
+
+    test "db miss (invalid coded term)" do
+      assert nil == CodedTerms.get_coded_term("ivdde", "marc_relator")
     end
   end
 end

--- a/test/meadow_web/schema/query/controlled_types/fetch_coded_term_label_test.exs
+++ b/test/meadow_web/schema/query/controlled_types/fetch_coded_term_label_test.exs
@@ -27,8 +27,11 @@ defmodule MeadowWeb.Schema.Query.FetchCodedTermLabelTest do
 
     @tag id: "http://wrongsstatements.org/vocab/InC/1.0/"
     test "retrieves nil for a bad query", %{gql_result: result} do
-      assert {:ok, %{data: query_data}} = result
+      assert {:ok, %{data: query_data, errors: errors}} = result
       assert get_in(query_data, ["fetchCodedTermLabel"]) |> is_nil()
+
+      assert get_in(List.first(errors), [:message]) ==
+               "http://wrongsstatements.org/vocab/InC/1.0/ is invalid coded term for scheme RIGHTS_STATEMENT"
     end
   end
 end


### PR DESCRIPTION
- This  PR uses `Cachex` to cache a coded term after first lookup to minimize db queries and optimize perfomance. 
- I broke out a separate issue to cache the coded term lists themselves since it's not as urgent (https://github.com/nulib/repodev_planning_and_docs/issues/1096)