### PR TITLE
Fix all compiler warnings

### DIFF
--- a/lib/meadow/batches.ex
+++ b/lib/meadow/batches.ex
@@ -48,9 +48,6 @@ defmodule Meadow.Batches do
     |> Repo.update()
   end
 
-  @doc """
-  Updates a Batch by batch id.
-  """
   def update_batch(batch_id, attrs) do
     batch = Repo.get!(Batch, batch_id)
     update_batch(batch, attrs)

--- a/lib/meadow/config.ex
+++ b/lib/meadow/config.ex
@@ -131,7 +131,7 @@ defmodule Meadow.Config do
   defp build_environment(accumulator, value, variable_name) do
     case value do
       nil -> accumulator
-      val -> [{to_charlist(variable_name), to_char_list(val)} | accumulator]
+      val -> [{to_charlist(variable_name), to_charlist(val)} | accumulator]
     end
   end
 

--- a/test/meadow/async_test.exs
+++ b/test/meadow/async_test.exs
@@ -37,7 +37,7 @@ defmodule Meadow.AsyncTest do
                  :dev
                )
 
-      assert_receive({"test:123", {:running, pid}}, 1000)
+      assert_receive({"test:123", {:running, ^pid}}, 1000)
     end
   end
 end

--- a/test/meadow/batch_driver_test.exs
+++ b/test/meadow/batch_driver_test.exs
@@ -3,6 +3,7 @@ defmodule Meadow.BatchDriverTest do
   use Meadow.DataCase
   use Meadow.IndexCase
 
+  import Assertions
   import ExUnit.CaptureLog
 
   alias Meadow.{BatchDriver, Batches}
@@ -46,13 +47,13 @@ defmodule Meadow.BatchDriverTest do
 
         {:ok, batch} = Batches.create_batch(attrs)
 
-        :timer.sleep(150)
-
-        assert Batches.list_batches() |> length() == 1
-        batch = Batches.get_batch!(batch.id)
-        assert batch.status == "complete"
-        assert batch.active == false
-        assert batch.works_updated == 3
+        assert_async(timeout: 3000, sleep_time: 150) do
+          assert Batches.list_batches() |> length() == 1
+          batch = Batches.get_batch!(batch.id)
+          assert batch.status == "complete"
+          assert batch.active == false
+          assert batch.works_updated == 3
+        end
       end)
 
     Works.list_works()

--- a/test/meadow/data/coded_terms_test.exs
+++ b/test/meadow/data/coded_terms_test.exs
@@ -57,12 +57,12 @@ defmodule Meadow.Data.CodedTermsTest do
 
   describe "get_coded_term/2" do
     test "cache miss" do
-      assert {{:ok, :db}, term} = CodedTerms.get_coded_term("cpl", "marc_relator")
+      assert {{:ok, :db}, _term} = CodedTerms.get_coded_term("cpl", "marc_relator")
     end
 
     test "cache hit" do
-      assert {{:ok, :db}, term} = CodedTerms.get_coded_term("ive", "marc_relator")
-      assert {{:ok, :memory}, term} = CodedTerms.get_coded_term("ive", "marc_relator")
+      assert {{:ok, :db}, _term} = CodedTerms.get_coded_term("ive", "marc_relator")
+      assert {{:ok, :memory}, _term} = CodedTerms.get_coded_term("ive", "marc_relator")
     end
 
     test "db miss (invalid coded term)" do

--- a/test/meadow/data/collections/collection_test.exs
+++ b/test/meadow/data/collections/collection_test.exs
@@ -13,7 +13,7 @@ defmodule Meadow.Data.Schemas.CollectionTest do
     test "created collection has a UUID identifier" do
       {:ok, collection} = %Collection{} |> Collection.changeset(@valid_attrs) |> Repo.insert()
 
-      assert {:ok, <<data::binary-size(16)>>} = Ecto.UUID.dump(collection.id)
+      assert {:ok, <<_data::binary-size(16)>>} = Ecto.UUID.dump(collection.id)
     end
 
     test "changeset is invalid if collection title is used already" do

