### PR TITLE
Create reusable DatabaseNotification module to handle change notifications from the database

### DIFF
--- a/lib/meadow/database_notification.ex
+++ b/lib/meadow/database_notification.ex
@@ -1,0 +1,168 @@
+defmodule Meadow.DatabaseNotification do
+  @moduledoc """
+  Listen for and handle database notifications.
+
+  Example:
+
+  ```
+  defmodule MyDatabaseNotification do
+    use Meadow.DatabaseNotification, tables: [:my_table]
+
+    def handle_notification(table, operation, key) do
+      # Handle the notification here
+      # `table` is the name of the table (as an atom)
+      # `operation` is `:insert`, `:update`, or `:delete`
+      # `key` is a map containing the primary key fields
+      # of the changed record.
+
+      :ok
+    end
+  end
+  ```
+
+  Add to the list of children in `lib/meadow/application/children.ex`:
+  ```
+  def specs(:dev) do
+    [
+      MyDatabaseNotification
+    ]
+  end
+  ```
+
+  ## Creating the database notification triggers
+
+  In order for the process to receive change notifications, the database has
+  to send them. #{__MODULE__} provides two functions to assist with the creation
+  (and destruction) of the necessary Postgres functions and triggers:
+
+  ```
+  defmodule MyDatabaseNotificationTrigger do
+    use Ecto.Migration
+    import Meadow.DatabaseNotification
+
+    def up do
+      create_notification_trigger(:my_table)
+    end
+
+    def down do
+      drop_notification_trigger(:my_table)
+    end
+  end
+  ```
+  """
+
+  @type operation :: :insert | :update | :delete
+  @callback handle_notification(
+              table :: atom(),
+              operation :: operation(),
+              key :: map(),
+              state :: any()
+            ) :: any()
+
+  defmacro __using__(args) do
+    quote location: :keep, bind_quoted: [tables: Keyword.get(args, :tables, [])] do
+      use GenServer
+      require Logger
+
+      @behaviour Meadow.DatabaseNotification
+
+      def child_spec(opts) do
+        %{
+          id: __MODULE__,
+          start: {__MODULE__, :start_link, [opts]}
+        }
+      end
+
+      def start_link(args \\ []) do
+        GenServer.start_link(__MODULE__, args, name: __MODULE__)
+      end
+
+      @impl GenServer
+      def init(initial_state) do
+        unquote(tables)
+        |> Enum.each(fn table ->
+          Logger.info("#{__MODULE__}: Listening for changes to '#{table}'")
+          Meadow.Repo.listen("#{table}_changed")
+        end)
+
+        {:ok, initial_state}
+      end
+
+      tables
+      |> Enum.each(fn table ->
+        with message <- "#{table}_changed" do
+          @impl GenServer
+          def handle_info({:notification, _pid, _ref, message, payload}, state) do
+            with data <- Jason.decode!(payload, keys: :atoms) do
+              {:noreply, state} =
+                handle_notification(
+                  unquote(table),
+                  Map.get(data, :operation) |> String.downcase() |> String.to_atom(),
+                  Map.get(data, :key, nil),
+                  state
+                )
+            end
+
+            {:noreply, state}
+          end
+        end
+      end)
+
+      @impl GenServer
+      def handle_info({:ssl_closed, _msg}, state), do: {:noreply, state}
+    end
+  end
+
+  def create_notification_trigger(table) do
+    Ecto.Migration.execute("""
+      CREATE OR REPLACE FUNCTION notify_#{table}_changed()
+      RETURNS trigger AS $$
+      DECLARE
+        changed JSONB;
+        key_field TEXT;
+        key JSONB := jsonb_object('{}');
+        payload TEXT;
+      BEGIN
+        IF TG_OP IN ('INSERT', 'UPDATE') THEN
+          changed = row_to_json(NEW)::JSONB;
+        ELSE
+          changed = row_to_json(OLD)::JSONB;
+        END IF;
+
+        -- Build the key dynamically based on the primary key
+        -- of the table. This will usually be {"id": record.id}
+        -- but this allows for notifications on tables with
+        -- compound keys.
+
+        FOR key_field IN
+          SELECT c.column_name
+          FROM information_schema.key_column_usage AS c
+          LEFT JOIN information_schema.table_constraints AS t
+          ON t.constraint_name = c.constraint_name
+          WHERE t.table_name = '#{table}' AND t.constraint_type = 'PRIMARY KEY'
+          ORDER BY c.ordinal_position
+        LOOP
+          key = jsonb_set(key, ('{'||key_field||'}')::text[], changed->key_field);
+        END LOOP;
+
+        SELECT json_build_object('operation', TG_OP, 'key', key)::text INTO payload;
+        PERFORM pg_notify('#{table}_changed', payload);
+
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    """)
+
+    Ecto.Migration.execute("""
+      CREATE TRIGGER #{table}_changed
+        AFTER INSERT OR UPDATE OR DELETE ON #{table}
+        FOR EACH ROW
+        EXECUTE PROCEDURE notify_#{table}_changed()
+    """)
+  end
+
+  def drop_notification_trigger(table) do
+    Ecto.Migration.execute("DROP TRIGGER IF EXISTS #{table}_changed ON #{table}")
+    Ecto.Migration.execute("DROP FUNCTION IF EXISTS notify_#{table}_changed")
+  end
+end

