### PR TITLE
Disable LOC Linked data option in authority dropdown

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -82,8 +82,7 @@ config :authoritex,
     Authoritex.Getty,
     Authoritex.LOC.Languages,
     Authoritex.LOC.Names,
-    Authoritex.LOC.SubjectHeadings,
-    Authoritex.LOC
+    Authoritex.LOC.SubjectHeadings
   ]
 
 config :honeybadger,

--- a/priv/repo/seeds/coded_terms/authority.json
+++ b/priv/repo/seeds/coded_terms/authority.json
@@ -62,9 +62,5 @@
   {
     "id": "lcsh",
     "label": "Library of Congress Subject Headings"
-  },
-  {
-    "id": "loc",
-    "label": "Library of Congress Linked Data"
   }
 ]


### PR DESCRIPTION
PR merge:

- Requires data reset on staging. (or you could manually delete the one authority from the db)

- Requires `devstack down -v` and rerunning `mix meadow.setup` in dev environment