### PR TITLE
Replace Viewers with Users in backend authorization

### DIFF
--- a/lib/meadow_web/schema/middleware/authorize.ex
+++ b/lib/meadow_web/schema/middleware/authorize.ex
@@ -21,9 +21,9 @@ defmodule MeadowWeb.Schema.Middleware.Authorize do
 
   defp authorized_role?(%{}, :any), do: true
   defp authorized_role?(%{role: "Administrator"}, _role), do: true
-  defp authorized_role?(%{role: "Manager"}, "Viewer"), do: true
   defp authorized_role?(%{role: "Manager"}, "Editor"), do: true
-  defp authorized_role?(%{role: "Editor"}, "Viewer"), do: true
+  defp authorized_role?(%{role: "Manager"}, "User"), do: true
+  defp authorized_role?(%{role: "Editor"}, "User"), do: true
   defp authorized_role?(%{role: role}, role), do: true
   defp authorized_role?(_, _), do: false
 end

--- a/test/meadow_web/schema/middleware/authorize_test.exs
+++ b/test/meadow_web/schema/middleware/authorize_test.exs
@@ -32,7 +32,7 @@ defmodule MeadowWeb.Schema.Middleware.AuthorizeTest do
 
     resolution =
       %Absinthe.Resolution{}
-      |> Map.put(:context, %{current_user: %{id: id, role: "Viewer"}})
+      |> Map.put(:context, %{current_user: %{id: id, role: "User"}})
       |> Authorize.call("Administrator")
 
     assert %{errors: [%{message: "Forbidden", status: 403}]} = resolution

--- a/test/meadow_web/schema/mutation/add_work_to_collection_test.exs
+++ b/test/meadow_web/schema/mutation/add_work_to_collection_test.exs
@@ -28,7 +28,7 @@ defmodule MeadowWeb.Schema.Mutation.AddWorkToCollectionTest do
       result =
         query_gql(
           variables: %{"workId" => work.id, "collectionId" => collection.id},
-          context: %{current_user: %{role: "Viewer"}}
+          context: %{current_user: %{role: "User"}}
         )
 
       assert {:ok, %{errors: [%{message: "Forbidden", status: 403}]}} = result

--- a/test/meadow_web/schema/mutation/add_works_to_collection_test.exs
+++ b/test/meadow_web/schema/mutation/add_works_to_collection_test.exs
@@ -44,7 +44,7 @@ defmodule MeadowWeb.Schema.Mutation.AddWorksToCollectionTest do
       {:ok, result} =
         query_gql(
           variables: %{"workIds" => work_ids, "collectionId" => collection.id},
-          context: %{current_user: %{role: "Viewer"}}
+          context: %{current_user: %{role: "User"}}
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result

--- a/test/meadow_web/schema/mutation/batch_update_test.exs
+++ b/test/meadow_web/schema/mutation/batch_update_test.exs
@@ -122,7 +122,7 @@ defmodule MeadowWeb.Schema.Mutation.BatchUpdateTest do
               }
             }
           },
-          context: %{current_user: %{username: "abc123", role: "Viewer"}}
+          context: %{current_user: %{username: "abc123", role: "User"}}
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result

--- a/test/meadow_web/schema/mutation/create_collection_test.exs
+++ b/test/meadow_web/schema/mutation/create_collection_test.exs
@@ -22,7 +22,7 @@ defmodule MeadowWeb.Schema.Mutation.CreateCollectionTest do
       {:ok, result} =
         query_gql(
           variables: %{"title" => "The collection title"},
-          context: %{current_user: %{role: "Viewer"}}
+          context: %{current_user: %{role: "User"}}
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result

--- a/test/meadow_web/schema/mutation/create_file_set_test.exs
+++ b/test/meadow_web/schema/mutation/create_file_set_test.exs
@@ -49,7 +49,7 @@ defmodule MeadowWeb.Schema.Mutation.CreateFileSetTest do
               "location" => "s3://#{@bucket}/#{@key}"
             }
           },
-          context: %{current_user: %{role: "Viewer"}}
+          context: %{current_user: %{role: "User"}}
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result