--- a/lib/meadow/iiif/manifest_listener.ex
+++ b/lib/meadow/iiif/manifest_listener.ex
@@ -2,49 +2,17 @@ defmodule Meadow.IIIF.ManifestListener do
   @moduledoc """
   Listens to INSERTS/UPDATES on Postgrex.Notifications topic "works_changed" and writes IIIF Manifests to S3
   """
-  use GenServer
+  use Meadow.DatabaseNotification, tables: [:works]
   require Logger
 
   alias Meadow.IIIF
 
-  @topic "works_changed"
-
-  def child_spec(opts) do
-    %{
-      id: __MODULE__,
-      start: {__MODULE__, :start_link, [opts]}
-    }
-  end
-
-  def start_link(opts \\ []),
-    do: GenServer.start_link(__MODULE__, opts)
-
   @impl true
-  def init(opts) do
-    case Meadow.Repo.listen(@topic) do
-      {:ok, _pid, _ref} ->
-        {:ok, opts}
+  def handle_notification(:works, :delete, _key, state), do: {:noreply, state}
 
-      error ->
-        {:stop, error}
-    end
+  def handle_notification(:works, _op, %{id: id}, state) do
+    Logger.info("Writing manifest for #{id}")
+    id |> IIIF.write_manifest()
+    {:noreply, state}
   end
-
-  @impl true
-  def handle_info({:notification, _pid, _ref, @topic, payload}, _state) do
-    case Jason.decode(payload, keys: :atoms) do
-      {:ok, data} ->
-        id = data.record.id
-        Logger.info("Writing manifest for #{id}")
-
-        id |> IIIF.write_manifest()
-
-        {:noreply, :event_handled}
-
-      error ->
-        {:stop, error, []}
-    end
-  end
-
-  def handle_info({:ssl_closed, _msg}, state), do: {:noreply, state}
 end

--- a/priv/repo/migrations/20201102222710_works_changed_notification.exs
+++ b/priv/repo/migrations/20201102222710_works_changed_notification.exs
@@ -1,0 +1,21 @@
+defmodule Meadow.Repo.Migrations.WorksChangedNotification do
+  use Ecto.Migration
+  import Meadow.DatabaseNotification
+
+  # This is a cleanup function and should be removed during the next
+  # migration rollup
+  defp revert_20200227215805_notify_work_updates do
+    execute("DROP TRIGGER IF EXISTS works_changed ON works")
+    execute("DROP FUNCTION IF EXISTS notify_work_changes")
+  end
+
+  def up do
+    revert_20200227215805_notify_work_updates()
+    flush()
+    create_notification_trigger(:works)
+  end
+
+  def down do
+    drop_notification_trigger(:works)
+  end
+end

