### PR TITLE
Refactor and simplify uncontrolled field batch updates

### DIFF
--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -27,7 +27,31 @@
     core-js "2.6.0"
     zen-observable "0.8.11"
 
+"@apollo/client@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.2.1.tgz#178dfcc1eb3a35052df8f2bd44be195b78f56e93"
+  integrity sha512-w1EdCf3lvSwsxG2zbn8Rm31nPh9gQrB7u61BnU1QCM5BNIfOxiuuldzGNMHi5kI9KleisFvZl/9OA7pEkVg/yw==
 "@apollo/client@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.2.2.tgz#fe5cad4d53373979f13a925e9da02d8743e798a5"
+  integrity sha512-lw80L0i8PHhv863iLEwf5AvNak9STPNC6/0MWQYGZHV4yEryj7muLAueRzXkZHpoddGAou80xL8KqLAODNy0/A==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.0.0"
+    "@types/zen-observable" "^0.8.0"
+    "@wry/context" "^0.5.2"
+    "@wry/equality" "^0.2.0"
+    fast-json-stable-stringify "^2.0.0"
+    graphql-tag "^2.11.0"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.12.1"
+    prop-types "^15.7.2"
+    symbol-observable "^2.0.0"
+    terser "^5.2.0"
+    ts-invariant "^0.4.4"
+    tslib "^1.10.0"
+    zen-observable "^0.8.14"
+
+"@apollo/client@latest":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.2.2.tgz#fe5cad4d53373979f13a925e9da02d8743e798a5"
   integrity sha512-lw80L0i8PHhv863iLEwf5AvNak9STPNC6/0MWQYGZHV4yEryj7muLAueRzXkZHpoddGAou80xL8KqLAODNy0/A==

--- a/lib/meadow/data/works/batch_functions.ex
+++ b/lib/meadow/data/works/batch_functions.ex
@@ -34,17 +34,17 @@ defmodule Meadow.Data.Works.BatchFunctions do
           end
 
           @doc """
-          Batch update uncontrolled #{unquote(schema)} values
+          Merge map of values into #{unquote(schema)}
           """
