### PR TITLE
End-to-end implementation for library_unit

### DIFF
--- a/assets/js/components/Work/Tabs/Administrative.jsx
+++ b/assets/js/components/Work/Tabs/Administrative.jsx
@@ -42,7 +42,12 @@ const WorkTabsAdministrative = ({ work }) => {
     refetchQueries: [{ query: GET_WORK, variables: { id: work.id } }],
     awaitRefetchQueries: true,
   });
-  const { preservationLevel, status, projectCycle } = administrativeMetadata;
+  const {
+    libraryUnit,
+    preservationLevel,
+    status,
+    projectCycle,
+  } = administrativeMetadata;
 
   const methods = useForm({
     defaultValues: {},
@@ -66,6 +71,13 @@ const WorkTabsAdministrative = ({ work }) => {
   }, [work]);
 
   // Get select dropdown options.  Need a better way to organize this
+  const {
+    loading: libraryUnitLoading,
+    error: libraryUnitError,
+    data: libraryUnitData,
+  } = useQuery(CODE_LIST_QUERY, {
+    variables: { scheme: "LIBRARY_UNIT" },
+  });
   const {
     loading: preservationLevelsLoading,
     error: preservationLevelsError,
@@ -91,6 +103,9 @@ const WorkTabsAdministrative = ({ work }) => {
 
     let workUpdateInput = {
       administrativeMetadata: {
+        libraryUnit: currentFormValues.libraryUnit
+          ? { id: currentFormValues.libraryUnit, scheme: "LIBRARY_UNIT" }
+          : {},
         preservationLevel: currentFormValues.preservationLevel
           ? {
               id: currentFormValues.preservationLevel,
@@ -122,6 +137,7 @@ const WorkTabsAdministrative = ({ work }) => {
 
   if (
     collectionsLoading ||
+    libraryUnitLoading ||
     preservationLevelsLoading ||
     statusLoading ||
     visibilityLoading ||
@@ -132,6 +148,7 @@ const WorkTabsAdministrative = ({ work }) => {
 
   if (
     collectionsError ||
+    libraryUnitError ||
     preservationLevelsError ||
     statusError ||
     visibilityError ||
@@ -205,6 +222,22 @@ const WorkTabsAdministrative = ({ work }) => {
                   <p>
                     {collection ? collection.title : "Not part of a collection"}
                   </p>
+                )}
+              </UIFormField>
+
+              <UIFormField label="Library Unit" required={published}>
+                {isEditing ? (
+                  <UIFormSelect
+                    isReactHookForm
+                    name="libraryUnit"
+                    showHelper={true}
+                    label="Library Unit"
+                    options={libraryUnitData.codeList}
+                    defaultValue={libraryUnit ? libraryUnit.id : ""}
+                    required={work.published}
+                  />
+                ) : (
+                  <p>{libraryUnit ? libraryUnit.label : "None selected"}</p>
                 )}
               </UIFormField>
 

--- a/assets/js/components/Work/Tabs/Administrative.test.jsx
+++ b/assets/js/components/Work/Tabs/Administrative.test.jsx
@@ -5,6 +5,7 @@ import WorkTabsAdministrative from "./Administrative";
 import { fireEvent, waitFor, screen } from "@testing-library/react";
 import { getCollectionsMock } from "../../Collection/collection.gql.mock";
 import {
+  codeListLibraryUnitMock,
   codeListPreservationLevelMock,
   codeListStatusMock,
   codeListVisibilityMock,
@@ -17,6 +18,7 @@ describe("Work Administrative tab component", () => {
       mocks: [
         getCollectionsMock,
         getCollectionsMock,
+        codeListLibraryUnitMock,
         codeListPreservationLevelMock,
         codeListStatusMock,
         codeListVisibilityMock,

--- a/assets/js/components/Work/Tabs/Tabs.test.js
+++ b/assets/js/components/Work/Tabs/Tabs.test.js
@@ -9,6 +9,7 @@ import { mockWork } from "../work.gql.mock";
 import { iiifServerUrlMock } from "../../IIIF/iiif.gql.mock";
 import {
   codeListLicenseMock,
+  codeListLibraryUnitMock,
   codeListPreservationLevelMock,
   codeListRightsStatementMock,
   codeListStatusMock,
@@ -19,6 +20,7 @@ import { getCollectionsMock } from "../../Collection/collection.gql.mock";
 
 const mocks = [
   codeListLicenseMock,
+  codeListLibraryUnitMock,
   codeListPreservationLevelMock,
   codeListRightsStatementMock,
   codeListStatusMock,

--- a/assets/js/components/Work/controlledVocabulary.gql.mock.js
+++ b/assets/js/components/Work/controlledVocabulary.gql.mock.js
@@ -120,6 +120,36 @@ export const codeListMarcRelatorMock = {
   },
 };
 
+export const codeListLibraryUnitMock = {
+  request: {
+    query: CODE_LIST_QUERY,
+    variables: {
+      scheme: "LIBRARY_UNIT",
+    },
+  },
+  result: {
+    data: {
+      codeList: [
+        {
+          id: "1",
+          label: "Unit 1",
+          __typename: "CodedTerm",
+        },
+        {
+          id: "2",
+          label: "Unit 2",
+          __typename: "CodedTerm",
+        },
+        {
+          id: "3",
+          label: "Unit 3",
+          __typename: "CodedTerm",
+        },
+      ],
+    },
+  },
+};
+
 export const codeListPreservationLevelMock = {
   request: {
     query: CODE_LIST_QUERY,

--- a/assets/js/components/Work/work.gql.js
+++ b/assets/js/components/Work/work.gql.js
@@ -24,6 +24,10 @@ export const GET_WORK = gql`
       id
       accessionNumber
       administrativeMetadata {
+        libraryUnit {
+          id
+          label
+        }
         preservationLevel {
           id
           label
@@ -242,6 +246,10 @@ export const UPDATE_WORK = gql`
     updateWork(id: $id, work: $work) {
       id
       administrativeMetadata {
+        libraryUnit {
+          id
+          label
+        }
         preservationLevel {
           id
           label

--- a/assets/js/components/Work/work.gql.mock.js
+++ b/assets/js/components/Work/work.gql.mock.js
@@ -5,6 +5,7 @@ export const mockWork = {
   id: "ABC123",
   accessionNumber: "Donohue_001",
   administrativeMetadata: {
+    libraryUnit: { id: "Unit 1", label: "Unit 1" },
     preservationLevel: { id: 1, label: "Level 1" },
     projectCycle: "Project Cycle Name",
     projectDesc: ["New Project Description", "Another Project Description"],
@@ -203,6 +204,7 @@ const mockWork2 = {
   id: "ABC123",
   accessionNumber: "Donohue_002b",
   administrativeMetadata: {
+    libraryUnit: null,
     preservationLevel: null,
     projectCycle: null,
     projectDesc: [],

--- a/assets/js/mock-data/elasticsearch-response.js
+++ b/assets/js/mock-data/elasticsearch-response.js
@@ -14,6 +14,7 @@ export const elasticSearchResponse = {
         _source: {
           accessionNumber: "Voyager:2586736",
           administrativeMetadata: {
+            libraryUnit: null,
             preservationLevel: null,
             projectCycle: null,
             projectDesc: [],
@@ -353,6 +354,7 @@ export const elasticSearchResponse = {
         _source: {
           accessionNumber: "BFMF_B21_F04_037",
           administrativeMetadata: {
+            libraryUnit: null,
             preservationLevel: null,
             projectCycle: null,
             projectDesc: [],

--- a/lib/meadow/data/schemas/work_administrative_metadata.ex
+++ b/lib/meadow/data/schemas/work_administrative_metadata.ex
@@ -9,6 +9,7 @@ defmodule Meadow.Data.Schemas.WorkAdministrativeMetadata do
 
   @timestamps_opts [type: :utc_datetime_usec]
   embedded_schema do
+    field :library_unit, Types.CodedTerm
     field :preservation_level, Types.CodedTerm
     field :project_name, {:array, :string}, default: []
     field :project_desc, {:array, :string}, default: []
@@ -24,6 +25,7 @@ defmodule Meadow.Data.Schemas.WorkAdministrativeMetadata do
   def changeset(metadata, params) do
     metadata
     |> cast(params, [
+      :library_unit,
       :preservation_level,
       :project_name,
       :project_desc,

--- a/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
+++ b/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
@@ -95,6 +95,7 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
   @desc "Schemes for code list table. (Ex: Subjects, MARC relators, prevervation levels, etc)"
   enum :code_list_scheme do
     value(:authority, as: "authority", description: "Authority")
+    value(:library_unit, as: "library_unit", description: "Library Unit")
     value(:license, as: "license", description: "License")
     value(:marc_relator, as: "marc_relator", description: "MARC Relator")
     value(:preservation_level, as: "preservation_level", description: "Preservation Level")

--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -172,6 +172,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
 
   @desc "`work_administrative_metadata` represents all administrative metadata associated with a work object. It is stored in a single json field."
   object :work_administrative_metadata do
+    field :library_unit, :coded_term
     field :preservation_level, :coded_term
     field :status, :coded_term
 
@@ -205,6 +206,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
 
   @desc "Input fields for works administrative metadata"
   input_object :work_administrative_metadata_input do
+    field :library_unit, :coded_term_input
     field :preservation_level, :coded_term_input
     field :status, :coded_term_input
 

--- a/priv/repo/seeds/coded_terms/library_unit.json
+++ b/priv/repo/seeds/coded_terms/library_unit.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "FACULTY_COLLECTIONS",
+    "label": "Faculty Collections"
+  },
+  {
+    "id": "GOVERNMENT_AND_GEOGRAPHIC_INFORMATION_COLLECTION",
+    "label": "Government & Geographic Information Collection"
+  },
+  {
+    "id": "HERSKOVITS_LIBRARY",
+    "label": "Herskovits Library of African Studies"
+  },
+  {
+    "id": "MUSIC_LIBRARY",
+    "label": "Music Library"
+  },
+  {
+    "id": "SPECIAL_COLLECTIONS",
+    "label": "Charles Deering McCormick Library of Special Collections"
+  },
+  {
+    "id": "TRANSPORTATION_LIBRARY",
+    "label": "Transportation Library"
+  },
+  {
+    "id": "UNIVERSITY_ARCHIVES",
+    "label": "University Archives"
+  },
+  {
+    "id": "UNIVERSITY_MAIN_LIBRARY",
+    "label": "University (MAIN) Library"
+  }
+]

--- a/test/gql/WorkAdministrativeMetadataFields.frag.gql
+++ b/test/gql/WorkAdministrativeMetadataFields.frag.gql
@@ -1,5 +1,9 @@
 fragment WorkAdministrativeMetadataFields on Work {
   administrativeMetadata {
+    libraryUnit {
+      id
+      label
+    }
     preservationLevel {
       id
       label

--- a/test/meadow/data/coded_terms_test.exs
+++ b/test/meadow/data/coded_terms_test.exs
@@ -5,6 +5,7 @@ defmodule Meadow.Data.CodedTermsTest do
 
   @schemes [
     "authority",
+    "library_unit",
     "license",
     "marc_relator",
     "preservation_level",


### PR DESCRIPTION
End-to-end implementation for `library_unit` in the WorkAdmininstrativeMetadata embedded schema.

- Adds library_term as a CodedTerm, with a new seed json an updated CodedTermsTest.
- Adds library_term to the GraphQL API as well as the administrative tab component in the UI, with mocks and updated tests.

<img width="1025" alt="library_unit" src="https://user-images.githubusercontent.com/1395707/96038030-2f4f2d00-0e2c-11eb-8f7b-c4e6922479b2.png">


Note: make sure to run `mix meadow.setup` locally to seed the `library_unit` CodedTerm.