### PR TITLE
Shared link host url comes from API in the UI

### DIFF
--- a/assets/js/components/UI/ui.gql.js
+++ b/assets/js/components/UI/ui.gql.js
@@ -1,0 +1,9 @@
+import gql from "graphql-tag";
+
+export const DIGITAL_COLLECTIONS_URL = gql`
+  query DigitalCollectionsUrl {
+    digitalCollectionsUrl {
+      url
+    }
+  }
+`;

--- a/assets/js/components/UI/ui.gql.mock.js
+++ b/assets/js/components/UI/ui.gql.mock.js
@@ -1,0 +1,16 @@
+import { DIGITAL_COLLECTIONS_URL } from "./ui.gql";
+
+export const mockDCUrl = "https://imamockurl.io/";
+
+export const digitalCollectionsUrlMock = {
+  request: {
+    query: DIGITAL_COLLECTIONS_URL,
+  },
+  result: {
+    data: {
+      digitalCollectionsUrl: {
+        url: mockDCUrl,
+      },
+    },
+  },
+};

--- a/assets/js/components/Work/SharedLinkNotification.jsx
+++ b/assets/js/components/Work/SharedLinkNotification.jsx
@@ -2,9 +2,26 @@ import React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import PropTypes from "prop-types";
 import moment from "moment";
+import { useQuery } from "@apollo/client";
+import { DIGITAL_COLLECTIONS_URL } from "@js/components/UI/ui.gql";
 
 export default function WorkSharedLinkNotification({ linkData }) {
+  const { data, loading, error } = useQuery(DIGITAL_COLLECTIONS_URL);
   const linkUrl = `http://fen.rdc-staging.library.northwestern.edu/shared/${linkData.sharedLinkId}`;
+
+  if (error) {
+    return (
+      <p className="notifcation is-danger">
+        There was an error retrieving the Digital Collections url
+      </p>
+    );
+  }
+
+  if (loading) {
+    return null;
+  }
+
+  const sharedUrl = `${data.digitalCollectionsUrl.url}shared/${linkData.sharedLinkId}`;
 
   return (
     <div
@@ -14,12 +31,18 @@ export default function WorkSharedLinkNotification({ linkData }) {
       <p>
         <FontAwesomeIcon icon="link" />
         <span className="px-2">
-          Your shared link has been created successfully
+          Your shared link has been created successfully and will expire:
+        </span>
+        <span data-testid="link-date">
+          <strong>
+            {moment(linkData.expires).format("MMM DD, YYYY h:mm A")}
+          </strong>
         </span>
       </p>
-      <p data-testid="link-url">{linkUrl}</p>
-      <p data-testid="link-date">
-        will expire at: {moment(linkData.expires).format("MMM DD, YYYY h:mm A")}
+      <p data-testid="link-url">
+        <a href={sharedUrl} target="_blank">
+          {sharedUrl}
+        </a>
       </p>
     </div>
   );

--- a/assets/js/components/Work/SharedLinkNotification.test.js
+++ b/assets/js/components/Work/SharedLinkNotification.test.js
@@ -1,7 +1,12 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import WorkSharedLinkNotification from "./SharedLinkNotification";
 import moment from "moment";
+import { renderWithApollo } from "@js/services/testing-helpers";
+import {
+  digitalCollectionsUrlMock,
+  mockDCUrl,
+} from "@js/components/UI/ui.gql.mock";
 
 const createSharedLink = {
   expires: "2020-09-02T20:04:40.166275Z",
@@ -10,36 +15,38 @@ const createSharedLink = {
 };
 
 describe("WorkSharedLinkNotification component", () => {
-  it("renders the component", () => {
-    const { getByTestId } = render(
-      <WorkSharedLinkNotification linkData={createSharedLink} />
+  beforeEach(() => {
+    renderWithApollo(
+      <WorkSharedLinkNotification linkData={createSharedLink} />,
+      {
+        mocks: [digitalCollectionsUrlMock],
+      }
     );
-    expect(getByTestId("notification-shared-link")).toBeInTheDocument();
   });
 
-  it("renders the success message", () => {
-    const { getByTestId, getByText, debug } = render(
-      <WorkSharedLinkNotification linkData={createSharedLink} />
-    );
+  it("renders the component", async () => {
+    expect(await screen.findByTestId("notification-shared-link"));
+  });
 
+  it("renders the success message", async () => {
     expect(
-      getByText("Your shared link has been created successfully")
-    ).toBeInTheDocument();
+      await screen.findByText(
+        "Your shared link has been created successfully and will expire:"
+      )
+    );
   });
 
-  it("renders the link url and expiration dates", () => {
-    const { getByTestId } = render(
-      <WorkSharedLinkNotification linkData={createSharedLink} />
-    );
-
-    expect(getByTestId("link-url")).toHaveTextContent(
-      createSharedLink.sharedLinkId
+  it("renders the link url and expiration dates", async () => {
+    expect(await screen.findByTestId("link-url")).toHaveTextContent(
+      `${mockDCUrl}shared/${createSharedLink.sharedLinkId}`
     );
 
     const formattedDate = moment(createSharedLink.expires).format(
       "MMM DD, YYYY h:mm A"
     );
 
-    expect(getByTestId("link-date")).toHaveTextContent(formattedDate);
+    expect(await screen.findByTestId("link-date")).toHaveTextContent(
+      formattedDate
+    );
   });
 });


### PR DESCRIPTION
This now is wired up, and slightly updated the UI for Sharable Link, and created the actual link so users can see the Work.

![image](https://user-images.githubusercontent.com/3020266/98854814-af16ea00-2420-11eb-8496-733b7df78a54.png)
