### PR TITLE
Ingest sheet validation use status field to show/hide preview items o…

### DIFF
--- a/assets/js/components/IngestSheet/IngestSheet.jsx
+++ b/assets/js/components/IngestSheet/IngestSheet.jsx
@@ -13,11 +13,7 @@ import IngestSheetCompleted from "./Completed";
  * Refer to latest values to clarify this component's logic.
  */
 
-const IngestSheet = ({
-  ingestSheetData,
-  projectId,
-  subscribeToIngestSheetUpdates,
-}) => {
+const IngestSheet = ({ ingestSheetData, subscribeToIngestSheetUpdates }) => {
   const { id, status, title } = ingestSheetData;
 
   const {
@@ -29,6 +25,9 @@ const IngestSheet = ({
     variables: { sheetId: id },
     fetchPolicy: "network-only",
   });
+
+  //console.log("\nIngestSheet() => progressData", progressData);
+  //console.log("IngestSheet() => status", status);
 
   useEffect(() => {
     subscribeToIngestSheetUpdates();

--- a/assets/js/components/IngestSheet/IngestSheet.jsx
+++ b/assets/js/components/IngestSheet/IngestSheet.jsx
@@ -8,11 +8,6 @@ import PropTypes from "prop-types";
 import IngestSheetApprovedInProgress from "./ApprovedInProgress";
 import IngestSheetCompleted from "./Completed";
 
-/**
- * Note: This component is dependent on the GraphQL "IngestSheet" data type "status" property.
- * Refer to latest values to clarify this component's logic.
- */
-
 const IngestSheet = ({ ingestSheetData, subscribeToIngestSheetUpdates }) => {
   const { id, status, title } = ingestSheetData;
 
@@ -26,16 +21,13 @@ const IngestSheet = ({ ingestSheetData, subscribeToIngestSheetUpdates }) => {
     fetchPolicy: "network-only",
   });
 
-  //console.log("\nIngestSheet() => progressData", progressData);
-  //console.log("IngestSheet() => status", status);
-
   useEffect(() => {
     subscribeToIngestSheetUpdates();
   }, []);
 
   if (progressError) return <Error error={progressError} />;
 
-  const styles = { h2IsHidden: { display: "none" } };
+  const isCompleted = status === "COMPLETED";
 
   return (
     <div className="box">
@@ -43,25 +35,16 @@ const IngestSheet = ({ ingestSheetData, subscribeToIngestSheetUpdates }) => {
         <UISkeleton rows={15} />
       ) : (
         <>
-          <h2
-            className="title is-size-5"
-            style={["COMPLETED"].indexOf(status) > -1 ? styles.h2IsHidden : {}}
-          >
+          <h2 className={`title is-size-5 ${isCompleted ? "is-hidden" : ""}`}>
             Ingest Sheet Contents
           </h2>
+
           {["APPROVED"].indexOf(status) > -1 && (
-            <>
-              <IngestSheetApprovedInProgress ingestSheet={ingestSheetData} />
-            </>
+            <IngestSheetApprovedInProgress ingestSheet={ingestSheetData} />
           )}
 
-          {["COMPLETED"].indexOf(status) > -1 && (
-            <>
-              <IngestSheetCompleted
-                sheetId={ingestSheetData.id}
-                title={title}
-              />
-            </>
+          {isCompleted && (
+            <IngestSheetCompleted sheetId={ingestSheetData.id} title={title} />
           )}
 
           {["VALID", "ROW_FAIL", "FILE_FAIL", "UPLOADED"].indexOf(status) >
@@ -69,7 +52,9 @@ const IngestSheet = ({ ingestSheetData, subscribeToIngestSheetUpdates }) => {
             <IngestSheetValidations
               sheetId={id}
               status={status}
-              initialProgress={progressData.ingestSheetValidationProgress}
+              percentComplete={
+                progressData.ingestSheetValidationProgress.percentComplete
+              }
               subscribeToIngestSheetValidationProgress={progressSubscribeToMore}
             />
           )}

--- a/assets/js/components/IngestSheet/Report.jsx
+++ b/assets/js/components/IngestSheet/Report.jsx
@@ -30,22 +30,18 @@ function IngestSheetReport({ sheetId, progress, status }) {
 
   const ingestSheetRows = data.ingestSheetRows;
 
-  {
-    /* Don't show if sheet isn't complete */
-  }
-  if (progress.percentComplete === 0) {
+  // Validation is still running, so keep table hidden
+  if (status === "UPLOADED") {
     return null;
   }
 
+  // Render Errors table
   if (sheetHasErrors()) {
     return <IngestSheetErrorsState validations={ingestSheetRows} />;
-  } else {
-    return (
-      <>
-        <IngestSheetUnapprovedState validations={ingestSheetRows} />
-      </>
-    );
   }
+
+  // By default render valid Work groupings
+  return <IngestSheetUnapprovedState validations={ingestSheetRows} />;
 }
 
 IngestSheetReport.propTypes = {

--- a/assets/js/components/IngestSheet/Report.jsx
+++ b/assets/js/components/IngestSheet/Report.jsx
@@ -2,15 +2,15 @@ import React from "react";
 import PropTypes from "prop-types";
 import { useQuery } from "@apollo/client";
 import Error from "../UI/Error";
-import Loading from "../UI/Loading";
 import IngestSheetErrorsState from "./ErrorsState";
 import IngestSheetUnapprovedState from "./UnapprovedState";
 import {
   GET_INGEST_SHEET_ROW_VALIDATION_ERRORS,
   GET_INGEST_SHEET_ROW_VALIDATIONS,
 } from "./ingestSheet.gql";
+import UISkeleton from "@js/components/UI/Skeleton";
 
-function IngestSheetReport({ sheetId, progress, status }) {
+function IngestSheetReport({ sheetId, status }) {
   const sheetHasErrors = () => {
     return ["FILE_FAIL", "ROW_FAIL"].indexOf(status) > -1;
   };
@@ -25,28 +25,20 @@ function IngestSheetReport({ sheetId, progress, status }) {
     }
   );
 
-  if (loading) return <Loading />;
+  if (loading) return <UISkeleton rows={15} />;
   if (error) return <Error error={error} />;
-
-  const ingestSheetRows = data.ingestSheetRows;
-
-  // Validation is still running, so keep table hidden
-  if (status === "UPLOADED") {
-    return null;
-  }
 
   // Render Errors table
   if (sheetHasErrors()) {
-    return <IngestSheetErrorsState validations={ingestSheetRows} />;
+    return <IngestSheetErrorsState validations={data.ingestSheetRows} />;
   }
 
   // By default render valid Work groupings
-  return <IngestSheetUnapprovedState validations={ingestSheetRows} />;
+  return <IngestSheetUnapprovedState validations={data.ingestSheetRows} />;
 }
 
 IngestSheetReport.propTypes = {
   sheetId: PropTypes.string.isRequired,
-  progress: PropTypes.object.isRequired,
   status: PropTypes.string,
 };
 

--- a/assets/js/components/IngestSheet/Validations.jsx
+++ b/assets/js/components/IngestSheet/Validations.jsx
@@ -19,7 +19,11 @@ function IngestSheetValidations({
   const [progress, setProgress] = useState({ states: [] });
   const [startValidation, { validationData }] = useMutation(START_VALIDATION);
 
+  // console.log("\nIngestSheetValidations() initialProgress", initialProgress);
+  // console.log("IngestSheetValidations() status", status);
+
   useEffect(() => {
+    //console.log("Validations() useEffect()");
     setProgress(initialProgress);
     subscribeToIngestSheetValidationProgress({
       document: SUBSCRIBE_TO_INGEST_SHEET_VALIDATION_PROGRESS,
@@ -27,10 +31,12 @@ function IngestSheetValidations({
       updateQuery: debounce(handleProgressUpdate, 250, { maxWait: 250 }),
     });
 
+    //console.log("Validations() useEffect() calls startValidation");
     startValidation({ variables: { id: sheetId } });
   }, []);
 
   const handleProgressUpdate = (prev, { subscriptionData }) => {
+    //console.log("Validations() handleProgressUpdate", prev, subscriptionData);
     if (!subscriptionData.data) return prev;
 
     const progress = subscriptionData.data.ingestSheetValidationProgress;

--- a/assets/js/components/IngestSheet/ingestSheet.gql.js
+++ b/assets/js/components/IngestSheet/ingestSheet.gql.js
@@ -108,10 +108,6 @@ export const GET_INGEST_SHEET_ROW_VALIDATION_ERRORS = gql`
 export const GET_INGEST_SHEET_VALIDATION_PROGRESS = gql`
   query IngestSheetValidationProgress($sheetId: ID!) {
     ingestSheetValidationProgress(id: $sheetId) {
-      states {
-        state
-        count
-      }
       percentComplete
     }
   }


### PR DESCRIPTION
…r errors

Previously this was relying upon a percentage value from progress bar data to show results, but now using `status` instead.

All in all, cleaned up the code and thinned out the data flowing through the components in Validation, up until the point where a user hits "Approve".    Moving onto that next.