### PR TITLE
Pin react-hook-form to v6.9.2, as there appears to be a bug in their …

### DIFF
--- a/assets/js/components/BatchEdit/About/About.jsx
+++ b/assets/js/components/BatchEdit/About/About.jsx
@@ -45,7 +45,6 @@ const BatchEditAbout = () => {
   const methods = useForm({
     defaultValues: {},
   });
-  const { dirtyFields, touched } = methods.formState;
 
   const onCloseModal = () => {
     setIsConfirmModalOpen(false);

--- a/assets/js/components/BatchEdit/Administrative/Administrative.jsx
+++ b/assets/js/components/BatchEdit/Administrative/Administrative.jsx
@@ -29,10 +29,7 @@ const BatchEditAdministrative = () => {
     : 0;
 
   // Initialize React hook form
-  const methods = useForm({
-    defaultValues: {},
-  });
-  const { dirtyFields, touched } = methods.formState;
+  const methods = useForm();
 
   const onCloseModal = () => {
     setIsConfirmModalOpen(false);

--- a/assets/js/components/BatchEdit/Confirmation.jsx
+++ b/assets/js/components/BatchEdit/Confirmation.jsx
@@ -43,7 +43,7 @@ const BatchEditConfirmation = ({
     },
     onError(error) {
       console.log("onError() error", error);
-      toastWrapper("is-danger", error);
+      toastWrapper("is-danger", error.toString());
       handleClose();
     },
   });

--- a/assets/js/components/BatchEdit/Tabs.jsx
+++ b/assets/js/components/BatchEdit/Tabs.jsx
@@ -1,7 +1,6 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import BatchEditAbout from "./About/About";
 import BatchEditAdministrative from "./Administrative/Administrative";
-import PropTypes from "prop-types";
 import { CodeListProvider } from "@js/context/code-list-context";
 
 export default function BatchEditTabs() {

--- a/assets/js/components/Work/Tabs/About/ControlledMetadata.test.js
+++ b/assets/js/components/Work/Tabs/About/ControlledMetadata.test.js
@@ -4,11 +4,7 @@ import { mockWork } from "../../work.gql.mock";
 import WorkTabsAboutControlledMetadata from "./ControlledMetadata";
 import { waitFor } from "@testing-library/react";
 import { CodeListProvider } from "@js/context/code-list-context";
-import {
-  codeListAuthorityMock,
-  codeListMarcRelatorMock,
-  codeListSubjectRoleMock,
-} from "@js/components/Work/controlledVocabulary.gql.mock";
+import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
 
 describe("Work About tab Controlled Metadata component", () => {
   function setupTests() {
@@ -19,11 +15,7 @@ describe("Work About tab Controlled Metadata component", () => {
         />
       </CodeListProvider>,
       {
-        mocks: [
-          codeListAuthorityMock,
-          codeListMarcRelatorMock,
-          codeListSubjectRoleMock,
-        ],
+        mocks: allCodeListMocks,
       }
     );
   }

--- a/assets/js/screens/BatchEdit/BatchEdit.jsx
+++ b/assets/js/screens/BatchEdit/BatchEdit.jsx
@@ -71,7 +71,7 @@ const ScreensBatchEdit = () => {
                 ) : (
                   <div>
                     <p
-                      className="notification is-warning mt-5"
+                      className="notification is-warning is-light mt-5"
                       data-testid="batch-edit-preview-notification"
                     >
                       <span className="icon">

--- a/assets/package.json
+++ b/assets/package.json
@@ -43,7 +43,7 @@
     "react-apollo": "^3.1.5",
     "react-beautiful-dnd": "^13.0.0",
     "react-csv": "^2.0.3",
-    "react-hook-form": "^6.9.6",
+    "react-hook-form": "6.9.2",
     "react-json-pretty": "^2.2.0",
     "recharts": "^1.8.5"
   },

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -1552,9 +1552,9 @@
   integrity sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
-  version "7.1.10"
-  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.10.tgz#ca58fc195dd9734e77e57c6f2df565623636ab40"
-  integrity sha512-x8OM8XzITIMyiwl5Vmo2B1cR1S1Ipkyv4mdlbJjMa1lmuKvKY9FrBbEANIaMlnWn5Rf7uO+rC/VgYabNkE17Hw==
+  version "7.1.11"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.11.tgz#7fae4660a009a4031e293f25b213f142d823b3c4"
+  integrity sha512-E5nSOzrjnvhURYnbOR2dClTqcyhPbPvtEwLHf7JJADKedPbcZsoJVfP+I2vBNfBjz4bnZIuhL/tNmRi5nJ7Jlw==
   dependencies:
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
@@ -1624,9 +1624,9 @@
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
 "@types/node@*":
-  version "14.14.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.5.tgz#e92d3b8f76583efa26c1a63a21c9d3c1143daa29"
-  integrity sha512-H5Wn24s/ZOukBmDn03nnGTp18A60ny9AmCwnEcgJiTgSGsCO7k+NWP7zjCCbhlcnVCoI+co52dUAt9GMhOSULw==
+  version "14.14.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.6.tgz#146d3da57b3c636cc0d1769396ce1cfa8991147f"
+  integrity sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -2652,9 +2652,9 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 camelcase@^6.0.0, camelcase@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.1.0.tgz#27dc176173725fb0adf8a48b647f4d7871944d78"
-  integrity sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ==
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
+  integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-api@^3.0.0:
   version "3.0.0"
@@ -2667,9 +2667,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001135:
-  version "1.0.30001151"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001151.tgz#1ddfde5e6fff02aad7940b4edb7d3ac76b0cb00b"
-  integrity sha512-Zh3sHqskX6mHNrqUerh+fkf0N72cMxrmflzje/JyVImfpknscMnkeJrlFGJcqTmaa0iszdYptGpWMJCRQDkBVw==
+  version "1.0.30001154"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001154.tgz#f3bbc245ce55e4c1cd20fa731b097880181a7f17"
+  integrity sha512-y9DvdSti8NnYB9Be92ddMZQrcOe04kcQtcxtBx4NkB04+qZ+JUWotnXBJTmxlKudhxNTQ3RRknMwNU2YQl/Org==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -3680,9 +3680,9 @@ elasticsearch@^16.7.1:
     lodash "^4.17.10"
 
 electron-to-chromium@^1.3.571:
-  version "1.3.584"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.584.tgz#506cf7ba5895aafa8241876ab028654b61fd9ceb"
-  integrity sha512-NB3DzrTzJFhWkUp+nl2KtUtoFzrfGXTir2S+BU4tXGyXH9vlluPuFpE3pTKeH7+PY460tHLjKzh6K2+TWwW+Ww==
+  version "1.3.585"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.585.tgz#71cdb722c73488b9475ad1c572cf43a763ef9081"
+  integrity sha512-xoeqjMQhgHDZM7FiglJAb2aeOxHZWFruUc3MbAGTgE7GB8rr5fTn1Sdh5THGuQtndU3GuXlu91ZKqRivxoCZ/A==
 
 elliptic@^6.5.3:
   version "6.5.3"
@@ -6273,9 +6273,9 @@ node-notifier@^8.0.0:
     which "^2.0.2"
 
 node-releases@^1.1.61:
-  version "1.1.64"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.64.tgz#71b4ae988e9b1dd7c1ffce58dd9e561752dfebc5"
-  integrity sha512-Iec8O9166/x2HRMJyLLLWkd0sFFLrFNy+Xf+JQfSQsdBJzPcHpNl3JQ9gD4j+aJxmCa25jNsIbM4bmACtSbkSg==
+  version "1.1.65"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.65.tgz#52d9579176bd60f23eba05c4438583f341944b81"
+  integrity sha512-YpzJOe2WFIW0V4ZkJQd/DGR/zdVwc/pI4Nl1CZrBO19FdRcSTmsuhdttw9rsTzzJLrNcSloLiBbEYx1C4f6gpA==
 
 node-sass@^4.14.1:
   version "4.14.1"
@@ -7344,10 +7344,10 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-hook-form@^6.9.6:
-  version "6.9.6"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.9.6.tgz#bbcdfa34a660edcdd160cba2d501583b0e3d60a9"
-  integrity sha512-TyLqWHgFS1WLELDuUBvMWLHEzmR7aS7xOY+eOxMtS1w4jFhqF1xmHnMhJsbiFPSgC+OeTJ1Pc0U4K0y6cA7ERA==
+react-hook-form@6.9.2:
+  version "6.9.2"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.9.2.tgz#9512cd424e62235fda13c8fc1821f88c352e3d23"
+  integrity sha512-vCPEbHVCRvsoqrQARgQ7a3VrXzqbFOO53gHFRdQzLzHMT9kxum3wfcSi8A1b49KPRsomvsqexH4tBUJMneEu+Q==
 
 react-input-autosize@^2.2.2:
   version "2.2.2"
@@ -9072,9 +9072,9 @@ uuid@^8.3.0:
   integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
 
 v8-compile-cache@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"
-  integrity sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"
+  integrity sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==
 
 v8-to-istanbul@^6.0.1:
   version "6.0.1"


### PR DESCRIPTION
…reset() method.  Also upgraded React to v17.

I couldn't find a solution to this after burning 2 hours on it, so just reverting back to v6.9.2   It could either be a bug in React Hook Form's `reset()` method, or a collision with how we're implementing FieldArrays, then calling `reset()`.   We can look into it later after the next release in a week or so and see if it resolves itself.

To test, make sure to do a `yarn install` before testing in the UI.