### PR TITLE
Implement code to check for manual Controlled Term id values, and fil…

### DIFF
--- a/assets/js/components/UI/Form/ControlledTermArray.jsx
+++ b/assets/js/components/UI/Form/ControlledTermArray.jsx
@@ -39,7 +39,7 @@ const UIFormControlledTermArray = ({
                 >{`${label} #${index + 1}`}</legend>
 
                 {/* Existing values are NOT editable, so we save form data needed in the POST update, in hidden fields here */}
-                {!item.new && (
+                {(item.term || item.termId) && (
                   <>
                     <p>
                       {item.term.label} {item.role && `(${item.role.label})`}
@@ -63,7 +63,7 @@ const UIFormControlledTermArray = ({
                 )}
 
                 {/* New form entries */}
-                {item.new && (
+                {!item.termId && !item.term && (
                   <>
                     {hasRole(name) && (
                       <div className="field">
@@ -117,7 +117,7 @@ const UIFormControlledTermArray = ({
         type="button"
         className="button is-text is-small"
         onClick={() => {
-          append({ new: true, termId: "", label: "", roleId: "" });
+          append({ termId: "", label: "", roleId: "" });
         }}
         data-testid="button-add-field-array-row"
       >

--- a/assets/js/components/UI/Form/ControlledTermArrayItem.jsx
+++ b/assets/js/components/UI/Form/ControlledTermArrayItem.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { useLazyQuery } from "@apollo/client";
 import { AUTHORITY_SEARCH } from "../../Work/controlledVocabulary.gql";
-import UIError from "../Error";
 import UIFormSelect from "./Select";
 import { useCombobox } from "downshift";
 

--- a/assets/js/components/Work/Tabs/About.jsx
+++ b/assets/js/components/Work/Tabs/About.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { toastWrapper } from "../../../services/helpers";
 import { useForm } from "react-hook-form";
@@ -87,7 +87,7 @@ const WorkTabsAbout = ({ work }) => {
       toastWrapper("is-success", "Work form updated successfully");
     },
     onError(error) {
-      console.log("error :>> ", error);
+      console.log("error in the updateWork GraphQL mutation :>> ", error);
     },
     refetchQueries: [{ query: GET_WORK, variables: { id: work.id } }],
     awaitRefetchQueries: true,
@@ -160,6 +160,7 @@ const WorkTabsAbout = ({ work }) => {
     });
   };
 
+  // TODO: Eventually figure out why this doesn't get set on certain GraphQL errors?
   if (updateWorkError) return <UIError error={updateWorkError} />;
 
   return (

--- a/assets/js/services/metadata.js
+++ b/assets/js/services/metadata.js
@@ -152,16 +152,26 @@ export function prepControlledTermInput(
   formItems = [],
   includeLabel = false
 ) {
-  let arr = formItems.map(({ termId, roleId, label }) => {
-    let obj = { term: termId };
-    if (roleId) {
-      obj.role = { id: roleId, scheme: findScheme(controlledTerm) };
-    }
-    if (includeLabel) {
-      obj.label = label;
-    }
-    return obj;
-  });
+  // First, filter out any controlled term fieldsets which come through without
+  // a valid controlled term id selected
+  let arr = formItems
+    .filter((item) => {
+      if (!item.termId) {
+        return false;
+      }
+      return true;
+    })
+    // Next prepare the object in the right shape
+    .map(({ termId, roleId, label }) => {
+      let obj = { term: termId };
+      if (roleId) {
+        obj.role = { id: roleId, scheme: findScheme(controlledTerm) };
+      }
+      if (includeLabel) {
+        obj.label = label;
+      }
+      return obj;
+    });
 
   return arr;
 }

--- a/assets/js/services/metadata.test.js
+++ b/assets/js/services/metadata.test.js
@@ -35,6 +35,34 @@ describe("prepControlledTermInput()", () => {
     expect(response[1].role.id).toEqual("arc");
     expect(response[1].role.scheme).toEqual("MARC_RELATOR");
   });
+
+  it("filters out any fieldset items which contain an undefined term id", () => {
+    const response = metadata.prepControlledTermInput(
+      {
+        hasRole: true,
+        label: "Creator",
+        name: "creator",
+        scheme: "MARC_RELATOR",
+      },
+      [
+        {
+          authority: "loc",
+          termId: "http://vocab.getty.edu/ulan/500276588",
+          label: "Getty Lee",
+        },
+        {
+          authority: "getty",
+          termId: "",
+          label: "Foot, D. D.",
+        },
+      ]
+    );
+
+    expect(response).toHaveLength(1);
+    expect(response).toEqual([
+      { term: "http://vocab.getty.edu/ulan/500276588" },
+    ]);
+  });
 });
 
 describe("prepFieldArrayItemsForPost()", () => {


### PR DESCRIPTION
…ter them out of the form post object.  They crash the app, and built-in Apollo Client error callbacks cannot handle the app crash.

This code checks that an undefined `term id` for a Controlled Term, doesn't sneak into the POST object being sent with the `updateWork` mutation.  If a user manually enters a value in the search bar, without clicking on an item in the dropdown list to officially select the item, then the item in the field array is ignored when prepping the object for it's upcoming POST to the `updateWork` mutation.

![image](https://user-images.githubusercontent.com/3020266/93392646-c8dbec80-f836-11ea-85ba-a8b49d429f30.png)


