### PR TITLE
Index model name as “name” instead of “title”

### DIFF
--- a/lib/meadow/data/schemas/collection.ex
+++ b/lib/meadow/data/schemas/collection.ex
@@ -62,7 +62,7 @@ defmodule Meadow.Data.Schemas.Collection do
         findingAidUrl: collection.finding_aid_url,
         id: collection.id,
         keywords: collection.keywords,
-        model: %{application: "Meadow", title: "Collection"},
+        model: %{application: "Meadow", name: "Collection"},
         modifiedDate: collection.updated_at,
         published: collection.published,
         representativeImage:

--- a/test/meadow/data/indexer_test.exs
+++ b/test/meadow/data/indexer_test.exs
@@ -196,6 +196,7 @@ defmodule Meadow.Data.IndexerTest do
       [header, doc] = subject |> Indexer.encode!(:index) |> decode_njson()
       assert header |> get_in(["index", "_id"]) == subject.id
       assert doc |> get_in(["model", "application"]) == "Meadow"
+      assert doc |> get_in(["model", "name"]) == "Collection"
       assert doc |> get_in(["title"]) == subject.title
     end
 
@@ -203,6 +204,7 @@ defmodule Meadow.Data.IndexerTest do
       [header, doc] = subject |> Indexer.encode!(:index) |> decode_njson()
       assert header |> get_in(["index", "_id"]) == subject.id
       assert doc |> get_in(["model", "application"]) == "Meadow"
+      assert doc |> get_in(["model", "name"]) == "Image"
       assert doc |> get_in(["fileSets"]) |> length == 2
 
       with metadata <- subject.descriptive_metadata do
@@ -219,6 +221,7 @@ defmodule Meadow.Data.IndexerTest do
       [header, doc] = subject |> Indexer.encode!(:index) |> decode_njson()
       assert header |> get_in(["index", "_id"]) == subject.id
       assert doc |> get_in(["model", "application"]) == "Meadow"
+      assert doc |> get_in(["model", "name"]) == "FileSet"
       assert doc |> get_in(["description"]) == subject.metadata.description
       assert doc |> get_in(["label"]) == subject.metadata.label
     end


### PR DESCRIPTION
Fixes a longstanding bug in collection indexing and adds tests for all other indexable types