-          def replace_uncontrolled_value(query, unquote(schema), field_name, new_value) do
+          def merge_metadata_values(query, unquote(schema), values, mode) do
             from query,
               update: [
                 set: [
                   {unquote(schema),
                    fragment(
-                     unquote("replace_uncontrolled_value(#{schema}, ?::text, ?::jsonb)"),
-                     ^field_name,
-                     ^new_value
+                     unquote("merge_jsonb_values(#{schema}, ?::jsonb, ?::text)"),
+                     ^values,
+                     ^to_string(mode)
                    )},
                   {:updated_at, ^DateTime.utc_now()}
                 ]

--- a/lib/meadow_web/resolvers/batches.ex
+++ b/lib/meadow_web/resolvers/batches.ex
@@ -4,20 +4,24 @@ defmodule MeadowWeb.Resolvers.Data.Batches do
   """
   alias Meadow.Batches
 
-  def update(_, %{query: query, delete: delete, add: add}, _) do
-    if empty_param(add) and empty_param(delete) do
-      {:ok, %{message: "No updates specified"}}
-    else
-      Meadow.Async.run_once("batch_update", fn -> Batches.batch_update(query, delete, add) end)
-      {:ok, %{message: "Batch started"}}
+  def update(_, params, _) do
+    with query <- Map.get(params, :query),
+         delete <- Map.get(params, :delete),
+         add <- Map.get(params, :add),
+         replace <- Map.get(params, :replace) do
+      if empty_param(add) and empty_param(delete) and empty_param(replace) do
+        {:ok, %{message: "No updates specified"}}
+      else
+        Meadow.Async.run_once("batch_update", fn ->
+          Batches.batch_update(query, delete, add, replace)
+        end)
+
+        {:ok, %{message: "Batch started"}}
+      end
     end
   end
 
-  def update(arg1, %{query: query, delete: delete}, arg3),
-    do: update(arg1, %{query: query, delete: delete, add: %{descriptive_metadata: %{}}}, arg3)
-
   defp empty_param(nil), do: true
-  defp empty_param(param) when map_size(param) == 0, do: true
-  defp empty_param(%{descriptive_metadata: param}) when map_size(param) == 0, do: true
+  defp empty_param(%{} = param) when map_size(param) == 0, do: true
   defp empty_param(_), do: false
 end

--- a/lib/meadow_web/schema/types/data/batch_types.ex
+++ b/lib/meadow_web/schema/types/data/batch_types.ex
@@ -13,6 +13,7 @@ defmodule MeadowWeb.Schema.Data.BatchTypes do
       arg(:query, non_null(:string))
       arg(:delete, :batch_delete_input, default_value: %{})
       arg(:add, :batch_add_input, default_value: nil)
+      arg(:replace, :batch_add_input, default_value: nil)
       middleware(Middleware.Authenticate)
       resolve(&Batches.update/3)
     end

--- a/priv/repo/migrations/20200930043521_create_batch_update_functions.exs
+++ b/priv/repo/migrations/20200930043521_create_batch_update_functions.exs
@@ -31,19 +31,36 @@ defmodule Meadow.Repo.Migrations.CreateBatchUpdateFunctions do
     """
 
     execute """
-    CREATE OR REPLACE FUNCTION replace_uncontrolled_value(metadata jsonb, field_name text, new_value jsonb)
+    CREATE OR REPLACE FUNCTION merge_jsonb_values(metadata jsonb, new_values jsonb, mode text)
       RETURNS jsonb
       LANGUAGE 'plpgsql'
     AS $function$
+    DECLARE
+      result jsonb := metadata;
+      new_value jsonb;
+    key text;
+    value jsonb;
     BEGIN
-      RETURN jsonb_set(metadata, ('{'||field_name||'}')::text[], new_value);
+      RAISE DEBUG '% (%)', new_values, mode;
+      FOR key, value IN SELECT * FROM jsonb_each(new_values) LOOP
+        CASE mode
+          WHEN 'append' THEN
+            new_value = result->key || value;
+          WHEN 'replace' THEN
+            new_value = value;
+          ELSE
+            RAISE EXCEPTION 'Unknown merge mode: %', mode;
+        END CASE;
+        result = jsonb_set(result, ('{'||key||'}')::text[], new_value);
+      END LOOP;
+      RETURN result;
     END;
     $function$
     """
   end
 
   def down do
-    execute "DROP FUNCTION IF EXISTS replace_controlled_value;"
+    execute "DROP FUNCTION IF EXISTS merge_jsonb_values;"
     execute "DROP FUNCTION IF EXISTS replace_uncontrolled_value;"
   end
 end

--- a/test/meadow/batches_test.exs
+++ b/test/meadow/batches_test.exs
@@ -83,20 +83,26 @@ defmodule Meadow.BatchesTest do
 
       add = %{
         descriptive_metadata: %{
+          box_name: ["His Airness"]
+        }
+      }
+
+      replace = %{
+        descriptive_metadata: %{
           title: "All these values",
           alternate_title: ["New Alternate 1", "New Alternate 2"],
           box_number: []
         }
       }
 
-      assert {:ok, _result} = Batches.batch_update(query, nil, add)
+      assert {:ok, _result} = Batches.batch_update(query, nil, add, replace)
 
       assert Works.get_works_by_title("All these values") |> length() == 3
 
       Works.list_works()
       |> Enum.each(fn work ->
         assert work.descriptive_metadata.alternate_title |> length() == 2
-        assert work.descriptive_metadata.box_name == ["Michael Jordan"]
+        assert work.descriptive_metadata.box_name == ["Michael Jordan", "His Airness"]
         assert work.descriptive_metadata.box_number == []
       end)
     end
@@ -124,7 +130,7 @@ defmodule Meadow.BatchesTest do
         }
       }
 
-      assert {:ok, _result} = Batches.batch_update(query, delete, add)
+      assert {:ok, _result} = Batches.batch_update(query, delete, add, nil)
 
       assert List.first(Works.get_works_by_title("Work 1")).descriptive_metadata.genre
              |> length() == 1
@@ -143,7 +149,7 @@ defmodule Meadow.BatchesTest do
       assert Works.list_works(collection_id: new_collection.id) |> length == 0
 
       assert {:ok, _result} =
-               Batches.batch_update(query, nil, %{collection_id: new_collection.id})
+               Batches.batch_update(query, nil, nil, %{collection_id: new_collection.id})
 
       assert Works.list_works(collection_id: new_collection.id) |> length == 3
     end


### PR DESCRIPTION
Merge all uncontrolled fields at once instead of iterating over each one
Separate out fields that should be replaced from those being appended