--- a/test/meadow/data/collections_test.exs
+++ b/test/meadow/data/collections_test.exs
@@ -18,7 +18,7 @@ defmodule Meadow.Data.CollectionsTest do
     end
 
     test "create_collection/1 with valid data creates a collection" do
-      assert {:ok, %Collection{} = collection} = Collections.create_collection(@valid_attrs)
+      assert {:ok, %Collection{} = _collection} = Collections.create_collection(@valid_attrs)
     end
 
     test "update_collection/2 updates a collection" do
@@ -37,7 +37,7 @@ defmodule Meadow.Data.CollectionsTest do
 
     test "delete_collection/1 deletes a collection" do
       collection = collection_fixture()
-      assert {:ok, %Collection{} = collection} = Collections.delete_collection(collection)
+      assert {:ok, %Collection{} = _collection} = Collections.delete_collection(collection)
       assert Enum.empty?(Collections.list_collections())
     end
 

--- a/test/meadow/data/controlled_terms_test.exs
+++ b/test/meadow/data/controlled_terms_test.exs
@@ -20,13 +20,13 @@ defmodule Meadow.Data.ControlledTermsTest do
     end
 
     test "memory cache hit" do
-      assert {{:ok, :miss}, term} = ControlledTerms.fetch("mock1:result1")
+      assert {{:ok, :miss}, _term} = ControlledTerms.fetch("mock1:result1")
       assert {{:ok, :memory}, term} = ControlledTerms.fetch("mock1:result1")
       assert term == %{id: "mock1:result1", label: "First Result"}
     end
 
     test "db cache hit" do
-      assert {{:ok, :miss}, term} = ControlledTerms.fetch("mock1:result1")
+      assert {{:ok, :miss}, _term} = ControlledTerms.fetch("mock1:result1")
       Cachex.clear!(Meadow.Cache.ControlledTerms)
       assert {{:ok, :db}, term} = ControlledTerms.fetch("mock1:result1")
       assert term == %{id: "mock1:result1", label: "First Result"}
@@ -44,13 +44,13 @@ defmodule Meadow.Data.ControlledTermsTest do
     end
 
     test "memory cache hit" do
-      assert term = ControlledTerms.fetch!("mock1:result1")
+      assert _term = ControlledTerms.fetch!("mock1:result1")
       assert term = ControlledTerms.fetch!("mock1:result1")
       assert term == %{id: "mock1:result1", label: "First Result"}
     end
 
     test "db cache hit" do
-      assert term = ControlledTerms.fetch!("mock1:result1")
+      assert _term = ControlledTerms.fetch!("mock1:result1")
       Cachex.clear!(Meadow.Cache.ControlledTerms)
       assert term = ControlledTerms.fetch!("mock1:result1")
       assert term == %{id: "mock1:result1", label: "First Result"}

--- a/test/meadow/data/file_sets_test.exs
+++ b/test/meadow/data/file_sets_test.exs
@@ -23,7 +23,7 @@ defmodule Meadow.Data.FileSetsTest do
     end
 
     test "create_file_set/1 with valid data creates a file_set" do
-      assert {:ok, %FileSet{} = file_set} = FileSets.create_file_set(@valid_attrs)
+      assert {:ok, %FileSet{} = _file_set} = FileSets.create_file_set(@valid_attrs)
     end
 
     test "create_file_set/1 with invalid data does not create a file_set" do
@@ -32,7 +32,7 @@ defmodule Meadow.Data.FileSetsTest do
 
     test "delete_file_set/1 deletes a file_set" do
       file_set = file_set_fixture()
-      assert {:ok, %FileSet{} = file_set} = FileSets.delete_file_set(file_set)
+      assert {:ok, %FileSet{} = _file_set} = FileSets.delete_file_set(file_set)
       assert Enum.empty?(FileSets.list_file_sets())
     end
 

--- a/test/meadow/data/schemas/file_set_test.exs
+++ b/test/meadow/data/schemas/file_set_test.exs
@@ -20,7 +20,7 @@ defmodule Meadow.Data.Schemas.FileSetTest do
         |> FileSet.changeset(@valid_attrs)
         |> Repo.insert()
 
