### PR TITLE
Make batch update API input fields reflect which fields can be updated in that operation

### DIFF
--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -7645,7 +7645,12 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-phoenix@^1.4.0, "phoenix@file:../deps/phoenix":
+phoenix@^1.4.0:
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/phoenix/-/phoenix-1.5.6.tgz#759e2dca05ec228632ec28fc9df1b8e9856695ec"
+  integrity sha512-PI/GbwY6+zOSFmtX9SntQ8EIpJ0bDzn5Zyioij2SilG87lgUHSIaiAy9AIatqL9m7ykRrV6hDLBtgxnRMtI5jQ==
+
+"phoenix@file:../deps/phoenix":
   version "1.5.5"
 
 "phoenix_html@file:../deps/phoenix_html":

--- a/lib/meadow_web/schema/types/data/batch_types.ex
+++ b/lib/meadow_web/schema/types/data/batch_types.ex
@@ -11,9 +11,12 @@ defmodule MeadowWeb.Schema.Data.BatchTypes do
     @desc "Start a batch update operation"
     field :batch_update, :message do
       arg(:query, non_null(:string))
+      @desc "`delete` deletes specific existing controlled values"
       arg(:delete, :batch_delete_input, default_value: %{})
+      @desc "`add` appends to existing values (multi-valued fields only)"
       arg(:add, :batch_add_input, default_value: nil)
-      arg(:replace, :batch_add_input, default_value: nil)
+      @desc "`replace` replaces existing values (single and multi valued fields)"
+      arg(:replace, :batch_replace_input, default_value: nil)
       middleware(Middleware.Authenticate)
       resolve(&Batches.update/3)
     end
@@ -26,11 +29,57 @@ defmodule MeadowWeb.Schema.Data.BatchTypes do
   @desc "Input fields for batch add operations"
   input_object :batch_add_input do
     field :collection_id, :id
-    field :descriptive_metadata, :work_descriptive_metadata_input
+    field :descriptive_metadata, :batch_add_descriptive_metadata_input
+  end
+
+  @desc "Input fields for batch replace operations"
+  input_object :batch_replace_input do
+    field :collection_id, :id
+    field :descriptive_metadata, :batch_replace_descriptive_metadata_input
   end
 
   @desc "Input fields for batch delete operations"
   input_object :batch_delete_input do
     import_fields(:controlled_fields_input)
+  end
+
+  @desc "Input fields available for batch add (append) operations on works descriptive metadata"
+  input_object :batch_add_descriptive_metadata_input do
+    import_fields(:batch_editable_multi_valued_descriptive_metadata_input)
+    import_fields(:controlled_fields_input)
+  end
+
+  @desc "Input fields available for batch replace operations on works descriptive metadata"
+  input_object :batch_replace_descriptive_metadata_input do
+    field :title, :string
+    import_fields(:batch_editable_multi_valued_descriptive_metadata_input)
+  end
+
+  input_object :batch_editable_multi_valued_descriptive_metadata_input do
+    field :abstract, list_of(:string)
+    field :alternate_title, list_of(:string)
+    field :box_name, list_of(:string)
+    field :box_number, list_of(:string)
+    field :caption, list_of(:string)
+    field :catalog_key, list_of(:string)
+    field :description, list_of(:string)
+    field :folder_name, list_of(:string)
+    field :folder_number, list_of(:string)
+    field :keywords, list_of(:string)
+    field :license, :coded_term_input
+    field :notes, list_of(:string)
+    field :terms_of_use, :string
+    field :physical_description_material, list_of(:string)
+    field :physical_description_size, list_of(:string)
+    field :provenance, list_of(:string)
+    field :publisher, list_of(:string)
+    field :related_material, list_of(:string)
+    field :related_url, list_of(:related_url_entry_input)
+    field :rights_holder, list_of(:string)
+    field :rights_statement, :coded_term_input
+    field :scope_and_contents, list_of(:string)
+    field :series, list_of(:string)
+    field :source, list_of(:string)
+    field :table_of_contents, list_of(:string)
   end
 end


### PR DESCRIPTION
- Make the API reflect which fields can be updated via that specific operation
  - identifier fields cannot be updated via batch
  - single valued fields not updatable via `add`
  - controlled fields not updatable via `replace`
  - Add some comments for usability