### PR TITLE
ingestSheetRows removed from ingestSheet query

### DIFF
--- a/assets/js/components/IngestSheet/ingestSheet.gql.js
+++ b/assets/js/components/IngestSheet/ingestSheet.gql.js
@@ -153,10 +153,17 @@ export const START_VALIDATION = gql`
 export const INGEST_SHEET_QUERY = gql`
   query IngestSheetQuery($sheetId: ID!) {
     ingestSheet(id: $sheetId) {
-      ...IngestSheetParts
+      fileErrors
+      id
+      title
+      filename
+      state {
+        name
+        state
+      }
+      status
     }
   }
-  ${IngestSheet.fragments.parts}
 `;
 
 export const INGEST_SHEET_SUBSCRIPTION = gql`

--- a/assets/js/screens/Project/Project.jsx
+++ b/assets/js/screens/Project/Project.jsx
@@ -52,6 +52,7 @@ const ScreensProject = () => {
       },
     };
   };
+
   const handleFacetClick = () => {
     history.push("/search", {
       externalFacet: {


### PR DESCRIPTION
This removes `ingestSheetRows` from the `ingestSheet` query.  The `ingestSheetUpdate` subscription still is pulling in the rows though.  I can look into how and what the front end is using from these rows next, though guessing at some point it was using this data to construct some kind of row level validation?