### PR TITLE
Add administrative and core metadata to batch update API

### DIFF
--- a/lib/meadow/data/works.ex
+++ b/lib/meadow/data/works.ex
@@ -480,4 +480,16 @@ defmodule Meadow.Data.Works do
       |> URI.to_string()
     end
   end
+
+  @doc """
+  Set :updated_at
+  """
+  def merge_updated_at(query) do
+    from query,
+      update: [
+        set: [
+          {:updated_at, ^DateTime.utc_now()}
+        ]
+      ]
+  end
 end

--- a/lib/meadow/data/works/batch_functions.ex
+++ b/lib/meadow/data/works/batch_functions.ex
@@ -45,8 +45,7 @@ defmodule Meadow.Data.Works.BatchFunctions do
                      unquote("merge_jsonb_values(#{schema}, ?::jsonb, ?::text)"),
                      ^values,
                      ^to_string(mode)
-                   )},
-                  {:updated_at, ^DateTime.utc_now()}
+                   )}
                 ]
               ]
           end

--- a/lib/meadow_web/schema/schema.ex
+++ b/lib/meadow_web/schema/schema.ex
@@ -11,11 +11,11 @@ defmodule MeadowWeb.Schema do
   alias Meadow.Ingest
 
   import_types(__MODULE__.AccountTypes)
+  import_types(__MODULE__.Data.WorkTypes)
   import_types(__MODULE__.Data.BatchTypes)
   import_types(__MODULE__.IngestTypes)
   import_types(__MODULE__.Data.CollectionTypes)
   import_types(__MODULE__.Data.ControlledTermTypes)
-  import_types(__MODULE__.Data.WorkTypes)
   import_types(__MODULE__.Data.FileSetTypes)
   import_types(__MODULE__.Data.FieldTypes)
   import_types(__MODULE__.Data.SharedLinkTypes)

--- a/lib/meadow_web/schema/types/data/batch_types.ex
+++ b/lib/meadow_web/schema/types/data/batch_types.ex
@@ -28,14 +28,17 @@ defmodule MeadowWeb.Schema.Data.BatchTypes do
 
   @desc "Input fields for batch add operations"
   input_object :batch_add_input do
-    field :collection_id, :id
     field :descriptive_metadata, :batch_add_descriptive_metadata_input
+    field :administrative_metadata, :batch_add_administrative_metadata_input
   end
 
   @desc "Input fields for batch replace operations"
   input_object :batch_replace_input do
     field :collection_id, :id
+    field :visibility, :coded_term_input
+    field :published, :boolean
     field :descriptive_metadata, :batch_replace_descriptive_metadata_input
+    field :administrative_metadata, :batch_replace_administrative_metadata_input
   end
 
   @desc "Input fields for batch delete operations"
@@ -49,10 +52,26 @@ defmodule MeadowWeb.Schema.Data.BatchTypes do
     import_fields(:controlled_fields_input)
   end
 
+  @desc "Input fields available for batch add (append) operations on works administrative metadata"
+  input_object :batch_add_administrative_metadata_input do
+    import_fields(:batch_editable_multi_valued_administrative_metadata_input)
+  end
+
   @desc "Input fields available for batch replace operations on works descriptive metadata"
   input_object :batch_replace_descriptive_metadata_input do
     field :title, :string
+    field :terms_of_use, :string
+    field :rights_statement, :coded_term_input
+    field :license, :coded_term_input
     import_fields(:batch_editable_multi_valued_descriptive_metadata_input)
+  end
+
+  @desc "Input fields available for batch replace operations on works administrative metadata"
+  input_object :batch_replace_administrative_metadata_input do
+    field :preservation_level, :coded_term_input
+    field :status, :coded_term_input
+    field :project_cycle, :string
+    import_fields(:batch_editable_multi_valued_administrative_metadata_input)
   end
 
   input_object :batch_editable_multi_valued_descriptive_metadata_input do
@@ -66,9 +85,7 @@ defmodule MeadowWeb.Schema.Data.BatchTypes do
     field :folder_name, list_of(:string)
     field :folder_number, list_of(:string)
     field :keywords, list_of(:string)
-    field :license, :coded_term_input
     field :notes, list_of(:string)
-    field :terms_of_use, :string
     field :physical_description_material, list_of(:string)
     field :physical_description_size, list_of(:string)
     field :provenance, list_of(:string)
@@ -76,10 +93,18 @@ defmodule MeadowWeb.Schema.Data.BatchTypes do
     field :related_material, list_of(:string)
     field :related_url, list_of(:related_url_entry_input)
     field :rights_holder, list_of(:string)
-    field :rights_statement, :coded_term_input
     field :scope_and_contents, list_of(:string)
     field :series, list_of(:string)
     field :source, list_of(:string)
     field :table_of_contents, list_of(:string)
+  end
+
+  input_object :batch_editable_multi_valued_administrative_metadata_input do
+    field :project_name, list_of(:string)
+    field :project_desc, list_of(:string)
+    field :project_proposer, list_of(:string)
+    field :project_manager, list_of(:string)
+    field :project_manager, list_of(:string)
+    field :project_task_number, list_of(:string)
   end
 end


### PR DESCRIPTION
- Exposes AdministrativeMetadata through batch update API
- Exposes core metadata (visibility and published) through batch update API
- Fixes some previous issues:
   - collectionId exposed through `replace` API and not `add`
   - Single valued descriptive fields:`rights_statement`, `license` and `terms_of_use` moved from `add` to `replace`