### PR TITLE
Backend for Batch Dashboard

### DIFF
--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -6741,7 +6741,12 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-phoenix@^1.4.0, "phoenix@file:../deps/phoenix":
+phoenix@^1.4.0:
+  version "1.5.7"
+  resolved "https://registry.yarnpkg.com/phoenix/-/phoenix-1.5.7.tgz#86775bc51271e49930fd7d879ec3ec2addd6bf08"
+  integrity sha512-RgVdTRsK5NpnUPkjPyLg9P8qQQvuDaUsazH06t+ARu9EnPryQ7asE76VDjVZ43fqjY/p8er6y6OQb17YViG47g==
+
+"phoenix@file:../deps/phoenix":
   version "1.5.6"
 
 "phoenix_html@file:../deps/phoenix_html":

--- a/lib/meadow/application/children.ex
+++ b/lib/meadow/application/children.ex
@@ -28,6 +28,7 @@ defmodule Meadow.Application.Children do
   defp workers(nil) do
     [
       EDTF,
+      Meadow.BatchDriver,
       {Meadow.Data.IndexWorker, interval: Config.index_interval()},
       Meadow.IIIF.ManifestListener,
       {Meadow.Ingest.Progress, interval: Config.progress_ping_interval()},

--- a/lib/meadow/batch_driver.ex
+++ b/lib/meadow/batch_driver.ex
@@ -1,0 +1,38 @@
+defmodule Meadow.BatchDriver do
+  @moduledoc """
+  IntervalTask to kickoff queued batch update/delete jobs
+  """
+  import Ecto.Query, warn: false
+  require Logger
+
+  alias Meadow.Batches
+  alias Meadow.IntervalTask
+
+  use IntervalTask, default_interval: 30_000, function: :drive_batch
+
+  require Logger
+
+  @timeout 360
+
+  @doc """
+  If no batches are currently running, find the next one and start it
+  """
+  def drive_batch(state) do
+    with {:ok, count} <- Batches.purge_stalled(@timeout) do
+      if count > 0 do
+        Logger.info("Purging #{count} stalled #{Inflex.inflect("batch", count)} from queue")
+      end
+    end
+
+    case Batches.next_batch() do
+      nil ->
+        :noop
+
+      batch ->
+        Logger.info("Found next batch to start #{inspect(batch)}")
+        Batches.process_batch(batch)
+    end
+
+    {:noreply, state}
+  end
+end

--- a/lib/meadow/batches.ex
+++ b/lib/meadow/batches.ex
@@ -5,26 +5,208 @@ defmodule Meadow.Batches do
 
   import Ecto.Query, warn: false
   alias Meadow.Data.{Indexer, Works}
-  alias Meadow.Data.Schemas.Work
+  alias Meadow.Data.Schemas.{Batch, Work}
   alias Meadow.Repo
 
   require Logger
 
   @controlled_fields ~w(contributor creator genre language location style_period subject technique)a
 
-  def batch_update(query, delete, add, replace) do
-    Logger.info("Beginning batch update using query: #{query}")
-    Logger.info("delete: #{inspect(delete)}")
-    Logger.info("add: #{inspect(add)}")
-    Logger.info("replace: #{inspect(replace)}")
+  @doc """
+  Creates a batch.
 
+  ## Examples
+
+      iex> create_batch(%{field: value})
+      {:ok, %Meadow.Schemas.Batch{}}
+
+      iex> create_batch(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_batch(attrs \\ %{}) do
+    %Batch{}
+    |> Batch.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Same as create_batch/1 but raises on error
+  """
+  def create_batch!(attrs \\ %{}) do
+    %Batch{}
+    |> Batch.changeset(attrs)
+    |> Repo.insert!()
+  end
+
+  @doc """
+  Updates a Batch.
+  """
+  def update_batch(%Batch{} = batch, attrs) do
+    batch
+    |> Batch.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Updates a Batch by batch id.
+  """
+  def update_batch(batch_id, attrs) do
+    batch = Repo.get!(Batch, batch_id)
+    update_batch(batch, attrs)
+  end
+
+  @doc """
+  Same as update_batch(%Batch{} = batch, attrs) but raises an error
+  """
+  def update_batch!(%Batch{} = batch, attrs) do
+    batch
+    |> Batch.changeset(attrs)
+    |> Repo.update!()
+  end
+
+  @doc """
+  Returns a list of Batches.
+
+  ## Examples
+
+      iex> list_batches()
+      [%Batch{}, ...]
+
+  """
+  def list_batches do
+    Repo.all(Batch)
+  end
+
+  @doc """
+  Gets a batch.
+
+  Raises `Ecto.NoResultsError` if the Batch does not exist.
+
+  ## Examples
+
+      iex> get_batch!("123")
+      %Batch{}
+
+      iex> get_batch!("456")
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_batch!(id) do
+    Batch
+    |> Repo.get!(id)
+  end
+
+  def process_batch(%Batch{type: "update"} = batch) do
+    case set_active(batch) do
+      {:ok, batch} ->
+        log_batch_info(batch)
+
+        try do
+          case do_update(batch) do
+            {:ok, _any} ->
+              Logger.info("Setting batch to complete")
+              {:ok, set_complete!(batch)}
+
+            {:error, any} ->
+              Logger.info("Batch #{batch.id} transaction error: #{inspect(any)}")
+
+              {:error,
+               set_error!(batch, "An error occured during the transaction: #{inspect(any)}")}
+          end
+        rescue
+          e ->
+            Logger.info("Rescued error for batch #{batch.id}: #{Exception.message(e)}")
+            {:error, set_error!(batch, Exception.message(e))}
+        end
+
+      {:error, %Ecto.Changeset{}} ->
+        Logger.info("Couldn't start batch. Active batch already exists")
+        {:ok, batch}
+    end
+  end
+
+  def process_batch(%Batch{type: mode}) do
+    {:error, "mode: #{mode} not implemented"}
+  end
+
+  defp do_update(batch) do
     Meadow.Repo.transaction(
       fn ->
-        process_updates(query, delete, add, replace)
+        process_updates(
+          batch.query,
+          decode_value(batch.delete),
+          decode_value(batch.add),
+          decode_value(batch.replace),
+          batch.id
+        )
+
         Indexer.synchronize_index()
-        Logger.info("Batch update complete")
       end,
       timeout: :infinity
+    )
+  end
+
+  defp set_active(batch) do
+    update_batch(batch, %{
+      started: DateTime.utc_now(),
+      status: "in_progress",
+      active: true
+    })
+  end
+
+  defp set_complete!(batch) do
+    update_batch!(batch, %{
+      started: DateTime.utc_now(),
+      status: "complete",
+      active: false
+    })
+  end
+
+  defp set_error!(batch, message) do
+    update_batch!(batch, %{
+      started: DateTime.utc_now(),
+      status: "error",
+      active: false,
+      error: message
+    })
+  end
+
+  @doc """
+  Returns the next batch in queue, if there is one
+  """
+  def next_batch do
+    Repo.one(
+      from(b in Batch, where: b.status == "queued", order_by: [asc: b.inserted_at], limit: 1)
+    )
+  end
+
+  @doc """
+  Finds stalled active batches and sets them to error state
+  """
+  def purge_stalled(seconds) do
+    {count, _} =
+      stalled(seconds)
+      |> Repo.update_all(
+        set: [
+          active: "false",
+          status: "error",
+          error: "Batch timed out",
+          works_updated: 0,
+          updated_at: DateTime.utc_now()
+        ]
+      )
+
+    {:ok, count}
+  end
+
+  defp stalled(seconds) do
+    timeout = DateTime.utc_now() |> DateTime.add(-seconds, :second)
+
+    from(b in Batch,
+      where:
+        b.active == true and
+          b.started <= ^timeout
     )
   end
 
@@ -86,8 +268,6 @@ defmodule Meadow.Batches do
   defp apply_uncontrolled_field_changes([], _add, _replace), do: []
 
   defp apply_uncontrolled_field_changes(work_ids, add, replace) do
-    Logger.info("Batch updating uncontrolled fields")
-
     add = if is_nil(add), do: %{}, else: add
     replace = if is_nil(replace), do: %{}, else: replace
 
@@ -103,8 +283,9 @@ defmodule Meadow.Batches do
     end
   end
 
-  defp merge_uncontrolled_fields(work_ids, new_values, _mode) when map_size(new_values) == 0,
-    do: work_ids
+  defp merge_uncontrolled_fields(work_ids, new_values, _mode)
+       when map_size(new_values) == 0,
+       do: work_ids
 
   defp merge_uncontrolled_fields(work_ids, new_values, mode) do
     mergeable_descriptive_metadata =
@@ -186,19 +367,54 @@ defmodule Meadow.Batches do
     work_ids
   end
 
+  defp apply_batch_association(work_ids, batch_id) do
+    Logger.info("Associating batch_id: #{batch_id} with works")
+    {:ok, b_id} = Ecto.UUID.dump(batch_id)
+
+    entries =
+      Enum.map(work_ids, fn work_id ->
+        with {:ok, w_id} <- Ecto.UUID.dump(work_id) do
+          %{
+            batch_id: b_id,
+            work_id: w_id,
+            inserted_at: DateTime.utc_now(),
+            updated_at: DateTime.utc_now()
+          }
+        end
+      end)
+
+    Repo.insert_all("works_batches", entries, on_conflict: :nothing)
+    work_ids
+  end
+
   # Iterate over the Elasticsearch scroll and apply changes to each page of work IDs.
 
-  defp process_updates({:ok, %{"hits" => %{"hits" => []}}}, _delete, _add, _replace) do
+  defp process_updates(
+         {:ok, %{"hits" => %{"hits" => [], "total" => total}}},
+         _delete,
+         _add,
+         _replace,
+         batch_id
+       ) do
+    update_batch(batch_id, %{works_updated: total})
     {:ok, :noop}
   end
 
-  defp process_updates({:ok, %{"_scroll_id" => scroll_id, "hits" => hits}}, delete, add, replace) do
+  defp process_updates(
+         {:ok, %{"_scroll_id" => scroll_id, "hits" => hits}},
+         delete,
+         add,
+         replace,
+         batch_id
+       ) do
     current_hits = Map.get(hits, "hits")
 
     current_hits
     |> Enum.map(&Map.get(&1, "_id"))
     |> apply_controlled_field_changes(delete, add)
     |> apply_uncontrolled_field_changes(add, replace)
+    |> apply_batch_association(batch_id)
+    |> load_works()
 
     total = Map.get(hits, "total")
 
@@ -213,19 +429,39 @@ defmodule Meadow.Batches do
       "/_search/scroll",
       Jason.encode!(%{scroll: "1m", scroll_id: scroll_id})
     )
