### PR TITLE
1206 ingest validation investigate

### DIFF
--- a/assets/js/components/IngestSheet/ActionRow.jsx
+++ b/assets/js/components/IngestSheet/ActionRow.jsx
@@ -46,6 +46,7 @@ const IngestSheetActionRow = ({ projectId, sheetId, status, title }) => {
       },
     }
   );
+
   const [
     approveIngestSheet,
     { loading: approveLoading, error: approveError },

--- a/assets/js/components/IngestSheet/ActionRow.jsx
+++ b/assets/js/components/IngestSheet/ActionRow.jsx
@@ -3,7 +3,7 @@ import UIModalDelete from "../UI/Modal/Delete";
 import {
   DELETE_INGEST_SHEET,
   APPROVE_INGEST_SHEET,
-  GET_INGEST_SHEETS,
+  INGEST_SHEETS,
 } from "./ingestSheet.gql";
 import { useMutation, useApolloClient } from "@apollo/client";
 import PropTypes from "prop-types";
@@ -22,7 +22,7 @@ const IngestSheetActionRow = ({ projectId, sheetId, status, title }) => {
       update(cache, { data: { deleteIngestSheet } }) {
         try {
           const { project } = client.readQuery({
-            query: GET_INGEST_SHEETS,
+            query: INGEST_SHEETS,
             variables: { projectId },
           });
           const index = project.ingestSheets.findIndex(
@@ -30,7 +30,7 @@ const IngestSheetActionRow = ({ projectId, sheetId, status, title }) => {
           );
           project.ingestSheets.splice(index, 1);
           client.writeQuery({
-            query: GET_INGEST_SHEETS,
+            query: INGEST_SHEETS,
             data: { project },
           });
         } catch (error) {

--- a/assets/js/components/IngestSheet/ApprovedInProgress.jsx
+++ b/assets/js/components/IngestSheet/ApprovedInProgress.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import UIProgressBar from "../UI/UIProgressBar";
 import PropTypes from "prop-types";
 import { useSubscription } from "@apollo/client";
@@ -20,14 +20,13 @@ const IngestSheetApprovedInProgress = ({ ingestSheet }) => {
     );
   if (error) {
     console.log(error);
-    return <p>Error: {error.message}</p>;
+    return <p>Error in Ingest Progress Subscription: {error.message}</p>;
   }
 
-  const { ingestProgress } = data;
   return (
     <UIProgressBar
-      percentComplete={Number(ingestProgress.percentComplete)}
-      totalValue={ingestProgress.totalFileSets}
+      percentComplete={Number(data.ingestProgress.percentComplete)}
+      totalValue={data.ingestProgress.totalFileSets}
       isIngest={true}
     />
   );

--- a/assets/js/components/IngestSheet/ErrorsState.jsx
+++ b/assets/js/components/IngestSheet/ErrorsState.jsx
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const IngestSheetErrorsState = ({ validations }) => {
-  const rowHasErrors = object =>
+const IngestSheetErrorsState = ({ rows }) => {
+  const rowHasErrors = (object) =>
     object && object.errors && object.errors.length > 0;
   return (
     <>
@@ -17,14 +17,14 @@ const IngestSheetErrorsState = ({ validations }) => {
           </tr>
         </thead>
         <tbody>
-          {validations.map(object => (
+          {rows.map((object) => (
             <tr key={object.row}>
               <td>{object && object.row}</td>
               <td>
                 <span className="tag is-danger">{object && object.state}</span>
               </td>
               <td>
-                {object && object.fields.map(field => field.value).join("; ")}
+                {object && object.fields.map((field) => field.value).join("; ")}
               </td>
               <td>
                 {rowHasErrors(object)
@@ -42,7 +42,7 @@ const IngestSheetErrorsState = ({ validations }) => {
 };
 
 IngestSheetErrorsState.propTypes = {
-  validations: PropTypes.arrayOf(PropTypes.object)
+  rows: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default IngestSheetErrorsState;

--- a/assets/js/components/IngestSheet/IngestSheet.jsx
+++ b/assets/js/components/IngestSheet/IngestSheet.jsx
@@ -12,10 +12,10 @@ const IngestSheet = ({ ingestSheetData, subscribeToIngestSheetUpdates }) => {
   const { id, status, title } = ingestSheetData;
 
   const {
-    data: progressData,
-    loading: progressLoading,
-    error: progressError,
-    subscribeToMore: progressSubscribeToMore,
+    data: validationProgressData,
+    loading: validationProgressLoading,
+    error: validationProgressError,
+    subscribeToMore: validationProgressSubscribeToMore,
   } = useQuery(GET_INGEST_SHEET_VALIDATION_PROGRESS, {
     variables: { sheetId: id },
     fetchPolicy: "network-only",
@@ -25,13 +25,13 @@ const IngestSheet = ({ ingestSheetData, subscribeToIngestSheetUpdates }) => {
     subscribeToIngestSheetUpdates();
   }, []);
 
-  if (progressError) return <Error error={progressError} />;
+  if (validationProgressError) return <Error error={validationProgressError} />;
 
   const isCompleted = status === "COMPLETED";
 
   return (
     <div className="box">
-      {progressLoading ? (
+      {validationProgressLoading ? (
         <UISkeleton rows={15} />
       ) : (
         <>
@@ -53,9 +53,12 @@ const IngestSheet = ({ ingestSheetData, subscribeToIngestSheetUpdates }) => {
               sheetId={id}
               status={status}
               percentComplete={
-                progressData.ingestSheetValidationProgress.percentComplete
+                validationProgressData.ingestSheetValidationProgress
+                  .percentComplete
               }
-              subscribeToIngestSheetValidationProgress={progressSubscribeToMore}
+              subscribeToIngestSheetValidationProgress={
+                validationProgressSubscribeToMore
+              }
             />
           )}
         </>

--- a/assets/js/components/IngestSheet/IngestSheet.jsx
+++ b/assets/js/components/IngestSheet/IngestSheet.jsx
@@ -12,26 +12,28 @@ const IngestSheet = ({ ingestSheetData, subscribeToIngestSheetUpdates }) => {
   const { id, status, title } = ingestSheetData;
 
   const {
-    data: validationProgressData,
-    loading: validationProgressLoading,
-    error: validationProgressError,
+    data,
+    loading,
+    error,
     subscribeToMore: validationProgressSubscribeToMore,
   } = useQuery(GET_INGEST_SHEET_VALIDATION_PROGRESS, {
     variables: { sheetId: id },
     fetchPolicy: "network-only",
   });
 
+  console.log("\ndata", data);
+
   useEffect(() => {
     subscribeToIngestSheetUpdates();
   }, []);
 
-  if (validationProgressError) return <Error error={validationProgressError} />;
+  if (error) return <Error error={error} />;
 
   const isCompleted = status === "COMPLETED";
 
   return (
     <div className="box">
-      {validationProgressLoading ? (
+      {loading ? (
         <UISkeleton rows={15} />
       ) : (
         <>
@@ -53,8 +55,7 @@ const IngestSheet = ({ ingestSheetData, subscribeToIngestSheetUpdates }) => {
               sheetId={id}
               status={status}
               percentComplete={
-                validationProgressData.ingestSheetValidationProgress
-                  .percentComplete
+                data.ingestSheetValidationProgress.percentComplete
               }
               subscribeToIngestSheetValidationProgress={
                 validationProgressSubscribeToMore

--- a/assets/js/components/IngestSheet/List.jsx
+++ b/assets/js/components/IngestSheet/List.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import { useApolloClient, useMutation } from "@apollo/client";
-import { GET_INGEST_SHEETS, DELETE_INGEST_SHEET } from "./ingestSheet.gql.js";
+import { INGEST_SHEETS, DELETE_INGEST_SHEET } from "./ingestSheet.gql.js";
 import UIModalDelete from "../UI/Modal/Delete";
 import { toastWrapper } from "../../services/helpers";
 import { getClassFromIngestSheetStatus } from "../../services/helpers";

--- a/assets/js/components/IngestSheet/List.jsx
+++ b/assets/js/components/IngestSheet/List.jsx
@@ -50,7 +50,8 @@ const IngestSheetList = ({ project, subscribeToIngestSheetStatusChanges }) => {
     <div>
       {project.ingestSheets.length === 0 && (
         <p className="notification" data-testid="no-ingest-sheets-notification">
-          No ingest sheets are found.
+          <FontAwesomeIcon icon="info-circle" />{" "}
+          <span className="ml-1">No ingest sheets</span>
         </p>
       )}
 

--- a/assets/js/components/IngestSheet/Report.jsx
+++ b/assets/js/components/IngestSheet/Report.jsx
@@ -4,7 +4,7 @@ import { useQuery } from "@apollo/client";
 import Error from "../UI/Error";
 import IngestSheetErrorsState from "./ErrorsState";
 import IngestSheetUnapprovedState from "./UnapprovedState";
-import { GET_INGEST_SHEET_ROWS } from "./ingestSheet.gql";
+import { INGEST_SHEET_ROWS } from "./ingestSheet.gql";
 import UISkeleton from "@js/components/UI/Skeleton";
 
 function IngestSheetReport({ sheetId, status }) {
@@ -16,12 +16,10 @@ function IngestSheetReport({ sheetId, status }) {
     state: hasErrors ? "FAIL" : "PASS",
   };
 
-  const { loading, error, data } = useQuery(GET_INGEST_SHEET_ROWS, {
+  const { loading, error, data } = useQuery(INGEST_SHEET_ROWS, {
     variables: ingestSheetQueryVars,
     fetchPolicy: "network-only",
   });
-
-  console.log("data", data);
 
   if (loading) return <UISkeleton rows={15} />;
   if (error) return <Error error={error} />;

--- a/assets/js/components/IngestSheet/UnapprovedState.jsx
+++ b/assets/js/components/IngestSheet/UnapprovedState.jsx
@@ -1,19 +1,19 @@
 import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 
-const IngestSheetUnapprovedState = ({ validations }) => {
+const IngestSheetUnapprovedState = ({ rows }) => {
   const [groupings, setGroupings] = useState();
 
   useEffect(() => {
-    orderRows(validations);
-  }, [validations]);
+    orderRows(rows);
+  }, [rows]);
 
-  function orderRows(validations = []) {
+  function orderRows(rows = []) {
     const workMap = new Map();
 
-    validations.forEach(row => {
+    rows.forEach((row) => {
       const workObj = row.fields.find(
-        field => field.header === "work_accession_number"
+        (field) => field.header === "work_accession_number"
       );
       const workAccessionNumber = workObj.value;
       let filesetObj = {};
@@ -23,9 +23,9 @@ const IngestSheetUnapprovedState = ({ validations }) => {
       }
 
       const otherFields = row.fields.filter(
-        field => field.header !== "work_accession_number"
+        (field) => field.header !== "work_accession_number"
       );
-      otherFields.forEach(field => {
+      otherFields.forEach((field) => {
         filesetObj[field.header] = field.value;
       });
 
@@ -41,7 +41,7 @@ const IngestSheetUnapprovedState = ({ validations }) => {
       // so React can display the results
       const groupingsArray = [...groupings];
 
-      return groupingsArray.map(grouping => {
+      return groupingsArray.map((grouping) => {
         const work = grouping[0];
         const filesets = grouping[1];
 
@@ -79,7 +79,7 @@ const IngestSheetUnapprovedState = ({ validations }) => {
 };
 
 IngestSheetUnapprovedState.propTypes = {
-  validations: PropTypes.arrayOf(PropTypes.object)
+  rows: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default IngestSheetUnapprovedState;

--- a/assets/js/components/IngestSheet/Validations.jsx
+++ b/assets/js/components/IngestSheet/Validations.jsx
@@ -4,7 +4,7 @@ import UIProgressBar from "../UI/UIProgressBar";
 import debounce from "lodash.debounce";
 import IngestSheetReport from "./Report";
 import {
-  SUBSCRIBE_TO_INGEST_SHEET_VALIDATION_PROGRESS,
+  INGEST_SHEET_VALIDATION_PROGRESS_SUBSCRIPTION,
   START_VALIDATION,
 } from "./ingestSheet.gql";
 import { useMutation } from "@apollo/client";
@@ -17,23 +17,22 @@ function IngestSheetValidations({
 }) {
   const [startValidation, { validationData }] = useMutation(START_VALIDATION);
   const isValidating = status === "UPLOADED";
-  console.log("percentComplete", percentComplete);
+  console.log("\nIngestSheetValidations() percentComplete", percentComplete);
 
   useEffect(() => {
-    // Kick off the subscription
     subscribeToIngestSheetValidationProgress({
-      document: SUBSCRIBE_TO_INGEST_SHEET_VALIDATION_PROGRESS,
+      document: INGEST_SHEET_VALIDATION_PROGRESS_SUBSCRIPTION,
       variables: { sheetId },
       updateQuery: debounce(handleProgressUpdate, 250, { maxWait: 250 }),
     });
-
     startValidation({ variables: { id: sheetId } });
   }, []);
 
+  // This function handles fresh data from the subscription, which
+  // updates the "ingestSheetValidationProgress" query used in the parent component,
+  // which in turn feeds data back into this component
   const handleProgressUpdate = (prev, { subscriptionData }) => {
     if (!subscriptionData.data) return prev;
-
-    // Feed in latest subscription updates to the component
     return {
       ingestSheetValidationProgress:
         subscriptionData.data.ingestSheetValidationProgress.percentComplete,

--- a/assets/js/components/IngestSheet/Validations.jsx
+++ b/assets/js/components/IngestSheet/Validations.jsx
@@ -17,7 +17,6 @@ function IngestSheetValidations({
 }) {
   const [startValidation, { validationData }] = useMutation(START_VALIDATION);
   const isValidating = status === "UPLOADED";
-  console.log("\nIngestSheetValidations() percentComplete", percentComplete);
 
   useEffect(() => {
     subscribeToIngestSheetValidationProgress({

--- a/assets/js/components/IngestSheet/Validations.jsx
+++ b/assets/js/components/IngestSheet/Validations.jsx
@@ -17,6 +17,7 @@ function IngestSheetValidations({
 }) {
   const [startValidation, { validationData }] = useMutation(START_VALIDATION);
   const isValidating = status === "UPLOADED";
+  console.log("percentComplete", percentComplete);
 
   useEffect(() => {
     // Kick off the subscription

--- a/assets/js/components/IngestSheet/Validations.jsx
+++ b/assets/js/components/IngestSheet/Validations.jsx
@@ -47,13 +47,7 @@ function IngestSheetValidations({
           label="Please wait for validation"
         />
       ) : (
-        <>
-          <IngestSheetReport status={status} sheetId={sheetId} />
-          <p className="notification">
-            Currently setting a LIMIT = 100 on the <code>ingestSheetRows</code>{" "}
-            query for Ingest stress testing
-          </p>
-        </>
+        <IngestSheetReport status={status} sheetId={sheetId} />
       )}
     </section>
   );

--- a/assets/js/components/IngestSheet/ingestSheet.gql.js
+++ b/assets/js/components/IngestSheet/ingestSheet.gql.js
@@ -5,6 +5,8 @@ IngestSheet.fragments = {
   parts: gql`
     fragment IngestSheetParts on IngestSheet {
       fileErrors
+      filename
+      id
       ingestSheetRows {
         errors {
           field
@@ -17,14 +19,12 @@ IngestSheet.fragments = {
         row
         state
       }
-      id
-      title
-      filename
       state {
         name
         state
       }
       status
+      title
     }
   `,
 };
@@ -70,61 +70,6 @@ export const DELETE_INGEST_SHEET = gql`
   }
 `;
 
-export const GET_INGEST_SHEET_ROWS = gql`
-  query IngestSheetRowValidationErrors(
-    $limit: Int
-    $sheetId: ID!
-    $state: [State]
-  ) {
-    ingestSheetRows(limit: $limit, sheetId: $sheetId, state: $state) {
-      row
-      fields {
-        header
-        value
-      }
-      errors {
-        field
-        message
-      }
-      state
-    }
-  }
-`;
-
-export const GET_INGEST_SHEET_STATE = gql`
-  query IngestSheetState($sheetId: ID!) {
-    ingestSheet(id: $sheetId) {
-      id
-      state {
-        title
-        state
-      }
-    }
-  }
-`;
-
-export const GET_INGEST_SHEET_VALIDATION_PROGRESS = gql`
-  query IngestSheetValidationProgress($sheetId: ID!) {
-    ingestSheetValidationProgress(id: $sheetId) {
-      percentComplete
-    }
-  }
-`;
-
-export const GET_INGEST_SHEETS = gql`
-  query GetIngestSheets($projectId: ID!) {
-    project(id: $projectId) {
-      id
-      ingestSheets {
-        id
-        title
-        status
-        updatedAt
-      }
-    }
-  }
-`;
-
 export const GET_PRESIGNED_URL = gql`
   query {
     presignedUrl {
@@ -163,14 +108,35 @@ export const INGEST_SHEET_QUERY = gql`
   query IngestSheetQuery($sheetId: ID!) {
     ingestSheet(id: $sheetId) {
       fileErrors
-      id
-      title
       filename
+      id
       state {
         name
         state
       }
       status
+      title
+    }
+  }
+`;
+
+export const INGEST_SHEET_ROWS = gql`
+  query IngestSheetRowValidationErrors(
+    $limit: Int
+    $sheetId: ID!
+    $state: [State]
+  ) {
+    ingestSheetRows(limit: $limit, sheetId: $sheetId, state: $state) {
+      row
+      fields {
+        header
+        value
+      }
+      errors {
+        field
+        message
+      }
+      state
     }
   }
 `;
@@ -178,10 +144,48 @@ export const INGEST_SHEET_QUERY = gql`
 export const INGEST_SHEET_SUBSCRIPTION = gql`
   subscription OnIngestSheetUpdate($sheetId: ID!) {
     ingestSheetUpdate(sheetId: $sheetId) {
-      ...IngestSheetParts
+      fileErrors
+      filename
+      id
+      state {
+        name
+        state
+      }
+      status
+      title
     }
   }
-  ${IngestSheet.fragments.parts}
+`;
+
+//TODO: Keeping this as a reference, and might switch back to it
+
+// export const INGEST_SHEET_SUBSCRIPTION = gql`
+//   subscription OnIngestSheetUpdate($sheetId: ID!) {
+//     ingestSheetUpdate(sheetId: $sheetId) {
+//       ...IngestSheetParts
+//     }
+//   }
+//   ${IngestSheet.fragments.parts}
+// `;
+
+export const INGEST_SHEET_VALIDATION_PROGRESS = gql`
+  query IngestSheetValidationProgress($sheetId: ID!) {
+    ingestSheetValidationProgress(id: $sheetId) {
+      percentComplete
+    }
+  }
+`;
+
+export const INGEST_SHEET_VALIDATION_PROGRESS_SUBSCRIPTION = gql`
+  subscription OnIngestSheetValidationProgress($sheetId: ID!) {
+    ingestSheetValidationProgress(sheetId: $sheetId) {
+      states {
+        state
+        count
+      }
+      percentComplete
+    }
+  }
 `;
 
 export const INGEST_SHEET_WORKS = gql`
@@ -221,22 +225,24 @@ export const INGEST_SHEET_WORKS = gql`
   }
 `;
 
-export const START_VALIDATION = gql`
-  mutation ValidateIngestSheet($id: ID!) {
-    validateIngestSheet(sheetId: $id) {
-      message
+export const INGEST_SHEETS = gql`
+  query GetIngestSheets($projectId: ID!) {
+    project(id: $projectId) {
+      id
+      ingestSheets {
+        id
+        title
+        status
+        updatedAt
+      }
     }
   }
 `;
 
-export const INGEST_SHEET_VALIDATION_PROGRESS_SUBSCRIPTION = gql`
-  subscription OnIngestSheetValidationProgress($sheetId: ID!) {
-    ingestSheetValidationProgress(sheetId: $sheetId) {
-      states {
-        state
-        count
-      }
-      percentComplete
+export const START_VALIDATION = gql`
+  mutation ValidateIngestSheet($id: ID!) {
+    validateIngestSheet(sheetId: $id) {
+      message
     }
   }
 `;

--- a/assets/js/components/IngestSheet/ingestSheet.gql.js
+++ b/assets/js/components/IngestSheet/ingestSheet.gql.js
@@ -29,6 +29,14 @@ IngestSheet.fragments = {
   `,
 };
 
+export const APPROVE_INGEST_SHEET = gql`
+  mutation ApproveIngestSheet($id: ID!) {
+    approveIngestSheet(id: $id) {
+      message
+    }
+  }
+`;
+
 export const CREATE_INGEST_SHEET = gql`
   mutation CreateIngestSheet(
     $title: String!
@@ -62,16 +70,23 @@ export const DELETE_INGEST_SHEET = gql`
   }
 `;
 
-export const GET_INGEST_SHEETS = gql`
-  query GetIngestSheets($projectId: ID!) {
-    project(id: $projectId) {
-      id
-      ingestSheets {
-        id
-        title
-        status
-        updatedAt
+export const GET_INGEST_SHEET_ROWS = gql`
+  query IngestSheetRowValidationErrors(
+    $limit: Int
+    $sheetId: ID!
+    $state: [State]
+  ) {
+    ingestSheetRows(limit: $limit, sheetId: $sheetId, state: $state) {
+      row
+      fields {
+        header
+        value
       }
+      errors {
+        field
+        message
+      }
+      state
     }
   }
 `;
@@ -88,23 +103,6 @@ export const GET_INGEST_SHEET_STATE = gql`
   }
 `;
 
-export const GET_INGEST_SHEET_ROW_VALIDATION_ERRORS = gql`
-  query IngestSheetRowValidationErrors($limit: Int, $sheetId: ID!) {
-    ingestSheetRows(limit: $limit, sheetId: $sheetId, state: FAIL) {
-      row
-      fields {
-        header
-        value
-      }
-      errors {
-        field
-        message
-      }
-      state
-    }
-  }
-`;
-
 export const GET_INGEST_SHEET_VALIDATION_PROGRESS = gql`
   query IngestSheetValidationProgress($sheetId: ID!) {
     ingestSheetValidationProgress(id: $sheetId) {
@@ -113,19 +111,16 @@ export const GET_INGEST_SHEET_VALIDATION_PROGRESS = gql`
   }
 `;
 
-export const GET_INGEST_SHEET_ROW_VALIDATIONS = gql`
-  query IngestSheetRows($limit: Int, $sheetId: ID!) {
-    ingestSheetRows(limit: $limit, sheetId: $sheetId) {
-      row
-      fields {
-        header
-        value
+export const GET_INGEST_SHEETS = gql`
+  query GetIngestSheets($projectId: ID!) {
+    project(id: $projectId) {
+      id
+      ingestSheets {
+        id
+        title
+        status
+        updatedAt
       }
-      errors {
-        field
-        message
-      }
-      state
     }
   }
 `;
@@ -138,10 +133,28 @@ export const GET_PRESIGNED_URL = gql`
   }
 `;
 
-export const START_VALIDATION = gql`
-  mutation ValidateIngestSheet($id: ID!) {
-    validateIngestSheet(sheetId: $id) {
-      message
+export const INGEST_PROGRESS_SUBSCRIPTION = gql`
+  subscription IngestProgress($sheetId: ID!) {
+    ingestProgress(sheetId: $sheetId) {
+      totalFileSets
+      completedFileSets
+      percentComplete
+    }
+  }
+`;
+
+export const INGEST_SHEET_COMPLETED_ERRORS = gql`
+  query IngestSheetCompletedErrors($id: ID!) {
+    ingestSheetErrors(id: $id) {
+      accessionNumber
+      action
+      description
+      errors
+      filename
+      outcome
+      role
+      rowNumber
+      workAccessionNumber
     }
   }
 `;
@@ -169,36 +182,6 @@ export const INGEST_SHEET_SUBSCRIPTION = gql`
     }
   }
   ${IngestSheet.fragments.parts}
-`;
-
-export const SUBSCRIBE_TO_INGEST_SHEET_VALIDATION_PROGRESS = gql`
-  subscription IngestSheetValidationProgress($sheetId: ID!) {
-    ingestSheetValidationProgress(sheetId: $sheetId) {
-      states {
-        state
-        count
-      }
-      percentComplete
-    }
-  }
-`;
-
-export const APPROVE_INGEST_SHEET = gql`
-  mutation ApproveIngestSheet($id: ID!) {
-    approveIngestSheet(id: $id) {
-      message
-    }
-  }
-`;
-
-export const INGEST_PROGRESS_SUBSCRIPTION = gql`
-  subscription IngestProgress($sheetId: ID!) {
-    ingestProgress(sheetId: $sheetId) {
-      totalFileSets
-      completedFileSets
-      percentComplete
-    }
-  }
 `;
 
 export const INGEST_SHEET_WORKS = gql`
@@ -238,18 +221,22 @@ export const INGEST_SHEET_WORKS = gql`
   }
 `;
 
-export const INGEST_SHEET_COMPLETED_ERRORS = gql`
-  query IngestSheetCompletedErrors($id: ID!) {
-    ingestSheetErrors(id: $id) {
-      accessionNumber
-      action
-      description
-      errors
-      filename
-      outcome
-      role
-      rowNumber
-      workAccessionNumber
+export const START_VALIDATION = gql`
+  mutation ValidateIngestSheet($id: ID!) {
+    validateIngestSheet(sheetId: $id) {
+      message
+    }
+  }
+`;
+
+export const SUBSCRIBE_TO_INGEST_SHEET_VALIDATION_PROGRESS = gql`
+  subscription IngestSheetValidationProgress($sheetId: ID!) {
+    ingestSheetValidationProgress(sheetId: $sheetId) {
+      states {
+        state
+        count
+      }
+      percentComplete
     }
   }
 `;

--- a/assets/js/components/IngestSheet/ingestSheet.gql.js
+++ b/assets/js/components/IngestSheet/ingestSheet.gql.js
@@ -134,7 +134,7 @@ export const GET_PRESIGNED_URL = gql`
 `;
 
 export const INGEST_PROGRESS_SUBSCRIPTION = gql`
-  subscription IngestProgress($sheetId: ID!) {
+  subscription OnIngestProgress($sheetId: ID!) {
     ingestProgress(sheetId: $sheetId) {
       totalFileSets
       completedFileSets
@@ -176,7 +176,7 @@ export const INGEST_SHEET_QUERY = gql`
 `;
 
 export const INGEST_SHEET_SUBSCRIPTION = gql`
-  subscription SubscribeToIngestSheet($sheetId: ID!) {
+  subscription OnIngestSheetUpdate($sheetId: ID!) {
     ingestSheetUpdate(sheetId: $sheetId) {
       ...IngestSheetParts
     }
@@ -229,8 +229,8 @@ export const START_VALIDATION = gql`
   }
 `;
 
-export const SUBSCRIBE_TO_INGEST_SHEET_VALIDATION_PROGRESS = gql`
-  subscription IngestSheetValidationProgress($sheetId: ID!) {
+export const INGEST_SHEET_VALIDATION_PROGRESS_SUBSCRIPTION = gql`
+  subscription OnIngestSheetValidationProgress($sheetId: ID!) {
     ingestSheetValidationProgress(sheetId: $sheetId) {
       states {
         state

--- a/assets/js/screens/IngestSheet/IngestSheet.jsx
+++ b/assets/js/screens/IngestSheet/IngestSheet.jsx
@@ -41,16 +41,14 @@ const ScreensIngestSheet = ({ match }) => {
   });
 
   const {
-    subscribeToMore,
     data: sheetData,
     loading: sheetLoading,
     error: sheetError,
+    subscribeToMore: sheetSubscribeToMore,
   } = useQuery(INGEST_SHEET_QUERY, {
     variables: { sheetId },
     fetchPolicy: "network-only",
   });
-
-  console.log("ScreensIngestSheet() sheetData", sheetData);
 
   if (crumbsError || sheetError)
     return <Error error={crumbsError ? crumbsError : sheetError} />;
@@ -139,20 +137,7 @@ const ScreensIngestSheet = ({ match }) => {
             <IngestSheet
               ingestSheetData={sheetData.ingestSheet}
               projectId={id}
-              subscribeToIngestSheetUpdates={() =>
-                subscribeToMore({
-                  document: INGEST_SHEET_SUBSCRIPTION,
-                  variables: { sheetId },
-                  updateQuery: (prev, { subscriptionData }) => {
-                    if (!subscriptionData.data) return prev;
-                    return {
-                      ingestSheet: {
-                        ...subscriptionData.data.ingestSheetUpdate,
-                      },
-                    };
-                  },
-                })
-              }
+              subscribeToIngestSheetUpdates={sheetSubscribeToMore}
             />
           )}
         </div>

--- a/assets/js/screens/IngestSheet/IngestSheet.jsx
+++ b/assets/js/screens/IngestSheet/IngestSheet.jsx
@@ -1,7 +1,5 @@
 import React from "react";
 import Error from "../../components/UI/Error";
-import UILoadingPage from "../../components/UI/LoadingPage";
-import UILoading from "../../components/UI/Loading";
 import UISkeleton from "../../components/UI/Skeleton";
 import IngestSheet from "../../components/IngestSheet/IngestSheet";
 import gql from "graphql-tag";
@@ -51,6 +49,8 @@ const ScreensIngestSheet = ({ match }) => {
     variables: { sheetId },
     fetchPolicy: "network-only",
   });
+
+  console.log("ScreensIngestSheet() sheetData", sheetData);
 
   if (crumbsError || sheetError)
     return <Error error={crumbsError ? crumbsError : sheetError} />;
@@ -145,9 +145,11 @@ const ScreensIngestSheet = ({ match }) => {
                   variables: { sheetId },
                   updateQuery: (prev, { subscriptionData }) => {
                     if (!subscriptionData.data) return prev;
-                    const updatedSheet =
-                      subscriptionData.data.ingestSheetUpdate;
-                    return { ingestSheet: { ...updatedSheet } };
+                    return {
+                      ingestSheet: {
+                        ...subscriptionData.data.ingestSheetUpdate,
+                      },
+                    };
                   },
                 })
               }


### PR DESCRIPTION
This PR does some cleanup work:

- Renames the queries/mutations/subscriptions on the front end side so they are a little more clear and follow conventions in the Apollo Client documentation
- Follows the subscription data and query data through every component to isolate any bottlenecks
- Thins out the data fetched via GraphQL queries
- Cleans up and thins out component code

After tracing the data through components, looks like the reason it sticks at the Progress bar for the ingest job itself, is that the `ingestSheetUpdate` subscription is not receiving a `status` change from `APPROVED` to `COMPLETED`.   The back end is working on this now to investigate.