### PR TITLE
Cleanup indexing and API for date_created

### DIFF
--- a/lib/meadow/data/schemas/types/edtf_date.ex
+++ b/lib/meadow/data/schemas/types/edtf_date.ex
@@ -10,38 +10,38 @@ defmodule Meadow.Data.Types.EDTFDate do
 
   def type, do: :map
 
-  def cast(edtf_date), do: humanize(edtf_date)
+  def cast(edtf), do: humanize(edtf)
 
-  def load(edtf_date), do: humanize(edtf_date)
+  def load(edtf), do: humanize(edtf)
 
   def dump(nil), do: nil
 
-  def dump(%{edtf_date: edtf_date, humanized_date: humanized_date}),
-    do: {:ok, %{edtf_date: edtf_date, humanized_date: humanized_date}}
+  def dump(%{edtf: edtf, humanized: humanized}),
+    do: {:ok, %{edtf: edtf, humanized: humanized}}
 
   def dump(_), do: :error
 
   defp humanize(nil), do: {:ok, nil}
 
-  defp humanize(%{edtf_date: ""}),
-    do: {:error, message: "edtf_date cannot be blank"}
+  defp humanize(%{edtf: ""}),
+    do: {:error, message: "edtf cannot be blank"}
 
-  defp humanize(%{edtf_date: edtf_date, humanized_date: humanized_date}),
-    do: {:ok, %{edtf_date: edtf_date, humanized_date: humanized_date}}
+  defp humanize(%{edtf: edtf, humanized: humanized}),
+    do: {:ok, %{edtf: edtf, humanized: humanized}}
 
-  defp humanize(%{"edtf_date" => edtf_date, "humanized_date" => humanized_date}),
-    do: {:ok, %{edtf_date: edtf_date, humanized_date: humanized_date}}
+  defp humanize(%{"edtf" => edtf, "humanized" => humanized}),
+    do: {:ok, %{edtf: edtf, humanized: humanized}}
 
-  defp humanize(%{edtf_date: edtf_date}), do: humanize(edtf_date)
+  defp humanize(%{edtf: edtf}), do: humanize(edtf)
 
-  defp humanize(edtf_date) when is_binary(edtf_date) do
-    case Works.parse_edtf_date(edtf_date) do
-      {:ok, %{edtf_date: edtf_date, humanized_date: humanized_date}} ->
-        {:ok, %{edtf_date: edtf_date, humanized_date: humanized_date}}
+  defp humanize(edtf) when is_binary(edtf) do
+    case Works.parse_edtf(edtf) do
+      {:ok, %{edtf: edtf, humanized: humanized}} ->
+        {:ok, %{edtf: edtf, humanized: humanized}}
     end
   end
 
   defp humanize(%{}), do: {:ok, nil}
 
-  defp humanize(_), do: {:error, message: "Invalid edtf_date type"}
+  defp humanize(_), do: {:error, message: "Invalid edtf type"}
 end

--- a/lib/meadow/data/works.ex
+++ b/lib/meadow/data/works.ex
@@ -496,8 +496,8 @@ defmodule Meadow.Data.Works do
   @doc """
   Callout to EDTF.js port
   """
-  def parse_edtf_date(edtf_date) do
+  def parse_edtf(edtf) do
     # obviously this is temporary
-    {:ok, %{edtf_date: edtf_date, humanized_date: "Tue, 01 Jul 1975"}}
+    {:ok, %{edtf: edtf, humanized: "Tue, 01 Jul 1975"}}
   end
 end

--- a/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
+++ b/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
@@ -70,8 +70,8 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
 
   @desc "EDTF Date"
   object :edtf_date_entry do
-    field :edtf_date, :string
-    field :humanized_date, :string
+    field :edtf, :string
+    field :humanized, :string
   end
 
   @desc "RelatedURLEntry"
@@ -94,7 +94,7 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
 
   @desc "EDTF date input"
   input_object :edtf_date_input do