-    |> process_updates(delete, add, replace)
+    |> process_updates(delete, add, replace, batch_id)
   end
 
-  defp process_updates(query, delete, add, replace) do
+  defp process_updates(query, delete, add, replace, batch_id) do
     query =
       Jason.decode!(query)
       |> Map.put("_source", "")
       |> Jason.encode!()
 
     Logger.info("Starting Elasticsearch scroll for batch update")
+    Logger.info("query #{inspect(query)}")
 
     Meadow.ElasticsearchCluster
     |> Elasticsearch.post("/meadow/_search?scroll=10m", query)
-    |> process_updates(delete, add, replace)
+    |> process_updates(delete, add, replace, batch_id)
+  end
+
+  defp load_works(work_ids) do
+    from(w in Work, where: w.id in ^work_ids)
+    |> Repo.all()
+  end
+
+  defp decode_value(nil), do: nil
+
+  defp decode_value(json_string) do
+    Jason.decode!(json_string, keys: :atoms)
+  end
+
+  defp log_batch_info(batch) do
+    Logger.info("Processing batch update for batch: #{batch.id}")
+    Logger.info("query: #{batch.query}")
+    Logger.info("delete: #{inspect(batch.delete)}")
+    Logger.info("add: #{inspect(batch.add)}")
+    Logger.info("replace: #{inspect(batch.replace)}")
   end
 end

