### PR TITLE
Fix ingest sheet progress bug with updated_at query

### DIFF
--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -6668,13 +6668,8 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-phoenix@^1.4.0:
+phoenix@^1.4.0, "phoenix@file:../deps/phoenix":
   version "1.5.5"
-  resolved "https://registry.yarnpkg.com/phoenix/-/phoenix-1.5.5.tgz#0db2b7fb8c798c594cab91e16995afedd3d2e228"
-  integrity sha512-4QenJ+pEFZvAqA73uFXhkRAWZhGYaV+IN1pAJ3SHamsFkPAYkTnyvFZmU6HxzxnZxDts5gNox/XzzUE6lY9eLg==
-
-"phoenix@file:../deps/phoenix":
-  version "1.5.4"
 
 "phoenix_html@file:../deps/phoenix_html":
   version "2.14.2"

--- a/lib/meadow/ingest/progress.ex
+++ b/lib/meadow/ingest/progress.ex
@@ -61,8 +61,7 @@ defmodule Meadow.Ingest.Progress do
   end
 
   def works_processing_longer_than(seconds) do
-    now = DateTime.utc_now()
-    timeout = DateTime.add(now, -seconds, :second)
+    timeout = DateTime.utc_now() |> DateTime.add(-seconds, :second)
 
     from(p in Progress,
       where:
@@ -231,6 +230,9 @@ defmodule Meadow.Ingest.Progress do
 
   def send_notifications do
     Sheets.list_ingest_sheets_by_status(:approved)
+    |> Enum.each(&send_notification(&1.id))
+
+    Sheets.list_recently_updated(60)
     |> Enum.each(&send_notification(&1.id))
   end
 

--- a/lib/meadow/ingest/schemas/sheet.ex
+++ b/lib/meadow/ingest/schemas/sheet.ex
@@ -43,7 +43,7 @@ defmodule Meadow.Ingest.Schemas.Sheet do
         else: attrs
 
     ingest_sheet
-    |> cast(attrs, [:title, :filename, :project_id, :file_errors, :status])
+    |> cast(attrs, [:title, :filename, :project_id, :file_errors, :status, :updated_at])
     |> cast_embed(:state, with: &state_changeset/2)
     |> cast_assoc(:works)
     |> validate_required([:title, :filename, :project_id])

--- a/lib/meadow/ingest/sheets.ex
+++ b/lib/meadow/ingest/sheets.ex
@@ -424,4 +424,13 @@ defmodule Meadow.Ingest.Sheets do
       |> Repo.all()
     end
   end
+
+  def list_recently_updated(seconds) do
+    since = DateTime.utc_now() |> DateTime.add(-seconds, :second)
+
+    from(s in Sheet,
+      where: s.updated_at >= ^since
+    )
+    |> Repo.all()
+  end
 end

--- a/priv/repo/migrations/20200925213350_create_ingest_sheet_update_trigger.exs
+++ b/priv/repo/migrations/20200925213350_create_ingest_sheet_update_trigger.exs
@@ -19,7 +19,9 @@ defmodule Meadow.Repo.Migrations.CreateIngestSheetUpdateTrigger do
       AND ingest_progress.status NOT IN ('ok', 'error');
 
       IF pending = 0 THEN
-        UPDATE ingest_sheets SET status = 'completed' WHERE ingest_sheets.id = current_sheet_id;
+        UPDATE ingest_sheets
+        SET status = 'completed', updated_at = NOW() AT TIME ZONE 'utc'
+        WHERE ingest_sheets.id = current_sheet_id;
       END IF;
       RETURN NEW;
     END;

--- a/test/meadow/ingest/sheets_test.exs
+++ b/test/meadow/ingest/sheets_test.exs
@@ -107,5 +107,24 @@ defmodule Meadow.Ingest.SheetsTest do
       ingest_sheet = ingest_sheet_fixture(Map.put(@valid_attrs, :project_id, project.id))
       assert %Ecto.Changeset{} = Sheets.change_ingest_sheet(ingest_sheet)
     end
+
+    test "list_ingest_sheets_by_status/1" do
+      project = project_fixture()
+      ingest_sheet = ingest_sheet_fixture(Map.put(@valid_attrs, :project_id, project.id))
+      assert Sheets.list_ingest_sheets_by_status(ingest_sheet.status) == [ingest_sheet]
+      assert Sheets.list_ingest_sheets_by_status(:completed) == []
+    end
+
+    test "list_recently_updated/1" do
+      project = project_fixture()
+      ingest_sheet = ingest_sheet_fixture(Map.put(@valid_attrs, :project_id, project.id))
+      assert Sheets.list_recently_updated(60) == [ingest_sheet]
+
+      Sheets.update_ingest_sheet(ingest_sheet, %{
+        updated_at: DateTime.add(DateTime.utc_now(), -120, :second)
+      })
+
+      assert Sheets.list_recently_updated(60) == []
+    end
   end
 end


### PR DESCRIPTION
This PR fixes a bug with the ingest sheet progress bar stalling out at the end.

- Adds `Sheets.list_recently_updated/1`
- Update `Progress.send_notifications/0` to send notifications for ingest sheets that have been updated in the last minute
- Update `create_ingest_sheet_update_trigger` migration to set `updated_at` automatically
- Tests