### PR TITLE
Add Select All modal functionality to Search screen

### DIFF
--- a/assets/js/components/Search/ActionRow.jsx
+++ b/assets/js/components/Search/ActionRow.jsx
@@ -2,69 +2,80 @@ import React from "react";
 import PropTypes from "prop-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Button } from "@nulib/admin-react-components";
+import SearchBatchModal from "@js/components/Search/BatchModal";
 
 export default function SearchActionRow({
+  handleCsvExport,
   handleDeselectAll,
   handleEditAllItems,
   handleViewAndEdit,
   numberOfResults,
   selectedItems = [],
 }) {
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
+
   return (
-    <div className="field is-grouped" data-testid="search-action-row">
-      <p className="control">
-        <Button
-          isLight
-          onClick={handleEditAllItems}
-          disabled={selectedItems.length > 0}
-          data-testid="edit-all-button"
-        >
-          <span className="icon">
-            <FontAwesomeIcon icon="edit" />
-          </span>
-          <span>Edit all {numberOfResults} Items</span>
-        </Button>
-      </p>
-      <p className="control">
-        <Button
-          isLight
-          data-testid="view-and-edit-button"
-          disabled={selectedItems.length === 0}
-          onClick={handleViewAndEdit}
-        >
-          <span className="icon">
-            <FontAwesomeIcon icon="eye" />
-          </span>
-          <span>View and edit {selectedItems.length} Items</span>
-        </Button>
-      </p>
-      {selectedItems.length > 0 && (
+    <React.Fragment>
+      <div className="field is-grouped" data-testid="search-action-row">
         <p className="control">
           <Button
             isLight
-            data-testid="deselect-all-button"
-            onClick={handleDeselectAll}
+            onClick={() => setIsModalOpen(!isModalOpen)}
+            disabled={selectedItems.length > 0}
+            data-testid="select-all-button"
           >
-            <span className="icon">
-              <FontAwesomeIcon icon="minus-square" />
-            </span>
-            <span>Deselect all</span>
+            <span>Select All</span>
           </Button>
         </p>
-      )}
-      <p className="control">
-        <Button isLight disabled>
-          <span className="icon">
-            <FontAwesomeIcon icon="file-csv" />
-          </span>
-          <span>Export CSV</span>
-        </Button>
-      </p>
-    </div>
+        <p className="control">
+          <Button
+            isLight
+            data-testid="view-and-edit-button"
+            disabled={selectedItems.length === 0}
+            onClick={handleViewAndEdit}
+          >
+            <span className="icon">
+              <FontAwesomeIcon icon="eye" />
+            </span>
+            <span>View and edit {selectedItems.length} Items</span>
+          </Button>
+        </p>
+        {selectedItems.length > 0 && (
+          <p className="control">
+            <Button
+              isLight
+              data-testid="deselect-all-button"
+              onClick={handleDeselectAll}
+            >
+              <span className="icon">
+                <FontAwesomeIcon icon="minus-square" />
+              </span>
+              <span>Deselect all</span>
+            </Button>
+          </p>
+        )}
+        <p className="control">
+          <Button isLight disabled>
+            <span className="icon">
+              <FontAwesomeIcon icon="file-csv" />
+            </span>
+            <span>Export CSV</span>
+          </Button>
+        </p>
+      </div>
+      <SearchBatchModal
+        handleCloseClick={() => setIsModalOpen(false)}
+        handleCsvExport={handleCsvExport}
+        handleEditAllItems={handleEditAllItems}
+        isOpen={isModalOpen}
+        numberOfResults={numberOfResults}
+      />
+    </React.Fragment>
   );
 }
 
 SearchActionRow.propTypes = {
+  handleCsvExport: PropTypes.func.isRequired,
   handleDeselectAll: PropTypes.func,
   handleEditAllItems: PropTypes.func.isRequired,
   handleViewAndEdit: PropTypes.func.isRequired,

--- a/assets/js/components/Search/ActionRow.test.js
+++ b/assets/js/components/Search/ActionRow.test.js
@@ -3,14 +3,13 @@ import { render, screen } from "@testing-library/react";
 import SearchActionRow from "./ActionRow";
 import userEvent from "@testing-library/user-event";
 
-const mockHandleEditAllItems = jest.fn();
-const mockHandleDeselectAll = jest.fn();
-const mockHandleViewAndEdit = jest.fn();
-
 let props = {
-  handleEditAllItems: mockHandleEditAllItems,
-  handleDeselectAll: mockHandleDeselectAll,
-  handleViewAndEdit: mockHandleViewAndEdit,
+  handleCsvExport: jest.fn(),
+  handleDeselectAll: jest.fn(),
+  handleEditAllItems: jest.fn(),
+  handleViewAndEdit: jest.fn(),
+  numberOfResults: 33,
+  selectedItems: [],
 };
 
 describe("SearchActionRow component", () => {
@@ -19,32 +18,29 @@ describe("SearchActionRow component", () => {
     expect(screen.getByTestId("search-action-row"));
   });
 
-  it("renders 'edit all' enabled by default, and 'view and edit' disabled by default  when search items are selected", () => {
+  it("renders 'select all' button enabled by default, and 'edit X items' button disabled by default ", () => {
     render(<SearchActionRow {...props} selectedItems={[]} />);
 
-    const editAllButton = screen.getByTestId("edit-all-button");
+    const selectAllButton = screen.getByTestId("select-all-button");
 
-    expect(editAllButton).not.toBeDisabled();
+    expect(selectAllButton).not.toBeDisabled();
     expect(screen.getByTestId("view-and-edit-button")).toBeDisabled();
-
-    userEvent.click(editAllButton);
-    expect(mockHandleEditAllItems).toHaveBeenCalled();
   });
 
-  it("renders 'view and edit' disabled, 'view and edit' enabled, and 'deselect all' button enabled when search items are selected", () => {
+  it("renders a disabled 'select all' button, and enabled 'view and edit' and 'deselect all' buttons when search items are selected", () => {
     render(<SearchActionRow {...props} selectedItems={["abc", "dfg"]} />);
 
     const viewAndEditButton = screen.getByTestId("view-and-edit-button");
     const deselectAll = screen.getByTestId("deselect-all-button");
 
-    expect(screen.getByTestId("edit-all-button")).toBeDisabled();
+    expect(screen.getByTestId("select-all-button")).toBeDisabled();
     expect(viewAndEditButton).not.toBeDisabled();
     expect(deselectAll).not.toBeDisabled();
 
     userEvent.click(viewAndEditButton);
-    expect(mockHandleViewAndEdit).toHaveBeenCalled();
+    expect(props.handleViewAndEdit).toHaveBeenCalled();
 
     userEvent.click(deselectAll);
-    expect(mockHandleDeselectAll).toHaveBeenCalled();
+    expect(props.handleDeselectAll).toHaveBeenCalled();
   });
 });

--- a/assets/js/components/Search/BatchModal.jsx
+++ b/assets/js/components/Search/BatchModal.jsx
@@ -1,0 +1,74 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Button } from "@nulib/admin-react-components";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+function SearchBatchModal({
+  handleCloseClick,
+  handleCsvExport,
+  handleEditAllItems,
+  isOpen,
+  numberOfResults,
+}) {
+  return (
+    <div
+      className={`modal ${isOpen ? "is-active" : ""}`}
+      data-testid="select-all-modal"
+    >
+      <div className="modal-background"></div>
+      <div className="modal-card">
+        <header className="modal-card-head">
+          <p className="modal-card-title">Batch update options</p>
+          <button
+            className="delete"
+            aria-label="close"
+            onClick={handleCloseClick}
+          ></button>
+        </header>
+        <section className="modal-card-body">
+          <div className="columns">
+            <div className="column">
+              <Button
+                className="is-fullwidth"
+                data-testid="button-batch-edit"
+                onClick={handleEditAllItems}
+              >
+                <span className="icon">
+                  <FontAwesomeIcon icon="edit" />
+                </span>
+                <span>Batch edit {numberOfResults} works</span>
+              </Button>
+            </div>
+            <div className="column">
+              <Button
+                className="is-fullwidth"
+                data-testid="button-csv-export"
+                onClick={handleCsvExport}
+              >
+                <span className="icon">
+                  <FontAwesomeIcon icon="file-csv" />
+                </span>
+                <span>Export metadata from {numberOfResults} works </span>
+              </Button>
+            </div>
+          </div>
+        </section>
+        <footer className="modal-card-foot is-justify-content-flex-end">
+          <Button isText onClick={handleCloseClick}>
+            Cancel
+          </Button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+SearchBatchModal.propTypes = {
+  handleCloseClick: PropTypes.func.isRequired,
+  handleCsvExport: PropTypes.func.isRequired,
+  handleEditAllItems: PropTypes.func.isRequired,
+  isOpen: PropTypes.bool,
+  numberOfResults: PropTypes.number.isRequired,
+};
+
+export default SearchBatchModal;

--- a/assets/js/components/Search/BatchModal.test.js
+++ b/assets/js/components/Search/BatchModal.test.js
@@ -1,0 +1,35 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import SearchBatchModal from "./BatchModal";
+import userEvent from "@testing-library/user-event";
+
+let props = {
+  handleCloseClick: jest.fn(),
+  handleCsvExport: jest.fn(),
+  handleEditAllItems: jest.fn(),
+  isOpen: false,
+  numberOfResults: 35,
+};
+
+describe("SearchBatchModal component", () => {
+  it("renders hidden state", () => {
+    render(<SearchBatchModal {...props} />);
+    expect(screen.getByTestId("select-all-modal")).not.toHaveClass("is-active");
+  });
+
+  it("renders visible state", () => {
+    props = { ...props, isOpen: true };
+    render(<SearchBatchModal {...props} />);
+    expect(screen.getByTestId("select-all-modal")).toHaveClass("is-active");
+  });
+
+  it("calls the appropriate callback functions on button clicks", () => {
+    props = { ...props, isOpen: true };
+    render(<SearchBatchModal {...props} />);
+    userEvent.click(screen.getByTestId("button-batch-edit"));
+    userEvent.click(screen.getByTestId("button-csv-export"));
+
+    expect(props.handleCsvExport).toHaveBeenCalled();
+    expect(props.handleEditAllItems).toHaveBeenCalled();
+  });
+});

--- a/assets/js/screens/Search/Search.jsx
+++ b/assets/js/screens/Search/Search.jsx
@@ -24,6 +24,10 @@ const ScreensSearch = () => {
   const [resultStats, setResultStats] = useState(0);
   const dispatch = useBatchDispatch();
 
+  const handleCsvExport = () => {
+    console.log("handle Csv Export");
+  };
+
   const handleEditAllItems = async () => {
     // Grab all aggregated Controlled Term items from Elasticsearch directly,
     // to populate the "Remove" items in Batch Edit
@@ -103,6 +107,7 @@ const ScreensSearch = () => {
 
               <DisplayAuthorized action="delete">
                 <SearchActionRow
+                  handleCsvExport={handleCsvExport}
                   handleDeselectAll={handleDeselectAll}
                   handleEditAllItems={handleEditAllItems}
                   handleViewAndEdit={handleViewAndEdit}


### PR DESCRIPTION
The Search screen now supports a Select All option, which initiates a modal selector.

![image](https://user-images.githubusercontent.com/3020266/100935847-44ece480-34b6-11eb-860e-892d1e1ff9c6.png)

![image](https://user-images.githubusercontent.com/3020266/100935911-5b933b80-34b6-11eb-8295-636e7c7451b3.png)
