### PR TITLE
Implement metadata update CSV export

### DIFF
--- a/lib/meadow/data/csv_export.ex
+++ b/lib/meadow/data/csv_export.ex
@@ -1,0 +1,142 @@
+defmodule Meadow.Data.CSVExport do
+  @moduledoc """
+  Generates a CSV representation of works matching an Elasticsearch query
+  """
+
+  alias Meadow.Data.Schemas.{WorkAdministrativeMetadata, WorkDescriptiveMetadata}
+  alias Meadow.Utils.ElasticsearchResultStream
+  alias NimbleCSV.RFC4180, as: CSV
+
+  @exportable_types ["Image"]
+  @top_level_fields [
+    ["id"],
+    ["accessionNumber"],
+    ["collection", "id"],
+    ["published"],
+    ["visibility"]
+  ]
+
+  @doc """
+  Generates the CSV output for an Elasticsearch query
+
+  Example:
+    iex> generate_csv(%{query: %{match_all: %{}}})
+    "{\"query\":{\"match_all\":{}}}\r\nid,accession_number..."
+  """
+  def generate_csv(query) when is_binary(query) do
+    query
+    |> stream_csv()
+    |> Enum.join("")
+  end
+
+  def generate_csv(query), do: Jason.encode!(query) |> generate_csv()
+
+  def stream_csv(query) when is_binary(query) do
+    Stream.resource(
+      fn -> :header end,
+      fn
+        nil -> {:halt, nil}
+        :header -> {generate_header(query), :rows}
+        :rows -> {generate_rows(works_only_query(query)), nil}
+      end,
+      fn _ -> :ok end
+    )
+    |> Stream.map(fn thing -> IO.iodata_to_binary(thing) end)
+  end
+
+  def stream_csv(query), do: Jason.encode!(query) |> stream_csv()
+
+  defp works_only_query(query) do
+    with actual_query <- Jason.decode!(query) |> Map.get("query") do
+      %{
+        query: %{
+          bool: %{
+            must: [
+              %{terms: %{"model.name.keyword" => @exportable_types}},
+              actual_query
+            ]
+          }
+        }
+      }
+      |> Jason.encode!()
+    end
+  end
+
+  defp fields do
+    @top_level_fields ++
+      fields_for(WorkAdministrativeMetadata, "administrativeMetadata") ++
+      fields_for(WorkDescriptiveMetadata, "descriptiveMetadata")
+  end
+
+  defp fields_for(module, prefix) do
+    apply(module, :field_names, [])
+    |> Enum.map(fn field -> [prefix, Inflex.camelize(field, :lower)] end)
+  end
+
+  defp generate_header(query) do
+    with fields <- fields() do
+      [
+        [query | List.duplicate(nil, length(fields) - 1)],
+        fields
+        |> Enum.map(fn field_path ->
+          case field_path |> List.last() do
+            "id" -> field_path |> Enum.map(&Inflex.underscore/1) |> Enum.join("_")
+            field_name -> Inflex.underscore(field_name)
+          end
+        end)
+      ]
+      |> CSV.dump_to_stream()
+    end
+  end
+
+  defp generate_rows(query) do
+    query
+    |> ElasticsearchResultStream.results()
+    |> Stream.map(&to_row/1)
+    |> CSV.dump_to_stream()
+  end
+
+  defp to_row(hit) do
+    fields()
+    |> Enum.map(fn field_path ->
+      hit
+      |> get_in(["_source" | field_path])
+      |> to_field()
+    end)
+  end
+
+  defp to_field(value) when is_list(value) do
+    value
+    |> Enum.map(&to_field/1)
+    |> Enum.join(" | ")
+  end
+
+  defp to_field(%{"edtf" => value}), do: value
+
+  defp to_field(%{"role" => role, "term" => %{"id" => id}}) do
+    case normalize_coded_term(role) do
+      nil -> id
+      prefix -> [prefix, id] |> Enum.join(":")
+    end
+  end
+
+  defp to_field(%{"label" => related_url_label, "url" => url}) do
+    case normalize_coded_term(related_url_label) do
+      nil -> url
+      prefix -> [prefix, url] |> Enum.join(":")
+    end
+  end
+
+  defp to_field(%{"id" => id}), do: id
+
+  defp to_field(%{}), do: nil
+
+  defp to_field(value), do: to_string(value)
+
+  defp normalize_coded_term(%{"id" => id, "scheme" => "subject_role"}),
+    do: String.downcase(id) |> String.slice(0..2)
+
+  defp normalize_coded_term(%{"id" => id}), do: id
+
+  defp normalize_coded_term(_), do: nil
+end

--- a/lib/meadow/utils/data_loader.ex
+++ b/lib/meadow/utils/data_loader.ex
@@ -9,9 +9,10 @@ defmodule Meadow.Utils.DataLoader do
   alias Meadow.Data.Schemas.{
     FileSet,
     FileSetMetadata,
-    Work,
-    WorkDescriptiveMetadata
+    Work
   }
+
+  alias Meadow.Utils.MetadataGenerator
 
   use Meadow.Constants
 
@@ -23,11 +24,7 @@ defmodule Meadow.Utils.DataLoader do
   defp insert_work do
     Repo.insert!(%Work{
       accession_number: Faker.String.base64(),
-      descriptive_metadata: %WorkDescriptiveMetadata{
-        description: [Faker.Lorem.sentence()],
-        keywords: Faker.Lorem.words(1..5),
-        title: Faker.Lorem.sentence()
-      },
+      descriptive_metadata: MetadataGenerator.random_descriptive_metadata(),
       file_sets: insert_file_sets()
     })
   end