--- a/test/meadow/database_notification_test.exs
+++ b/test/meadow/database_notification_test.exs
@@ -1,0 +1,92 @@
+defmodule Meadow.DatabaseNotificationTest do
+  alias Ecto.Adapters.SQL
+  alias Meadow.DatabaseNotification
+  use Meadow.UnsandboxedDataCase, async: false
+
+  @migration_version 20_991_120_154_501
+
+  defmodule NotificationTestMigration do
+    use Ecto.Migration
+    import DatabaseNotification
+
+    @table :database_notification_test
+
+    def up do
+      create table(@table) do
+        add(:data, :string)
+      end
+
+      create_notification_trigger(@table)
+    end
+
+    def down do
+      drop_notification_trigger(@table)
+      drop(table(@table))
+    end
+  end
+
+  defmodule NotificationTestListener do
+    use DatabaseNotification, tables: [:database_notification_test]
+
+    @impl true
+    def handle_notification(:database_notification_test, op, key, listener) do
+      send(listener, {op, key})
+      {:noreply, listener}
+    end
+  end
+
+  setup %{repo: repo} do
+    Ecto.Migrator.up(repo, @migration_version, NotificationTestMigration)
+    start_supervised!({NotificationTestListener, self()})
+
+    on_exit(fn ->
+      Ecto.Migrator.down(repo, @migration_version, NotificationTestMigration)
+    end)
+
+    sql = "INSERT INTO database_notification_test (data) VALUES ('initial value') RETURNING id"
+
+    [[uuid]] =
+      repo
+      |> SQL.query!(sql)
+      |> Map.get(:rows)
+
+    {:ok, record_id} = Ecto.UUID.load(uuid)
+    {:ok, %{record_id: record_id, repo: repo}}
+  end
+
+  describe "insert" do
+    test "insert notification", %{record_id: record_id} do
+      assert_receive({:insert, %{id: ^record_id}})
+      refute_receive({:update, _})
+      refute_receive({:delete, _})
+    end
+  end
+
+  describe "update" do
+    setup %{repo: repo} do
+      assert_receive({:insert, _})
+      SQL.query!(repo, "UPDATE database_notification_test SET data = 'updated value'")
+      :ok
+    end
+
+    test "update notification", %{record_id: record_id} do
+      refute_receive({:insert, _})
+      assert_receive({:update, %{id: ^record_id}})
+      refute_receive({:delete, _})
+    end
+  end
+
+  describe "delete" do
+    setup %{repo: repo} do
+      assert_receive({:insert, _})
+      SQL.query!(repo, "DELETE FROM database_notification_test")
+      :ok
+    end
+
+    test "delete notification", %{record_id: record_id} do
+      refute_receive({:insert, _})
+      refute_receive({:update, _})
+      assert_receive({:delete, %{id: ^record_id}})
+    end
+  end
+end

--- a/test/meadow/iiif/manifest_listener_test.exs
+++ b/test/meadow/iiif/manifest_listener_test.exs
@@ -5,35 +5,25 @@ defmodule Meadow.IIIF.ManifestListenerTest do
   alias Meadow.IIIF.ManifestListener
   alias Meadow.Utils.Pairtree
 
-  setup _context do
-    listener = start_supervised!(ManifestListener)
-    %{listener: listener}
-  end
-
   @pyramid_bucket Config.pyramid_bucket()
 
-  describe "init/1" do
-    test "sets itself as a listener to the \"works_changed\" topic" do
-      assert ManifestListener.init("works_changed") == {:ok, "works_changed"}
-    end
-  end
-
-  describe "handle_info/2" do
+  describe "handle_notification/4" do
     test "writes a manifest to S3 when it receives a Postgres INSERT/UPDATE notification" do
       work = work_fixture()
       destination = Pairtree.manifest_key(work.id)
