### PR TITLE
Allow MeadowWeb.Resolvers.Ingest.ingest_sheet_works/3 to set a limit

### DIFF
--- a/lib/meadow/ingest/sheets.ex
+++ b/lib/meadow/ingest/sheets.ex
@@ -302,20 +302,19 @@ defmodule Meadow.Ingest.Sheets do
     list_ingest_sheet_row_counts(sheet.id)
   end
 
-  def list_ingest_sheet_works(%Sheet{} = ingest_sheet) do
-    ingest_sheet
-    |> Repo.preload(:works)
-    |> Map.get(:works)
-    |> Works.add_representative_image()
+  def list_ingest_sheet_works(ingest_sheet, limit \\ nil)
+
+  def list_ingest_sheet_works(%Sheet{} = ingest_sheet, limit) do
+    ingest_sheet.id
+    |> list_ingest_sheet_works(limit)
   end
 
-  def list_ingest_sheet_works(sheet_id) do
-    from(s in Meadow.Ingest.Schemas.Sheet,
-      where: s.id == ^sheet_id,
-      preload: :works
+  def list_ingest_sheet_works(sheet_id, limit) do
+    from(w in Work,
+      where: w.ingest_sheet_id == ^sheet_id,
+      limit: ^limit
     )
-    |> Repo.one()
-    |> Map.get(:works)
+    |> Repo.all()
     |> Works.add_representative_image()
   end
 

--- a/lib/meadow_web/resolvers/ingest.ex
+++ b/lib/meadow_web/resolvers/ingest.ex
@@ -176,6 +176,10 @@ defmodule MeadowWeb.Resolvers.Ingest do
      |> Enum.map(&update_action_doc/1)}
   end
 
+  def ingest_sheet_works(_, %{id: sheet_id, limit: limit}, _) do
+    {:ok, sheet_id |> Sheets.list_ingest_sheet_works(limit)}
+  end
+
   def ingest_sheet_works(_, %{id: sheet_id}, _) do
     {:ok, sheet_id |> Sheets.list_ingest_sheet_works()}
   end

--- a/lib/meadow_web/schema/types/ingest_types.ex
+++ b/lib/meadow_web/schema/types/ingest_types.ex
@@ -65,6 +65,7 @@ defmodule MeadowWeb.Schema.IngestTypes do
     @desc "Get works created for an Ingest Sheet"
     field :ingest_sheet_works, list_of(:work) do
       arg(:id, non_null(:id))
+      arg(:limit, :integer)
       middleware(Middleware.Authenticate)
       resolve(&Resolvers.Ingest.ingest_sheet_works/3)
     end

--- a/test/meadow/ingest/sheets_test.exs
+++ b/test/meadow/ingest/sheets_test.exs
@@ -126,5 +126,17 @@ defmodule Meadow.Ingest.SheetsTest do
 
       assert Sheets.list_recently_updated(60) == []
     end
+
+    test "list_ingest_sheet_works/2" do
+      project = project_fixture()
+      ingest_sheet = ingest_sheet_fixture(Map.put(@valid_attrs, :project_id, project.id))
+
+      1..30
+      |> Enum.each(fn _ -> work_fixture(%{ingest_sheet_id: ingest_sheet.id}) end)
+
+      assert Sheets.list_ingest_sheet_works(ingest_sheet) |> length() == 30
+      assert Sheets.list_ingest_sheet_works(ingest_sheet, 2) |> length() == 2
+      assert Sheets.list_ingest_sheet_works(ingest_sheet, 50) |> length() == 30
+    end
   end
 end


### PR DESCRIPTION
- The ingestSheetWorks query now supports a limit argument (defaults to `nil`).

Example query:
```gql
query {ingestSheetWorks(id:"dec73280-7be1-42a5-b812-42e84e048396", limit:2) {
  id
}}
```

- Backend support for limits added to `Meadow.Ingest.Sheets.list_ingest_sheet_works/2`, with new tests for the function.