--- a/lib/meadow/utils/elasticsearch_result_stream.ex
+++ b/lib/meadow/utils/elasticsearch_result_stream.ex
@@ -1,0 +1,33 @@
+defmodule Meadow.Utils.ElasticsearchResultStream do
+  @moduledoc """
+  Retrieves results from the Meadow Elasticsearch cluster and lazily streams one result
+  at a time
+  """
+
+  def results(query) when is_binary(query) do
+    Stream.resource(
+      fn -> first(query) end,
+      fn cursor -> next(cursor) end,
+      fn _ -> :ok end
+    )
+  end
+
+  defp first(query) do
+    Meadow.ElasticsearchCluster
+    |> Elasticsearch.post("/meadow/_search?scroll=10m", query)
+  end
+
+  defp next({:ok, %{"_scroll_id" => scroll_id, "hits" => %{"hits" => hits}}})
+       when is_list(hits) and length(hits) > 0 do
+    {
+      hits,
+      Elasticsearch.post(
+        Meadow.ElasticsearchCluster,
+        "/_search/scroll",
+        Jason.encode!(%{scroll: "1m", scroll_id: scroll_id})
+      )
+    }
+  end
+
+  defp next(_), do: {:halt, nil}
+end

--- a/lib/meadow/utils/metadata_generator.ex
+++ b/lib/meadow/utils/metadata_generator.ex
@@ -156,7 +156,11 @@ defmodule Meadow.Utils.MetadataGenerator do
   end
 
   def generate_descriptive_metadata_for(work) do
