### PR TITLE
Update EDTF.js to 3.1.0 and add support for Lists with continuations

### DIFF
--- a/lib/edtf/humanize/list.ex
+++ b/lib/edtf/humanize/list.ex
@@ -31,22 +31,17 @@ defmodule EDTF.Humanize.List do
     end
   end
 
-  # The following two commented functions are unreachable due to a parsing bug in EDTF.js
-  # Examples:
-  #   EDTF.humanize("{..1984}") should return "all years before 1984"
-  #   EDTF.humanize("{1984..}") should return "all years after 1984"
+  def humanize(%{type: "Continuation", subtype: "List", position: :earlier, value: value}) do
+    with {human, time_unit} <- humanize_with_unit(value) do
+      "all #{Inflex.pluralize(time_unit)} before #{human}"
+    end
+  end
 
-  # def humanize(%{type: "Continuation", subtype: "List", position: :earlier, value: value}) do
-  #   with {human, time_unit} <- humanize_with_unit(value) do
-  #     "all #{Inflex.pluralize(time_unit)} before #{human}"
-  #   end
-  # end
-
-  # def humanize(%{type: "Continuation", subtype: "List", position: :later, value: value}) do
-  #   with {human, time_unit} <- humanize_with_unit(value) do
-  #     "all #{Inflex.pluralize(time_unit)} after #{human}"
-  #   end
-  # end
+  def humanize(%{type: "Continuation", subtype: "List", position: :later, value: value}) do
+    with {human, time_unit} <- humanize_with_unit(value) do
+      "all #{Inflex.pluralize(time_unit)} after #{human}"
+    end
+  end
 
   defp continuation(type, position, value),
     do: %{type: "Continuation", subtype: type, position: position, value: value}

--- a/priv/edtf/package.json
+++ b/priv/edtf/package.json
@@ -6,6 +6,6 @@
   "author": "bmquinn",
   "license": "Apache-2.0",
   "dependencies": {
-    "edtf": "^3.0.1"
+    "edtf": "^3.1.0"
   }
 }

--- a/priv/edtf/yarn.lock
+++ b/priv/edtf/yarn.lock
@@ -17,12 +17,13 @@ drange@^1.0.2:
   resolved "https://registry.yarnpkg.com/drange/-/drange-1.1.1.tgz#b2aecec2aab82fcef11dbbd7b9e32b83f8f6c0b8"
   integrity sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==
 
-edtf@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/edtf/-/edtf-3.0.1.tgz#0f3f066340bc29075e34a14763a9f6ca6169ed68"
-  integrity sha512-YxSe9caZIvAO8xYYqTEHofi4az6AJdpVZZE7+E6P8EVWRF9y2bVtsDQtANlxD4v7FlFKPDtsCDZe40v/WnNA1g==
+edtf@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/edtf/-/edtf-3.1.0.tgz#63ff89a0e8b29345b72a233ea7455ec4af10d58b"
+  integrity sha512-m9pPUyBb/REAYraG/+l+D7HRHpCwK+8jaZyBrO0BP0elRSRxt0O+4ttbpY5SyctkLL/hF/AMEaco36m74ZxQIw==
   dependencies:
-    nearley "^2.19.4"
+    nearley "^2.19.7"
+  optionalDependencies:
     randexp "^0.5.3"
 
 moo@^0.5.0:
@@ -30,7 +31,7 @@ moo@^0.5.0:
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"
   integrity sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==
 
-nearley@^2.19.4:
+nearley@^2.19.7:
   version "2.19.7"
   resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.19.7.tgz#eafbe3e2d8ccfe70adaa5c026ab1f9709c116218"
   integrity sha512-Y+KNwhBPcSJKeyQCFjn8B/MIe+DDlhaaDgjVldhy5xtFewIbiQgcbZV8k2gCVwkI1ZsKCnjIYZbR+0Fim5QYgg==

--- a/test/edtf_test.exs
+++ b/test/edtf_test.exs
@@ -129,6 +129,9 @@ defmodule EDTFTest do
 
       assert EDTF.humanize("{2019-06, 2020-06, 2021-06..2021-07}") ==
                "June 2019, June 2020, and June 2021 to July 2021"
+
+      assert EDTF.humanize("{..1984}") == "all years before 1984 and 1984"
+      assert EDTF.humanize("{1984..}") == "1984 and all years after 1984"
     end
 
     test "season" do


### PR DESCRIPTION
`EDTF.js` released `3.1.0` after fixing the issue we submitted yesterday: https://github.com/inukshuk/edtf.js/issues/27

- Adds support for Lists with continuations in `EDTF.parse/` and `EDTF.humanize/1`
- Adds test assertions for the new behavior

Note: don't forget to run `mix meadow.setup` locally to get the `EDTF.js` update