### PR TITLE
Bug fix for osd viewer reload

### DIFF
--- a/assets/js/components/Work/Work.jsx
+++ b/assets/js/components/Work/Work.jsx
@@ -19,6 +19,7 @@ const Work = ({ work }) => {
           <OpenSeadragonViewer
             manifestUrl={work.manifestUrl}
             options={osdOptions}
+            key={work.manifestUrl}
           />
         </div>
       </section>


### PR DESCRIPTION
Just by introducing`key` on the viewer component, react re-renders it as key changes for every work.