-      assert {:ok, <<data::binary-size(16)>>} = Ecto.UUID.dump(file_set.id)
+      assert {:ok, <<_data::binary-size(16)>>} = Ecto.UUID.dump(file_set.id)
     end
   end
 end

--- a/test/meadow/data/schemas/index_time_test.exs
+++ b/test/meadow/data/schemas/index_time_test.exs
@@ -23,7 +23,7 @@ defmodule Meadow.Data.Schemas.IndexTimeTest do
         |> IndexTime.changeset(@valid_attrs)
         |> Repo.insert()
 
-      assert {:ok, <<data::binary-size(16)>>} = Ecto.UUID.dump(index_time.id)
+      assert {:ok, <<_data::binary-size(16)>>} = Ecto.UUID.dump(index_time.id)
     end
   end
 end

--- a/test/meadow/data/schemas/work_test.exs
+++ b/test/meadow/data/schemas/work_test.exs
@@ -15,7 +15,7 @@ defmodule Meadow.Data.Schemas.WorkTest do
         |> Work.changeset(@valid_attrs)
         |> Repo.insert()
 
-      assert {:ok, <<data::binary-size(16)>>} = Ecto.UUID.dump(work.id)
+      assert {:ok, <<_data::binary-size(16)>>} = Ecto.UUID.dump(work.id)
     end
   end
 end

--- a/test/meadow/data/shared_links_test.exs
+++ b/test/meadow/data/shared_links_test.exs
@@ -33,7 +33,7 @@ defmodule Meadow.Data.SharedLinksTest do
 
   test "revoke/1" do
     work = work_fixture()
-    assert {:ok, link1} = SharedLinks.generate(work.id)
+    assert {:ok, _link1} = SharedLinks.generate(work.id)
     assert {:ok, link2} = SharedLinks.generate(work.id)
     assert SharedLinks.count() == 2
     assert SharedLinks.revoke(link2.shared_link_id) == :ok
@@ -42,8 +42,8 @@ defmodule Meadow.Data.SharedLinksTest do
 
   test "delete_expired/0" do
     work = work_fixture()
-    assert {:ok, link1} = SharedLinks.generate(work.id)
-    assert {:ok, link2} = SharedLinks.generate(work.id, -1000)
+    assert {:ok, _link1} = SharedLinks.generate(work.id)
+    assert {:ok, _link2} = SharedLinks.generate(work.id, -1000)
     assert SharedLinks.count() == 2
     assert SharedLinks.delete_expired() == {:ok, 1}
     assert SharedLinks.count() == 1

--- a/test/meadow/data/works_test.exs
+++ b/test/meadow/data/works_test.exs
@@ -25,7 +25,7 @@ defmodule Meadow.Data.WorksTest do
     end
 
     test "create_work/1 with valid data creates a work" do
-      assert {:ok, %Work{} = work} = Works.create_work(@valid_attrs)
+      assert {:ok, %Work{} = _work} = Works.create_work(@valid_attrs)
     end
 
     test "create_work/1 with invalid data does not create a work" do
@@ -68,7 +68,7 @@ defmodule Meadow.Data.WorksTest do
 
     test "delete_work/1 deletes a work" do
       work = work_fixture()
-      assert {:ok, %Work{} = work} = Works.delete_work(work)
+      assert {:ok, %Work{} = _work} = Works.delete_work(work)
       assert Enum.empty?(Works.list_works())
     end
 
@@ -90,7 +90,7 @@ defmodule Meadow.Data.WorksTest do
         collection_fixture()
         |> Map.get(:id)
 
-      assert {:ok, %Work{collection_id: collection_id} = work} =
+      assert {:ok, %Work{collection_id: ^collection_id}} =
                Works.add_to_collection(work, collection_id)
     end
 

--- a/test/meadow/ingest/projects/project_test.exs
+++ b/test/meadow/ingest/projects/project_test.exs
@@ -19,7 +19,7 @@ defmodule Meadow.Ingest.Schemas.ProjectTest do
 
     test "created project has a UUID identifier" do
       assert {:ok, %Project{} = project} = Projects.create_project(@valid_attrs)
-      assert {:ok, <<data::binary-size(16)>>} = Ecto.UUID.dump(project.id)
+      assert {:ok, <<_data::binary-size(16)>>} = Ecto.UUID.dump(project.id)
     end
 
     test "creating a project generates a folder name" do

