### PR TITLE
Fixes to make maintenance easier via EC2 instance

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -43,7 +43,7 @@ alias Meadow.Data.Schemas.{
   WorkDescriptiveMetadata
 }
 
-alias Meadow.Ingest.{Progress, Projects, Sheets, SheetsToWorks}
+alias Meadow.Ingest.{Progress, Projects, Rows, Sheets, SheetsToWorks}
 
 alias Meadow.Ingest.Schemas.{
   Project,

--- a/config/config.exs
+++ b/config/config.exs
@@ -5,7 +5,7 @@
 # is restricted to this project.
 
 # General application configuration
-use Mix.Config
+import Config
 
 config :meadow,
   ecto_repos: [Meadow.Repo],

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # Configure your database
 config :meadow, Meadow.Repo,
@@ -102,29 +102,31 @@ config :meadow,
 config :elastix,
   custom_headers: {Meadow.Utils.AWS, :add_aws_signature, ["us-east-1", "fake", "fake"]}
 
-config :ex_aws,
-  access_key_id: "fake",
-  secret_access_key: "fake"
+unless System.get_env("REAL_AWS_CONFIG", "false") == "true" do
+  config :ex_aws,
+    access_key_id: "fake",
+    secret_access_key: "fake"
 
-config :ex_aws, :s3,
-  access_key_id: "minio",
-  secret_access_key: "minio123",
-  host: "devbox.library.northwestern.edu",
-  port: 9001,
-  scheme: "https://",
-  region: "us-east-1"
+  config :ex_aws, :s3,
+    access_key_id: "minio",
+    secret_access_key: "minio123",
+    host: "devbox.library.northwestern.edu",
+    port: 9001,
+    scheme: "https://",
+    region: "us-east-1"
 
-config :ex_aws, :sqs,
-  host: "localhost",
-  port: 4101,
-  scheme: "http://",
-  region: "us-east-1"
+  config :ex_aws, :sqs,
+    host: "localhost",
+    port: 4101,
+    scheme: "http://",
+    region: "us-east-1"
 
-config :ex_aws, :sns,
-  host: "localhost",
-  port: 4101,
-  scheme: "http://",
-  region: "us-east-1"
+  config :ex_aws, :sns,
+    host: "localhost",
+    port: 4101,
+    scheme: "http://",
+    region: "us-east-1"
+end
 
 config :exldap, :settings,
   server: System.get_env("LDAP_SERVER", "localhost"),

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 ### YOU PROBABLY WANT TO USE RELEASES.EXS INSTEAD ###
 

--- a/config/sequins.exs
+++ b/config/sequins.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 alias Meadow.Pipeline.Actions.{
   CopyFileToPreservation,

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # Configure your database
 config :meadow, Meadow.Repo,

--- a/lib/meadow/application/children.ex
+++ b/lib/meadow/application/children.ex
@@ -14,26 +14,18 @@ defmodule Meadow.Application.Children do
   end
 
   defp specs(:dev) do
-    [
-      EDTF,
-      {Meadow.Data.IndexWorker, interval: Config.index_interval()},
-      Meadow.IIIF.ManifestListener,
-      {Meadow.Ingest.Progress, interval: Config.progress_ping_interval()},
-      Meadow.Ingest.SheetNotifier,
-      Meadow.Ingest.WorkCreator,
-      Meadow.Ingest.WorkRedriver,
-      mock_ark_server(3943)
-    ]
+    [mock_ark_server(3943) | workers(System.get_env("NO_WORKERS", nil))]
   end
 
   defp specs(:test) do
-    [
-      EDTF,
-      mock_ark_server(3944)
-    ]
+    [EDTF, mock_ark_server(3944)]
   end
 
   defp specs(:prod) do
+    workers(System.get_env("NO_WORKERS", nil))
+  end
+
+  defp workers(nil) do
     [
       EDTF,
       {Meadow.Data.IndexWorker, interval: Config.index_interval()},
@@ -43,6 +35,11 @@ defmodule Meadow.Application.Children do
       Meadow.Ingest.WorkCreator,
       Meadow.Ingest.WorkRedriver
     ]
+  end
+
+  defp workers(_) do
+    Logger.warn("Skipping background workers because NO_WORKERS is set")
+    []
   end
 
   defp mock_ark_server(port) do

--- a/lib/meadow/release_tasks.ex
+++ b/lib/meadow/release_tasks.ex
@@ -11,57 +11,32 @@ defmodule Meadow.ReleaseTasks do
     Meadow.Ingest.WorkRedriver
   ]
 
-  alias Ecto.Adapters.SQL
-  alias Meadow.{IntervalTask, Pipeline}
-  alias Meadow.Utils.Logging
+  require Logger
 
   def migrate do
-    [:elasticsearch, :ex_aws, :hackney, :sequins] |> Enum.each(&Application.ensure_all_started/1)
-    Pipeline.queue_config() |> Sequins.setup()
+    Logger.info("Starting Meadow")
+    System.put_env("NO_WORKERS", "true")
+    Application.ensure_all_started(@app)
+    pause!()
 
     for repo <- repos() do
+      Logger.info("Migrating #{repo}")
       create_storage_for(repo)
       {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
     end
 
+    Logger.info("Hot swapping Elasticsearch index #{@elastic_search_index}")
     Elasticsearch.Index.hot_swap(Meadow.ElasticsearchCluster, @elastic_search_index)
-  end
-
-  def seed, do: _seed("priv/repo/seeds.exs")
-  def seed(name) when is_binary(name), do: _seed("priv/repo/seeds/#{name}.exs")
-  def seed([name | []]), do: seed(name)
-
-  def seed([name | names]) do
-    seed(name)
-    seed(names)
-  end
-
-  defp _seed(file) do
-    Logging.with_log_level(:info, fn ->
-      Path.join(Application.app_dir(:meadow), file)
-      |> Code.compile_file()
-      |> Enum.each(fn {module, _} -> module.run() end)
-    end)
-  end
-
-  def reset! do
-    Enum.each(@modules, &IntervalTask.pause!(&1))
-
-    for repo <- repos() do
-      SQL.query!(
-        repo,
-        "SELECT * FROM pg_catalog.pg_tables WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema'"
-      )
-      |> Map.get(:rows)
-      |> Enum.each(fn [_, table, _, _, _, _, _, _] ->
-        SQL.query!(repo, "DROP TABLE #{table} CASCADE")
-      end)
-    end
-
-    migrate()
-    seed()
   after
-    Enum.each(@modules, &IntervalTask.resume!(&1))
+    resume!()
+  end
+
+  def pause! do
+    Enum.each(@modules, &Meadow.IntervalTask.pause!/1)
+  end
+
+  def resume! do
+    Enum.each(@modules, &Meadow.IntervalTask.resume!/1)
   end
 
   defp create_storage_for(repo) do

--- a/lib/mix/tasks/elasticsearch.ex
+++ b/lib/mix/tasks/elasticsearch.ex
@@ -13,3 +13,27 @@ defmodule Mix.Tasks.Meadow.Elasticsearch.Setup do
     Elasticsearch.Build.run(~w|meadow --existing --cluster Meadow.ElasticsearchCluster|)
   end
 end
+
+defmodule Mix.Tasks.Meadow.Elasticsearch.Clear do
+  @moduledoc """
+  Clear the elasticsearch meadow and shared_links indices
+  """
+  use Mix.Task
+  require Logger
+
+  @shortdoc @moduledoc
+  def run(_) do
+    [:ex_aws, :hackney] |> Enum.each(&Application.ensure_all_started/1)
+
+    with url <- Application.get_env(:meadow, Meadow.ElasticsearchCluster) |> Keyword.get(:url) do
+      Logger.info("Clearing data from meadow index")
+      Elastix.Document.delete_matching(url, "meadow", %{query: %{match_all: %{}}})
+
+      Logger.info("Clearing data from shared_links index")
+
+      Elastix.Document.delete_matching(url, "shared_links", %{
+        query: %{match: %{"target_index.keyword": "meadow"}}
+      })
+    end
+  end
+end

--- a/lib/mix/tasks/sqns.ex
+++ b/lib/mix/tasks/sqns.ex
@@ -9,3 +9,33 @@ defmodule Mix.Tasks.Meadow.Pipeline.Setup do
     Pipeline.queue_config() |> Sequins.setup()
   end
 end
+
+defmodule Mix.Tasks.Meadow.Pipeline.Purge do
+  @moduledoc "Purges messages from all ingest pipeline queues"
+  alias Meadow.Pipeline
+  use Mix.Task
+
+  require Logger
+
+  @shortdoc @moduledoc
+  def run(_) do
+    [:ex_aws, :hackney] |> Enum.each(&Application.ensure_all_started/1)
+
+    Pipeline.queue_config()
+    |> Sequins.parse_queues()
+    |> Enum.each(fn queue ->
+      Logger.info("Purging queue: #{queue}")
+
+      case ExAws.SQS.get_queue_url(queue) |> ExAws.request() do
+        {:ok, result} ->
+          result
+          |> get_in([:body, :queue_url])
+          |> ExAws.SQS.purge_queue()
+          |> ExAws.request!()
+
+        {:error, _} ->
+          Logger.warn("Queue #{queue} doesn't exist")
+      end
+    end)
+  end
+end

--- a/priv/repo/migrations/20200227215805_notify_work_updates.exs
+++ b/priv/repo/migrations/20200227215805_notify_work_updates.exs
@@ -29,6 +29,7 @@ defmodule Meadow.Repo.Migrations.NotifyWorkUpdates do
   end
 
   def down do
-    execute("DROP TRIGGER 'works_changed'")
+    execute("DROP TRIGGER IF EXISTS works_changed ON works")
+    execute("DROP FUNCTION IF EXISTS notify_work_changes")
   end
 end


### PR DESCRIPTION
**Note:** This PR is a companion to the one in [repodev_planning_and_docs](https://github.com/nulib/repodev_planning_and_docs/pull/1190)

Major Changes:

* Remove `Meadow.ReleaseTasks.reset!()`
* Add mix tasks:
  * `meadow.pipeline.purge` – Purges messages from all ingest pipeline queue
  * `meadow.reset` – Clear out meadow database, indices, and queues
* Add environment variables:
  * `NO_PIPELINE` – prevent the pipeline from starting on startup
  * `NO_WORKERS` – prevent background tasks from starting on startup
* Add two functions to `Meadow.ReleaseTasks`:
  * `pause!/0` – pause background workers
  * `resume!/0` – resume background workers
* Fix rollback of `work_updates` trigger
* Add `REAL_AWS_CONFIG` environment variable to skip local minio/goaws config  _[STAGING]_
* Replace `use Mix.Config` with `import Config` _[STAGING]_

Things marked _[STAGING]_ are present primarily to make it possible to configure the staging dev instance and are not easily testable on dev (beyond ensuring they don't break anything or cause unexpected behavior).