### PR TITLE
Implement batch add and delete functionality for controlled and uncontrolled fields

### DIFF
--- a/lib/meadow/data/schemas/types/controlled_term.ex
+++ b/lib/meadow/data/schemas/types/controlled_term.ex
@@ -16,6 +16,8 @@ defmodule Meadow.Data.Types.ControlledTerm do
   def cast(_), do: {:error, message: "Invalid controlled term type"}
 
   def load(uri) when is_binary(uri), do: validate_uri(uri)
+  def load(%{id: id}), do: validate_uri(id)
+  def load(%{"id" => id}), do: validate_uri(id)
   def load(_), do: :error
 
   def dump(uri) when is_binary(uri), do: {:ok, uri}

--- a/lib/meadow/data/works.ex
+++ b/lib/meadow/data/works.ex
@@ -9,6 +9,8 @@ defmodule Meadow.Data.Works do
   alias Meadow.Repo
   alias Meadow.Utils.Pairtree
 
+  use Meadow.Data.Works.BatchFunctions
+
   @doc """
   Returns the list of Works.
 

--- a/lib/meadow/data/works/batch_functions.ex
+++ b/lib/meadow/data/works/batch_functions.ex
@@ -1,0 +1,68 @@
+defmodule Meadow.Data.Works.BatchFunctions do
+  @moduledoc """
+  Build batch replace functions for different metadata fields. This is necessary
+  because Ecto.Query.fragment() doesn't allow interpolation for its first argument
+  to prevent SQL injection attacks
+  """
+
+  @schemas ~w(descriptive_metadata administrative_metadata)a
+
+  defmacro __using__(_) do
+    batch_functions =
+      Enum.map(@schemas, fn schema ->
+        quote do
+          @doc """
+          Batch update controlled #{unquote(schema)} values
+          """
+          def replace_controlled_value(query, unquote(schema), field_name, remove, add) do
+            to_remove = simplify_terms(remove)
+            to_add = simplify_terms(add)
+
+            from query,
+              update: [
+                set: [
+                  {unquote(schema),
+                   fragment(
+                     unquote("replace_controlled_value(#{schema}, ?::text, ?::jsonb, ?::jsonb)"),
+                     ^field_name,
+                     ^to_remove,
+                     ^to_add
+                   )},
+                  {:updated_at, ^DateTime.utc_now()}
+                ]
+              ]
+          end
+
+          @doc """
+          Batch update uncontrolled #{unquote(schema)} values
+          """
+          def replace_uncontrolled_value(query, unquote(schema), field_name, new_value) do
+            from query,
+              update: [
+                set: [
+                  {unquote(schema),
+                   fragment(
+                     unquote("replace_uncontrolled_value(#{schema}, ?::text, ?::jsonb)"),
+                     ^field_name,
+                     ^new_value
+                   )},
+                  {:updated_at, ^DateTime.utc_now()}
+                ]
+              ]
+          end
+        end
+      end)
+
+    simplify_functions =
+      quote do
+        defp simplify_terms(nil), do: []
+        defp simplify_terms([]), do: []
+        defp simplify_terms([term | terms]), do: [simplify_term(term) | simplify_terms(terms)]
+
+        defp simplify_term(%{role: role, term: %{id: id}}), do: %{role: role, term: id}
+        defp simplify_term(term), do: term
+      end
+
+    [simplify_functions | batch_functions]
+  end
+end

--- a/lib/meadow_web/schema/types/data/batch_types.ex
+++ b/lib/meadow_web/schema/types/data/batch_types.ex
@@ -12,7 +12,7 @@ defmodule MeadowWeb.Schema.Data.BatchTypes do
     field :batch_update, :message do
       arg(:query, non_null(:string))
       arg(:delete, :batch_delete_input, default_value: %{})
-      arg(:add, :batch_add_input, default_value: %{})
+      arg(:add, :batch_add_input, default_value: nil)
       middleware(Middleware.Authenticate)
       resolve(&Batches.update/3)
     end
@@ -24,16 +24,11 @@ defmodule MeadowWeb.Schema.Data.BatchTypes do
 
   @desc "Input fields for batch add operations"
   input_object :batch_add_input do
-    field :descriptive_metadata, :batch_add_descriptive_metadata_input
+    field :descriptive_metadata, :work_descriptive_metadata_input
   end
 
   @desc "Input fields for batch delete operations"
   input_object :batch_delete_input do
-    import_fields(:controlled_fields_input)
-  end
-
-  @desc "Descriptive metadata input fields for batch add operations"
-  input_object :batch_add_descriptive_metadata_input do
     import_fields(:controlled_fields_input)
   end
 end

--- a/priv/repo/migrations/20200930043521_create_batch_update_functions.exs
+++ b/priv/repo/migrations/20200930043521_create_batch_update_functions.exs
@@ -1,0 +1,49 @@
+defmodule Meadow.Repo.Migrations.CreateBatchUpdateFunctions do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    CREATE OR REPLACE FUNCTION replace_controlled_value(metadata jsonb, field_name text, remove jsonb, add jsonb)
+      RETURNS jsonb
+      LANGUAGE 'plpgsql'
+    AS $function$
+    DECLARE
+      existing jsonb := metadata->field_name;
+      result jsonb := '[]'::jsonb;
+      val jsonb;
+    BEGIN
+      FOR val IN SELECT * FROM jsonb_array_elements(existing) LOOP
+        IF val NOT IN (SELECT * FROM jsonb_array_elements(remove)) THEN
+          result = result || val;
+        END IF;
+      END LOOP;
+
+      FOR val IN SELECT * FROM jsonb_array_elements(add) LOOP
+        IF val NOT IN (SELECT * FROM jsonb_array_elements(existing)) THEN
+          result = result || val;
+        END IF;
+      END LOOP;
+
+      result = jsonb_set(metadata, ('{'||field_name||'}')::text[], result);
+        RETURN result;
+      END;
+    $function$;
+    """
+
+    execute """
+    CREATE OR REPLACE FUNCTION replace_uncontrolled_value(metadata jsonb, field_name text, new_value jsonb)
+      RETURNS jsonb
+      LANGUAGE 'plpgsql'
+    AS $function$
+    BEGIN
+      RETURN jsonb_set(metadata, ('{'||field_name||'}')::text[], new_value);
+    END;
+    $function$
+    """
+  end
+
+  def down do
+    execute "DROP FUNCTION IF EXISTS replace_controlled_value;"
+    execute "DROP FUNCTION IF EXISTS replace_uncontrolled_value;"
+  end
+end


### PR DESCRIPTION
- Create Meadow.Data.Works.BatchFunctions for updating controlled and uncontrolled fields using PL/SQL functions added in a migration.
- Update Meadow.Batches to use the new batch functions.
- Update GraphQL batch API to include the uncontrolled fields.
- Test all the things.
