### PR TITLE
Add date_created to API and Ecto schema

### DIFF
--- a/lib/meadow/data/schemas/types/edtf_date.ex
+++ b/lib/meadow/data/schemas/types/edtf_date.ex
@@ -1,0 +1,47 @@
+defmodule Meadow.Data.Types.EDTFDate do
+  @moduledoc """
+  Ecto.Type for converting between edtf string and humanized date
+  """
+
+  use Ecto.Type
+  alias Meadow.Data.Works
+
+  def embed_as(:json), do: :dump
+
+  def type, do: :map
+
+  def cast(edtf_date), do: humanize(edtf_date)
+
+  def load(edtf_date), do: humanize(edtf_date)
+
+  def dump(nil), do: nil
+
+  def dump(%{edtf_date: edtf_date, humanized_date: humanized_date}),
+    do: {:ok, %{edtf_date: edtf_date, humanized_date: humanized_date}}
+
+  def dump(_), do: :error
+
+  defp humanize(nil), do: {:ok, nil}
+
+  defp humanize(%{edtf_date: ""}),
+    do: {:error, message: "edtf_date cannot be blank"}
+
+  defp humanize(%{edtf_date: edtf_date, humanized_date: humanized_date}),
+    do: {:ok, %{edtf_date: edtf_date, humanized_date: humanized_date}}
+
+  defp humanize(%{"edtf_date" => edtf_date, "humanized_date" => humanized_date}),
+    do: {:ok, %{edtf_date: edtf_date, humanized_date: humanized_date}}
+
+  defp humanize(%{edtf_date: edtf_date}), do: humanize(edtf_date)
+
+  defp humanize(edtf_date) when is_binary(edtf_date) do
+    case Works.parse_edtf_date(edtf_date) do
+      {:ok, %{edtf_date: edtf_date, humanized_date: humanized_date}} ->
+        {:ok, %{edtf_date: edtf_date, humanized_date: humanized_date}}
+    end
+  end
+
+  defp humanize(%{}), do: {:ok, nil}
+
+  defp humanize(_), do: {:error, message: "Invalid edtf_date type"}
+end

--- a/lib/meadow/data/schemas/work_descriptive_metadata.ex
+++ b/lib/meadow/data/schemas/work_descriptive_metadata.ex
@@ -55,6 +55,10 @@ defmodule Meadow.Data.Schemas.WorkDescriptiveMetadata do
     :technique
   ]
 
+  @edtf_fields [
+    :date_created
+  ]
+
   @timestamps_opts [type: :utc_datetime_usec]
   embedded_schema do
     @fields
@@ -73,6 +77,11 @@ defmodule Meadow.Data.Schemas.WorkDescriptiveMetadata do
       embeds_many(f, ControlledMetadataEntry, on_replace: :delete)
     end)
 
+    @edtf_fields
+    |> Enum.each(fn f ->
+      field f, {:array, Types.EDTFDate}, default: []
+    end)
+
     embeds_many(:related_url, RelatedURLEntry, on_replace: :delete)
 
     timestamps()
@@ -87,7 +96,8 @@ defmodule Meadow.Data.Schemas.WorkDescriptiveMetadata do
     Enum.reduce(@controlled_fields, changeset, fn field, acc -> cast_embed(acc, field) end)
   end
 
-  defp permitted, do: @coded_fields ++ scalar_fields()
+  def permitted, do: @coded_fields ++ scalar_fields() ++ @edtf_fields
+
   defp scalar_fields, do: @fields |> Enum.map(fn {name, _} -> name end)
   def field_names, do: __schema__(:fields) -- [:id, :inserted_at, :updated_at]
 

--- a/lib/meadow/data/works.ex
+++ b/lib/meadow/data/works.ex
@@ -492,4 +492,12 @@ defmodule Meadow.Data.Works do
         ]
       ]
   end
+
+  @doc """
+  Callout to EDTF.js port
+  """
+  def parse_edtf_date(edtf_date) do
+    # obviously this is temporary
+    {:ok, %{edtf_date: edtf_date, humanized_date: "Tue, 01 Jul 1975"}}
+  end
 end

--- a/lib/meadow_web/schema/types/data/batch_types.ex
+++ b/lib/meadow_web/schema/types/data/batch_types.ex
@@ -82,6 +82,7 @@ defmodule MeadowWeb.Schema.Data.BatchTypes do
     field :box_number, list_of(:string)
     field :caption, list_of(:string)
     field :catalog_key, list_of(:string)
