### PR TITLE
Validate and approve ingest sheets automatically

### DIFF
--- a/assets/js/components/IngestSheet/ActionRow.jsx
+++ b/assets/js/components/IngestSheet/ActionRow.jsx
@@ -1,10 +1,6 @@
 import React, { useState } from "react";
 import UIModalDelete from "../UI/Modal/Delete";
-import {
-  DELETE_INGEST_SHEET,
-  APPROVE_INGEST_SHEET,
-  INGEST_SHEETS,
-} from "./ingestSheet.gql";
+import { DELETE_INGEST_SHEET, INGEST_SHEETS } from "./ingestSheet.gql";
 import { useMutation, useApolloClient } from "@apollo/client";
 import PropTypes from "prop-types";
 import { useHistory } from "react-router-dom";
@@ -14,8 +10,10 @@ import { Button } from "@nulib/admin-react-components";
 
 const IngestSheetActionRow = ({ projectId, sheetId, status, title }) => {
   const history = useHistory();
-  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const client = useApolloClient();
+
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+
   const [deleteIngestSheet, { data: deleteIngestSheetData }] = useMutation(
     DELETE_INGEST_SHEET,
     {
@@ -47,15 +45,6 @@ const IngestSheetActionRow = ({ projectId, sheetId, status, title }) => {
     }
   );
 
-  const [
-    approveIngestSheet,
-    { loading: approveLoading, error: approveError },
-  ] = useMutation(APPROVE_INGEST_SHEET);
-
-  const handleApproveClick = () => {
-    approveIngestSheet({ variables: { id: sheetId } });
-  };
-
   const handleDeleteClick = () => {
     deleteIngestSheet({ variables: { sheetId: sheetId } });
   };
@@ -71,12 +60,6 @@ const IngestSheetActionRow = ({ projectId, sheetId, status, title }) => {
   return (
     <>
       <div className="buttons is-right">
-        {status === "VALID" && (
-          <Button isPrimary onClick={handleApproveClick}>
-            Approve ingest sheet
-          </Button>
-        )}
-
         {["VALID", "ROW_FAIL", "FILE_FAIL", "UPLOADED"].indexOf(status) >
           -1 && (
           <Button onClick={onOpenModal}>
@@ -87,9 +70,6 @@ const IngestSheetActionRow = ({ projectId, sheetId, status, title }) => {
           </Button>
         )}
       </div>
-
-      {approveLoading && <p>Approval loading...</p>}
-      {approveError && <p>Error : (please try again)</p>}
 
       <UIModalDelete
         isOpen={deleteModalOpen}

--- a/assets/js/components/IngestSheet/Alert.jsx
+++ b/assets/js/components/IngestSheet/Alert.jsx
@@ -13,8 +13,7 @@ const IngestSheetAlert = ({ ingestSheet }) => {
       alertObj = {
         type: "is-success",
         title: "",
-        body:
-          "The Ingest Sheet has been approved and the ingest is in progress.",
+        body: "The Ingest Sheet is valid and Works are being created.",
         icon: "check",
       };
       break;
@@ -22,7 +21,7 @@ const IngestSheetAlert = ({ ingestSheet }) => {
       alertObj = {
         type: "is-success",
         title: "Ingestion Complete",
-        body: "Ingestion complete, and all files have been processed.",
+        body: "Ingestion complete, and all Works have been created.",
         icon: "check-circle",
       };
       break;
@@ -57,7 +56,7 @@ const IngestSheetAlert = ({ ingestSheet }) => {
       break;
     case "UPLOADED":
       alertObj = {
-        type: "",
+        type: "is-warning",
         title: "File uploaded",
         body: "File uploaded and ingest sheet validation is in progress.",
         icon: "info-circle",

--- a/assets/js/components/IngestSheet/Alert.test.jsx
+++ b/assets/js/components/IngestSheet/Alert.test.jsx
@@ -160,24 +160,6 @@ it("renders without crashing", () => {
   const { debug } = render(<IngestSheetAlert />);
 });
 
-it("displays info alert with approved message when the Ingest Sheet status is APPROVED", () => {
-  const { debug, getByTestId, getByText } = render(
-    <IngestSheetAlert ingestSheet={approved} />
-  );
-
-  const alertElement = getByTestId("ui-alert");
-
-  expect(alertElement).toBeInTheDocument();
-  expect(alertElement).toHaveClass("is-success");
-  expect(getByText("Approved", { exact: false })).toBeInTheDocument();
-  expect(
-    getByText(
-      "The Ingest Sheet has been approved and the ingest is in progress.",
-      { exact: false }
-    )
-  ).toBeInTheDocument();
-});
-
 const completed = {
   fileErrors: [],
   filename: "s3://dev-uploads/ingest_sheets/01DP6H30V4XV3Z5W4H782N2BXM.csv",
@@ -216,7 +198,9 @@ it("displays success alert with completed message when the Ingest Sheet status i
   expect(alertElement).toHaveClass("is-success");
   expect(getByText("Ingestion Complete", { exact: false })).toBeInTheDocument();
   expect(
-    getByText("All files have been processed.", { exact: false })
+    getByText("Ingestion complete, and all Works have been created.", {
+      exact: false,
+    })
   ).toBeInTheDocument();
 });
 
@@ -247,7 +231,7 @@ it("renders without crashing", () => {
   const { debug } = render(<IngestSheetAlert />);
 });
 
-it("displays success alert with completed message when the Ingest Sheet status is COMPLETED", () => {
+it("displays success alert with completed message when the Ingest Sheet status is DELETED", () => {
   const { debug, getByTestId, getByText } = render(
     <IngestSheetAlert ingestSheet={deleted} />
   );

--- a/assets/js/components/IngestSheet/ApprovedInProgress.jsx
+++ b/assets/js/components/IngestSheet/ApprovedInProgress.jsx
@@ -12,15 +12,14 @@ const IngestSheetApprovedInProgress = ({ ingestSheet }) => {
     }
   );
 
-  if (loading)
-    return (
-      <progress className="progress is-primary" max="100">
-        30%
-      </progress>
-    );
+  if (loading) return null;
   if (error) {
-    console.log(error);
-    return <p>Error in Ingest Progress Subscription: {error.message}</p>;
+    console.error(error);
+    return (
+      <p className="notification is-danger is-light">
+        Error in Ingest Progress Subscription: {error.message}
+      </p>
+    );
   }
 
   return (

--- a/assets/js/components/IngestSheet/Completed.jsx
+++ b/assets/js/components/IngestSheet/Completed.jsx
@@ -11,6 +11,7 @@ import IngestSheetCompletedErrors from "./Completed/Errors";
 import UIPreviewItems from "../UI/PreviewItems";
 import UISkeleton from "../UI/Skeleton";
 import { Button } from "@nulib/admin-react-components";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 const IngestSheetCompleted = ({ sheetId, title }) => {
   const history = useHistory();
@@ -53,7 +54,9 @@ const IngestSheetCompleted = ({ sheetId, title }) => {
         <IngestSheetCompletedErrors errors={ingestSheetErrors} />
       )}
 
-      <h2 className="title is-size-5 is-size-8">Works Preview</h2>
+      <h2 className="title is-size-5 is-size-8">
+        Preview of ingest sheet works...
+      </h2>
 
       <div data-testid="preview-wrapper">
         {errorsLoading || worksLoading ? (
@@ -62,9 +65,12 @@ const IngestSheetCompleted = ({ sheetId, title }) => {
           <div>
             <UIPreviewItems items={works} />
 
-            <div className="has-text-centered mt-6 mb-3">
-              <Button isPrimary onClick={handleClick}>
-                View All Ingest Sheet Works
+            <div className="mb-4 mt-2">
+              <Button onClick={handleClick} className="is-fullwidth">
+                <span className="icon">
+                  <FontAwesomeIcon icon="eye" />
+                </span>
+                <span>View all ingest sheet works</span>
               </Button>
             </div>
           </div>

--- a/assets/js/components/IngestSheet/IngestSheet.jsx
+++ b/assets/js/components/IngestSheet/IngestSheet.jsx
@@ -3,9 +3,7 @@ import IngestSheetValidations from "./Validations";
 import PropTypes from "prop-types";
 import IngestSheetApprovedInProgress from "./ApprovedInProgress";
 import IngestSheetCompleted from "./Completed";
-import {
-  INGEST_SHEET_SUBSCRIPTION,
-} from "@js/components/IngestSheet/ingestSheet.gql";
+import { INGEST_SHEET_SUBSCRIPTION } from "@js/components/IngestSheet/ingestSheet.gql";
 
 const IngestSheet = ({ ingestSheetData, subscribeToIngestSheetUpdates }) => {
   const { id, status, title } = ingestSheetData;
@@ -25,25 +23,23 @@ const IngestSheet = ({ ingestSheetData, subscribeToIngestSheetUpdates }) => {
     });
   }, []);
 
-
   const isCompleted = status === "COMPLETED";
 
   return (
     <div className="box">
-        <>
-          {["APPROVED"].indexOf(status) > -1 && (
-            <IngestSheetApprovedInProgress ingestSheet={ingestSheetData} />
-          )}
+      <>
+        {["APPROVED"].indexOf(status) > -1 && (
+          <IngestSheetApprovedInProgress ingestSheet={ingestSheetData} />
+        )}
 
-          {isCompleted && (
-            <IngestSheetCompleted sheetId={ingestSheetData.id} title={title} />
-          )}
+        {isCompleted && (
+          <IngestSheetCompleted sheetId={ingestSheetData.id} title={title} />
+        )}
 
-          {["VALID", "ROW_FAIL", "FILE_FAIL", "UPLOADED"].indexOf(status) >
-            -1 && (
-            <IngestSheetValidations sheetId={id} status={status} />
-          )}
-        </>
+        {["ROW_FAIL", "FILE_FAIL", "UPLOADED"].indexOf(status) > -1 && (
+          <IngestSheetValidations sheetId={id} status={status} />
+        )}
+      </>
     </div>
   );
 };

--- a/assets/js/components/IngestSheet/List.jsx
+++ b/assets/js/components/IngestSheet/List.jsx
@@ -84,6 +84,16 @@ const IngestSheetList = ({ project, subscribeToIngestSheetStatusChanges }) => {
                     </span>
                   </td>
                   <td className="has-text-right">
+                    {["APPROVED", "COMPLETED"].indexOf(status) > -1 && (
+                      <Link
+                        to={`/project/${project.id}/ingest-sheet/${id}`}
+                        className="button"
+                      >
+                        {<FontAwesomeIcon icon="eye" />}{" "}
+                        <span className="sr-only">View</span>
+                      </Link>
+                    )}
+
                     {["VALID", "ROW_FAIL", "FILE_FAIL", "UPLOADED"].indexOf(
                       status
                     ) > -1 && (

--- a/assets/js/components/IngestSheet/Validations.jsx
+++ b/assets/js/components/IngestSheet/Validations.jsx
@@ -1,18 +1,12 @@
 import PropTypes from "prop-types";
 import React, { useEffect } from "react";
-import {
-  START_VALIDATION,
-} from "./ingestSheet.gql";
+import { START_VALIDATION } from "./ingestSheet.gql";
 import { useMutation } from "@apollo/client";
 import IngestSheetReport from "./Report";
 
-
-
-function IngestSheetValidations({sheetId, status}) {
-
+function IngestSheetValidations({ sheetId, status }) {
   const [startValidation, { validationData }] = useMutation(START_VALIDATION);
   const isValidating = status === "UPLOADED";
-
 
   useEffect(() => {
     startValidation({ variables: { id: sheetId } });
@@ -20,22 +14,19 @@ function IngestSheetValidations({sheetId, status}) {
 
   return (
     <section>
-    {isValidating ? (
-       <div className="has-text-centered is-size-4">
-         Validating Ingest Sheet
-        <progress className="progress is-primary" max="100">
-          30%
-        </progress>
-      </div>
-    ) : (
-      <IngestSheetReport status={status} sheetId={sheetId} />
-    )}
-  </section>
-
-
+      {isValidating ? (
+        <React.Fragment>
+          <p className="has-text-centered mb-5">Validating ingest sheet...</p>
+          <progress className="progress is-small is-primary" max="100">
+            30%
+          </progress>
+        </React.Fragment>
+      ) : (
+        <IngestSheetReport status={status} sheetId={sheetId} />
+      )}
+    </section>
   );
 }
-
 
 IngestSheetValidations.propTypes = {
   sheetId: PropTypes.string.isRequired,

--- a/assets/js/components/IngestSheet/ingestSheet.gql.js
+++ b/assets/js/components/IngestSheet/ingestSheet.gql.js
@@ -29,14 +29,6 @@ IngestSheet.fragments = {
   `,
 };
 
-export const APPROVE_INGEST_SHEET = gql`
-  mutation ApproveIngestSheet($id: ID!) {
-    approveIngestSheet(id: $id) {
-      message
-    }
-  }
-`;
-
 export const CREATE_INGEST_SHEET = gql`
   mutation CreateIngestSheet(
     $title: String!

--- a/assets/js/components/UI/UIProgressBar.jsx
+++ b/assets/js/components/UI/UIProgressBar.jsx
@@ -6,11 +6,11 @@ const UIProgressBar = ({ percentComplete, totalValue, isIngest = false }) => {
   if (percentComplete < 100) {
     return (
       <>
-        <div className="has-text-centered is-size-4">{`${Math.round(
+        <div className="has-text-centered mb-3">{`${Math.round(
           percentComplete
         )} % complete`}</div>
         <ProgressBar percent={percentComplete} strokeColor="#4e2a84" />
-        <p className="has-text-centered">
+        <p className="has-text-centered mt-3">
           {isIngest
             ? `Ingesting ${totalValue || ""} file sets.`
             : "Validating file sets"}

--- a/assets/js/screens/IngestSheet/IngestSheet.jsx
+++ b/assets/js/screens/IngestSheet/IngestSheet.jsx
@@ -4,10 +4,7 @@ import UISkeleton from "../../components/UI/Skeleton";
 import IngestSheet from "../../components/IngestSheet/IngestSheet";
 import gql from "graphql-tag";
 import { useQuery } from "@apollo/client";
-import {
-  INGEST_SHEET_SUBSCRIPTION,
-  INGEST_SHEET_QUERY,
-} from "../../components/IngestSheet/ingestSheet.gql.js";
+import { INGEST_SHEET_QUERY } from "../../components/IngestSheet/ingestSheet.gql.js";
 import Layout from "../Layout";
 import {
   getClassFromIngestSheetStatus,
@@ -95,7 +92,7 @@ const ScreensIngestSheet = ({ match }) => {
                     <h1 className="title">
                       {sheetData.ingestSheet.title}{" "}
                       <span
-                        className={`tag ${getClassFromIngestSheetStatus(
+                        className={`tag is-light ${getClassFromIngestSheetStatus(
                           sheetData.ingestSheet.status
                         )}`}
                       >
@@ -106,7 +103,6 @@ const ScreensIngestSheet = ({ match }) => {
                         }
                       </span>
                     </h1>
-                    <h2 className="subtitle">Ingest Sheet</h2>
                   </div>
                   <div className="column is-half">
                     <IngestSheetActionRow
@@ -118,13 +114,28 @@ const ScreensIngestSheet = ({ match }) => {
                   </div>
                 </div>
 
-                {[
-                  "APPROVED",
-                  "FILE_FAIL",
-                  "ROW_FAIL",
-                  "UPLOADED",
-                  "VALID",
-                ].indexOf(sheetData.ingestSheet.status) > -1 && (
+                {sheetData.ingestSheet.status === "COMPLETED" && (
+                  <table className="table is-fullwidth">
+                    <thead>
+                      <tr>
+                        <th># works created</th>
+                        <th># file sets processed</th>
+                        <th>Date last modified</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td>XXXX</td>
+                        <td>XXXXXX</td>
+                        <td>Date goes here</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                )}
+
+                {["APPROVED", "FILE_FAIL", "ROW_FAIL", "UPLOADED"].indexOf(
+                  sheetData.ingestSheet.status
+                ) > -1 && (
                   <IngestSheetAlert ingestSheet={sheetData.ingestSheet} />
                 )}
               </>

--- a/lib/meadow_web/schema/types/ingest_types.ex
+++ b/lib/meadow_web/schema/types/ingest_types.ex
@@ -103,7 +103,6 @@ defmodule MeadowWeb.Schema.IngestTypes do
       arg(:project_id, non_null(:id))
       arg(:filename, non_null(:string))
       middleware(Middleware.Authenticate)
-
       middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Ingest.create_ingest_sheet/3)
     end
@@ -122,14 +121,6 @@ defmodule MeadowWeb.Schema.IngestTypes do
       middleware(Middleware.Authenticate)
       middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Ingest.delete_ingest_sheet/3)
-    end
-
-    @desc "Approve an Ingest Sheet"
-    field :approve_ingest_sheet, :status_message do
-      arg(:id, non_null(:id))
-      middleware(Middleware.Authenticate)
-      middleware(Middleware.Authorize, "Editor")
-      resolve(&Resolvers.Ingest.approve_ingest_sheet/3)
     end
 
     @desc "Kick off Validation of an Ingest Sheet"

--- a/test/meadow_web/schema/mutation/create_ingest_sheet_test.exs
+++ b/test/meadow_web/schema/mutation/create_ingest_sheet_test.exs
@@ -1,17 +1,45 @@
 defmodule MeadowWeb.Schema.Mutation.CreateSheet do
   use MeadowWeb.ConnCase, async: true
+  use Meadow.S3Case
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/CreateIngestSheet.gql")
 
-  test "should be a valid mutation" do
-    project = project_fixture()
+  @uploads_bucket Meadow.Config.upload_bucket()
+  @ingest_bucket Meadow.Config.ingest_bucket()
+  @sheet_key "/create_sheet_test/ingest_sheet.csv"
+  @sheet_fixture "test/fixtures/ingest_sheet.csv"
+  @image_fixture "test/fixtures/coffee.tif"
 
+  setup do
+    project = project_fixture(%{id: "47b69292-604f-4ce3-b25f-65869d9ff562d"})
+
+    upload_object(
+      @uploads_bucket,
+      @sheet_key,
+      File.read!(@sheet_fixture)
+    )
+
+    upload_object(
+      @ingest_bucket,
+      "#{project.folder}/coffee.tif",
+      File.read!(@image_fixture)
+    )
+
+    on_exit(fn ->
+      delete_object(@uploads_bucket, @sheet_key)
+      delete_object(@ingest_bucket, "#{project.folder}/coffee.tif")
+    end)
+
+    {:ok, %{project: project}}
+  end
+
+  test "should be a valid mutation", %{project: project} do
     result =
       query_gql(
         variables: %{
           "title" => "Test Ingest Sheet",
-          "filename" => "Test.csv",
+          "filename" => @sheet_key,
           "projectId" => project.id
         },
         context: gql_context()
@@ -24,14 +52,12 @@ defmodule MeadowWeb.Schema.Mutation.CreateSheet do
   end
 
   describe "authorization" do
-    test "viewers are not authorized to create ingest sheets" do
-      project = project_fixture()
-
+    test "viewers are not authorized to create ingest sheets", %{project: project} do
       {:ok, result} =
         query_gql(
           variables: %{
             "title" => "Test Ingest Sheet",
-            "filename" => "Test.csv",
+            "filename" => @sheet_key,
             "projectId" => project.id
           },
           context: %{current_user: %{role: "Viewer"}}
@@ -40,14 +66,12 @@ defmodule MeadowWeb.Schema.Mutation.CreateSheet do
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result
     end
 
-    test "editors and above are authorized to create ingest sheets" do
-      project = project_fixture()
-
+    test "editors and above are authorized to create ingest sheets", %{project: project} do
       {:ok, result} =
         query_gql(
           variables: %{
             "title" => "Test Ingest Sheet",
-            "filename" => "Test.csv",
+            "filename" => @sheet_key,
             "projectId" => project.id
           },
           context: %{current_user: %{role: "Editor"}}


### PR DESCRIPTION
Refactors `MeadowWeb.Resolvers.create_ingest_sheet/3` to validate and approve valid ingest sheet uploads automatically. 

Some UI updates...

![image](https://user-images.githubusercontent.com/3020266/101091555-ed19b080-357d-11eb-8e00-9ad8b9c7ed8e.png)

![image](https://user-images.githubusercontent.com/3020266/101091669-176b6e00-357e-11eb-9261-6646a4721b42.png)

![image](https://user-images.githubusercontent.com/3020266/101092570-7a113980-357f-11eb-91c2-f45d901bd714.png)