-    md = %{
+    work |> Works.update_work(%{descriptive_metadata: random_descriptive_metadata()})
+  end
+
+  def random_descriptive_metadata do
+    %{
       title: Faker.Lorem.sentence(),
       contributor: random_number_of(:contributor),
       creator: random_number_of(:creator),
@@ -167,8 +171,6 @@ defmodule Meadow.Utils.MetadataGenerator do
       subject: random_number_of(:subject),
       technique: random_number_of(:technique)
     }
-
-    work |> Works.update_work(%{descriptive_metadata: md})
   end
 
   defp random_number_of(field) do

--- a/lib/meadow_web/controllers/export_controller.ex
+++ b/lib/meadow_web/controllers/export_controller.ex
@@ -1,0 +1,44 @@
+defmodule MeadowWeb.ExportController do
+  use MeadowWeb, :controller
+  alias Meadow.Data.CSVExport
+  import Plug.Conn
+
+  plug :authorize_user
+
+  def export(conn, %{"file" => file} = params) do
+    export(conn, Path.extname(file), params)
+  end
+
+  defp export(conn, ".csv", %{"file" => file, "query" => query}) do
+    conn =
+      conn
+      |> put_resp_content_type("text/csv")
+      |> put_resp_header(
+        "content-disposition",
+        ~s[attachment; filename="#{file}"]
+      )
+      |> send_chunked(:ok)
+
+    for chunk <- CSVExport.stream_csv(query) do
+      chunk(conn, chunk)
+    end
+
+    conn
+  end
+
+  defp export(conn, _, _) do
+    conn
+    |> put_resp_content_type("text/plain")
+    |> resp(404, "Not Found")
+    |> halt()
+  end
+
+  def authorize_user(%{assigns: %{current_user: %{role: _}}} = conn, _params), do: conn
+
+  def authorize_user(conn, _params) do
+    conn
+    |> put_resp_content_type("text/plain")
+    |> resp(403, "Unauthorized")
+    |> halt()
+  end
+end

--- a/lib/meadow_web/router.ex
+++ b/lib/meadow_web/router.ex
@@ -48,6 +48,8 @@ defmodule MeadowWeb.Router do
   scope "/api" do
     pipe_through :api
 
+    post "/export/:file", MeadowWeb.ExportController, :export
+
     forward "/graphql", Absinthe.Plug, schema: MeadowWeb.Schema
 
     forward "/graphiql", Absinthe.Plug.GraphiQL,

--- a/test/fixtures/work_fixtures.exs
+++ b/test/fixtures/work_fixtures.exs
@@ -1,0 +1,4661 @@
+{[
+   %{
+     accession_number: "Voyager:2770003",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         },
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         },
+         %{
+           role: %{id: "pbl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}}
+       ],
+       title: "Voluptatibus nobis nihil minima earum aliquam!",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415261536",
+       location: [%{role: nil, term: %{id: "https://sws.geonames.org/2347283"}}],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "ea331225-6c62-4f03-b58b-f70e35c599b6"
+   },
+   %{
+     accession_number: "Voyager:2769774",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "pbl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
+         },
+         %{
+           role: %{id: "pbl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         },
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
+         },
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         },
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}}
+       ],
+       title: "Consectetur tenetur accusamus fugit laborum qui et atque.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415261536",
+       location: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3598132"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "c93206e3-e9a7-4cb5-b70f-c05aeadf5494"
+   },
+   %{
+     accession_number: "Voyager:3677974",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         },
+         %{
+           role: %{id: "stl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
+         },
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}}
+       ],
+       title: "Quas rerum nisi voluptatem non molestiae iste qui dolores et.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415261537",
+       location: [
+         %{role: nil, term: %{id: "https://sws.geonames.org/4921868"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3703443"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "361b9a65-dfd2-4c60-ab2a-ff01c35f54a2"
+   },
+   %{
+     accession_number: "Voyager:3677625",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
+       ],
+       title: "Inventore harum ex sequi saepe aut.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415261536",
+       location: [
+         %{role: nil, term: %{id: "https://sws.geonames.org/3703443"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/7549617"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3530597"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "443e4f2c-031c-4d1d-b24e-ec1e96942771"
+   },
+   %{
+     accession_number: "Voyager:3680002",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
+       ],
+       title: "Est qui ut quibusdam iure laudantium praesentium harum cumque repellendus!",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415261537",
+       location: [
+         %{
+           role: nil,
+           term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
+         }
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "6f5c9140-bdf9-4d93-8171-9041746725b5"
+   },
+   %{
+     accession_number: "Voyager:3681611",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
+         },
+         %{
+           role: %{id: "stl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
+         },
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
+         },
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
+       ],
+       title: "Consectetur deleniti qui ex molestias veritatis ut minima.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415261537",
+       location: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/292932"}},
+         %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3598132"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "36a7295a-f342-4413-805f-c795ace2c709"
+   },
+   %{
+     accession_number: "Voyager:3682832",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
+         },
+         %{
+           role: %{id: "pbl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         },
+         %{
+           role: %{id: "stl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}}
+       ],
+       title: "Veniam sed voluptas beatae minima necessitatibus et officia.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415261537",
+       location: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/7549617"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3582677"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/292932"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3530597"}},
+         %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "4d8fcc8e-43f1-499d-b188-c091e9c66dec"
+   },
+   %{
+     accession_number: "Accession:inu-afrmap-4004497",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
+         },
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         },
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}}
+       ],
+       title: "Sunt eos omnis voluptatem voluptatem?",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415261536",
+       location: [
+         %{
+           role: nil,
+           term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
+         },
+         %{role: nil, term: %{id: "https://sws.geonames.org/2347283"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "e74f050f-d39e-4efe-b145-2a349531dd12"
+   },
+   %{
+     accession_number: "Voyager:3677912",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         },
+         %{
+           role: %{id: "pbl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         },
+         %{
+           role: %{id: "pbl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}}
+       ],
+       title: "Omnis totam ipsam minus.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415261536",
+       location: [
+         %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3703443"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/292932"}},
+         %{
+           role: nil,
+           term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
+         },
+         %{role: nil, term: %{id: "https://sws.geonames.org/3530597"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "0caa2cd5-3cfe-45db-9359-db6bc442a494"
+   },
+   %{
+     accession_number: "Voyager:3682407",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "pbl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}}
+       ],
+       title: "At neque iste natus iusto nemo consequatur aperiam consequatur.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415261537",
+       location: [
+         %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3582677"}},
+         %{
+           role: nil,
+           term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
+         }
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "4503609b-f441-47b1-85b4-746871c93cd5"
+   },
+   %{
+     accession_number: "Voyager:2370677",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         },
+         %{
+           role: %{id: "stl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}}
+       ],
+       title: "Illo ducimus magni sed.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264062",
+       location: [
+         %{role: nil, term: %{id: "https://sws.geonames.org/3598132"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3582677"}},
+         %{
+           role: nil,
+           term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
+         },
+         %{role: nil, term: %{id: "https://sws.geonames.org/2347283"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3703443"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "0acfa920-693f-45d4-83f4-ce32154f9d81"
+   },
+   %{
+     accession_number: "Voyager:2370807",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "stl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
+         },
+         %{
+           role: %{id: "pbl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
+         },
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}}
+       ],
+       title: "Non voluptas quas molestias est?",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264062",
+       location: [
+         %{role: nil, term: %{id: "https://sws.geonames.org/4921868"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3530597"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "9eb3eb1b-2a2d-425e-ba30-4d352fcf5588"
+   },
+   %{
+     accession_number: "Voyager:2373630",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         },
+         %{
+           role: %{id: "pbl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         },
+         %{
+           role: %{id: "stl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         },
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
+       ],
+       title: "Et quis soluta amet itaque odio et adipisci illo aperiam!",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264062",
+       location: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/7549617"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3530597"}},
+         %{
+           role: nil,
+           term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
+         }
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "9121914a-dbe5-4854-85e9-82cddf3df224"
+   },
+   %{
+     accession_number: "Voyager:2373664",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "pbl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
+         },
+         %{
+           role: %{id: "pbl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         },
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         },
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}}
+       ],
+       title: "Laborum labore recusandae quia velit vero.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264063",
+       location: [
+         %{role: nil, term: %{id: "https://sws.geonames.org/3530597"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3703443"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "eb406254-ae2d-4ab2-b781-e5877828c712"
+   },
+   %{
+     accession_number: "Voyager:2553149",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
+         },
+         %{
+           role: %{id: "pbl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         },
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}}
+       ],
+       title: "Esse quia reiciendis nihil error ab iste?",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264063",
+       location: [%{role: nil, term: %{id: "https://sws.geonames.org/3530597"}}],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "a1d79736-6a34-41cf-b1e2-9d89bff422e0"
+   },
+   %{
+     accession_number: "Voyager:2559667",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
+         },
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         },
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         },
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}}
+       ],
+       title: "Dolor quos a illo asperiores nihil natus voluptas.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264063",
+       location: [
+         %{role: nil, term: %{id: "https://sws.geonames.org/4921868"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3530597"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3598132"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "c829282a-13c1-4721-a1d2-1ce87129ccd3"
+   },
+   %{
+     accession_number: "Voyager:2564709",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
+         },
+         %{
+           role: %{id: "stl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         },
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         },
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}}
+       ],
+       title: "Occaecati autem quis aut perspiciatis magni aliquid quas?",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264063",
+       location: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/7549617"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/292932"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/4921868"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3598132"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "8552bac8-ce6f-4bce-ac93-17292d589fc8"
+   },
+   %{
+     accession_number: "Voyager:2559745",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         },
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         },
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         },
+         %{
+           role: %{id: "stl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}}
+       ],
+       title: "Perferendis velit earum molestiae harum.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264063",
+       location: [
+         %{role: nil, term: %{id: "https://sws.geonames.org/3703443"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "97b21901-f252-4d80-a421-c9c26f2e11cf"
+   },
+   %{
+     accession_number: "Voyager:2564748",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         },
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
+         },
+         %{
+           role: %{id: "stl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}}
+       ],
+       title: "Est labore quia ea et vel cumque fugit suscipit?",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264063",
+       location: [
+         %{role: nil, term: %{id: "https://sws.geonames.org/3598132"}},
+         %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}},
+         %{
+           role: nil,
+           term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
+         }
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "39a3b7d3-a72f-4796-81f3-f02b63b70d87"
+   },
+   %{
+     accession_number: "Voyager:2564967",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         },
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         },
+         %{
+           role: %{id: "pbl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
+       ],
+       title: "Mollitia nobis aut saepe!",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264063",
+       location: [%{role: nil, term: %{id: "https://sws.geonames.org/3598132"}}],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "ebc3ff1a-64fd-4e06-a70d-34f7b58e8bcf"
+   },
+   %{
+     accession_number: "Voyager:2567367",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}}
+       ],
+       title: "Et sit delectus atque eum exercitationem?",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264063",
+       location: [
+         %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3703443"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3530597"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/7549617"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "300f5a25-e0cc-43e4-adb4-0f7c7d8aa455"
+   },
+   %{
+     accession_number: "Voyager:2564969",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
+       ],
+       title: "Iste aliquam est provident explicabo voluptatem sed perferendis.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264063",
+       location: [%{role: nil, term: %{id: "https://sws.geonames.org/3582677"}}],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "0094fd27-687a-4e13-a74a-b582fac97ef4"
+   },
+   %{
+     accession_number: "Voyager:2573030",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         },
+         %{
+           role: %{id: "stl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}}
+       ],
+       title: "Et corrupti laborum omnis!",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264064",
+       location: [
+         %{
+           role: nil,
+           term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
+         },
+         %{role: nil, term: %{id: "https://sws.geonames.org/292932"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3530597"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/2347283"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "afe7f4a9-529e-4571-8da3-dfaa450bcaa8"
+   },
+   %{
+     accession_number: "Voyager:2570495",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}}
+       ],
+       title: "Voluptatem officia fugit eos architecto quisquam qui!",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264063",
+       location: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3703443"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "07b81bc8-39a9-4c49-959c-8d44a0ea86d9"
+   },
+   %{
+     accession_number: "Voyager:2586368",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         },
+         %{
+           role: %{id: "stl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}}
+       ],
+       title: "Voluptatem repellat odit qui sed alias eveniet recusandae.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264064",
+       location: [%{role: nil, term: %{id: "https://sws.geonames.org/4921868"}}],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "828ce089-5b4c-4c53-b279-6ca6f7c20ce2"
+   },
+   %{
+     accession_number: "Voyager:2576748",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
+         },
+         %{
+           role: %{id: "stl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         },
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}}
+       ],
+       title: "Voluptate assumenda eveniet ullam.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264064",
+       location: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "58d0d305-4b33-4939-8276-f6308e39a1f0"
+   },
+   %{
+     accession_number: "Voyager:2588297",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}}
+       ],
+       title: "Laborum voluptas maiores quod ut eligendi enim aut dolorum voluptatibus.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264065",
+       location: [
+         %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3582677"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3703443"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "6f6f79e0-bda1-4de6-a40f-c49c34465e85"
+   },
+   %{
+     accession_number: "Voyager:2586736",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
+         },
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}}
+       ],
+       title: "Aspernatur animi natus magnam voluptate ab explicabo!",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264064",
+       location: [
+         %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3530597"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "7e26e562-6818-4452-90c8-d8adcd985f46"
+   },
+   %{
+     accession_number: "Voyager:2588396",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         },
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         },
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         },
+         %{
+           role: %{id: "pbl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}}
+       ],
+       title: "Eius cum optio et illum?",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264065",
+       location: [
+         %{role: nil, term: %{id: "https://sws.geonames.org/3598132"}},
+         %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "142c1355-203e-4d32-b51a-e8290164e293"
+   },
+   %{
+     accession_number: "Voyager:2588408",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         },
+         %{
+           role: %{id: "pbl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         },
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         },
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}}
+       ],
+       title: "Laudantium aut omnis eius quia eum animi impedit eum aut?",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264065",
+       location: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/2347283"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3703443"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3582677"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "38f8a6f1-172c-4af9-8a8b-1364891e742b"
+   },
+   %{
+     accession_number: "Voyager:2591350",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "pbl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         },
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
+         },
+         %{
+           role: %{id: "stl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}}
+       ],
+       title: "Aliquid ratione culpa est ad necessitatibus vitae soluta reiciendis!",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264065",
+       location: [
+         %{role: nil, term: %{id: "https://sws.geonames.org/3582677"}},
+         %{
+           role: nil,
+           term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
+         }
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "2b517d8b-e9b5-4076-9bad-c9369567da74"
+   },
+   %{
+     accession_number: "Voyager:2592728",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         },
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         },
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}}
+       ],
+       title: "Sapiente iure maxime omnis quae et maiores!",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264065",
+       location: [
+         %{role: nil, term: %{id: "https://sws.geonames.org/3582677"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3703443"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/4921868"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3598132"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "d3b1a1d6-5334-4e2c-9de3-74c8dfe2cb70"
+   },
+   %{
+     accession_number: "Voyager:2564705",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
+       ],
+       title: "Incidunt eligendi consequatur doloribus ut?",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264063",
+       location: [
+         %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3598132"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/292932"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "fef4c5f8-250a-40a1-8529-dbcbd5ab2676"
+   },
+   %{
+     accession_number: "Voyager:2564944",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         },
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         },
+         %{
+           role: %{id: "stl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         },
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}}
+       ],
+       title: "Molestiae labore distinctio in qui.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264063",
+       location: [
+         %{role: nil, term: %{id: "https://sws.geonames.org/3703443"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/292932"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "fa4881cf-8a84-47be-a552-08e090c189c8"
+   },
+   %{
+     accession_number: "Voyager:2566127",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         },
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         },
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
+         },
+         %{
+           role: %{id: "stl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
+       ],
+       title: "Incidunt consequuntur dolores eos!",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264063",
+       location: [
+         %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/7549617"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3598132"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/4921868"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3582677"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "7905c2af-18f4-4d2a-b031-7668fc1c284a"
+   },
+   %{
+     accession_number: "Voyager:2573027",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}}
+       ],
+       title: "Velit quae iste et voluptatibus eligendi voluptas quis est id.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264064",
+       location: [
+         %{role: nil, term: %{id: "https://sws.geonames.org/292932"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3530597"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "95215ceb-63af-4f5e-88c8-7375798f814d"
+   },
+   %{
+     accession_number: "Voyager:2577952",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         },
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
+       ],
+       title: "Dolorum tempore officia occaecati qui omnis sit.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264064",
+       location: [
+         %{
+           role: nil,
+           term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
+         },
+         %{role: nil, term: %{id: "https://sws.geonames.org/3530597"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3598132"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "b279db8d-93ac-479c-808b-02cedf0b3b7a"
+   },
+   %{
+     accession_number: "Voyager:2588027",
+     administrative_metadata: %{
+       library_unit: %{
+         "id" => "UNIVERSITY_MAIN_LIBRARY",
+         "label" => "University (MAIN) Library",
+         "scheme" => "library_unit"
+       },
+       preservation_level: %{id: "2", label: "Level 2", scheme: "preservation_level"},
+       project_cycle: "Redevelopment",
+       project_desc: ["Description of Project", "Another Description of Project"],
+       project_manager: ["Brisco County, Jr."],
+       project_name: ["The Coming Thing"],
+       project_proposer: ["Socrates Poole", "Lord Bowler"],
+       project_task_number: ["1899.827"],
+       status: %{id: "STARTED", label: "Started", scheme: "status"}
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
+       ],
+       legacy_identifier: ["827", "BCDE.2"],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}}
+       ],
+       date_created: [%{"edtf" => "~1899", "humanized" => "circa 1899?"}],
+       contributor: [
+         %{
+           role: %{id: "pbl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
+         },
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         },
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         },
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         },
+         %{
+           role: %{id: "stl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         }
+       ],
+       series: ["The Adventures of Brisco County, Jr."],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}}
+       ],
+       table_of_contents: ["Season One", "There Is No Season Two"],
+       provenance: ["Television"],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}}
+       ],
+       physical_description_material: ["DVD"],
+       related_url: [
+         %{
+           "label" => %{
+             "id" => "RELATED_INFORMATION",
+             "label" => "Related Information",
+             "scheme" => "related_url"
+           },
+           "url" => "https://www.imdb.com/title/tt0105932/"
+         }
+       ],
+       keywords: ["orb", "bly", "western"],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}}
+       ],
+       title: "Eaque optio est praesentium tenetur impedit autem minima.",
+       terms_of_use: "Terms of Use",
+       ark: "ark:/99999/fk415264064",
+       location: [
+         %{role: nil, term: %{id: "https://sws.geonames.org/2347283"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3530597"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3582677"}}
+       ],
+       description: ["Description"],
+       citation: ["Citation"],
+       rights_holder: ["Rights Holder"],
+       notes: ["Notes"],
+       physical_description_size: ["12cm"],
+       alternate_title: ["That Bruce Campbell Show"],
+       catalog_key: ["Catalog Key"],
+       source: ["Source"],
+       rights_statement: %{
+         id: "http://rightsstatements.org/vocab/InC/1.0/",
+         label: "In Copyright",
+         scheme: "rights_statement"
+       },
+       abstract: ["Abstract"],
+       folder_name: ["Folder 2"],
+       box_name: ["Box 1"],
+       box_number: ["1"],
+       license: %{
+         id: "http://www.europeana.eu/portal/rights/rr-r.html",
+         label: "All rights reserved",
+         scheme: "license"
+       },
+       publisher: ["Boam/Cuse Productions", "Warner Bros. Television"],
+       folder_number: ["2"],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         }
+       ],
+       related_material: ["Related Material"],
+       identifier: ["BRISCO"],
+       scope_and_contents: ["Scope", "Contents"],
+       caption: ["Caption"]
+     },
+     id: "d4bfad17-1c81-4a4a-aa9d-29aca65fa93e",
+     published: false,
+     visibility: %{
+       id: "AUTHENTICATED",
+       label: "Institution",
+       scheme: "visibility"
+     }
+   },
+   %{
+     accession_number: "Voyager:2592725",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
+       ],
+       title: "Molestiae quia voluptas porro officiis qui commodi nobis animi.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264065",
+       location: [
+         %{role: nil, term: %{id: "https://sws.geonames.org/2347283"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3703443"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/292932"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3582677"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "dc20eb57-2333-4e57-9067-72c91a3fa7fe"
+   },
+   %{
+     accession_number: "Voyager:3744344",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
+         },
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         },
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         },
+         %{
+           role: %{id: "mrb", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}}
+       ],
+       title: "Esse maxime ipsa qui iure.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264065",
+       location: [
+         %{
+           role: nil,
+           term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
+         }
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "0bb6bd72-b349-4855-8ea6-0500dc752ff7"
+   },
+   %{
+     accession_number: "UA065",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         },
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
+         },
+         %{
+           role: %{id: "pbl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
+         },
+         %{
+           role: %{id: "vac", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         },
+         %{
+           role: %{id: "lil", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}}
+       ],
+       title: "Aut architecto excepturi omnis!",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264460",
+       location: [
+         %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "370b9abc-cd6a-4544-a7de-de773cdd82f8"
+   },
+   %{
+     accession_number: "S003",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
+         },
+         %{
+           role: %{id: "aut", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}}
+       ],
+       title: "Qui quae aliquam quam molestiae omnis nisi omnis et delectus?",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264460",
+       location: [
+         %{role: nil, term: %{id: "https://sws.geonames.org/3530597"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/7549617"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/3582677"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+         },
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "d468e803-2228-424e-8a59-876c31ac6316"
+   },
+   %{
+     accession_number: "PAWA004",
+     administrative_metadata: %{
+       library_unit: nil,
+       preservation_level: nil,
+       project_cycle: nil,
+       project_desc: [],
+       project_manager: [],
+       project_name: [],
+       project_proposer: [],
+       project_task_number: [],
+       status: nil
+     },
+     descriptive_metadata: %{
+       genre: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
+       ],
+       legacy_identifier: [],
+       creator: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
+       ],
+       date_created: [],
+       contributor: [
+         %{
+           role: %{id: "pbl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
+         },
+         %{
+           role: %{id: "stl", scheme: "marc_relator"},
+           term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
+         }
+       ],
+       series: [],
+       language: [
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
+         %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
+       ],
+       table_of_contents: [],
+       provenance: [],
+       style_period: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}}
+       ],
+       physical_description_material: [],
+       related_url: [],
+       keywords: [],
+       technique: [
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
+         %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}}
+       ],
+       title: "Voluptatem commodi quia molestiae.",
+       terms_of_use: nil,
+       ark: "ark:/99999/fk415264460",
+       location: [
+         %{role: nil, term: %{id: "https://sws.geonames.org/3530597"}},
+         %{role: nil, term: %{id: "https://sws.geonames.org/4921868"}}
+       ],
+       description: [],
+       citation: [],
+       rights_holder: [],
+       notes: [],
+       physical_description_size: [],
+       alternate_title: [],
+       catalog_key: [],
+       source: [],
+       rights_statement: nil,
+       abstract: [],
+       folder_name: [],
+       box_name: [],
+       box_number: [],
+       license: nil,
+       publisher: [],
+       folder_number: [],
+       subject: [
+         %{
+           role: %{id: "TOPICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+         },
+         %{
+           role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
+           term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+         }
+       ],
+       related_material: [],
+       identifier: [],
+       scope_and_contents: [],
+       caption: []
+     },
+     id: "3ddaf8fa-99d3-4962-88ab-da36bde05bbe"
+   }
+ ],
+ [
+   %{
+     id: "http://vocab.getty.edu/aat/300185712",
+     label: "object genres (object classifications)"
+   },
+   %{id: "http://vocab.getty.edu/ulan/500018219", label: "Curtis, Edward S."},
+   %{
+     id: "http://vocab.getty.edu/ulan/500445403",
+     label: "Aberdare, Henry Bruce, 2nd Baron"
+   },
+   %{
+     id: "http://id.loc.gov/authorities/names/n85153068",
+     label: "Mandela, Nelson, 1918-2013"
+   },
+   %{
+     id: "http://id.loc.gov/authorities/names/no2011087251",
+     label: "Valim, Jose"
+   },
+   %{id: "http://id.loc.gov/vocabulary/languages/bug", label: "Bugis"},
+   %{id: "http://id.loc.gov/vocabulary/languages/nia", label: "Nias"},
+   %{id: "http://vocab.getty.edu/aat/300375737", label: "Yachting Style"},
+   %{
+     id: "http://vocab.getty.edu/aat/300438611",
+     label: "micro hot table technique"
+   },
+   %{id: "http://vocab.getty.edu/aat/300410254", label: "sarga (technique)"},
+   %{id: "http://vocab.getty.edu/aat/300053376", label: "soak-stain technique"},
+   %{id: "https://sws.geonames.org/4921868", label: "Indiana"},
+   %{id: "https://sws.geonames.org/3530597", label: "Mexico City"},
+   %{
+     id: "http://id.loc.gov/authorities/subjects/sh85076671",
+     label: "Library catalogs and users"
+   },
+   %{
+     id: "http://id.loc.gov/authorities/subjects/sh85070610",
+     label: "John Cotton Dana Library Public Relations Award"
+   },
+   %{id: "http://vocab.getty.edu/aat/300266117", label: "genre painters"},
+   %{id: "http://vocab.getty.edu/aat/300386217", label: "genre artists"},
+   %{id: "http://vocab.getty.edu/ulan/500030701", label: "Kahlo, Frida"},
+   %{id: "http://vocab.getty.edu/ulan/500115207", label: "Muybridge, Eadweard"},
+   %{id: "http://vocab.getty.edu/ulan/500029268", label: "Pei, I. M."},
+   %{
+     id: "http://id.loc.gov/authorities/names/n79091588",
+     label: "Dewey, Melvil, 1851-1931"
+   },
+   %{id: "http://id.loc.gov/vocabulary/languages/div", label: "Divehi"},
+   %{id: "http://vocab.getty.edu/aat/300378910", label: "Quaint Style"},
+   %{id: "http://vocab.getty.edu/aat/300400619", label: "Levallois technique"},
+   %{id: "https://sws.geonames.org/3582677", label: "Belize City"},
+   %{id: "http://vocab.getty.edu/tgn/7549617", label: "Coco Channel"},
+   %{id: "http://vocab.getty.edu/tgn/1114106", label: "Coco Channel"},
+   %{
+     id: "http://id.loc.gov/authorities/subjects/sh2002006395",
+     label: "Library"
+   },
+   %{id: "http://vocab.getty.edu/aat/300026031", label: "document genres"},
+   %{id: "http://vocab.getty.edu/aat/300056462", label: "art genres"},
+   %{
+     id: "http://id.loc.gov/authorities/names/n50053919",
+     label: "Ranganathan, S. R. (Shiyali Ramamrita), 1892-1972"
+   },
+   %{
+     id: "http://id.loc.gov/authorities/names/n78030997",
+     label: "Lovelace, Ada King, Countess of, 1815-1852"
+   },
+   %{
+     id: "http://id.loc.gov/authorities/names/n83175996",
+     label: "Hopper, Grace Murray"
+   },
+   %{id: "http://id.loc.gov/vocabulary/languages/cha", label: "Chamorro"},
+   %{id: "http://vocab.getty.edu/aat/300375728", label: "Glasgow style"},
+   %{id: "http://vocab.getty.edu/aat/300378903", label: "Style Guimard"},
+   %{id: "http://vocab.getty.edu/aat/300265034", label: "Six's Technique"},
+   %{
+     id: "http://vocab.getty.edu/aat/300435429",
+     label: "materials/technique description"
+   },
+   %{id: "http://id.worldcat.org/fast/1204604", label: "Indiana"},
+   %{id: "http://id.loc.gov/vocabulary/languages/lin", label: "Lingala"},
+   %{
+     id: "http://vocab.getty.edu/aat/300375743",
+     label: "Modern Style (Art Nouveau )"
+   },
+   %{id: "http://id.loc.gov/authorities/names/n79022925", label: "Indiana"},
+   %{
+     id: "http://id.loc.gov/authorities/subjects/sh85076710",
+     label: "Library pages"
+   },
+   %{id: "http://vocab.getty.edu/ulan/500102192", label: "Claudel, Camille"},
+   %{id: "https://sws.geonames.org/292932", label: "Ajman"},
+   %{id: "https://sws.geonames.org/3703443", label: "Panama City"},
+   %{id: "https://sws.geonames.org/2347283", label: "Benin City"},
+   %{id: "http://vocab.getty.edu/aat/300312140", label: "White Style"},
+   %{id: "http://vocab.getty.edu/aat/300139140", label: "genre pictures"},
+   %{id: "https://sws.geonames.org/3598132", label: "Guatemala City"},
+   %{id: "http://id.loc.gov/vocabulary/languages/kor", label: "Korean"}
+ ]}

