### PR TITLE
BatchEdit for collection

### DIFF
--- a/assets/js/components/BatchEdit/About/About.jsx
+++ b/assets/js/components/BatchEdit/About/About.jsx
@@ -30,6 +30,7 @@ const BatchEditAbout = () => {
   const [batchReplaces, setBatchReplaces] = useState({
     descriptiveMetadata: {},
   });
+  const [batchCollection, setBatchCollection] = useState({});
 
   const batchDispatch = useBatchDispatch();
 
@@ -100,8 +101,12 @@ const BatchEditAbout = () => {
     setBatchDeletes(deleteReadyItems);
     setBatchReplaces({
       descriptiveMetadata: { ...replaceItems, ...multiValues.replace },
-      collectionId: currentFormValues["collectionId"],
     });
+
+    Object.keys(currentFormValues["collection"]).length > 0
+      ? setBatchCollection(JSON.parse(currentFormValues["collection"]))
+      : setBatchCollection({});
+
     setIsConfirmModalOpen(true);
   };
 
@@ -179,6 +184,7 @@ const BatchEditAbout = () => {
           batchAdds={batchAdds}
           batchDeletes={batchDeletes}
           batchReplaces={batchReplaces}
+          batchCollection={batchCollection}
           filteredQuery={JSON.stringify(batchState.filteredQuery)}
           handleClose={onCloseModal}
           handleFormReset={handleFormReset}

--- a/assets/js/components/BatchEdit/About/About.jsx
+++ b/assets/js/components/BatchEdit/About/About.jsx
@@ -100,6 +100,7 @@ const BatchEditAbout = () => {
     setBatchDeletes(deleteReadyItems);
     setBatchReplaces({
       descriptiveMetadata: { ...replaceItems, ...multiValues.replace },
+      collectionId: currentFormValues["collectionId"],
     });
     setIsConfirmModalOpen(true);
   };

--- a/assets/js/components/BatchEdit/About/About.test.js
+++ b/assets/js/components/BatchEdit/About/About.test.js
@@ -10,6 +10,7 @@ import {
   codeListRelatedUrlMock,
   codeListRightsStatementMock,
 } from "../../Work/controlledVocabulary.gql.mock";
+import { getCollectionsMock } from "../../Collection/collection.gql.mock";
 import { BatchProvider } from "../../../context/batch-edit-context";
 
 const items = ["ABC123", "ZYC889"];
@@ -26,6 +27,7 @@ describe("BatchEditAbout component", () => {
           codeListLicenseMock,
           codeListRelatedUrlMock,
           codeListRightsStatementMock,
+          getCollectionsMock,
         ],
       }
     );

--- a/assets/js/components/BatchEdit/About/CoreMetadata.jsx
+++ b/assets/js/components/BatchEdit/About/CoreMetadata.jsx
@@ -9,6 +9,7 @@ import UIFormFieldArray from "../../UI/Form/FieldArray";
 import UIFormBatchFieldArray from "../../UI/Form/BatchFieldArray";
 import UIFormSelect from "../../UI/Form/Select";
 import { CODE_LIST_QUERY } from "../../Work/controlledVocabulary.gql.js";
+import { GET_COLLECTIONS } from "@js/components/Collection/collection.gql";
 
 const BatchEditAboutCoreMetadata = ({ ...restProps }) => {
   const {
@@ -18,6 +19,12 @@ const BatchEditAboutCoreMetadata = ({ ...restProps }) => {
   } = useQuery(CODE_LIST_QUERY, {
     variables: { scheme: "RIGHTS_STATEMENT" },
   });
+
+  const {
+    loading: collectionLoading,
+    error: collectionError,
+    data: collectionData,
+  } = useQuery(GET_COLLECTIONS);
 
   return (
     <div
@@ -44,6 +51,25 @@ const BatchEditAboutCoreMetadata = ({ ...restProps }) => {
           data-testid="alternate-title"
           label="Alternate Title"
         />
+      </div>
+      <div className="column is-full">
+        <UIFormField label="Collection">
+          <UIFormSelect
+            isReactHookForm
+            name="collectionId"
+            label="Collection"
+            options={
+              collectionData &&
+              collectionData.collections.map((collection) => ({
+                id: collection.id,
+                value: collection.id,
+                label: collection.title,
+              }))
+            }
+            data-testid="collection"
+            showHelper
+          />
+        </UIFormField>
       </div>
       <div className="column is-half">
         {/* Date Created */}

--- a/assets/js/components/BatchEdit/About/CoreMetadata.jsx
+++ b/assets/js/components/BatchEdit/About/CoreMetadata.jsx
@@ -10,6 +10,7 @@ import UIFormBatchFieldArray from "../../UI/Form/BatchFieldArray";
 import UIFormSelect from "../../UI/Form/Select";
 import { CODE_LIST_QUERY } from "../../Work/controlledVocabulary.gql.js";
 import { GET_COLLECTIONS } from "@js/components/Collection/collection.gql";
+import { useFormContext } from "react-hook-form";
 
 const BatchEditAboutCoreMetadata = ({ ...restProps }) => {
   const {
@@ -25,6 +26,9 @@ const BatchEditAboutCoreMetadata = ({ ...restProps }) => {
     error: collectionError,
     data: collectionData,
   } = useQuery(GET_COLLECTIONS);
+
+  const context = useFormContext();
+  const register = context.register;
 
   return (
     <div
@@ -54,21 +58,20 @@ const BatchEditAboutCoreMetadata = ({ ...restProps }) => {
       </div>
       <div className="column is-full">
         <UIFormField label="Collection">
-          <UIFormSelect
-            isReactHookForm
-            name="collectionId"
-            label="Collection"
-            options={
-              collectionData &&
-              collectionData.collections.map((collection) => ({
-                id: collection.id,
-                value: collection.id,
-                label: collection.title,
-              }))
-            }
-            data-testid="collection"
-            showHelper
-          />
+          <div className="select">
+            <select name="collection" ref={register()} data-testid="collection">
+              <option value="">-- Select --</option>
+              {collectionData &&
+                collectionData.collections.map((collection) => (
+                  <option
+                    key={collection.id}
+                    value={JSON.stringify(collection)}
+                  >
+                    {collection.title}
+                  </option>
+                ))}
+            </select>
+          </div>
         </UIFormField>
       </div>
       <div className="column is-half">

--- a/assets/js/components/BatchEdit/About/CoreMetadata.test.js
+++ b/assets/js/components/BatchEdit/About/CoreMetadata.test.js
@@ -32,6 +32,7 @@ describe("BatchEditAboutCoreMetadata component", () => {
       "rights-statement",
       "date-created",
       "alternate-title",
+      "collection",
     ];
     for (let item of itemTestIds) {
       expect(screen.getByTestId(item)).toBeInTheDocument();

--- a/assets/js/components/BatchEdit/Confirmation.jsx
+++ b/assets/js/components/BatchEdit/Confirmation.jsx
@@ -31,7 +31,6 @@ const BatchEditConfirmation = ({
 }) => {
   const history = useHistory();
   const [confirmationError, setConfirmationError] = useState({});
-  let collectionForDisplay;
 
   const [batchUpdate] = useMutation(BATCH_UPDATE, {
     onCompleted({ batchUpdate }) {
@@ -64,6 +63,10 @@ const BatchEditConfirmation = ({
       hasDeletes
     );
 
+    if (hasCollection) {
+      batchReplaces.collectionId = batchCollection.id;
+    }
+
     batchUpdate({
       variables: {
         query: filteredQuery,
@@ -85,11 +88,6 @@ const BatchEditConfirmation = ({
 
   const hasCollection =
     batchCollection && Object.keys(batchCollection).length > 0;
-
-  if (hasCollection) {
-    batchReplaces.collectionId = batchCollection.id;
-    collectionForDisplay = { collectionId: batchCollection.title };
-  }
 
   const hasDataToPost = hasAdds || hasDeletes || hasReplaces || hasCollection;
 
@@ -137,7 +135,9 @@ const BatchEditConfirmation = ({
               <BatchEditConfirmationTable
                 itemsObj={{
                   ...batchReplaces.descriptiveMetadata,
-                  ...collectionForDisplay,
+                  ...(batchCollection.title && {
+                    collection: batchCollection.title,
+                  }),
                 }}
                 type="replace"
               />

--- a/assets/js/components/BatchEdit/Confirmation.jsx
+++ b/assets/js/components/BatchEdit/Confirmation.jsx
@@ -81,7 +81,12 @@ const BatchEditConfirmation = ({
   const hasReplaces =
     batchReplaces && Object.keys(batchReplaces.descriptiveMetadata).length > 0;
 
-  const hasDataToPost = hasAdds || hasDeletes || hasReplaces;
+  const collection =
+    batchReplaces && batchReplaces.collectionId
+      ? { collectionId: batchReplaces.collectionId }
+      : false;
+
+  const hasDataToPost = hasAdds || hasDeletes || hasReplaces || collection;
 
   return (
     <div
@@ -121,11 +126,14 @@ const BatchEditConfirmation = ({
             </section>
           )}
 
-          {hasReplaces && (
+          {(hasReplaces || collection) && (
             <section className="content">
               <h3>Replacing</h3>
               <BatchEditConfirmationTable
-                itemsObj={batchReplaces.descriptiveMetadata}
+                itemsObj={{
+                  ...batchReplaces.descriptiveMetadata,
+                  ...collection,
+                }}
                 type="replace"
               />
             </section>

--- a/assets/js/components/BatchEdit/Confirmation.jsx
+++ b/assets/js/components/BatchEdit/Confirmation.jsx
@@ -22,6 +22,7 @@ const BatchEditConfirmation = ({
   batchAdds,
   batchDeletes,
   batchReplaces,
+  batchCollection,
   filteredQuery,
   handleClose,
   handleFormReset,
@@ -30,6 +31,7 @@ const BatchEditConfirmation = ({
 }) => {
   const history = useHistory();
   const [confirmationError, setConfirmationError] = useState({});
+  let collectionForDisplay;
 
   const [batchUpdate] = useMutation(BATCH_UPDATE, {
     onCompleted({ batchUpdate }) {
@@ -81,12 +83,15 @@ const BatchEditConfirmation = ({
   const hasReplaces =
     batchReplaces && Object.keys(batchReplaces.descriptiveMetadata).length > 0;
 
-  const collection =
-    batchReplaces && batchReplaces.collectionId
-      ? { collectionId: batchReplaces.collectionId }
-      : false;
+  const hasCollection =
+    batchCollection && Object.keys(batchCollection).length > 0;
 
-  const hasDataToPost = hasAdds || hasDeletes || hasReplaces || collection;
+  if (hasCollection) {
+    batchReplaces.collectionId = batchCollection.id;
+    collectionForDisplay = { collectionId: batchCollection.title };
+  }
+
+  const hasDataToPost = hasAdds || hasDeletes || hasReplaces || hasCollection;
 
   return (
     <div
@@ -126,13 +131,13 @@ const BatchEditConfirmation = ({
             </section>
           )}
 
-          {(hasReplaces || collection) && (
+          {(hasReplaces || hasCollection) && (
             <section className="content">
               <h3>Replacing</h3>
               <BatchEditConfirmationTable
                 itemsObj={{
                   ...batchReplaces.descriptiveMetadata,
-                  ...collection,
+                  ...collectionForDisplay,
                 }}
                 type="replace"
               />
@@ -186,6 +191,7 @@ BatchEditConfirmation.propTypes = {
   batchAdds: PropTypes.object,
   batchDeletes: PropTypes.object,
   batchReplaces: PropTypes.object,
+  batchCollection: PropTypes.object,
   filteredQuery: PropTypes.string,
   handleClose: PropTypes.func,
   handleFormReset: PropTypes.func,

--- a/assets/js/components/BatchEdit/Tabs.test.js
+++ b/assets/js/components/BatchEdit/Tabs.test.js
@@ -10,6 +10,7 @@ import {
   codeListRelatedUrlMock,
   codeListRightsStatementMock,
 } from "../Work/controlledVocabulary.gql.mock.js";
+import { getCollectionsMock } from "../Collection/collection.gql.mock";
 import { BatchProvider } from "../../context/batch-edit-context";
 
 const items = ["ABC123", "ZYC889"];
@@ -26,6 +27,7 @@ describe("BatchEditTabs component", () => {
           codeListLicenseMock,
           codeListRelatedUrlMock,
           codeListRightsStatementMock,
+          getCollectionsMock,
         ],
       }
     );

--- a/assets/js/screens/BatchEdit/BatchEdit.test.js
+++ b/assets/js/screens/BatchEdit/BatchEdit.test.js
@@ -10,6 +10,7 @@ import {
   codeListRelatedUrlMock,
   codeListRightsStatementMock,
 } from "../../components/Work/controlledVocabulary.gql.mock";
+import { getCollectionsMock } from "../../components/Collection/collection.gql.mock";
 import { BatchProvider } from "../../context/batch-edit-context";
 
 jest.mock("../../services/elasticsearch");
@@ -39,6 +40,7 @@ describe("BatchEdit component", () => {
           codeListLicenseMock,
           codeListRelatedUrlMock,
           codeListRightsStatementMock,
+          getCollectionsMock,
         ],
         // NOTE: We're not using this in the component anymore, but keeping it in for a pattern to
         // reference in the future.

--- a/assets/js/services/metadata.js
+++ b/assets/js/services/metadata.js
@@ -8,6 +8,7 @@ export const METADATA_FIELDS = {
   BOX_NUMBER: { name: "boxNumber", label: "Box Number" },
   CAPTION: { name: "caption", label: "Caption" },
   CATALOG_KEY: { name: "catalogKey", label: "Catalog Key" },
+  COLLECTION: { name: "collectionId", label: "Collection" },
   CONTRIBUTOR: {
     hasRole: true,
     label: "Contributor",

--- a/assets/js/services/metadata.js
+++ b/assets/js/services/metadata.js
@@ -8,7 +8,7 @@ export const METADATA_FIELDS = {
   BOX_NUMBER: { name: "boxNumber", label: "Box Number" },
   CAPTION: { name: "caption", label: "Caption" },
   CATALOG_KEY: { name: "catalogKey", label: "Catalog Key" },
-  COLLECTION: { name: "collectionId", label: "Collection" },
+  COLLECTION: { name: "collection", label: "Collection" },
   CONTRIBUTOR: {
     hasRole: true,
     label: "Contributor",


### PR DESCRIPTION

For collection, it's currently displaying ID, i would however like to display `Collection title` by fetching it using `GET_COLLECTION` query in `BatchConfirm` page. So the setup of adding collection as an object to batchreplace won't work as it accepts only string per graphQL. Let me know your thoughts and I will modify code accordingly.

<img width="699" alt="Screen Shot 2020-10-16 at 8 07 17 AM" src="https://user-images.githubusercontent.com/72217877/96262092-f11a5080-0f86-11eb-888f-e8798871e89d.png">

---


<img width="801" alt="Screen Shot 2020-10-16 at 6 08 42 AM" src="https://user-images.githubusercontent.com/72217877/96261385-00e56500-0f86-11eb-8057-c3f03518f559.png">
<img width="755" alt="Screen Shot 2020-10-16 at 6 08 50 AM" src="https://user-images.githubusercontent.com/72217877/96261386-00e56500-0f86-11eb-9f53-fe395730d0b4.png">
<img width="740" alt="Screen Shot 2020-10-16 at 6 31 23 AM" src="https://user-images.githubusercontent.com/72217877/96261389-017dfb80-0f86-11eb-9aae-361153661113.png">