+    field :date_created, list_of(:edtf_date_input)
     field :description, list_of(:string)
     field :folder_name, list_of(:string)
     field :folder_number, list_of(:string)

--- a/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
+++ b/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
@@ -68,6 +68,12 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
     field :scheme, :code_list_scheme
   end
 
+  @desc "EDTF Date"
+  object :edtf_date_entry do
+    field :edtf_date, :string
+    field :humanized_date, :string
+  end
+
   @desc "RelatedURLEntry"
   object :related_url_entry do
     field :url, :string
@@ -84,6 +90,11 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
   input_object :coded_term_input do
     field :id, :id
     field :scheme, :code_list_scheme
+  end
+
+  @desc "EDTF date input"
+  input_object :edtf_date_input do
+    field :edtf_date, :string
   end
 
   @desc "Related URL input"

--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -154,6 +154,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
   object :work_descriptive_metadata do
     field :ark, :string
     field :citation, list_of(:string)
+    field :date_created, list_of(:edtf_date_entry)
     field :license, :coded_term
     field :rights_statement, :coded_term
     field :related_url, list_of(:related_url_entry)
@@ -215,6 +216,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
 
   @desc "Input fields for works descriptive metadata"
   input_object :work_descriptive_metadata_input do
+    field :date_created, list_of(:edtf_date_input)
     field :license, :coded_term_input
     field :rights_statement, :coded_term_input
     field :related_url, list_of(:related_url_entry_input)

--- a/test/gql/WorkDescriptiveMetadataFields.frag.gql
+++ b/test/gql/WorkDescriptiveMetadataFields.frag.gql
@@ -2,6 +2,10 @@ fragment WorkDescriptiveMetadataFields on Work {
   descriptiveMetadata {
     ark
     title
+    dateCreated {
+      edtfDate
+      humanizedDate
+    }
     description
     contributor {
       term {

--- a/test/meadow/data/schemas/types/edtf_date_test.exs
+++ b/test/meadow/data/schemas/types/edtf_date_test.exs
@@ -1,0 +1,33 @@
+defmodule Meadow.Data.Types.EDTF.DateTest do
+  @moduledoc false
+  use Meadow.AuthorityCase
+  use Meadow.DataCase
+
+  alias Meadow.Data.Types.EDTFDate
+
+  @edtf_date_db_type %{
+    edtf_date: "1975-07-01",
+    humanized_date: "Tue, 01 Jul 1975"
+  }
+
+  describe "Meadow.Data.Types.EDTFDate" do
+    test "cast function" do
+      assert {:ok, @edtf_date_db_type} == EDTFDate.cast(@edtf_date_db_type)
+      assert EDTFDate.cast(1234) == {:error, [message: "Invalid edtf_date type"]}
+
+      assert EDTFDate.cast("1975-07-01") ==
+               {:ok, %{edtf_date: "1975-07-01", humanized_date: "Tue, 01 Jul 1975"}}
+    end
+
+    test "dump function" do
+      assert EDTFDate.dump(@edtf_date_db_type) == {:ok, @edtf_date_db_type}
+      assert EDTFDate.dump(134_524) == :error
+    end
+
+    test "load function" do
+      assert EDTFDate.load(@edtf_date_db_type) == {:ok, @edtf_date_db_type}
+
+      assert EDTFDate.load(1234) == {:error, [message: "Invalid edtf_date type"]}
+    end
+  end
+end


### PR DESCRIPTION
- Adds `date_created` to work descriptive metadata
- Creates custom Ecto type for `date_created`
  - DB format: `%{edtf_date: "1975-07-01", humanized_date: "Tue, 01 Jul 1975"}`
  - for now there is no actual validation (since that is represented in other tickets). (any string will "humanize" as "Tue, 01 Jul 1975")
- Adds `date_created` to GraphQL API (work queries and mutations and batchUpdate mutation)

<img width="1402" alt="Screen Shot 2020-11-02 at 1 04 54 PM" src="https://user-images.githubusercontent.com/6372022/97915896-759efa00-1d0f-11eb-8763-3139d27ca575.png">



*** Requires a `down -v` locally or a database reset on staging....