--- a/test/meadow/data/csv_export_test.exs
+++ b/test/meadow/data/csv_export_test.exs
@@ -1,0 +1,119 @@
+defmodule Meadow.Data.CSVExportTest do
+  use Meadow.DataCase
+  use Meadow.IndexCase
+
+  alias NimbleCSV.RFC4180, as: CSV
+  alias Meadow.Data.{CSVExport, Indexer, Works}
+
+  import Assertions
+
+  @query %{query: %{match_all: %{}}}
+  @sample_record %{
+    abstract: "Abstract",
+    accession_number: "Voyager:2588027",
+    alternate_title: "That Bruce Campbell Show",
+    box_name: "Box 1",
+    box_number: "1",
+    caption: "Caption",
+    catalog_key: "Catalog Key",
+    citation: "Citation",
+    contributor:
+      "pbl:http://id.loc.gov/authorities/names/n83175996 | vac:http://id.loc.gov/authorities/names/n85153068 | lil:http://id.loc.gov/authorities/names/n50053919 | aut:http://id.loc.gov/authorities/names/no2011087251 | mrb:http://id.loc.gov/authorities/names/no2011087251 | stl:http://id.loc.gov/authorities/names/n85153068",
+    creator:
+      "http://vocab.getty.edu/ulan/500030701 | http://vocab.getty.edu/ulan/500445403 | http://vocab.getty.edu/ulan/500102192 | http://vocab.getty.edu/ulan/500029268",
+    date_created: "~1899",
+    description: "Description",
+    folder_name: "Folder 2",
+    folder_number: "2",
+    genre: "http://vocab.getty.edu/aat/300185712",
+    identifier: "BRISCO",
+    keywords: "orb | bly | western",
+    language:
+      "http://id.loc.gov/vocabulary/languages/bug | http://id.loc.gov/vocabulary/languages/nia | http://id.loc.gov/vocabulary/languages/lin | http://id.loc.gov/vocabulary/languages/cha",
+    legacy_identifier: "827 | BCDE.2",
+    library_unit: "UNIVERSITY_MAIN_LIBRARY",
+    license: "http://www.europeana.eu/portal/rights/rr-r.html",
+    location:
+      "https://sws.geonames.org/2347283 | https://sws.geonames.org/3530597 | https://sws.geonames.org/3582677",
+    notes: "Notes",
+    physical_description_material: "DVD",
+    physical_description_size: "12cm",
+    preservation_level: "2",
+    project_cycle: "Redevelopment",
+    project_desc: "Description of Project | Another Description of Project",
+    project_manager: "Brisco County, Jr.",
+    project_name: "The Coming Thing",
+    project_proposer: "Socrates Poole | Lord Bowler",
+    project_task_number: "1899.827",
+    provenance: "Television",
+    published: "false",
+    publisher: "Boam/Cuse Productions | Warner Bros. Television",
+    related_material: "Related Material",
+    related_url: "RELATED_INFORMATION:https://www.imdb.com/title/tt0105932/",
+    rights_holder: "Rights Holder",
+    rights_statement: "http://rightsstatements.org/vocab/InC/1.0/",
+    scope_and_contents: "Scope | Contents",
+    series: "The Adventures of Brisco County, Jr.",
+    source: "Source",
+    status: "STARTED",
+    style_period:
+      "http://vocab.getty.edu/aat/300378903 | http://vocab.getty.edu/aat/300312140 | http://vocab.getty.edu/aat/300375743",
+    subject:
+      "geo:http://id.loc.gov/authorities/subjects/sh85070610 | top:http://id.loc.gov/authorities/subjects/sh2002006395 | top:http://id.loc.gov/authorities/subjects/sh85076671 | geo:http://id.loc.gov/authorities/subjects/sh85076671 | geo:http://id.loc.gov/authorities/subjects/sh85076710",
+    table_of_contents: "Season One | There Is No Season Two",
+    technique:
+      "http://vocab.getty.edu/aat/300438611 | http://vocab.getty.edu/aat/300400619 | http://vocab.getty.edu/aat/300053376",
+    terms_of_use: "Terms of Use",
+    title: "Eaque optio est praesentium tenetur impedit autem minima.",
+    visibility: "AUTHENTICATED"
+  }
+
+  setup do
+    collection = collection_fixture()
+
+    with {{work_fixture_data, controlled_term_data}, []} <-
+           Code.eval_file("test/fixtures/work_fixtures.exs") do
+      Authoritex.Mock.set_data(controlled_term_data)
+
+      work_fixture_data
+      |> Enum.each(fn work_data ->
+        work_data |> Map.put(:collection_id, collection.id) |> Works.create_work!()
+      end)
+
+      Indexer.synchronize_index()
+    end
+
+    {:ok, %{collection: collection}}
+  end
+
+  test "export_works/0", %{collection: collection} do
+    result = CSVExport.generate_csv(@query)
+    [query | [csv | []]] = String.split(result, ~r/[\r\n]+/, parts: 2)
+    [header | data] = CSV.parse_string(csv, skip_headers: false)
+    sample_row = Enum.find(data, &Enum.member?(&1, @sample_record[:accession_number]))
+    sample_record = Enum.zip(header, sample_row) |> Enum.into(%{})
+
+    generated_ids = data |> Enum.map(&List.first/1)
+    work_ids = Works.list_works() |> Enum.map(&Map.get(&1, :id))
+    assert_lists_equal(generated_ids, work_ids)
+
+    assert query =~ "match_all"
+
+    assert Enum.member?(header, "id")
+    assert {:ok, _} = Map.get(sample_record, "id") |> Ecto.UUID.dump()
+
+    assert Enum.member?(header, "collection_id")
+    assert Map.get(sample_record, "collection_id") == collection.id
+
+    with shoulder <- Meadow.Config.ark_config() |> Map.get(:default_shoulder) do
+      assert Enum.member?(header, "ark")
+      assert Map.get(sample_record, "ark") |> String.starts_with?(shoulder)
+    end
+
+    @sample_record
+    |> Enum.each(fn {field, expected_value} ->
+      assert Enum.member?(header, to_string(field))
+      assert Map.get(sample_record, to_string(field)) == expected_value
+    end)
+  end
+end

