### PR TITLE
Adds Absinthe middleware for authorization

### DIFF
--- a/lib/meadow_web/schema/middleware/authorize.ex
+++ b/lib/meadow_web/schema/middleware/authorize.ex
@@ -1,0 +1,29 @@
+defmodule MeadowWeb.Schema.Middleware.Authorize do
+  @moduledoc """
+  Checks if the current user can perform an action based on their role
+
+  """
+  @behaviour Absinthe.Middleware
+
+  def call(%{context: %{current_user: current_user}} = resolution, role) do
+    if authorized_role?(current_user, role) do
+      resolution
+    else
+      resolution
+      |> Absinthe.Resolution.put_result({:error, %{message: "Forbidden", status: 403}})
+    end
+  end
+
+  def call(resolution, _role) do
+    resolution
+    |> Absinthe.Resolution.put_result({:error, %{message: "Forbidden", status: 403}})
+  end
+
+  defp authorized_role?(%{}, :any), do: true
+  defp authorized_role?(%{role: "Administrator"}, _role), do: true
+  defp authorized_role?(%{role: "Manager"}, "Viewer"), do: true
+  defp authorized_role?(%{role: "Manager"}, "Editor"), do: true
+  defp authorized_role?(%{role: "Editor"}, "Viewer"), do: true
+  defp authorized_role?(%{role: role}, role), do: true
+  defp authorized_role?(_, _), do: false
+end

--- a/lib/meadow_web/schema/types/data/batch_types.ex
+++ b/lib/meadow_web/schema/types/data/batch_types.ex
@@ -18,6 +18,7 @@ defmodule MeadowWeb.Schema.Data.BatchTypes do
       @desc "`replace` replaces existing values (single and multi valued fields)"
       arg(:replace, :batch_replace_input, default_value: nil)
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
       resolve(&Batches.update/3)
     end
   end

--- a/lib/meadow_web/schema/types/data/collection_types.ex
+++ b/lib/meadow_web/schema/types/data/collection_types.ex
@@ -34,6 +34,7 @@ defmodule MeadowWeb.Schema.Data.CollectionTypes do
       arg(:published, :boolean)
       arg(:visibility, :coded_term_input)
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Manager")
       resolve(&Resolvers.Data.Collections.create_collection/3)
     end
 
@@ -49,6 +50,7 @@ defmodule MeadowWeb.Schema.Data.CollectionTypes do
       arg(:published, :boolean)
       arg(:visibility, :coded_term_input)
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Manager")
       resolve(&Resolvers.Data.Collections.update_collection/3)
     end
 
@@ -57,6 +59,7 @@ defmodule MeadowWeb.Schema.Data.CollectionTypes do
       arg(:collection_id, non_null(:id))
       arg(:work_ids, list_of(:id))
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Data.Collections.add_works/3)
     end
 
@@ -65,6 +68,7 @@ defmodule MeadowWeb.Schema.Data.CollectionTypes do
       arg(:collection_id, non_null(:id))
       arg(:work_ids, list_of(:id))
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Data.Collections.remove_works/3)
     end
 
@@ -73,6 +77,7 @@ defmodule MeadowWeb.Schema.Data.CollectionTypes do
       arg(:collection_id, non_null(:id))
       arg(:work_id, non_null(:id))
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Manager")
       resolve(&Resolvers.Data.Collections.set_collection_image/3)
     end
 
@@ -80,6 +85,7 @@ defmodule MeadowWeb.Schema.Data.CollectionTypes do
     field :delete_collection, :collection do
       arg(:collection_id, non_null(:id))
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Manager")
       resolve(&Resolvers.Data.Collections.delete_collection/3)
     end
   end

--- a/lib/meadow_web/schema/types/data/file_set_types.ex
+++ b/lib/meadow_web/schema/types/data/file_set_types.ex
@@ -27,6 +27,7 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
       arg(:work_id, non_null(:id))
       arg(:metadata, non_null(:file_set_metadata_input))
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Data.create_file_set/3)
     end
 
@@ -34,6 +35,7 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
     field :delete_file_set, :file_set do
       arg(:file_set_id, non_null(:id))
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Data.delete_file_set/3)
     end
   end

--- a/lib/meadow_web/schema/types/data/shared_link_types.ex
+++ b/lib/meadow_web/schema/types/data/shared_link_types.ex
@@ -12,6 +12,7 @@ defmodule MeadowWeb.Schema.Data.SharedLinkTypes do
     field :create_shared_link, :shared_link do
       arg(:work_id, non_null(:id))
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Manager")
       resolve(&Data.SharedLinks.generate/3)
     end
   end

--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -47,6 +47,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
       arg(:published, :boolean)
       arg(:file_sets, list_of(:file_set_input))
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Data.create_work/3)
     end
 
