### PR TITLE
Support batch Published updates for publish and unpublish all items i…

### DIFF
--- a/assets/js/components/BatchEdit/About/About.jsx
+++ b/assets/js/components/BatchEdit/About/About.jsx
@@ -22,6 +22,7 @@ import {
   prepFacetKey,
 } from "../../../services/metadata";
 import { Button } from "@nulib/admin-react-components";
+import BatchEditPublish from "@js/components/BatchEdit/Publish";
 
 const BatchEditAbout = () => {
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
@@ -31,6 +32,10 @@ const BatchEditAbout = () => {
     descriptiveMetadata: {},
   });
   const [batchCollection, setBatchCollection] = useState({});
+  const [batchPublish, setBatchPublish] = useState({
+    publish: false,
+    unpublish: false,
+  });
 
   const batchDispatch = useBatchDispatch();
 
@@ -106,6 +111,9 @@ const BatchEditAbout = () => {
     setBatchDeletes(deleteReadyItems);
     setBatchReplaces({
       descriptiveMetadata: { ...replaceItems, ...multiValues.replace },
+      ...((batchPublish.publish || batchPublish.unpublish) && {
+        published: { ...batchPublish },
+      }),
     });
 
     Object.keys(currentFormValues["collection"]).length > 0
@@ -144,6 +152,13 @@ const BatchEditAbout = () => {
             </Button>
           </>
         </UITabsStickyHeader>
+
+        <UIAccordion testid="publish-wrapper" title="Publish">
+          <BatchEditPublish
+            batchPublish={batchPublish}
+            setBatchPublish={setBatchPublish}
+          />
+        </UIAccordion>
 
         <UIAccordion testid="core-metadata-wrapper" title="Core Metadata">
           <BatchEditAboutCoreMetadata />

--- a/assets/js/components/BatchEdit/Confirmation.jsx
+++ b/assets/js/components/BatchEdit/Confirmation.jsx
@@ -94,7 +94,9 @@ const BatchEditConfirmation = ({
     batchDeletes && !Object.values(batchDeletes).every((item) => !item.length);
 
   const hasReplaces =
-    batchReplaces && Object.keys(batchReplaces[batchEditType]).length > 0;
+    batchReplaces &&
+    (Object.keys(batchReplaces[batchEditType]).length > 0 ||
+      batchReplaces.published);
 
   const hasCollection =
     batchCollection && Object.keys(batchCollection).length > 0;
@@ -157,6 +159,11 @@ const BatchEditConfirmation = ({
                     batchVisibility.id && {
                       visibility: batchVisibility,
                     }),
+                  ...(batchReplaces.published && {
+                    published: batchReplaces.published.publish
+                      ? "Publish works"
+                      : "Unpublish works",
+                  }),
                 }}
                 type="replace"
               />

--- a/assets/js/components/BatchEdit/Publish.jsx
+++ b/assets/js/components/BatchEdit/Publish.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+function BatchEditPublish({ batchPublish, setBatchPublish }) {
+  const { publish, unpublish } = batchPublish;
+
+  return (
+    <div data-testid="batch-edit-publish-wrapper" className="is-flex">
+      <div className="field mt-3">
+        <input
+          className="is-checkradio"
+          id={`publish`}
+          type="checkbox"
+          name={`publish`}
+          onChange={() =>
+            setBatchPublish({ publish: !publish, unpublish: false })
+          }
+          checked={publish}
+        />
+        <label htmlFor={`publish`}>Publish works</label>
+      </div>
+
+      <div className="field mt-3">
+        <input
+          className="is-checkradio"
+          id={`unpublish`}
+          type="checkbox"
+          name={`unpublish`}
+          onChange={() =>
+            setBatchPublish({ publish: false, unpublish: !unpublish })
+          }
+          checked={unpublish}
+        />
+        <label htmlFor={`unpublish`}>Unpublish works</label>
+      </div>
+    </div>
+  );
+}
+
+BatchEditPublish.propTypes = {
+  batchPublish: PropTypes.object,
+  setBatchPublish: PropTypes.func,
+};
+
+export default BatchEditPublish;

--- a/assets/js/components/BatchEdit/Publish.test.js
+++ b/assets/js/components/BatchEdit/Publish.test.js
@@ -1,0 +1,39 @@
+import React from "react";
+import BatchEditPublish from "@js/components/BatchEdit/Publish";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockClick = jest.fn();
+const props = {
+  batchPublish: {
+    publish: false,
+    unpublish: false,
+  },
+  setBatchPublish: mockClick,
+};
+
+describe("BatchEditPublish component", () => {
+  beforeEach(() => {
+    render(<BatchEditPublish {...props} />);
+  });
+
+  it("renders", () => {
+    expect(screen.getByTestId("batch-edit-publish-wrapper"));
+  });
+
+  it("renders publish and unpublish checkboxes", () => {
+    expect(screen.getByLabelText("Publish works"));
+    expect(screen.getByLabelText("Unpublish works"));
+  });
+
+  it("allows only one checkbox to be selected", () => {
+    const publishCheckbox = screen.getByLabelText("Publish works");
+    const unPublishCheckbox = screen.getByLabelText("Unpublish works");
+    userEvent.click(publishCheckbox);
+    userEvent.click(unPublishCheckbox);
+    expect(publishCheckbox).not.toBeChecked();
+
+    userEvent.click(publishCheckbox);
+    expect(unPublishCheckbox).not.toBeChecked();
+  });
+});

--- a/assets/js/components/Work/HeaderButtons.jsx
+++ b/assets/js/components/Work/HeaderButtons.jsx
@@ -9,6 +9,8 @@ export default function WorkHeaderButtons({
   hasCollection,
   published,
 }) {
+  const isPublishBtnDisabled = !hasCollection && !published;
+
   return (
     <div className="buttons is-right" data-testid="work-header-buttons">
       <Button
@@ -24,9 +26,9 @@ export default function WorkHeaderButtons({
         className={`${published ? "is-outlined" : "has-tooltip-multiline"}`}
         data-testid="publish-button"
         onClick={handlePublishClick}
-        disabled={!hasCollection}
+        disabled={isPublishBtnDisabled}
         data-tooltip={
-          !hasCollection
+          isPublishBtnDisabled
             ? "A work must belong to a Collection in order to be published.  Add to a Collection in the Administrative tab below."
             : undefined
         }

--- a/assets/js/components/Work/HeaderButtons.jsx
+++ b/assets/js/components/Work/HeaderButtons.jsx
@@ -7,13 +7,20 @@ export default function WorkHeaderButtons({
   handleCreateSharableBtnClick,
   handlePublishClick,
   hasCollection,
-  onOpenModal,
   published,
 }) {
   return (
     <div className="buttons is-right" data-testid="work-header-buttons">
       <Button
-        isPrimary
+        onClick={handleCreateSharableBtnClick}
+        data-testid="button-sharable-link"
+      >
+        <span className="icon">
+          <FontAwesomeIcon icon="link" />
+        </span>
+        <span>Create sharable link</span>
+      </Button>
+      <Button
         className={`${published ? "is-outlined" : "has-tooltip-multiline"}`}
         data-testid="publish-button"
         onClick={handlePublishClick}
@@ -26,18 +33,6 @@ export default function WorkHeaderButtons({
       >
         {!published ? "Publish" : "Unpublish"}
       </Button>
-      <Button
-        onClick={handleCreateSharableBtnClick}
-        data-testid="button-sharable-link"
-      >
-        <span className="icon">
-          <FontAwesomeIcon icon="link" />
-        </span>
-        <span>Create sharable link</span>
-      </Button>
-      <Button isText data-testid="delete-button" onClick={onOpenModal}>
-        Delete
-      </Button>
     </div>
   );
 }
@@ -46,6 +41,5 @@ WorkHeaderButtons.propTypes = {
   handleCreateSharableBtnClick: PropTypes.func,
   handlePublishClick: PropTypes.func,
   hasCollection: PropTypes.bool,
-  onOpenModal: PropTypes.func,
   published: PropTypes.bool,
 };

--- a/assets/js/components/Work/HeaderButtons.test.js
+++ b/assets/js/components/Work/HeaderButtons.test.js
@@ -37,7 +37,15 @@ describe("WorkHeaderButtons component", () => {
   it("renders an Unpublish button", () => {
     let newProps = { ...props, published: true };
     const { getByText } = render(<WorkHeaderButtons {...newProps} />);
-    expect(getByText(/unpublish/i));
+    const unpublishBtn = getByText(/unpublish/i);
+    expect(unpublishBtn);
+    expect(unpublishBtn).not.toBeDisabled();
+  });
+
+  it("renders an enabled Unpublish button even if a Work does not have a Collection", () => {
+    let newProps = { ...props, hasCollection: false, published: true };
+    const { getByText } = render(<WorkHeaderButtons {...newProps} />);
+    expect(getByText(/unpublish/i)).not.toBeDisabled();
   });
 
   it("renders sharable link button which fires a callback function", () => {

--- a/assets/js/components/Work/HeaderButtons.test.js
+++ b/assets/js/components/Work/HeaderButtons.test.js
@@ -4,13 +4,11 @@ import { fireEvent, render } from "@testing-library/react";
 
 const mockHandleCreateSharableBtnClick = jest.fn();
 const mockHandlePublishClick = jest.fn();
-const mockOnOpenModal = jest.fn();
 
 const props = {
   handleCreateSharableBtnClick: mockHandleCreateSharableBtnClick,
   handlePublishClick: mockHandlePublishClick,
   hasCollection: true,
-  onOpenModal: mockOnOpenModal,
   published: false,
 };
 
@@ -24,7 +22,7 @@ describe("WorkHeaderButtons component", () => {
     const { getByTestId } = render(<WorkHeaderButtons {...props} />);
     const el = getByTestId("publish-button");
 
-    expect(el).toHaveClass("is-primary");
+    expect(el).not.toBeDisabled();
 
     fireEvent.click(el);
     expect(mockHandlePublishClick).toHaveBeenCalled();
@@ -47,12 +45,5 @@ describe("WorkHeaderButtons component", () => {
     const el = getByTestId("button-sharable-link");
     fireEvent.click(el);
     expect(mockHandleCreateSharableBtnClick).toHaveBeenCalled();
-  });
-
-  it("renders a delete button which fires a callback function", () => {
-    const { getByTestId } = render(<WorkHeaderButtons {...props} />);
-    const el = getByTestId("delete-button");
-    fireEvent.click(el);
-    expect(mockOnOpenModal).toHaveBeenCalled();
   });
 });

--- a/assets/js/components/Work/TagsList.jsx
+++ b/assets/js/components/Work/TagsList.jsx
@@ -8,11 +8,19 @@ export default function WorkTagsList({ work }) {
   }
   return (
     <p>
-      <span className={`tag mr-1 ${work.published ? "is-info" : "is-warning"}`}>
+      <span
+        className={`tag mr-1 is-light ${
+          work.published ? "is-info" : "is-warning"
+        }`}
+      >
         {work.published ? "Published" : "Not Published"}
       </span>
       {work.visibility && (
-        <span className={`tag mr-1 ${setVisibilityClass(work.visibility.id)}`}>
+        <span
+          className={`tag mr-1 is-light ${setVisibilityClass(
+            work.visibility.id
+          )}`}
+        >
           {work.visibility.label}
         </span>
       )}

--- a/assets/js/screens/Work/Work.jsx
+++ b/assets/js/screens/Work/Work.jsx
@@ -20,6 +20,8 @@ import WorkSharedLinkNotification from "../../components/Work/SharedLinkNotifica
 import WorkMultiEditBar from "../../components/Work/MultiEditBar";
 import { useBatchState } from "../../context/batch-edit-context";
 import { ErrorBoundary } from "react-error-boundary";
+import { Button } from "@nulib/admin-react-components";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 const ScreensWork = () => {
   const params = useParams();
@@ -165,7 +167,6 @@ const ScreensWork = () => {
                           handleCreateSharableBtnClick
                         }
                         handlePublishClick={handlePublishClick}
-                        onOpenModal={onOpenModal}
                         published={data.work.published}
                         hasCollection={data.work.collection ? true : false}
                       />
@@ -229,6 +230,14 @@ const ScreensWork = () => {
       ) : (
         <ErrorBoundary FallbackComponent={ErrorFallback}>
           <Work work={data.work} />
+          <div className="container buttons">
+            <Button data-testid="delete-button" onClick={onOpenModal}>
+              <span className="icon">
+                <FontAwesomeIcon icon="trash" />
+              </span>
+              <span>Delete this work</span>
+            </Button>
+          </div>
         </ErrorBoundary>
       )}
 

--- a/assets/js/screens/Work/Work.test.jsx
+++ b/assets/js/screens/Work/Work.test.jsx
@@ -38,3 +38,10 @@ xit("renders breadcrumbs", async () => {
   const crumbsEl = await findByTestId("work-breadcrumbs");
   expect(crumbsEl).toBeInTheDocument();
 });
+
+xit("renders a delete button which fires a callback function", () => {
+  const { getByTestId } = render(<WorkHeaderButtons {...props} />);
+  const el = getByTestId("delete-button");
+  fireEvent.click(el);
+  expect(mockOnOpenModal).toHaveBeenCalled();
+});

--- a/assets/js/services/metadata.js
+++ b/assets/js/services/metadata.js
@@ -51,6 +51,7 @@ export const METADATA_FIELDS = {
     label: "Project Task Number",
   },
   PROVENANCE: { name: "provenance", label: "Provenance" },
+  PUBLISHED: { name: "published", label: "Published" },
   PUBLISHER: { name: "publisher", label: "Publisher" },
   RELATED_MATERIAL: { name: "relatedMaterial", label: "Related Material" },
   RELATED_URL: { name: "relatedUrl", label: "Related URL" },
@@ -105,6 +106,7 @@ const {
   PROJECT_PROPOSER,
   PROJECT_TASK_NUMBER,
   PROVENANCE,
+  PUBLISHED,
   PUBLISHER,
   RELATED_MATERIAL,
   RELATED_URL,
@@ -464,6 +466,14 @@ export function removeLabelsFromBatchEditPostData(
           item
         );
       });
+
+    // Handle published or unpublished values
+    // The "published" object can only have one of its properties set
+    // to TRUE... "publish" or "unpublish".  Not both.
+    const { published } = batchReplaces;
+    if (published && (published.publish || published.unpublish)) {
+      returnObj.replace.published = published.publish;
+    }
   }
 
   if (hasDeletes) {


### PR DESCRIPTION
…n the UI

A user can now publish or unpublish Works in batch edit mode.  The checkboxes are mutually exclusive.

![image](https://user-images.githubusercontent.com/3020266/98598050-81eefe00-229f-11eb-85df-3afd6fb61c78.png)