--- a/test/meadow_web/controllers/export_controller_test.exs
+++ b/test/meadow_web/controllers/export_controller_test.exs
@@ -1,0 +1,47 @@
+defmodule MeadowWeb.ExportControllerTest do
+  use MeadowWeb.ConnCase, async: true
+  use Meadow.DataCase, async: true
+  alias Meadow.Data.Indexer
+
+  @query ~s({"query":{"term":{"model.name.keyword": "Image"}}})
+
+  describe "POST /api/export/:filename (failure)" do
+    test "unauthorized request", %{conn: conn} do
+      conn =
+        conn
+        |> post("/api/export/export.csv", %{query: @query})
+
+      assert text_response(conn, 403) =~ "Unauthorized"
+    end
+
+    test "unknown output type", %{conn: conn} do
+      conn =
+        conn
+        |> auth_user(user_fixture("TestAdmins"))
+        |> post("/api/export/export.xls", %{query: @query})
+
+      assert text_response(conn, 404) =~ "Not Found"
+    end
+  end
+
+  describe "POST /api/export/:filename (success)" do
+    setup do
+      0..5 |> Enum.each(fn _ -> work_fixture() end)
+      Indexer.synchronize_index()
+    end
+
+    test "successful request", %{conn: conn} do
+      conn =
+        conn
+        |> auth_user(user_fixture("TestAdmins"))
+        |> post("/api/export/export.csv", %{query: @query})
+
+      assert Plug.Conn.get_resp_header(conn, "content-disposition")
+             |> Enum.member?(~s(attachment; filename="export.csv"))
+
+      assert conn.state == :chunked
+      assert response_content_type(conn, :csv)
+      assert response(conn, 200)
+    end
+  end
+end


### PR DESCRIPTION
## Testing

There is no GraphQL API for this yet because it was out of scope for the ticket. To test from iex:

```
iex> query = ~s({"query": {"term": {"model.name.keyword": "Image"}}})
iex> File.write("test.csv", Meadow.Data.CsvExport.generate_csv(query))
```

Then look at `test.csv` and make sure it looks right. Obviously, you can test with other queries as well, but things might get confusing if the result set contains non-image (e.g., FileSet or Collection) records.