@@ -55,6 +56,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
       arg(:id, non_null(:id))
       arg(:work, non_null(:work_update_input))
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Data.update_work/3)
     end
 
@@ -63,6 +65,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
       arg(:work_id, non_null(:id))
       arg(:file_set_id, non_null(:id))
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Data.set_work_image/3)
     end
 
@@ -70,6 +73,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     field :delete_work, :work do
       arg(:work_id, non_null(:id))
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Data.delete_work/3)
     end
 
@@ -78,6 +82,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
       arg(:work_id, non_null(:id))
       arg(:collection_id, non_null(:id))
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Data.add_work_to_collection/3)
     end
   end

--- a/lib/meadow_web/schema/types/ingest_types.ex
+++ b/lib/meadow_web/schema/types/ingest_types.ex
@@ -84,14 +84,16 @@ defmodule MeadowWeb.Schema.IngestTypes do
     field :create_project, :project do
       arg(:title, non_null(:string))
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Ingest.create_project/3)
     end
 
-    @desc "Create a new Ingest Project"
+    @desc "Update an Ingest Project"
     field :update_project, :project do
       arg(:id, non_null(:id))
       arg(:title, :string)
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Ingest.update_project/3)
     end
 
@@ -101,6 +103,8 @@ defmodule MeadowWeb.Schema.IngestTypes do
       arg(:project_id, non_null(:id))
       arg(:filename, non_null(:string))
       middleware(Middleware.Authenticate)
+
+      middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Ingest.create_ingest_sheet/3)
     end
 
@@ -108,6 +112,7 @@ defmodule MeadowWeb.Schema.IngestTypes do
     field :delete_project, :project do
       arg(:project_id, non_null(:id))
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Ingest.delete_project/3)
     end
 
@@ -115,6 +120,7 @@ defmodule MeadowWeb.Schema.IngestTypes do
     field :delete_ingest_sheet, :ingest_sheet do
       arg(:sheet_id, non_null(:id))
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Ingest.delete_ingest_sheet/3)
     end
 
@@ -122,6 +128,7 @@ defmodule MeadowWeb.Schema.IngestTypes do
     field :approve_ingest_sheet, :status_message do
       arg(:id, non_null(:id))
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Ingest.approve_ingest_sheet/3)
     end
 
@@ -129,6 +136,7 @@ defmodule MeadowWeb.Schema.IngestTypes do
     field :validate_ingest_sheet, :status_message do
       arg(:sheet_id, non_null(:id))
       middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Ingest.validate_ingest_sheet/3)
     end
   end

--- a/test/gql/CreateFileSet.gql
+++ b/test/gql/CreateFileSet.gql
@@ -1,0 +1,15 @@
+mutation(
+  $accession_number: String!
+  $role: FileSetRole!
+  $metadata: FileSetMetadataInput!
+  $work_id: ID!
+) {
+  createFileSet(
+    accessionNumber: $accession_number
+    role: $role
+    metadata: $metadata
+    workId: $work_id
+  ) {
+    id
+  }
+}

--- a/test/gql/CreateProject.gql
+++ b/test/gql/CreateProject.gql
@@ -1,0 +1,5 @@
+mutation($title: String!) {
+  createProject(title: $title) {
+    title
+  }
+}

--- a/test/meadow_web/schema/middleware/authorize_test.exs
+++ b/test/meadow_web/schema/middleware/authorize_test.exs
@@ -1,0 +1,53 @@
+defmodule MeadowWeb.Schema.Middleware.AuthorizeTest do
+  use MeadowWeb.ConnCase, async: true
+
+  alias MeadowWeb.Schema.Middleware.Authorize
+
+  test "Authorize middleware checks against the current user's role in the context" do
+    %{id: id} = user_fixture()
+
+    resolution =
+      %Absinthe.Resolution{}
+      |> Map.put(:context, %{current_user: %{id: id, role: "Administrator"}})
+      |> Authorize.call("Administrator")
+
+    assert %{errors: []} = resolution
+    assert %{current_user: %{id: id}} = resolution.context
+  end
+
+  test "Authorize middleware takes the argument :any to authorize all users" do
+    %{id: id} = user_fixture()
+
+    resolution =
+      %Absinthe.Resolution{}
+      |> Map.put(:context, %{current_user: %{id: id}})
+      |> Authorize.call(:any)
+
+    assert %{errors: []} = resolution
+    assert %{current_user: %{id: id}} = resolution.context
+  end
+
+  test "Authorize middleware errors when the current user's role in the context does not match" do
+    %{id: id} = user_fixture()
+
+    resolution =
+      %Absinthe.Resolution{}
+      |> Map.put(:context, %{current_user: %{id: id, role: "Viewer"}})
+      |> Authorize.call("Administrator")
+
+    assert %{errors: [%{message: "Forbidden", status: 403}]} = resolution
+    assert %{} = resolution.context
+  end
+
+  test "Authorize middleware errors when the current user does not have a role" do
+    %{id: id} = user_fixture()
+
+    resolution =
+      %Absinthe.Resolution{}
+      |> Map.put(:context, %{current_user: %{id: id}})
+      |> Authorize.call("Administrator")
+
+    assert %{errors: [%{message: "Forbidden", status: 403}]} = resolution
+    assert %{} = resolution.context
+  end
+end