--- a/lib/meadow/data/schemas/batch.ex
+++ b/lib/meadow/data/schemas/batch.ex
@@ -1,0 +1,82 @@
+defmodule Meadow.Data.Schemas.Batch do
+  @moduledoc """
+  Batch edit (update/delete) schema
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Meadow.Data.Schemas.Work
+  alias MeadowWeb.Schema.ChangesetErrors
+
+  @statuses ~w(queued in_progress complete error)
+  @types ~w(update delete)
+
+  @primary_key {:id, Ecto.UUID, autogenerate: false, read_after_writes: true}
+  schema "batches" do
+    field :nickname, :string
+    field :status, :string, default: "queued"
+    field :user, :string
+    field :started, :utc_datetime_usec
+    field :type, :string
+    field :works_updated, :integer
+    field :query, :string
+    field :add, :string
+    field :delete, :string
+    field :replace, :string
+    field :error, :string
+    field :active, :boolean, default: false
+
+    many_to_many(
+      :works,
+      Work,
+      join_through: "works_batches",
+      on_replace: :delete
+    )
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(controlled_value, attrs) do
+    controlled_value
+    |> cast(attrs, [
+      :nickname,
+      :status,
+      :user,
+      :started,
+      :type,
+      :works_updated,
+      :query,
+      :add,
+      :delete,
+      :replace,
+      :error,
+      :active
+    ])
+    |> validate_required([:query, :type, :user])
+    |> unique_constraint(:active)
+    |> validate_inclusion(:status, @statuses)
+    |> validate_inclusion(:type, @types)
+    |> validate_changes(:add)
+    |> validate_changes(:replace)
+  end
+
+  defp validate_changes(changeset, field) do
+    case get_field(changeset, field) do
+      nil ->
+        changeset
+
+      "null" ->
+        changeset
+
+      changes ->
+        work_changeset = Work.changeset(%Work{accession_number: "FAKE"}, Jason.decode!(changes))
+
+        if work_changeset.valid? do
+          changeset
+        else
+          add_error(changeset, field, inspect(ChangesetErrors.error_details(work_changeset)))
+        end
+    end
+  end
+end

--- a/lib/meadow/data/schemas/work.ex
+++ b/lib/meadow/data/schemas/work.ex
@@ -5,6 +5,7 @@ defmodule Meadow.Data.Schemas.Work do
 
   use Ecto.Schema
   alias Meadow.Data.Schemas.ActionState
+  alias Meadow.Data.Schemas.Batch
   alias Meadow.Data.Schemas.Collection
   alias Meadow.Data.Schemas.FileSet
   alias Meadow.Data.Schemas.WorkAdministrativeMetadata
@@ -48,6 +49,13 @@ defmodule Meadow.Data.Schemas.Work do
     has_one(:project, through: [:ingest_sheet, :project])
 
     field(:representative_image, :string, virtual: true, default: nil)
+
+    many_to_many(
+      :batches,
+      Batch,
+      join_through: "works_batches",
+      on_replace: :delete
+    )
   end
 
   def changeset(work, attrs) do
@@ -91,6 +99,10 @@ defmodule Meadow.Data.Schemas.Work do
     |> assoc_constraint(:collection)
   end
 
+  def required_index_preloads do
+    [:collection, :file_sets, :ingest_sheet, :project, :batches]
+  end
+
   defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Work do
     alias Elasticsearch.Document.Meadow.Data.Schemas.WorkAdministrativeMetadata,
       as: AdministrativeMetadataDocument
@@ -106,6 +118,7 @@ defmodule Meadow.Data.Schemas.Work do
         accessionNumber: work.accession_number,
         collection: format(work.collection),
         createDate: work.inserted_at,
+        batches: work.batches |> Enum.map(fn batch -> batch.id end),
         fileSets:
           work.file_sets
           |> Enum.map(fn file_set ->

--- a/lib/meadow/data/schemas/work_administrative_metadata.ex
+++ b/lib/meadow/data/schemas/work_administrative_metadata.ex
@@ -35,15 +35,6 @@ defmodule Meadow.Data.Schemas.WorkAdministrativeMetadata do
       :project_cycle,
       :status
     ])
-
-    # The following are marked as required on the metadata
-    # spreadsheet, but commented out so that works can be
-    # created without them from ingest sheets.
-    #
-    # |> validate_required([:project_cycle, :status])
-    # |> validate_length(:project_name, min: 1)
-    # |> validate_length(:project_proposer, min: 1)
-    # |> validate_length(:project_manager, min: 1)
   end
 
   def field_names, do: __schema__(:fields) -- [:id, :inserted_at, :updated_at]

--- a/lib/meadow/elasticsearch_diff_store.ex
+++ b/lib/meadow/elasticsearch_diff_store.ex
@@ -30,7 +30,7 @@ defmodule Meadow.ElasticsearchDiffStore do
     |> Stream.chunk_every(@chunk_size)
     |> Stream.flat_map(fn chunk ->
       chunk
-      |> Repo.preload([:collection, :file_sets, :ingest_sheet, :project])
+      |> Repo.preload(Schemas.Work.required_index_preloads)
       |> Works.add_representative_image()
     end)
   end

--- a/lib/meadow/elasticsearch_store.ex
+++ b/lib/meadow/elasticsearch_store.ex
@@ -15,7 +15,7 @@ defmodule Meadow.ElasticsearchStore do
     |> Stream.chunk_every(10)
     |> Stream.flat_map(fn chunk ->
       chunk
-      |> Repo.preload([:collection, :file_sets, :ingest_sheet, :project])
+      |> Repo.preload(Schemas.Work.required_index_preloads)
       |> Works.add_representative_image()
     end)
   end

--- a/lib/meadow_web/schema/types/data/batch_types.ex
+++ b/lib/meadow_web/schema/types/data/batch_types.ex
@@ -10,6 +10,7 @@ defmodule MeadowWeb.Schema.Data.BatchTypes do
   object :batch_mutations do
     @desc "Start a batch update operation"
     field :batch_update, :message do
+      arg(:nickname, :string)
       arg(:query, non_null(:string))
       @desc "`delete` deletes specific existing controlled values"
       arg(:delete, :batch_delete_input, default_value: %{})

--- a/priv/repo/migrations/20201110192920_create_batches.exs
+++ b/priv/repo/migrations/20201110192920_create_batches.exs
@@ -1,0 +1,23 @@
+defmodule Meadow.Repo.Migrations.CreateBatches do
+  use Ecto.Migration
+
+  def change do
+    create table("batches") do
+      add(:nickname, :string)
+      add(:user, :string)
+      add(:type, :string)
+      add(:status, :string)
+      add(:query, :text)
+      add(:add, :text)
+      add(:delete, :text)
+      add(:replace, :text)
+      add(:error, :string)
+      add(:started, :utc_datetime_usec)
+      add(:works_updated, :integer)
+      add(:active, :boolean)
+      timestamps()
+    end
+
+    create(unique_index(:batches, [:active], where: "active=true"))
+  end
+end

--- a/priv/repo/migrations/20201202143133_create_works_batches.exs
+++ b/priv/repo/migrations/20201202143133_create_works_batches.exs
@@ -1,0 +1,18 @@
+defmodule Meadow.Repo.Migrations.CreateWorksBatches do
+    use Ecto.Migration
+
+    def change do
+      create table(:works_batches, primary_key: false) do
+        add(:work_id, references(:works, on_delete: :delete_all, type: :binary_id,), primary_key: true)
+        add(:batch_id, references(:batches, on_delete: :delete_all, type: :binary_id,), primary_key: true)
+        timestamps()
+      end
+
+      create(index(:works_batches, [:work_id]))
+      create(index(:works_batches, [:batch_id]))
+
+      create(
+        unique_index(:works_batches, [:work_id, :batch_id], name: :work_id_batch_id_unique_index)
+      )
+    end
+  end

--- a/test/meadow/batch_driver_test.exs
+++ b/test/meadow/batch_driver_test.exs
@@ -1,0 +1,66 @@
+defmodule Meadow.BatchDriverTest do
+  use ExUnit.Case
+  use Meadow.DataCase
+  use Meadow.IndexCase
+
+  import ExUnit.CaptureLog
+
+  alias Meadow.{BatchDriver, Batches}
+  alias Meadow.Data.{Indexer, Works}
+
+  @args [interval: 100]
+
+  setup do
+    worker = start_supervised!({BatchDriver, @args})
+    work_fixture()
+    work_fixture()
+    work_fixture()
+    Indexer.reindex_all!()
+    {:ok, %{worker: worker}}
+  end
+
+  test "drive_batch/1" do
+    assert Batches.list_batches() |> length() == 0
+    assert Works.list_works() |> length() == 3
+
+    logged =
+      capture_log(fn ->
+        assert Logger.enabled?(self())
+
+        query = ~s'{"query":{"term":{"workType.id": "IMAGE"}}}'
+        user = "user123"
+        type = "update"
+
+        replace = %{
+          descriptive_metadata: %{
+            alternate_title: ["First", "Second"]
+          }
+        }
+
+        attrs = %{
+          query: query,
+          type: type,
+          user: user,
+          replace: Jason.encode!(replace)
+        }
+
+        {:ok, batch} = Batches.create_batch(attrs)
+
+        :timer.sleep(150)
+
+        assert Batches.list_batches() |> length() == 1
+        batch = Batches.get_batch!(batch.id)
+        assert batch.status == "complete"
+        assert batch.active == false
+        assert batch.works_updated == 3
+      end)
+
+    Works.list_works()
+    |> Enum.each(fn work ->
+      assert work.descriptive_metadata.alternate_title |> length() == 2
+      assert work.descriptive_metadata.alternate_title == ["First", "Second"]
+    end)
+
+    assert logged |> String.contains?("Found next batch to start")
+  end
+end

--- a/test/meadow/data/indexer_test.exs
+++ b/test/meadow/data/indexer_test.exs
@@ -4,6 +4,7 @@ defmodule Meadow.Data.IndexerTest do
   use Meadow.IndexCase
   alias Ecto.Adapters.SQL.Sandbox
   alias Meadow.Data.{Collections, Indexer, Works}
+  alias Meadow.Data.Schemas
   alias Meadow.Ingest.{Projects, Sheets}
   alias Meadow.Repo
   alias Mix.Tasks.Elasticsearch.Build, as: BuildTask
@@ -186,7 +187,7 @@ defmodule Meadow.Data.IndexerTest do
          %{
            collection: collection,
            work:
-             List.first(works) |> Repo.preload([:collection, :file_sets, :ingest_sheet, :project]),
+             List.first(works) |> Repo.preload(Schemas.Work.required_index_preloads),
            file_set: List.first(file_sets) |> Repo.preload(:work)
          }}
       end

--- a/test/meadow_web/schema/mutation/batch_update_test.exs
+++ b/test/meadow_web/schema/mutation/batch_update_test.exs
@@ -62,7 +62,7 @@ defmodule MeadowWeb.Schema.Mutation.BatchUpdateTest do
     assert {:ok, query_data} = result
 
     response = get_in(query_data, [:data, "batchUpdate", "message"])
-    assert response == "Batch started"
+    assert response =~ "has been submitted"
   end
 
   test "adds only should be a valid mutation" do
@@ -87,7 +87,7 @@ defmodule MeadowWeb.Schema.Mutation.BatchUpdateTest do
     assert {:ok, query_data} = result
 
     response = get_in(query_data, [:data, "batchUpdate", "message"])
-    assert response == "Batch started"
+    assert response =~ "has been submitted"
   end
 
   test "no updates should not be a valid mutation" do
@@ -122,7 +122,7 @@ defmodule MeadowWeb.Schema.Mutation.BatchUpdateTest do
               }
             }
           },
-          context: %{current_user: %{role: "Viewer"}}
+          context: %{current_user: %{username: "abc123", role: "Viewer"}}
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result
@@ -144,7 +144,7 @@ defmodule MeadowWeb.Schema.Mutation.BatchUpdateTest do
               }
             }
           },
-          context: %{current_user: %{role: "Editor"}}
+          context: %{current_user: %{username: "abc123", role: "Editor"}}
         )
 
       assert result.data["batchUpdate"]


### PR DESCRIPTION
- Backend for batch update dashboard and one at a time batch processing.
   - Batch update mutation creates a batch in the database with a `status` of "queued"
- `Meadow.BatchDriver` `IntervalTask` that looks for `queued` batches to start
   - `active` flag in `batches` table has a unique constraint on the `true` value to prevent more than one batch from running at once. 
   - Also looks for batches that are `active` = `true` (and `status` = `in_progress` for longer than the `@timeout` (which I randomly set at 6 minutes. Not sure if that's realistic or not. Need to test on staging)
- Adds a many to many relationship between `Batch` and `Work`  and indexes `batch_ids` on works (so batches can be used as a facet in the UI)
- Adds the `current_user` from the Absinthe context to the batch entry.
- Batches fail/rollback - all or nothing - and an error message is stored in the `error` field in the database.

**_Edited some existing migrations so will require a data reset!_**


Notes:
- There is a tad of inconsistency on validation/error handling behavior among different fields - I'll open an issue for cleanup (https://github.com/nulib/repodev_planning_and_docs/issues/1296)
