### PR TITLE
Fix bug in Work CoreMetadata items not updating

### DIFF
--- a/assets/js/components/BatchEdit/About/About.jsx
+++ b/assets/js/components/BatchEdit/About/About.jsx
@@ -54,7 +54,6 @@ const BatchEditAbout = () => {
     // updated.
 
     let currentFormValues = methods.getValues();
-    console.log("currentFormValues :>> ", currentFormValues);
     let addItems = {};
     let deleteReadyItems = {};
 

--- a/assets/js/components/Collection/Form.jsx
+++ b/assets/js/components/Collection/Form.jsx
@@ -67,9 +67,6 @@ const CollectionForm = ({ collection }) => {
   };
 
   const onSubmit = (data) => {
-    console.log("data", data);
-    console.log("collection", collection);
-
     if (!collection) {
       createCollection({
         variables: { ...data },

--- a/assets/js/components/Work/Tabs/About.jsx
+++ b/assets/js/components/Work/Tabs/About.jsx
@@ -97,7 +97,6 @@ const WorkTabsAbout = ({ work }) => {
     // with React Hook Form's register().   So, we'll use getValues() to get the real data
     // updated.
     let currentFormValues = methods.getValues();
-
     const { description = "", title = "" } = currentFormValues;
 
     let workUpdateInput = {

--- a/assets/js/components/Work/Tabs/About/CoreMetadata.jsx
+++ b/assets/js/components/Work/Tabs/About/CoreMetadata.jsx
@@ -31,6 +31,7 @@ const WorkTabsAboutCoreMetadata = ({
         <UIFormField label="Title" required={published}>
           {isEditing ? (
             <UIInput
+              isReactHookForm
               name="title"
               label="Title"
               data-testid="title"
@@ -42,6 +43,7 @@ const WorkTabsAboutCoreMetadata = ({
           )}
         </UIFormField>
       </div>
+
       <div className="column is-full">
         {/* Alternate Title */}
         {isEditing ? (
@@ -65,7 +67,6 @@ const WorkTabsAboutCoreMetadata = ({
             <UIInput
               name="dateCreated"
               label="Date Created"
-              type="date"
               data-testid="date-created"
               defaultValue={descriptiveMetadata.dateCreated}
             />
@@ -82,6 +83,7 @@ const WorkTabsAboutCoreMetadata = ({
         <UIFormField label="Rights Statement">
           {isEditing ? (
             <UIFormSelect
+              isReactHookForm
               name="rightsStatement"
               label="Rights Statement"
               showHelper={true}
@@ -105,6 +107,7 @@ const WorkTabsAboutCoreMetadata = ({
         <UIFormField label="Description">
           {isEditing ? (
             <UIFormTextarea
+              isReactHookForm
               name="description"
               label="Description"
               data-testid="description"

--- a/assets/js/components/Work/Work.jsx
+++ b/assets/js/components/Work/Work.jsx
@@ -12,7 +12,6 @@ const osdOptions = {
 };
 
 const Work = ({ work }) => {
-  console.log("work.id :>> ", work.id);
   return (
     <>
       <section>


### PR DESCRIPTION
Left off a `isReactHookForm` prop on the form components, so the form item wasn't registering with ReactHookForm.