### PR TITLE
Use EFS storage for pyramid TIFF processor

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -70,18 +70,16 @@ config :meadow,
     target_url: get_required_var.("EZID_TARGET_BASE_URL")
   },
   environment: :prod,
-  pipeline_delay: System.get_env("PIPELINE_DELAY", "120000")
-
-config :meadow, ingest_bucket: get_required_var.("INGEST_BUCKET")
-config :meadow, preservation_bucket: get_required_var.("PRESERVATION_BUCKET")
-config :meadow, upload_bucket: get_required_var.("UPLOAD_BUCKET")
-config :meadow, pyramid_bucket: get_required_var.("PYRAMID_BUCKET")
-config :meadow, iiif_server_url: get_required_var.("IIIF_SERVER_URL")
-config :meadow, iiif_manifest_url: get_required_var.("IIIF_MANIFEST_URL")
-config :meadow, digital_collections_url: get_required_var.("DIGITAL_COLLECTIONS_URL")
-
-config :meadow,
+  digital_collections_url: get_required_var.("DIGITAL_COLLECTIONS_URL"),
+  iiif_manifest_url: get_required_var.("IIIF_MANIFEST_URL"),
+  iiif_server_url: get_required_var.("IIIF_SERVER_URL"),
+  ingest_bucket: get_required_var.("INGEST_BUCKET"),
+  pipeline_delay: System.get_env("PIPELINE_DELAY", "120000"),
+  preservation_bucket: get_required_var.("PRESERVATION_BUCKET"),
   progress_ping_interval: System.get_env("PROGRESS_PING_INTERVAL", "1000"),
+  pyramid_bucket: get_required_var.("PYRAMID_BUCKET"),
+  pyramid_tiff_working_dir: System.get_env("PYRAMID_TIFF_WORKING_DIR"),
+  upload_bucket: get_required_var.("UPLOAD_BUCKET"),
   validation_ping_interval: System.get_env("VALIDATION_PING_INTERVAL", "1000")
 
 config :honeybadger,

--- a/lib/meadow/pipeline/actions/create_pyramid_tiff.ex
+++ b/lib/meadow/pipeline/actions/create_pyramid_tiff.ex
@@ -102,7 +102,7 @@ defmodule Meadow.Pipeline.Actions.CreatePyramidTiff do
 
         port =
           Port.open({:spawn, command}, [
-            {:env, Config.s3_environment()},
+            {:env, Config.tiff_port_environment()},
             {:line, 512},
             :binary,
             :exit_status

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -98,6 +98,13 @@ resource "aws_ecs_task_definition" "meadow_app" {
   cpu                      = 2048
   memory                   = 4096
   tags                     = var.tags
+
+  volume {
+    name = "meadow-working"
+    efs_volume_configuration {
+      file_system_id = aws_efs_file_system.meadow_working.id
+    }
+  }
 }
 
 resource "aws_cloudwatch_log_group" "meadow_logs" {
@@ -149,7 +156,7 @@ resource "aws_ecs_service" "meadow" {
   cluster                             = aws_ecs_cluster.meadow.id
   task_definition                     = aws_ecs_task_definition.meadow_app.arn
   desired_count                       = 1
-  health_check_grace_period_seconds   = 360
+  health_check_grace_period_seconds   = 600
   launch_type                         = "FARGATE"
   depends_on                          = [aws_alb.meadow_load_balancer]
 

--- a/terraform/task-definitions/meadow_app.json
+++ b/terraform/task-definitions/meadow_app.json
@@ -4,6 +4,12 @@
     "image": "nulib/meadow:${docker_tag}",
     "cpu": 2000,
     "memoryReservation": 4000,
+    "mountPoints": [
+      {
+        "sourceVolume": "meadow-working",
+        "containerPath": "/working"
+      }
+    ],
     "essential": true,
     "environment": [
       {
@@ -99,6 +105,10 @@
         "value": "${pyramid_bucket}"
       },
       {
+        "name": "PYRAMID_TIFF_WORKING_DIR",
+        "value": "/working"
+      },
+      {
         "name": "RELEASE_COOKIE",
         "value": "${secret_key_base}"
       },
@@ -122,15 +132,18 @@
     "portMappings": [
       {
         "containerPort": 4000,
-        "hostPort": 4000
+        "hostPort": 4000,
+        "protocol": "tcp"
       },
       {
         "containerPort": 4369,
-        "hostPort": 4369
+        "hostPort": 4369,
+        "protocol": "tcp"
       },
       {
         "containerPort": 24601,
-        "hostPort": 24601
+        "hostPort": 24601,
+        "protocol": "tcp"
       }
     ],
     "logConfiguration": {
@@ -140,6 +153,7 @@
         "awslogs-region": "${region}",
         "awslogs-stream-prefix": "app"
       }
-    }
+    },
+    "volumesFrom": []
   }
 ]

--- a/test/meadow/config_test.exs
+++ b/test/meadow/config_test.exs
@@ -41,7 +41,7 @@ defmodule Meadow.ConfigTest do
     refute Config.environment?(:dev)
   end
 
-  test "s3_environment/0" do
+  test "tiff_port_environment/0" do
     get_val = fn env, key ->
       env
       |> Enum.find_value(fn
@@ -50,7 +50,7 @@ defmodule Meadow.ConfigTest do
       end)
     end
 
-    with env <- Config.s3_environment() do
+    with env <- Config.tiff_port_environment() do
       assert env |> get_val.('AWS_REGION') == 'us-east-1'
       assert env |> get_val.('AWS_SECRET_ACCESS_KEY') == 'minio123'
       assert env |> get_val.('AWS_ACCESS_KEY_ID') == 'minio'


### PR DESCRIPTION
* Add EFS filesystem and mount points
* Mount EFS filesystem on container as `/working`
* Allow Meadow to (optionally) use alternate working directory for TIFF derivatives
* Clean up config code

**NOTE**: The Terraform code in this PR needs to be applied before the Meadow changes are deployed