--- a/test/meadow_web/schema/mutation/create_ingest_sheet_test.exs
+++ b/test/meadow_web/schema/mutation/create_ingest_sheet_test.exs
@@ -34,7 +34,7 @@ defmodule MeadowWeb.Schema.Mutation.CreateSheet do
             "filename" => "Test.csv",
             "projectId" => project.id
           },
-          context: %{current_user: %{role: "Viewer"}}
+          context: %{current_user: %{role: "User"}}
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result

--- a/test/meadow_web/schema/mutation/create_project_test.exs
+++ b/test/meadow_web/schema/mutation/create_project_test.exs
@@ -26,7 +26,7 @@ defmodule MeadowWeb.Schema.Mutation.CreateProjectTest do
       {:ok, result} =
         query_gql(
           variables: %{"title" => "The project title"},
-          context: %{current_user: %{role: "Viewer"}}
+          context: %{current_user: %{role: "User"}}
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result

--- a/test/meadow_web/schema/mutation/create_work_test.exs
+++ b/test/meadow_web/schema/mutation/create_work_test.exs
@@ -67,7 +67,7 @@ defmodule MeadowWeb.Schema.Mutation.CreateWorkTest do
             "workType" => %{"id" => "IMAGE", "scheme" => "WORK_TYPE"},
             "visibility" => %{"id" => "OPEN", "scheme" => "VISIBILITY"}
           },
-          context: %{current_user: %{role: "Viewer"}}
+          context: %{current_user: %{role: "User"}}
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result

--- a/test/meadow_web/schema/mutation/remove_works_from_collection_test.exs
+++ b/test/meadow_web/schema/mutation/remove_works_from_collection_test.exs
@@ -49,7 +49,7 @@ defmodule MeadowWeb.Schema.Mutation.RemoveWorksFromCollectionTest do
             "workIds" => Enum.map(works, & &1.id),
             "collectionId" => collection_fixture.id
           },
-          context: %{current_user: %{role: "Viewer"}}
+          context: %{current_user: %{role: "User"}}
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result

--- a/test/meadow_web/schema/mutation/set_work_image_test.exs
+++ b/test/meadow_web/schema/mutation/set_work_image_test.exs
@@ -41,7 +41,7 @@ defmodule MeadowWeb.Schema.Mutation.SetWorkImageTest do
             "work_id" => work.id,
             "file_set_id" => expected_file_set.id
           },
-          context: %{current_user: %{role: "Viewer"}}
+          context: %{current_user: %{role: "User"}}
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result

--- a/test/meadow_web/schema/mutation/update_file_set_order_test.exs
+++ b/test/meadow_web/schema/mutation/update_file_set_order_test.exs
@@ -72,7 +72,7 @@ defmodule MeadowWeb.Schema.Mutation.UpdateFileSetOrderTest do
       result =
         query_gql(
           variables: %{"workId" => work.id, "fileSetIds" => Enum.reverse(file_set_ids)},
-          context: %{current_user: %{role: "Viewer"}}
+          context: %{current_user: %{role: "User"}}
         )
 
       assert {:ok, %{errors: [%{message: "Forbidden", status: 403}]}} = result

--- a/test/meadow_web/schema/mutation/update_project_test.exs
+++ b/test/meadow_web/schema/mutation/update_project_test.exs
@@ -34,7 +34,7 @@ defmodule MeadowWeb.Schema.Mutation.UpdateProjectTest do
             "id" => project.id,
             "title" => "The New Title"
           },
-          context: %{current_user: %{role: "Viewer"}}
+          context: %{current_user: %{role: "User"}}
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result

--- a/test/meadow_web/schema/mutation/update_work_test.exs
+++ b/test/meadow_web/schema/mutation/update_work_test.exs
@@ -43,7 +43,7 @@ defmodule MeadowWeb.Schema.Mutation.UpdateWorkTest do
             "collection_id" => collection.id,
             "descriptive_metadata" => %{"title" => "Something"}
           },
-          context: %{current_user: %{role: "Viewer"}}
+          context: %{current_user: %{role: "User"}}
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result


### PR DESCRIPTION
Line up authorization roles with frontend authorization to use "Users" rather than "Viewers"