### PR TITLE
Increase time limits to avoid timeouts on large TIFFs

### DIFF
--- a/config/sequins.exs
+++ b/config/sequins.exs
@@ -24,15 +24,15 @@ config :sequins, Meadow.Pipeline,
 config :sequins, IngestFileSet, queue_config: [processor_concurrency: 1]
 
 config :sequins, GenerateFileSetDigests,
-  queue_config: [max_number_of_messages: 3, visibility_timeout: 180],
+  queue_config: [max_number_of_messages: 3, visibility_timeout: 300],
   notify_on: [IngestFileSet: [status: :ok], GenerateFileSetDigests: [status: :retry]]
 
 config :sequins, CopyFileToPreservation,
-  queue_config: [max_number_of_messages: 3, visibility_timeout: 180],
+  queue_config: [max_number_of_messages: 3, visibility_timeout: 300],
   notify_on: [GenerateFileSetDigests: [status: :ok], CopyFileToPreservation: [status: :retry]]
 
 config :sequins, CreatePyramidTiff,
-  queue_config: [processor_concurrency: 1],
+  queue_config: [processor_concurrency: 1, visibility_timeout: 300],
   notify_on: [CopyFileToPreservation: [status: :ok], CreatePyramidTiff: [status: :retry]]
 
 config :sequins, FileSetComplete,

--- a/lib/meadow/pipeline/actions/create_pyramid_tiff.ex
+++ b/lib/meadow/pipeline/actions/create_pyramid_tiff.ex
@@ -8,7 +8,7 @@ defmodule Meadow.Pipeline.Actions.CreatePyramidTiff do
   use Action
   use Meadow.Pipeline.Actions.Common
 
-  @timeout 30_000
+  @timeout 300_000
 
   defp process(%{file_set_id: file_set_id}, _, _) do
     Logger.info("Beginning #{__MODULE__} for FileSet #{file_set_id}")
@@ -62,6 +62,9 @@ defmodule Meadow.Pipeline.Actions.CreatePyramidTiff do
       {^port, {:data, {:eol, "[fatal] " <> message}}} ->
         Logger.error(message)
         {:error, message}
+
+      {^port, {:data, {:eol, "[ping]"}}} ->
+        handle_output(port)
 
       {^port, {:data, {:eol, message}}} ->
         handle_message(message)

--- a/priv/tiff/pyramid.js
+++ b/priv/tiff/pyramid.js
@@ -51,7 +51,8 @@ const makeInputFile = location => {
       }).createReadStream();
 
     s3Stream.on("error", err => reject(err));
-    
+    s3Stream.on("data", chunk => portlog("ping"))
+
     s3Stream
       .pipe(writable)
       .on("close", () => resolve(fileName))


### PR DESCRIPTION
The pipeline has two different time limits built into it:

1. The `CreatePyramidTiff` action has a [timeout value](https://github.com/nulib/meadow/blob/1207-pyramid-tiff-timeout/lib/meadow/pipeline/actions/create_pyramid_tiff.ex#L11) that causes the operation to fail if Elixir hasn't heard back from the JavaScript port in a certain amount of time.
2. Each queue has a [`visibility_timeout` value](https://github.com/nulib/meadow/blob/1207-pyramid-tiff-timeout/config/sequins.exs#L24-L40) (default: 30 seconds). Exceeding the timeout doesn't cause a failure, but does put the message back into the queue for reprocessing if it hasn't been acknowledged after a certain amount of time. 

Setting the `visibility_timeout` too low can lead to a FileSet being processed by the same action (and all dependent actions) more than once. Since our actions are idempotent, this doesn't cause data problems, but it's inefficient.
Setting the `visibility_timeout` too high means that if an action really _does_ get stuck or fail in a way that Sequins and Broadway don't recognize, it will take longer for that message/action to retry.

Since a lot of this is (educated) guesswork, I'd argue for erring on the side of “too high.”

This PR:

* Increases the `visibility_timeout` on all actions that copy/stream TIFFs (digest/copy/derive) from 30 seconds to 5 minutes
* Adds a pingback message to the `CreatePyramidTiff` JavaScript code to avoid timeouts while the TIFF downloads from S3