-
-      notification =
-        {:notification, "bar", "foo", "works_changed",
-         "{\"operation\" : \"INSERT\", \"record\" : {\"id\":\"#{work.id}\",\"work_type\":\"image\",\"collection_id\":null,\"visibility\":\"restricted\",\"accession_number\":\"jjj\",\"descriptive_metadata\":{\"id\": \"4a6ecdbe-8509-4085-9f79-e6f2547dc852\", \"genre\": [], \"title\": null, \"keywords\": [], \"technique\": null, \"updated_at\": \"2020-03-03T10:55:13.594939Z\", \"description\": null, \"inserted_at\": \"2020-03-03T10:55:13.594939Z\", \"nul_subject\": []},\"administrative_metadata\":{\"id\": \"6dbc9f29-b66c-4f7c-a40e-d9484d892882\", \"updated_at\": \"2020-03-03T10:55:13.594917Z\", \"inserted_at\": \"2020-03-03T10:55:13.594917Z\", \"rights_statement\": null, \"preservation_level\": null},\"published\":false,\"inserted_at\":\"2020-03-03T10:55:13.594947\",\"updated_at\":\"2020-03-03T10:55:13.594947\",\"representative_file_set_id\":null}}"}
-
-      assert ManifestListener.handle_info(notification, []) == {:noreply, :event_handled}
+      ManifestListener.handle_notification(:works, :insert, %{id: work.id}, nil)
 
       assert(object_exists?(@pyramid_bucket, destination))
 
       on_exit(fn ->
         delete_object(@pyramid_bucket, destination)
       end)
+    end
+
+    test "ignores DELETE notification" do
+      work = work_fixture()
+      Repo.delete(work)
+      ManifestListener.handle_notification(:works, :delete, %{id: work.id}, nil)
     end
   end
 end

--- a/test/support/unsandboxed_data_case.ex
+++ b/test/support/unsandboxed_data_case.ex
@@ -1,0 +1,35 @@
+defmodule Meadow.UnsandboxedDataCase do
+  @moduledoc """
+  This module defines the setup for tests requiring
+  direct, unsandboxed access to the application's data
+  layer (e.g., for testing database triggers).
+
+  Use this module with caution:
+  * Use it only with `async: false`
+  * Clean up any data changes manually
+  """
+
+  use ExUnit.CaseTemplate
+
+  defmodule Repo do
+    @moduledoc false
+    use Ecto.Repo, adapter: Ecto.Adapters.Postgres, otp_app: :meadow
+  end
+
+  setup_all do
+    Application.put_env(
+      :meadow,
+      Meadow.UnsandboxedDataCase.Repo,
+      Application.get_env(:meadow, Meadow.Repo)
+      |> Keyword.delete(:pool)
+      |> Keyword.put(:show_sensitive_data_on_connection_error, true)
+    )
+
+    start_supervised!(Meadow.UnsandboxedDataCase.Repo)
+    :ok
+  end
+
+  setup do
+    {:ok, %{repo: Meadow.UnsandboxedDataCase.Repo}}
+  end
+end


### PR DESCRIPTION
This PR creates a reusable framework for handling `pg_notify` type database notifications from PostgreSQL. It includes:

* A `use`-able module to serve as the basis for listeners on the Elixir side (see [Meadow.IIIF.ManifestListener](https://github.com/nulib/meadow/blob/1229-notification-task/lib/meadow/iiif/manifest_listener.ex))
* Two migration helpers to create/drop the appropriate functions and triggers on the Ecto/Postgres side (See [this migration](https://github.com/nulib/meadow/blob/1229-notification-task/priv/repo/migrations/20201102222710_works_changed_notification.exs) for an example of it in action).