--- a/test/meadow_web/schema/mutation/add_work_to_collection_test.exs
+++ b/test/meadow_web/schema/mutation/add_work_to_collection_test.exs
@@ -19,4 +19,19 @@ defmodule MeadowWeb.Schema.Mutation.AddWorkToCollectionTest do
     collection_id = get_in(query_data, [:data, "addWorkToCollection", "collection", "id"])
     assert collection_id == collection.id
   end
+
+  describe "authorization" do
+    test "viewers are not authoried to add works to collections" do
+      collection = collection_fixture()
+      work = work_fixture()
+
+      result =
+        query_gql(
+          variables: %{"workId" => work.id, "collectionId" => collection.id},
+          context: %{current_user: %{role: "Viewer"}}
+        )
+
+      assert {:ok, %{errors: [%{message: "Forbidden", status: 403}]}} = result
+    end
+  end
 end

--- a/test/meadow_web/schema/mutation/create_collection_test.exs
+++ b/test/meadow_web/schema/mutation/create_collection_test.exs
@@ -16,4 +16,26 @@ defmodule MeadowWeb.Schema.Mutation.CreateCollectionTest do
     collection_title = get_in(query_data, [:data, "createCollection", "title"])
     assert collection_title == "The collection title"
   end
+
+  describe "authorization" do
+    test "viewers are not authorized to create collections" do
+      {:ok, result} =
+        query_gql(
+          variables: %{"title" => "The collection title"},
+          context: %{current_user: %{role: "Viewer"}}
+        )
+
+      assert %{errors: [%{message: "Forbidden", status: 403}]} = result
+    end
+
+    test "managers and above are authorized to create collections" do
+      {:ok, result} =
+        query_gql(
+          variables: %{"title" => "The collection title"},
+          context: %{current_user: %{role: "Manager"}}
+        )
+
+      assert result.data["createCollection"]
+    end
+  end
 end

--- a/test/meadow_web/schema/mutation/create_ingest_sheet_test.exs
+++ b/test/meadow_web/schema/mutation/create_ingest_sheet_test.exs
@@ -22,4 +22,38 @@ defmodule MeadowWeb.Schema.Mutation.CreateSheet do
     title = get_in(query_data, [:data, "createIngestSheet", "title"])
     assert title == "Test Ingest Sheet"
   end
+
+  describe "authorization" do
+    test "viewers are not authorized to create ingest sheets" do
+      project = project_fixture()
+
+      {:ok, result} =
+        query_gql(
+          variables: %{
+            "title" => "Test Ingest Sheet",
+            "filename" => "Test.csv",
+            "projectId" => project.id
+          },
+          context: %{current_user: %{role: "Viewer"}}
+        )
+
+      assert %{errors: [%{message: "Forbidden", status: 403}]} = result
+    end
+
+    test "editors and above are authorized to create ingest sheets" do
+      project = project_fixture()
+
+      {:ok, result} =
+        query_gql(
+          variables: %{
+            "title" => "Test Ingest Sheet",
+            "filename" => "Test.csv",
+            "projectId" => project.id
+          },
+          context: %{current_user: %{role: "Editor"}}
+        )
+
+      assert result.data["createIngestSheet"]
+    end
+  end
 end

--- a/test/meadow_web/schema/mutation/create_shared_link_test.exs
+++ b/test/meadow_web/schema/mutation/create_shared_link_test.exs
@@ -15,4 +15,26 @@ defmodule MeadowWeb.Resolvers.Data.SharedLinkTest do
 
     assert "1234" == get_in(query_data, [:data, "createSharedLink", "workId"])
   end
+
+  describe "authorization" do
+    test "viewers and editors are not authorized to create shared links" do
+      {:ok, result} =
+        query_gql(
+          variables: %{"workId" => "1234"},
+          context: %{current_user: %{role: "Editor"}}
+        )
+
+      assert %{errors: [%{message: "Forbidden", status: 403}]} = result
+    end
+
+    test "managers and above are authorized to create shared links" do
+      {:ok, result} =
+        query_gql(
+          variables: %{"workId" => "1234"},
+          context: %{current_user: %{role: "Manager"}}
+        )
+
+      assert result.data["createSharedLink"]
+    end
+  end
 end

