### PR TITLE
Implement FileSet reordering

### DIFF
--- a/lib/meadow/data/schemas/work.ex
+++ b/lib/meadow/data/schemas/work.ex
@@ -73,6 +73,10 @@ defmodule Meadow.Data.Schemas.Work do
     |> unique_constraint(:accession_number)
   end
 
+  def update_timestamp(work, timestamp \\ NaiveDateTime.utc_now()) do
+    cast(work, %{updated_at: timestamp}, [:updated_at])
+  end
+
   def update_changeset(work, attrs) do
     allowed_params = [
       :collection_id,

--- a/lib/meadow_web/resolvers/data.ex
+++ b/lib/meadow_web/resolvers/data.ex
@@ -135,4 +135,24 @@ defmodule MeadowWeb.Resolvers.Data do
         {:ok, file_set}
     end
   end
+
+  def update_file_set_order(_, %{work_id: work_id, file_set_ids: file_set_ids}, _) do
+    case Works.update_file_set_order(work_id, file_set_ids) do
+      {:error, message} when is_binary(message) ->
+        {
+          :error,
+          message: "Could not update file set order", details: %{error: message}
+        }
+
+      {:error, changeset} ->
+        {
+          :error,
+          message: "Could not update file set order",
+          details: ChangesetErrors.error_details(changeset)
+        }
+
+      {:ok, %{work: work}} ->
+        {:ok, work}
+    end
+  end
 end

--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -85,6 +85,15 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
       middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Data.add_work_to_collection/3)
     end
+
+    @desc "Change the order of a work's file sets"
+    field :update_file_set_order, :work do
+      arg(:work_id, non_null(:id))
+      arg(:file_set_ids, list_of(:id))
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Resolvers.Data.update_file_set_order/3)
+    end
   end
 
   @desc "A work object"
@@ -106,7 +115,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     field :inserted_at, non_null(:datetime)
     field :updated_at, non_null(:datetime)
     field :collection, :collection, resolve: dataloader(Data)
-    field :file_sets, list_of(:file_set), resolve: dataloader(Data)
+    field :file_sets, list_of(:file_set), resolve: dataloader(OrderedFileSets)
     field :representative_image, :string
 
     field :project, :project, resolve: dataloader(Data)

--- a/test/gql/UpdateFileSetOrder.gql
+++ b/test/gql/UpdateFileSetOrder.gql
@@ -1,0 +1,8 @@
+mutation($workId: ID!, $fileSetIds: [ID!]) {
+  updateFileSetOrder(workId: $workId, fileSetIds: $fileSetIds) {
+    id
+    fileSets {
+      id
+    }
+  }
+}

--- a/test/meadow_web/schema/mutation/update_file_set_order_test.exs
+++ b/test/meadow_web/schema/mutation/update_file_set_order_test.exs
@@ -1,0 +1,81 @@
+defmodule MeadowWeb.Schema.Mutation.UpdateFileSetOrderTest do
+  use MeadowWeb.ConnCase, acync: true
+  use Wormwood.GQLCase
+
+  load_gql(MeadowWeb.Schema, "test/gql/UpdateFileSetOrder.gql")
+
+  describe "mutation" do
+    setup do
+      work = work_with_file_sets_fixture(5)
+      {:ok, %{work: work, ids: work.file_sets |> Enum.map(& &1.id)}}
+    end
+
+    test "changes the file set order", %{work: work, ids: ids} do
+      new_order = Enum.shuffle(ids)
+
+      result =
+        query_gql(
+          variables: %{"workId" => work.id, "fileSetIds" => new_order},
+          context: gql_context()
+        )
+
+      assert {:ok, query_data} = result
+
+      with %{"id" => returned_work_id, "fileSets" => returned_file_sets} <-
+             get_in(query_data, [:data, "updateFileSetOrder"]) do
+        assert returned_work_id == work.id
+        assert returned_file_sets |> Enum.map(&Map.get(&1, "id")) == new_order
+      end
+    end
+
+    test "missing IDs", %{work: work, ids: ids} do
+      result =
+        query_gql(
+          variables: %{"workId" => work.id, "fileSetIds" => Enum.slice(ids, 0..2)},
+          context: gql_context()
+        )
+
+      assert {:ok, %{errors: [%{details: %{error: error_text}}]}} = result
+
+      Enum.slice(ids, 3..4)
+      |> Enum.each(fn id ->
+        assert String.contains?(error_text, id)
+      end)
+
+      assert String.match?(error_text, ~r/missing \[.+\]/)
+    end
+
+    test "extra IDs", %{work: work, ids: ids} do
+      extra_ids = [Ecto.UUID.generate(), Ecto.UUID.generate()]
+
+      result =
+        query_gql(
+          variables: %{"workId" => work.id, "fileSetIds" => (ids ++ extra_ids) |> Enum.shuffle()},
+          context: gql_context()
+        )
+
+      assert {:ok, %{errors: [%{details: %{error: error_text}}]}} = result
+
+      Enum.each(extra_ids, fn id ->
+        assert String.contains?(error_text, id)
+      end)
+
+      assert String.match?(error_text, ~r/^Extra/)
+    end
+  end
+
+  describe "authorization" do
+    test "viewers are not authoried to update file set order" do
+      work = work_with_file_sets_fixture(5)
+      file_set_ids = work.file_sets |> Enum.map(& &1.id)
+
+      result =
+        query_gql(
+          variables: %{"workId" => work.id, "fileSetIds" => Enum.reverse(file_set_ids)},
+          context: %{current_user: %{role: "Viewer"}}
+        )
+
+      assert {:ok, %{errors: [%{message: "Forbidden", status: 403}]}} = result
+    end
+  end
+end


### PR DESCRIPTION
* Add Meadow.Data.Works.update_file_set_order/2
* Add updateFileSetOrder mutation
* Add OrderedFileSets dataloader source so file sets always return in order

![image](https://user-images.githubusercontent.com/196872/100176625-49057a80-2e96-11eb-86fb-cf9dcfb1e0b2.png)
