### PR TITLE
Allow batch updating of collection_id

### DIFF
--- a/lib/meadow/data/works.ex
+++ b/lib/meadow/data/works.ex
@@ -39,6 +39,12 @@ defmodule Meadow.Data.Works do
     query = from(Work)
 
     Enum.reduce(criteria, query, fn
+      {:collection, collection}, query ->
+        from w in query, where: w.collection_id == ^collection.id
+
+      {:collection_id, collection_id}, query ->
+        from w in query, where: w.collection_id == ^collection_id
+
       {:limit, limit}, query ->
         from w in query, limit: ^limit
 

--- a/lib/meadow_web/schema/types/data/batch_types.ex
+++ b/lib/meadow_web/schema/types/data/batch_types.ex
@@ -24,6 +24,7 @@ defmodule MeadowWeb.Schema.Data.BatchTypes do
 
   @desc "Input fields for batch add operations"
   input_object :batch_add_input do
+    field :collection_id, :id
     field :descriptive_metadata, :work_descriptive_metadata_input
   end
 

--- a/test/meadow/batches_test.exs
+++ b/test/meadow/batches_test.exs
@@ -9,8 +9,11 @@ defmodule Meadow.BatchesTest do
     setup do
       MetadataGenerator.prewarm_cache()
 
+      collection = collection_fixture(%{title: "Original Collection"})
+
       works = [
         work_fixture(%{
+          collection: collection,
           descriptive_metadata: %{
             title: "Work 1",
             box_name: ["Michael Jordan"],
@@ -28,6 +31,7 @@ defmodule Meadow.BatchesTest do
           }
         }),
         work_fixture(%{
+          collection: collection,
           descriptive_metadata: %{
             title: "Work 2",
             box_name: ["Michael Jordan"],
@@ -48,6 +52,7 @@ defmodule Meadow.BatchesTest do
           }
         }),
         work_fixture(%{
+          collection: collection,
           descriptive_metadata: %{
             title: "Work 3",
             box_name: ["Michael Jordan"],
@@ -129,6 +134,18 @@ defmodule Meadow.BatchesTest do
 
       assert List.first(Works.get_works_by_title("Work 2")).descriptive_metadata.style_period
              |> length() == 1
+    end
+
+    test "batch_update/2 updates collection" do
+      query = ~s'{"query":{"term":{"workType.id": "IMAGE"}}}'
+      new_collection = collection_fixture(%{title: "New Collection"})
+
+      assert Works.list_works(collection_id: new_collection.id) |> length == 0
+
+      assert {:ok, _result} =
+               Batches.batch_update(query, nil, %{collection_id: new_collection.id})
+
+      assert Works.list_works(collection_id: new_collection.id) |> length == 3
     end
   end
 end


### PR DESCRIPTION
* Updates `collection_id` of works that match the query if the `add` parameter has a `collection_id` key
* Adds `collectionId` as a valid field to GraphQL `batchUpdate` `add` parameter
* Adds a test for collection updating