### PR TITLE
Bug fix for crossbrowser select options

### DIFF
--- a/assets/js/components/BatchEdit/About/CoreMetadata.jsx
+++ b/assets/js/components/BatchEdit/About/CoreMetadata.jsx
@@ -3,20 +3,12 @@ import PropTypes from "prop-types";
 import { useQuery } from "@apollo/client";
 import UITagNotYetSupported from "../../UI/TagNotYetSupported";
 import UIInput from "../../UI/Form/Input";
-import UIFormTextarea from "../../UI/Form/Textarea";
 import UIFormField from "../../UI/Form/Field";
 import UIFormBatchFieldArray from "../../UI/Form/BatchFieldArray";
 import UIFormSelect from "../../UI/Form/Select";
 import { GET_COLLECTIONS } from "@js/components/Collection/collection.gql";
 import { useFormContext } from "react-hook-form";
 import { useCodeLists } from "@js/context/code-list-context";
-/** @jsx jsx */
-import { css, jsx } from "@emotion/core";
-const selectOptionCss = css`
-  font-family: BlinkMacSystemFont, -apple-system, "Segoe UI", Roboto, Oxygen,
-    Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Helvetica,
-    Arial, sans-serif;
-`;
 
 const BatchEditAboutCoreMetadata = ({ ...restProps }) => {
   const codeLists = useCodeLists();
@@ -60,15 +52,12 @@ const BatchEditAboutCoreMetadata = ({ ...restProps }) => {
         <UIFormField label="Collection">
           <div className="select">
             <select name="collection" ref={register()} data-testid="collection">
-              <option value="" css={selectOptionCss}>
-                -- Select --
-              </option>
+              <option value="">-- Select --</option>
               {collectionData &&
                 collectionData.collections.map((collection) => (
                   <option
                     key={collection.id}
                     value={JSON.stringify(collection)}
-                    css={selectOptionCss}
                   >
                     {collection.title}
                   </option>

--- a/assets/js/components/BatchEdit/About/CoreMetadata.jsx
+++ b/assets/js/components/BatchEdit/About/CoreMetadata.jsx
@@ -10,6 +10,13 @@ import UIFormSelect from "../../UI/Form/Select";
 import { GET_COLLECTIONS } from "@js/components/Collection/collection.gql";
 import { useFormContext } from "react-hook-form";
 import { useCodeLists } from "@js/context/code-list-context";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+const selectOptionCss = css`
+  font-family: BlinkMacSystemFont, -apple-system, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Helvetica,
+    Arial, sans-serif;
+`;
 
 const BatchEditAboutCoreMetadata = ({ ...restProps }) => {
   const codeLists = useCodeLists();
@@ -53,12 +60,15 @@ const BatchEditAboutCoreMetadata = ({ ...restProps }) => {
         <UIFormField label="Collection">
           <div className="select">
             <select name="collection" ref={register()} data-testid="collection">
-              <option value="">-- Select --</option>
+              <option value="" css={selectOptionCss}>
+                -- Select --
+              </option>
               {collectionData &&
                 collectionData.collections.map((collection) => (
                   <option
                     key={collection.id}
                     value={JSON.stringify(collection)}
+                    css={selectOptionCss}
                   >
                     {collection.title}
                   </option>

--- a/assets/js/components/UI/Form/Select.jsx
+++ b/assets/js/components/UI/Form/Select.jsx
@@ -2,14 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { useFormContext } from "react-hook-form";
 
-/** @jsx jsx */
-import { css, jsx } from "@emotion/core";
-const selectOptionCss = css`
-  font-family: BlinkMacSystemFont, -apple-system, "Segoe UI", Roboto, Oxygen,
-    Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Helvetica,
-    Arial, sans-serif;
-`;
-
 const UIFormSelect = ({
   isReactHookForm,
   name,
@@ -40,16 +32,11 @@ const UIFormSelect = ({
           defaultValue={defaultValue}
           {...passedInProps}
         >
-          {showHelper && (
-            <option value="" css={selectOptionCss}>
-              -- Select --
-            </option>
-          )}
+          {showHelper && <option value="">-- Select --</option>}
           {options.map((option) => (
             <option
               key={option.id || option.value}
               value={option.id || option.value}
-              css={selectOptionCss}
             >
               {option.label}
             </option>

--- a/assets/js/components/UI/Form/Select.jsx
+++ b/assets/js/components/UI/Form/Select.jsx
@@ -2,6 +2,14 @@ import React from "react";
 import PropTypes from "prop-types";
 import { useFormContext } from "react-hook-form";
 
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+const selectOptionCss = css`
+  font-family: BlinkMacSystemFont, -apple-system, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", Helvetica,
+    Arial, sans-serif;
+`;
+
 const UIFormSelect = ({
   isReactHookForm,
   name,
@@ -32,11 +40,16 @@ const UIFormSelect = ({
           defaultValue={defaultValue}
           {...passedInProps}
         >
-          {showHelper && <option value="">-- Select --</option>}
+          {showHelper && (
+            <option value="" css={selectOptionCss}>
+              -- Select --
+            </option>
+          )}
           {options.map((option) => (
             <option
               key={option.id || option.value}
               value={option.id || option.value}
+              css={selectOptionCss}
             >
               {option.label}
             </option>

--- a/assets/styles/scss/_base.scss
+++ b/assets/styles/scss/_base.scss
@@ -84,3 +84,10 @@ table {
 .tag:not(body).is-success.is-light {
   color: $success;
 }
+
+//Select option font-family override for cross-browser consistency
+.select {
+  option {
+    font-family: BlinkMacSystemFont, -apple-system, Arial, sans-serif;
+  }
+}


### PR DESCRIPTION
The font-family is not supported in some browsers and it is a known issue, per https://bugzilla.mozilla.org/show_bug.cgi?id=1536148 which is still OPEN. 
I've successfully imposed it and was able to test on multiple browsers using browserstack with a custom font that bulma uses for its select options. I couldn’t get IE/Edge fired up to test it.

<img width="1071" alt="Screen Shot 2020-10-29 at 8 39 19 AM" src="https://user-images.githubusercontent.com/72217877/97581197-46605400-19c2-11eb-8dfd-f0c09c79a395.png">