--- a/test/meadow_web/schema/mutation/delete_collection_test.exs
+++ b/test/meadow_web/schema/mutation/delete_collection_test.exs
@@ -9,10 +9,36 @@ defmodule MeadowWeb.Schema.Mutation.DeleteCollectionTest do
 
     result =
       query_gql(
-        variables: %{"collection_id" => collection_fixture.id},
+        variables: %{"collectionId" => collection_fixture.id},
         context: gql_context()
       )
 
     assert {:ok, query_data} = result
+  end
+
+  describe "authorization" do
+    test "viewers and editors are not authorized to delete collections" do
+      collection_fixture = collection_fixture()
+
+      {:ok, result} =
+        query_gql(
+          variables: %{"collectionId" => collection_fixture.id},
+          context: %{current_user: %{role: "Editor"}}
+        )
+
+      assert %{errors: [%{message: "Forbidden", status: 403}]} = result
+    end
+
+    test "managers and above are authorized to delete collections" do
+      collection_fixture = collection_fixture()
+
+      {:ok, result} =
+        query_gql(
+          variables: %{"collectionId" => collection_fixture.id},
+          context: %{current_user: %{role: "Manager"}}
+        )
+
+      assert result.data["deleteCollection"]
+    end
   end
 end

--- a/test/meadow_web/schema/mutation/set_collection_image_test.exs
+++ b/test/meadow_web/schema/mutation/set_collection_image_test.exs
@@ -46,4 +46,38 @@ defmodule MeadowWeb.Schema.Mutation.SetCollectionImageTest do
 
     assert url == expected_work.representative_image
   end
+
+  describe "authorization" do
+    test "viewers and editors are not authorized to set representative images" do
+      collection = collection_fixture()
+      work = work_with_file_sets_fixture(1, %{collection_id: collection.id})
+
+      {:ok, result} =
+        query_gql(
+          variables: %{
+            "collection_id" => collection.id,
+            "work_id" => work.id
+          },
+          context: %{current_user: %{role: "Editor"}}
+        )
+
+      assert %{errors: [%{message: "Forbidden", status: 403}]} = result
+    end
+
+    test "managers and above are authorized to set representative images" do
+      collection = collection_fixture()
+      work = work_with_file_sets_fixture(1, %{collection_id: collection.id})
+
+      {:ok, result} =
+        query_gql(
+          variables: %{
+            "collection_id" => collection.id,
+            "work_id" => work.id
+          },
+          context: %{current_user: %{role: "Manager"}}
+        )
+
+      assert result.data["setCollectionImage"]
+    end
+  end
 end

--- a/test/meadow_web/schema/mutation/update_project_test.exs
+++ b/test/meadow_web/schema/mutation/update_project_test.exs
@@ -23,4 +23,36 @@ defmodule MeadowWeb.Schema.Mutation.UpdateProjectTest do
       assert title == "The New Title"
     end
   end
+
+  describe "authorization" do
+    test "viewers are not authorized to update projects" do
+      project = project_fixture()
+
+      {:ok, result} =
+        query_gql(
+          variables: %{
+            "id" => project.id,
+            "title" => "The New Title"
+          },
+          context: %{current_user: %{role: "Viewer"}}
+        )
+
+      assert %{errors: [%{message: "Forbidden", status: 403}]} = result
+    end
+
+    test "editors and above are authorized to update projects" do
+      project = project_fixture()
+
+      {:ok, result} =
+        query_gql(
+          variables: %{
+            "id" => project.id,
+            "title" => "The New Title"
+          },
+          context: %{current_user: %{role: "Editor"}}
+        )
+
+      assert result.data["updateProject"]
+    end
+  end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -191,7 +191,8 @@ defmodule Meadow.TestHelpers do
       current_user: %{
         username: "user1",
         email: "email@example.com",
-        display_name: "User Name"
+        display_name: "User Name",
+        role: "Administrator"
       }
     })
   end


### PR DESCRIPTION
- Adds `Absinthe.Middleware.Authorize` which takes a single  argument for the lowest authorized role: `"Viewer"`, `"Editor"`, `"Manager"`, `"Administrator"`, or `:any`, e.g. `middleware(Middleware.Authorize, "Manager")`
- Sets the role to "Administrator" by default in `Meadow.TestHelpers.gql_context/1`
- Refactors several tests to use Wormwood and GraphQL fragments

How to change your role in the cache (after logging in to set the cache):
`Cachex.get_and_update(Meadow.Cache.Users, "bmq449", fn entry -> Map.put(entry, :role, "Viewer") end)`
Change the netid and role arguments above to whatever you need