### PR TITLE
Handle {:ssl_closed, _msg} message in IIIF.ManifestListener

### DIFF
--- a/lib/meadow/iiif/manifest_listener.ex
+++ b/lib/meadow/iiif/manifest_listener.ex
@@ -45,4 +45,6 @@ defmodule Meadow.IIIF.ManifestListener do
         {:stop, error, []}
     end
   end
+
+  def handle_info({:ssl_closed, _msg}, state), do: {:noreply, state}
 end


### PR DESCRIPTION
This [known issue](https://elixirforum.com/t/genstage-unexpected-ssl-closed-message/9688/15) brings the ManifestListener down. The accepted workaround is to handle the message and throw it away.