-    field :edtf_date, :string
+    field :edtf, :string
   end
 
   @desc "Related URL input"

--- a/priv/elasticsearch/meadow.json
+++ b/priv/elasticsearch/meadow.json
@@ -102,6 +102,22 @@
           }
         },
         {
+          "edtf_strings": {
+            "match": "^edtf",
+            "match_pattern": "regex",
+            "mapping": {
+              "type": "text",
+              "analyzer": "full_analyzer",
+              "search_analyzer": "stopword_analyzer",
+              "search_quote_analyzer": "full_analyzer",
+              "fields": {
+                "keyword": { "type": "keyword" }
+              },
+              "copy_to": ["full_text"]
+            }
+          }
+        },
+        {
           "strings": {
             "match_mapping_type": "string",
             "mapping": {

--- a/test/gql/WorkDescriptiveMetadataFields.frag.gql
+++ b/test/gql/WorkDescriptiveMetadataFields.frag.gql
@@ -3,8 +3,8 @@ fragment WorkDescriptiveMetadataFields on Work {
     ark
     title
     dateCreated {
-      edtfDate
-      humanizedDate
+      edtf
+      humanized
     }
     description
     contributor {

--- a/test/meadow/data/schemas/types/edtf_date_test.exs
+++ b/test/meadow/data/schemas/types/edtf_date_test.exs
@@ -5,29 +5,29 @@ defmodule Meadow.Data.Types.EDTF.DateTest do
 
   alias Meadow.Data.Types.EDTFDate
 
-  @edtf_date_db_type %{
-    edtf_date: "1975-07-01",
-    humanized_date: "Tue, 01 Jul 1975"
+  @edtf_db_type %{
+    edtf: "1975-07-01",
+    humanized: "Tue, 01 Jul 1975"
   }
 
   describe "Meadow.Data.Types.EDTFDate" do
     test "cast function" do
-      assert {:ok, @edtf_date_db_type} == EDTFDate.cast(@edtf_date_db_type)
-      assert EDTFDate.cast(1234) == {:error, [message: "Invalid edtf_date type"]}
+      assert {:ok, @edtf_db_type} == EDTFDate.cast(@edtf_db_type)
+      assert EDTFDate.cast(1234) == {:error, [message: "Invalid edtf type"]}
 
       assert EDTFDate.cast("1975-07-01") ==
-               {:ok, %{edtf_date: "1975-07-01", humanized_date: "Tue, 01 Jul 1975"}}
+               {:ok, %{edtf: "1975-07-01", humanized: "Tue, 01 Jul 1975"}}
     end
 
     test "dump function" do
-      assert EDTFDate.dump(@edtf_date_db_type) == {:ok, @edtf_date_db_type}
+      assert EDTFDate.dump(@edtf_db_type) == {:ok, @edtf_db_type}
       assert EDTFDate.dump(134_524) == :error
     end
 
     test "load function" do
-      assert EDTFDate.load(@edtf_date_db_type) == {:ok, @edtf_date_db_type}
+      assert EDTFDate.load(@edtf_db_type) == {:ok, @edtf_db_type}
 
-      assert EDTFDate.load(1234) == {:error, [message: "Invalid edtf_date type"]}
+      assert EDTFDate.load(1234) == {:error, [message: "Invalid edtf type"]}
     end
   end
 end


### PR DESCRIPTION
- make sure Elasticsearch mapping is text for the EDTF fields

- remove the redundant `date` from `date_created` indexing and GraphQL API. (change `humanized_date` to `humanized` and `edtf_date` to `edtf`)

<img width="580" alt="Screen Shot 2020-11-04 at 1 43 12 PM" src="https://user-images.githubusercontent.com/6372022/98166892-66ea4b80-1ea5-11eb-986b-516e0b7c86d1.png">
<img width="453" alt="Screen Shot 2020-11-04 at 1 44 19 PM" src="https://user-images.githubusercontent.com/6372022/98166906-6e115980-1ea5-11eb-837e-0502c891e6fd.png">




