### PR TITLE
Add a configurable delay to the start of the ingest pipeline

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -84,6 +84,7 @@ config :meadow,
   },
   ingest_bucket: "dev-ingest",
   upload_bucket: "dev-uploads",
+  pipeline_delay: :timer.seconds(5),
   preservation_bucket: "dev-preservation",
   pyramid_bucket: "dev-pyramids",
   iiif_server_url:

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -69,7 +69,8 @@ config :meadow,
     password: get_required_var.("EZID_PASSWORD"),
     target_url: get_required_var.("EZID_TARGET_BASE_URL")
   },
-  environment: :prod
+  environment: :prod,
+  pipeline_delay: System.get_env("PIPElINE_DELAY", :timer.minutes(2))
 
 config :meadow, ingest_bucket: get_required_var.("INGEST_BUCKET")
 config :meadow, preservation_bucket: get_required_var.("PRESERVATION_BUCKET")

--- a/lib/meadow/application.ex
+++ b/lib/meadow/application.ex
@@ -25,7 +25,12 @@ defmodule Meadow.Application do
 
     children = base_children ++ Children.specs()
 
-    unless Config.environment?(:test), do: Pipeline.start()
+    unless Config.environment?(:test) do
+      Task.async(fn ->
+        :timer.sleep(Config.pipeline_delay())
+        Pipeline.start()
+      end)
+    end
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options

--- a/lib/meadow/config.ex
+++ b/lib/meadow/config.ex
@@ -130,6 +130,14 @@ defmodule Meadow.Config do
     Application.get_env(:meadow, :shared_link_ttl, :timer.hours(24 * 7 * 2))
   end
 
+  @doc "Time to wait (in ms) before starting the ingest pipeline"
+  def pipeline_delay do
+    case Application.get_env(:meadow, :pipeline_delay, 0) do
+      n when is_binary(n) -> String.to_integer(n)
+      n -> n
+    end
+  end
+
   defp ensure_trailing_slash(value) do
     if value |> String.ends_with?("/"),
       do: value,


### PR DESCRIPTION
This PR adds a configuration setting and a production environment variable to specify a length of time (in milliseconds) to wait before starting the ingest pipeline. My hope is that this will give the app more time to register with the load balancer and stabilize before trying to churn through any messages waiting in the queue.

The dev default is 5 seconds. The production default is 2 minutes.