--- a/test/meadow_web/schema/middleware/authenticate_test.exs
+++ b/test/meadow_web/schema/middleware/authenticate_test.exs
@@ -12,7 +12,7 @@ defmodule MeadowWeb.Schema.Middleware.AuthenticateTest do
       |> Authenticate.call({})
 
     assert %{errors: []} = resolution
-    assert %{current_user: %{id: id}} = resolution.context
+    assert %{current_user: %{id: ^id}} = resolution.context
   end
 
   test "Authenticate middleware errors when there is not a current user in the context" do

--- a/test/meadow_web/schema/middleware/authorize_test.exs
+++ b/test/meadow_web/schema/middleware/authorize_test.exs
@@ -12,7 +12,7 @@ defmodule MeadowWeb.Schema.Middleware.AuthorizeTest do
       |> Authorize.call("Administrator")
 
     assert %{errors: []} = resolution
-    assert %{current_user: %{id: id}} = resolution.context
+    assert %{current_user: %{id: ^id}} = resolution.context
   end
 
   test "Authorize middleware takes the argument :any to authorize all users" do
@@ -24,7 +24,7 @@ defmodule MeadowWeb.Schema.Middleware.AuthorizeTest do
       |> Authorize.call(:any)
 
     assert %{errors: []} = resolution
-    assert %{current_user: %{id: id}} = resolution.context
+    assert %{current_user: %{id: ^id}} = resolution.context
   end
 
   test "Authorize middleware errors when the current user's role in the context does not match" do

--- a/test/meadow_web/schema/mutation/create_project_test.exs
+++ b/test/meadow_web/schema/mutation/create_project_test.exs
@@ -13,7 +13,7 @@ defmodule MeadowWeb.Schema.Mutation.CreateProjectTest do
         context: gql_context()
       )
 
-    assert {:ok, query_data} = result
+    assert {:ok, _query_data} = result
 
     project = Projects.get_project_by_title("The project title")
     assert project.title == "The project title"

--- a/test/meadow_web/schema/mutation/delete_collection_test.exs
+++ b/test/meadow_web/schema/mutation/delete_collection_test.exs
@@ -13,7 +13,7 @@ defmodule MeadowWeb.Schema.Mutation.DeleteCollectionTest do
         context: gql_context()
       )
 
-    assert {:ok, query_data} = result
+    assert {:ok, _query_data} = result
   end
 
   describe "authorization" do

--- a/test/meadow_web/schema/subscription/ingest_progress_test.exs
+++ b/test/meadow_web/schema/subscription/ingest_progress_test.exs
@@ -25,11 +25,11 @@ defmodule MeadowWeb.Schema.Subscription.IngestProgressTest do
   end
 
   test "initiate subscription", %{ref: ref} do
-    assert_reply ref, :ok, %{subscriptionId: subscription_id}
+    assert_reply ref, :ok, %{subscriptionId: _subscription_id}
   end
 
   test "receive data", %{ref: ref, ingest_sheet: sheet, work_rows: [first_row | _]} do
-    assert_reply ref, :ok, %{subscriptionId: subscription_id}
+    assert_reply ref, :ok, %{subscriptionId: _subscription_id}
 
     Progress.update_entry(first_row, "CreateWork", "ok")
     Progress.update_entry(first_row, GenerateFileSetDigests, "ok")
@@ -50,7 +50,7 @@ defmodule MeadowWeb.Schema.Subscription.IngestProgressTest do
     work_rows: work_rows,
     file_set_rows: file_set_rows
   } do
-    assert_reply ref, :ok, %{subscriptionId: subscription_id}
+    assert_reply ref, :ok, %{subscriptionId: _subscription_id}
 
     work_rows
     |> Enum.each(fn row ->


### PR DESCRIPTION
Also fix flappy async test in batch_driver_test.exs

To check:
```
rm -rf _build/*/lib/meadow
mix test
```

Compiler warnings while building dependencies aren't our problem, but there should be no warnings during the last stage when it's building meadow itself. There also shouldn't be any warnings about unused variable assignments while running the test suite.