### PR TITLE
ProjectList back button bug fix

### DIFF
--- a/assets/js/components/Project/List.jsx
+++ b/assets/js/components/Project/List.jsx
@@ -107,39 +107,40 @@ const ProjectList = () => {
           </tr>
         </thead>
         <tbody>
-          {projectList.map((project) => {
-            const { id, folder, title, updatedAt, ingestSheets } = project;
-            return (
-              <tr key={id}>
-                <td>
-                  <Link to={`/project/${id}`} data-testid="project-title-row">
-                    {title}
-                  </Link>
-                </td>
-                <td>{folder}</td>
-                <td className="has-text-right">{ingestSheets.length}</td>
-                <td className="has-text-right">{formatDate(updatedAt)}</td>
-                <td>
-                  <div className="buttons-end">
-                    <p className="control">
-                      <Button className="button">
-                        <FontAwesomeIcon icon="edit" />
-                      </Button>
-                    </p>
-                    <p className="control">
-                      <Button
-                        className="button"
-                        data-testid="delete-button-row"
-                        onClick={(e) => onOpenModal(e, project)}
-                      >
-                        <FontAwesomeIcon icon="trash" />
-                      </Button>
-                    </p>
-                  </div>
-                </td>
-              </tr>
-            );
-          })}
+          {projectList &&
+            projectList.map((project) => {
+              const { id, folder, title, updatedAt, ingestSheets } = project;
+              return (
+                <tr key={id}>
+                  <td>
+                    <Link to={`/project/${id}`} data-testid="project-title-row">
+                      {title}
+                    </Link>
+                  </td>
+                  <td>{folder}</td>
+                  <td className="has-text-right">{ingestSheets.length}</td>
+                  <td className="has-text-right">{formatDate(updatedAt)}</td>
+                  <td>
+                    <div className="buttons-end">
+                      <p className="control">
+                        <Button className="button">
+                          <FontAwesomeIcon icon="edit" />
+                        </Button>
+                      </p>
+                      <p className="control">
+                        <Button
+                          className="button"
+                          data-testid="delete-button-row"
+                          onClick={(e) => onOpenModal(e, project)}
+                        >
+                          <FontAwesomeIcon icon="trash" />
+                        </Button>
+                      </p>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
         </tbody>
       </table>
       <UIModalDelete


### PR DESCRIPTION
In `projectList.map` projectList is sometimes empty if the query `GET_PROJECT` is pending. Verifying `projectList` exists before looping through it takes away the bug.