### PR TITLE
Implement Error Boundary pattern on Search and Work screens

### DIFF
--- a/assets/js/components/Search/Results.jsx
+++ b/assets/js/components/Search/Results.jsx
@@ -18,9 +18,8 @@ const SearchResults = ({
   selectedItems,
 }) => {
   const facetSensors = FACET_SENSORS.map((sensor) => sensor.componentId);
-
   return (
-    <>
+    <React.Fragment>
       <div data-testid="search-results-component">
         <IIIFProvider>
           <ReactiveList
@@ -84,7 +83,7 @@ const SearchResults = ({
           />
         </IIIFProvider>
       </div>
-    </>
+    </React.Fragment>
   );
 };
 

--- a/assets/js/components/Work/CardItem.jsx
+++ b/assets/js/components/Work/CardItem.jsx
@@ -6,7 +6,7 @@ import {
   formatDate,
   getImageUrl,
 } from "@js/services/helpers";
-import UIWorkImage from "../UI/WorkImage";
+import UIWorkImage from "@js/components/UI/WorkImage";
 
 const WorkCardItem = ({
   id,

--- a/assets/js/screens/Search/Search.jsx
+++ b/assets/js/screens/Search/Search.jsx
@@ -13,6 +13,7 @@ import {
   ELASTICSEARCH_AGGREGATION_FIELDS,
 } from "../../services/elasticsearch";
 import { useBatchDispatch } from "../../context/batch-edit-context";
+import { ErrorBoundary } from "react-error-boundary";
 
 const ScreensSearch = () => {
   let history = useHistory();
@@ -113,18 +114,31 @@ const ScreensSearch = () => {
               />
             </div>
 
-            <SearchResults
-              handleOnDataChange={handleOnDataChange}
-              handleQueryChange={handleQueryChange}
-              handleSelectItem={handleSelectItem}
-              isListView={isListView}
-              selectedItems={selectedItems}
-            />
+            <ErrorBoundary FallbackComponent={ErrorFallback}>
+              <SearchResults
+                handleOnDataChange={handleOnDataChange}
+                handleQueryChange={handleQueryChange}
+                handleSelectItem={handleSelectItem}
+                isListView={isListView}
+                selectedItems={selectedItems}
+              />
+            </ErrorBoundary>
           </div>
         </div>
       </section>
     </Layout>
   );
 };
+
+function ErrorFallback({ error }) {
+  return (
+    <div role="alert" className="notification is-danger">
+      <p>There was an error displaying Search</p>
+      <p>
+        <strong>Error</strong>: {error.message}
+      </p>
+    </div>
+  );
+}
 
 export default ScreensSearch;

--- a/assets/js/screens/Work/Work.jsx
+++ b/assets/js/screens/Work/Work.jsx
@@ -17,9 +17,9 @@ import { Link } from "react-router-dom";
 import WorkTagsList from "../../components/Work/TagsList";
 import WorkHeaderButtons from "../../components/Work/HeaderButtons";
 import WorkSharedLinkNotification from "../../components/Work/SharedLinkNotification";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import WorkMultiEditBar from "../../components/Work/MultiEditBar";
 import { useBatchState } from "../../context/batch-edit-context";
+import { ErrorBoundary } from "react-error-boundary";
 
 const ScreensWork = () => {
   const params = useParams();
@@ -216,7 +216,13 @@ const ScreensWork = () => {
         </div>
       </section>
 
-      {loading ? <UISkeleton rows={20} /> : <Work work={data.work} />}
+      {loading ? (
+        <UISkeleton rows={20} />
+      ) : (
+        <ErrorBoundary FallbackComponent={ErrorFallback}>
+          <Work work={data.work} />
+        </ErrorBoundary>
+      )}
 
       {data && (
         <UIModalDelete
@@ -233,5 +239,16 @@ const ScreensWork = () => {
     </Layout>
   );
 };
+
+function ErrorFallback({ error }) {
+  return (
+    <div role="alert" className="notification is-danger">
+      <p>There was an error displaying the Work</p>
+      <p>
+        <strong>Error</strong>: {error.message}
+      </p>
+    </div>
+  );
+}
 
 export default ScreensWork;

--- a/assets/package.json
+++ b/assets/package.json
@@ -43,6 +43,7 @@
     "react-apollo": "^3.1.5",
     "react-beautiful-dnd": "^13.0.0",
     "react-csv": "^2.0.3",
+    "react-error-boundary": "^3.0.2",
     "react-hook-form": "6.9.2",
     "react-json-pretty": "^2.2.0",
     "recharts": "^1.8.5"

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -7349,6 +7349,13 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
+react-error-boundary@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.0.2.tgz#74399a4d9a68bfede1f3f4261ea0aabfc65d9868"
+  integrity sha512-KVzCusRTFpUYG0OFJbzbdRuxNQOBiGXVCqyNpBXM9z5NFsFLzMjUXMjx8gTja6M6WH+D2PvP3yKz4d8gD1PRaA==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+
 react-hook-form@6.9.2:
   version "6.9.2"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.9.2.tgz#9512cd424e62235fda13c8fc1821f88c352e3d23"


### PR DESCRIPTION
This wraps the Search and Work screen contents in a generic ErrorBoundary so the app doesn’t crash.  Instead it will look like the screen shots.  Eventually we can get more granular and specific on where the error messages are displayed, which will match errors the message is wrapping.

![image](https://user-images.githubusercontent.com/3020266/98305849-3cbd8a00-1f88-11eb-9404-dfba6a2a268f.png)

![image](https://user-images.githubusercontent.com/3020266/98305945-670f4780-1f88-11eb-89a1-d3ecab875ec3.png)
