### PR TITLE
Clean up Work and Batch Edit form UI

### DIFF
--- a/assets/js/components/BatchEdit/About/About.jsx
+++ b/assets/js/components/BatchEdit/About/About.jsx
@@ -133,14 +133,14 @@ const BatchEditAbout = () => {
         >
           <>
             <Button type="submit" isPrimary data-testid="save-button">
-              Save Data for {numberOfResults} Items
+              Save data for {numberOfResults} items
             </Button>
             <Button
               isText
               data-testid="cancel-button"
               onClick={handleFormReset}
             >
-              Clear Form
+              Clear form
             </Button>
           </>
         </UITabsStickyHeader>

--- a/assets/js/components/BatchEdit/About/ControlledMetadata.jsx
+++ b/assets/js/components/BatchEdit/About/ControlledMetadata.jsx
@@ -39,10 +39,10 @@ const BatchEditAboutControlledMetadata = ({ ...restProps }) => {
 
   return (
     <div data-testid="controlled-metadata" {...restProps}>
-      <ul>
+      <ul className="columns is-multiline">
         {!codeLists.isLoading &&
           CONTROLLED_METADATA.map(({ label, name, scheme }) => (
-            <li key={name} className="mb-5" data-testid={name}>
+            <li key={name} className="column is-half mb-5" data-testid={name}>
               <UIFormField label={label}>
                 <UIFormControlledTermArray
                   authorities={codeLists.authorityData.codeList}

--- a/assets/js/components/BatchEdit/About/CoreMetadata.jsx
+++ b/assets/js/components/BatchEdit/About/CoreMetadata.jsx
@@ -27,7 +27,7 @@ const BatchEditAboutCoreMetadata = ({ ...restProps }) => {
       data-testid="core-metadata"
       {...restProps}
     >
-      <div className="column is-full">
+      <div className="column is-two-thirds">
         {/* Title */}
         <UIFormField label="Title">
           <UIInput
@@ -39,7 +39,17 @@ const BatchEditAboutCoreMetadata = ({ ...restProps }) => {
         </UIFormField>
       </div>
 
-      <div className="column is-full">
+      <div className="column is-half">
+        {/* Description */}
+        <UIFormBatchFieldArray
+          name="description"
+          label="Description"
+          data-testid="description"
+          isTextarea={true}
+        />
+      </div>
+
+      <div className="column is-half">
         {/* Alternate Title */}
         <UIFormBatchFieldArray
           name="alternateTitle"
@@ -47,38 +57,7 @@ const BatchEditAboutCoreMetadata = ({ ...restProps }) => {
           label="Alternate Title"
         />
       </div>
-      <div className="column is-full">
-        <UIFormField label="Collection">
-          <div className="select">
-            <select name="collection" ref={register()} data-testid="collection">
-              <option value="">-- Select --</option>
-              {collectionData &&
-                collectionData.collections.map((collection) => (
-                  <option
-                    key={collection.id}
-                    value={JSON.stringify(collection)}
-                  >
-                    {collection.title}
-                  </option>
-                ))}
-            </select>
-          </div>
-        </UIFormField>
-      </div>
-      <div className="column is-half">
-        {/* Date Created */}
-        <UIFormField label="Date Created" notLive>
-          <UIInput
-            isReactHookForm
-            name="dateCreated"
-            label="Date Created"
-            type="date"
-            data-testid="date-created"
-          />
-          <UITagNotYetSupported label="Display not yet supported" />
-          <UITagNotYetSupported label="Update not yet supported" />
-        </UIFormField>
-      </div>
+
       <div className="column is-half">
         <UIFormField label="Rights Statement">
           <div className="select" data-testid="rights-statement">
@@ -101,14 +80,39 @@ const BatchEditAboutCoreMetadata = ({ ...restProps }) => {
           </div>
         </UIFormField>
       </div>
-      <div className="column is-full">
-        {/* Description */}
-        <UIFormBatchFieldArray
-          name="description"
-          label="Description"
-          data-testid="description"
-          isTextarea={true}
-        />
+
+      <div className="column is-half">
+        {/* Date Created */}
+        <UIFormField label="Date Created" notLive>
+          <UIInput
+            isReactHookForm
+            name="dateCreated"
+            label="Date Created"
+            type="date"
+            data-testid="date-created"
+          />
+          <UITagNotYetSupported label="Display not yet supported" />
+          <UITagNotYetSupported label="Update not yet supported" />
+        </UIFormField>
+      </div>
+
+      <div className="column is-half">
+        <UIFormField label="Collection">
+          <div className="select">
+            <select name="collection" ref={register()} data-testid="collection">
+              <option value="">-- Select --</option>
+              {collectionData &&
+                collectionData.collections.map((collection) => (
+                  <option
+                    key={collection.id}
+                    value={JSON.stringify(collection)}
+                  >
+                    {collection.title}
+                  </option>
+                ))}
+            </select>
+          </div>
+        </UIFormField>
       </div>
     </div>
   );

--- a/assets/js/components/BatchEdit/Administrative/Administrative.jsx
+++ b/assets/js/components/BatchEdit/Administrative/Administrative.jsx
@@ -91,14 +91,14 @@ const BatchEditAdministrative = () => {
         >
           <>
             <Button type="submit" isPrimary data-testid="save-button">
-              Save Data for {numberOfResults} Items
+              Save data for {numberOfResults} items
             </Button>
             <Button
               isText
               data-testid="cancel-button"
               onClick={handleFormReset}
             >
-              Clear Form
+              Clear form
             </Button>
           </>
         </UITabsStickyHeader>

--- a/assets/js/components/BatchEdit/ModalRemove.js
+++ b/assets/js/components/BatchEdit/ModalRemove.js
@@ -68,7 +68,9 @@ export default function BatchEditAboutModalRemove({
         <div className="box">
           <header>
             <h3 className="title">{currentRemoveField.label}</h3>
-            <h4 className="subtitle">Batch remove the following entries</h4>
+            <h4 className="subtitle">
+              Select values to remove from all batch Works
+            </h4>
           </header>
           <div className="my-4">
             {candidateList.map((item) => (
@@ -90,8 +92,8 @@ export default function BatchEditAboutModalRemove({
           </div>
           <footer>
             <div className="buttons is-right">
-              <Button isText onClick={closeModal}>
-                Close
+              <Button isLight onClick={closeModal}>
+                Save &amp; close
               </Button>
             </div>
           </footer>

--- a/assets/js/components/BatchEdit/Remove.js
+++ b/assets/js/components/BatchEdit/Remove.js
@@ -43,7 +43,7 @@ export default function BatchEditRemove({
           <span className="icon">
             <FontAwesomeIcon icon="minus-square" />
           </span>
-          <span>Remove entries in {label}</span>
+          <span>View and remove {label}</span>
         </Button>
       </UIFormField>
 

--- a/assets/js/components/BatchEdit/Remove.js
+++ b/assets/js/components/BatchEdit/Remove.js
@@ -4,6 +4,17 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import PropTypes from "prop-types";
 import { splitFacetKey } from "../../services/metadata";
 import { useBatchDispatch } from "../../context/batch-edit-context";
+import { Button } from "@nulib/admin-react-components";
+
+/** @jsx jsx */
+import { css, jsx } from "@emotion/core";
+const listItem = css`
+  display: flex;
+  align-items: center;
+  border-bottom: 2px solid white;
+  padding: 10px 0;
+  justify-content: space-between;
+`;
 
 export default function BatchEditRemove({
   handleRemoveClick,
@@ -24,29 +35,28 @@ export default function BatchEditRemove({
   return (
     <div data-testid="batch-edit-remove">
       <UIFormField>
-        <button
+        <Button
           data-testid="button-remove"
-          type="button"
-          className="button is-text is-small"
+          isLight
           onClick={() => handleRemoveClick({ label, name })}
         >
           <span className="icon">
             <FontAwesomeIcon icon="minus-square" />
           </span>
           <span>Remove entries in {label}</span>
-        </button>
+        </Button>
       </UIFormField>
 
       {removeItems.length > 0 && (
         <div className="content has-background-danger-light">
-          <ul className="py-4">
+          <ul className="ml-4">
             {removeItems.map((item) => {
               const { label, role, term } = splitFacetKey(item);
               return (
-                <li key={item}>
+                <li key={item} css={listItem}>
                   {`${label} - ${term}`}
                   <span
-                    className="is-pulled-right icon mr-2"
+                    className="is-pulled-right icon mr-2 is-clickable"
                     onClick={(e) => removeFromDelete(e, item)}
                     data-testid="remove-delete-entries"
                   >

--- a/assets/js/components/BatchEdit/Remove.test.js
+++ b/assets/js/components/BatchEdit/Remove.test.js
@@ -26,7 +26,7 @@ describe("BatchEditRemove component", () => {
     const { getByTestId } = setupTests();
     const el = getByTestId("button-remove");
     expect(el).toBeInTheDocument();
-    expect(el).toHaveTextContent(/^Remove entries in Item title$/);
+    expect(el).toHaveTextContent(/^View and remove Item title$/);
 
     fireEvent.click(el);
     expect(mockHandleRemoveClick).toHaveBeenCalled();

--- a/assets/js/components/Search/ActionRow.jsx
+++ b/assets/js/components/Search/ActionRow.jsx
@@ -22,7 +22,7 @@ export default function SearchActionRow({
           <span className="icon">
             <FontAwesomeIcon icon="edit" />
           </span>
-          <span>Edit All {numberOfResults} Items</span>
+          <span>Edit all {numberOfResults} Items</span>
         </Button>
       </p>
       <p className="control">
@@ -35,7 +35,7 @@ export default function SearchActionRow({
           <span className="icon">
             <FontAwesomeIcon icon="eye" />
           </span>
-          <span>View and Edit {selectedItems.length} Items</span>
+          <span>View and edit {selectedItems.length} Items</span>
         </Button>
       </p>
       {selectedItems.length > 0 && (
@@ -48,7 +48,7 @@ export default function SearchActionRow({
             <span className="icon">
               <FontAwesomeIcon icon="minus-square" />
             </span>
-            <span>Deselect All</span>
+            <span>Deselect all</span>
           </Button>
         </p>
       )}

--- a/assets/js/components/UI/Accordion.jsx
+++ b/assets/js/components/UI/Accordion.jsx
@@ -13,14 +13,16 @@ const UIAccordion = ({ title, testid, defaultOpen = true, children }) => {
   `;
   return (
     <div className="box is-relative mt-4" data-testid={testid}>
-      <h2 className="title is-size-5 mb-4">
-        {title}{" "}
-        <a onClick={() => setIsContentOpen(!isContentOpen)}>
-          <FontAwesomeIcon
-            icon={isContentOpen ? "chevron-down" : "chevron-right"}
-          />
-        </a>
-      </h2>
+      <div className="content">
+        <h3 className="mb-4">
+          {title}{" "}
+          <a onClick={() => setIsContentOpen(!isContentOpen)}>
+            <FontAwesomeIcon
+              icon={isContentOpen ? "chevron-down" : "chevron-right"}
+            />
+          </a>
+        </h3>
+      </div>
       <div css={wrapperCss}>{children}</div>
     </div>
   );

--- a/assets/js/components/UI/ControlledTerm/List.jsx
+++ b/assets/js/components/UI/ControlledTerm/List.jsx
@@ -10,13 +10,14 @@ const UIControlledTermList = ({ items = [], title }) => {
 
   return (
     <div className="content mb-4">
-      <ul data-testid="controlled-term-list">
+      <ul data-testid="controlled-term-list" className="ml-0">
         {items.map((item) => (
           <li
             key={`${item.term.id}-${item.role ? item.role.id : ""}`}
             data-testid="controlled-term-list-row"
+            className="is-flex is-flex-direction-column is-align-items-flex-start mb-4"
           >
-            <div className="buttons">
+            <>
               {componentId ? (
                 <UIFacetLink facetComponentId={componentId} item={item} />
               ) : (
@@ -35,7 +36,7 @@ const UIControlledTermList = ({ items = [], title }) => {
                   <span>{item.term.id}</span>
                 </a>
               )}
-            </div>
+            </>
           </li>
         ))}
       </ul>

--- a/assets/js/components/UI/Form/ControlledTermArray.jsx
+++ b/assets/js/components/UI/Form/ControlledTermArray.jsx
@@ -6,6 +6,7 @@ import UIFormSelect from "./Select";
 import UIFormControlledTermArrayItem from "./ControlledTermArrayItem";
 import { hasRole } from "../../../services/metadata";
 import { useFormContext } from "react-hook-form";
+import { Button } from "@nulib/admin-react-components";
 
 const UIFormControlledTermArray = ({
   authorities = [],
@@ -109,9 +110,8 @@ const UIFormControlledTermArray = ({
         })}
       </ul>
 
-      <button
-        type="button"
-        className="button is-text is-small"
+      <Button
+        isLight
         onClick={() => {
           append({ termId: "", label: "", roleId: "" });
         }}
@@ -121,7 +121,7 @@ const UIFormControlledTermArray = ({
           <FontAwesomeIcon icon="plus" />
         </span>
         <span>Add {fields.length > 0 && "another"}</span>
-      </button>
+      </Button>
     </>
   );
 };

--- a/assets/js/components/UI/Form/FieldArrayAddButton.jsx
+++ b/assets/js/components/UI/Form/FieldArrayAddButton.jsx
@@ -1,12 +1,12 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Button } from "@nulib/admin-react-components";
 
 function FieldArrayAddButton({ btnLabel, handleAddClick }) {
   return (
-    <button
-      type="button"
-      className="button is-text is-small"
+    <Button
+      isLight
       onClick={handleAddClick}
       data-testid="button-add-field-array-row"
     >
@@ -14,7 +14,7 @@ function FieldArrayAddButton({ btnLabel, handleAddClick }) {
         <FontAwesomeIcon icon="plus" />
       </span>
       <span>{btnLabel}</span>
-    </button>
+    </Button>
   );
 }
 

--- a/assets/js/components/UI/Form/RelatedURL.jsx
+++ b/assets/js/components/UI/Form/RelatedURL.jsx
@@ -124,8 +124,7 @@ const UIFormRelatedURL = ({
       </ul>
 
       <Button
-        type="button"
-        className="button is-text is-small"
+        isLight
         onClick={() => {
           append({ new: true, url: "", label: "" });
         }}

--- a/assets/js/components/UI/ResultsDisplaySwitcher.jsx
+++ b/assets/js/components/UI/ResultsDisplaySwitcher.jsx
@@ -11,12 +11,12 @@ const UIResultsDisplaySwitcher = ({ isListView, onGridClick, onListClick }) => {
             isListView ? "is-light" : "is-text"
           }`}
           onClick={onListClick}
-          title="List View"
+          title="List view"
         >
           <span className={`icon`}>
             <FontAwesomeIcon icon="th-list" />
           </span>
-          <span>List View</span>
+          <span>List view</span>
         </button>
       </div>
       <div className="column pt-0">
@@ -25,12 +25,12 @@ const UIResultsDisplaySwitcher = ({ isListView, onGridClick, onListClick }) => {
             isListView ? "is-text" : "is-light"
           }`}
           onClick={onGridClick}
-          title="Grid View"
+          title="Grid view"
         >
           <span className={`icon`}>
             <FontAwesomeIcon icon="th-large" />
           </span>
-          <span>Grid View</span>
+          <span>Grid view</span>
         </button>
       </div>
     </div>

--- a/assets/js/components/Work/HeaderButtons.jsx
+++ b/assets/js/components/Work/HeaderButtons.jsx
@@ -14,10 +14,15 @@ export default function WorkHeaderButtons({
     <div className="buttons is-right" data-testid="work-header-buttons">
       <Button
         isPrimary
-        className={`${published ? "is-outlined" : ""}`}
+        className={`${published ? "is-outlined" : "has-tooltip-multiline"}`}
         data-testid="publish-button"
         onClick={handlePublishClick}
         disabled={!hasCollection}
+        data-tooltip={
+          !hasCollection
+            ? "A work must belong to a Collection in order to be published.  Add to a Collection in the Administrative tab below."
+            : undefined
+        }
       >
         {!published ? "Publish" : "Unpublish"}
       </Button>

--- a/assets/js/components/Work/HeaderButtons.jsx
+++ b/assets/js/components/Work/HeaderButtons.jsx
@@ -28,7 +28,7 @@ export default function WorkHeaderButtons({
         <span className="icon">
           <FontAwesomeIcon icon="link" />
         </span>
-        <span>Create Sharable Link</span>
+        <span>Create sharable link</span>
       </Button>
       <Button isText data-testid="delete-button" onClick={onOpenModal}>
         Delete

--- a/assets/js/components/Work/Tabs/About.jsx
+++ b/assets/js/components/Work/Tabs/About.jsx
@@ -207,7 +207,6 @@ const WorkTabsAbout = ({ work }) => {
             className="box is-relative content mt-4"
             data-testid="uneditable-metadata"
           >
-            <h3 className="mb-4">Uneditable Metadata </h3>
             <div className="columns">
               <div className="column">
                 <UIFormField label="ARK">

--- a/assets/js/components/Work/Tabs/About.jsx
+++ b/assets/js/components/Work/Tabs/About.jsx
@@ -204,20 +204,26 @@ const WorkTabsAbout = ({ work }) => {
 
         {isEditing ? (
           <div
-            className="box is-relative mt-4"
+            className="box is-relative content mt-4"
             data-testid="uneditable-metadata"
           >
-            <h2 className="title is-size-5 mb-4">Uneditable Metadata </h2>
-            <div>
-              <UIFormField label="ARK">
-                <p>{work.ark}</p>
-              </UIFormField>
-              <UIFormField label="ID">
-                <p>{work.id}</p>
-              </UIFormField>
-              <UIFormField label="Accession Number">
-                <p>{work.accessionNumber}</p>
-              </UIFormField>
+            <h3 className="mb-4">Uneditable Metadata </h3>
+            <div className="columns">
+              <div className="column">
+                <UIFormField label="ARK">
+                  <p>{work.ark}</p>
+                </UIFormField>
+              </div>
+              <div className="column">
+                <UIFormField label="ID">
+                  <p>{work.id}</p>
+                </UIFormField>
+              </div>
+              <div className="column">
+                <UIFormField label="Accession Number">
+                  <p>{work.accessionNumber}</p>
+                </UIFormField>
+              </div>
             </div>
           </div>
         ) : null}

--- a/assets/js/components/Work/Tabs/About/ControlledMetadata.jsx
+++ b/assets/js/components/Work/Tabs/About/ControlledMetadata.jsx
@@ -25,10 +25,10 @@ const WorkTabsAboutControlledMetadata = ({
 
   return (
     <div data-testid="controlled-metadata">
-      <ul>
+      <ul className="columns is-multiline">
         {!codeLists.isLoading &&
           CONTROLLED_METADATA.map(({ label, name, scheme }) => (
-            <li key={name} className="mb-5">
+            <li key={name} className="mb-5 column is-half">
               <UIFormField label={label}>
                 {isEditing ? (
                   <UIFormControlledTermArray

--- a/assets/js/components/Work/Tabs/About/CoreMetadata.jsx
+++ b/assets/js/components/Work/Tabs/About/CoreMetadata.jsx
@@ -19,8 +19,7 @@ const WorkTabsAboutCoreMetadata = ({
 
   return (
     <div className="columns is-multiline" data-testid="core-metadata">
-      <div className="column is-full">
-        {/* Title */}
+      <div className="column is-two-thirds">
         <UIFormField label="Title" required={published}>
           {isEditing ? (
             <UIInput
@@ -37,8 +36,24 @@ const WorkTabsAboutCoreMetadata = ({
         </UIFormField>
       </div>
 
-      <div className="column is-full">
-        {/* Alternate Title */}
+      <div className="column is-half">
+        {/* Description */}
+        {isEditing ? (
+          <UIFormFieldArray
+            name="description"
+            data-testid="description"
+            label="Description"
+            isTextarea={true}
+          />
+        ) : (
+          <UIFormFieldArrayDisplay
+            items={descriptiveMetadata.description}
+            label="Description"
+          />
+        )}
+      </div>
+
+      <div className="column is-half">
         {isEditing ? (
           <UIFormFieldArray
             name="alternateTitle"
@@ -51,25 +66,6 @@ const WorkTabsAboutCoreMetadata = ({
             label="Alternate Title"
           />
         )}
-      </div>
-
-      <div className="column is-half">
-        {/* Date Created */}
-        <UIFormField label="Date Created" notLive>
-          {isEditing ? (
-            <UIInput
-              name="dateCreated"
-              label="Date Created"
-              data-testid="date-created"
-              defaultValue={descriptiveMetadata.dateCreated}
-            />
-          ) : (
-            <>
-              <UITagNotYetSupported label="Display not yet supported" />
-              <UITagNotYetSupported label="Update not yet supported" />
-            </>
-          )}
-        </UIFormField>
       </div>
       <div className="column is-half">
         {/* Rights Statement */}
@@ -97,21 +93,23 @@ const WorkTabsAboutCoreMetadata = ({
           )}
         </UIFormField>
       </div>
-      <div className="column is-full">
-        {/* Description */}
-        {isEditing ? (
-          <UIFormFieldArray
-            name="description"
-            data-testid="description"
-            label="Description"
-            isTextarea={true}
-          />
-        ) : (
-          <UIFormFieldArrayDisplay
-            items={descriptiveMetadata.description}
-            label="Description"
-          />
-        )}
+
+      <div className="column is-half">
+        <UIFormField label="Date Created" notLive>
+          {isEditing ? (
+            <UIInput
+              name="dateCreated"
+              label="Date Created"
+              data-testid="date-created"
+              defaultValue={descriptiveMetadata.dateCreated}
+            />
+          ) : (
+            <>
+              <UITagNotYetSupported label="Display not yet supported" />
+              <UITagNotYetSupported label="Update not yet supported" />
+            </>
+          )}
+        </UIFormField>
       </div>
     </div>
   );

--- a/assets/js/components/Work/Tabs/Administrative.jsx
+++ b/assets/js/components/Work/Tabs/Administrative.jsx
@@ -272,7 +272,8 @@ const WorkTabsAdministrative = ({ work }) => {
             </div>
           </div>
           <div className="column">
-            <div className="box is-relative">
+            <div className="box is-relative content">
+              <h3>Project Info</h3>
               <UIFormField label="Project Cycle">
                 {isEditing ? (
                   <UIFormInput

--- a/assets/js/screens/Work/Work.jsx
+++ b/assets/js/screens/Work/Work.jsx
@@ -178,24 +178,37 @@ const ScreensWork = () => {
                     />
                   )}
 
-                  <dl>
-                    <dt>Accession Number</dt>
-                    <dd>{data.work.accessionNumber}</dd>
-                    <dt>Project</dt>
-                    <dd>
-                      <Link to={`/project/${data.work.project.id}`}>
-                        {data.work.project.title}
-                      </Link>
-                    </dd>
-                    <dt>Ingest Sheet</dt>
-                    <dd>
-                      <Link
-                        to={`/project/${data.work.project.id}/ingest-sheet/${data.work.ingestSheet.id}`}
-                      >
-                        {data.work.ingestSheet.title}
-                      </Link>
-                    </dd>
-                  </dl>
+                  <hr />
+                  <div className="columns">
+                    <div className="column">
+                      <p>
+                        <strong>Accession Number</strong>
+                      </p>
+                      <p>{data.work.accessionNumber}</p>
+                    </div>
+                    <div className="column">
+                      <p>
+                        <strong>Project</strong>
+                      </p>
+                      <p>
+                        <Link to={`/project/${data.work.project.id}`}>
+                          {data.work.project.title}
+                        </Link>
+                      </p>
+                    </div>
+                    <div className="column">
+                      <p>
+                        <strong>Ingest Sheet</strong>
+                      </p>
+                      <p>
+                        <Link
+                          to={`/project/${data.work.project.id}/ingest-sheet/${data.work.ingestSheet.id}`}
+                        >
+                          {data.work.ingestSheet.title}
+                        </Link>
+                      </p>
+                    </div>
+                  </div>
 
                   {!data.work.collection && (
                     <p className="notification has-text-centered">

--- a/assets/js/screens/Work/Work.jsx
+++ b/assets/js/screens/Work/Work.jsx
@@ -209,15 +209,6 @@ const ScreensWork = () => {
                       </p>
                     </div>
                   </div>
-
-                  {!data.work.collection && (
-                    <p className="notification has-text-centered">
-                      <FontAwesomeIcon icon="exclamation-triangle" /> A work
-                      must belong to a Collection in order to be published.
-                      Click on the Administrative tab below, to add this work to
-                      a Collection.
-                    </p>
-                  )}
                 </div>
               </>
             )}

--- a/assets/package.json
+++ b/assets/package.json
@@ -54,6 +54,7 @@
     "@babel/plugin-transform-async-to-generator": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.1",
+    "@creativebulma/bulma-tooltip": "^1.2.0",
     "@nulib/prettier-config": "^1.2.0",
     "@testing-library/dom": "^7.26.3",
     "@testing-library/jest-dom": "^5.11.5",

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -9,6 +9,7 @@
 @import "~bulma-switch/dist/css/bulma-switch";
 @import "~bulma-checkradio/dist/css/bulma-checkradio";
 @import "~bulma-pageloader/dist/css/bulma-pageloader";
+@import "~@creativebulma/bulma-tooltip/src/sass";
 
 @import "./scss/mixins";
 @import "~@nulib/admin-react-components/dist/public/styles/base";

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -1090,6 +1090,11 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@creativebulma/bulma-tooltip@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@creativebulma/bulma-tooltip/-/bulma-tooltip-1.2.0.tgz#84dcdd59d94c09c2975fadbec1d3d765ae29c471"
+  integrity sha512-ooImbeXEBxf77cttbzA7X5rC5aAWm9UsXIGViFOnsqB+6M944GkB28S5R4UWRqjFd2iW4zGEkEifAU+q43pt2w==
+
 "@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"


### PR DESCRIPTION
This tightens up all the white space in Work and Batch Edit forms.  Especially on the Controlled item boxes.   I also made the buttons regular size and the `isLight` color so they stick out a bit more and the user can see what the action is?

![image](https://user-images.githubusercontent.com/3020266/98141987-dc95ed80-1e8c-11eb-9d1e-e7c8c8a05184.png)

![image](https://user-images.githubusercontent.com/3020266/98142129-0818d800-1e8d-11eb-8205-db8ef24e02e8.png)

![image](https://user-images.githubusercontent.com/3020266/98172163-7aea7900-1eb6-11eb-94d4-290a259cb134.png)
