### PR TITLE
Batch update GraphQL API

### DIFF
--- a/assets/js/components/BatchEdit/batch-edit.gql.js
+++ b/assets/js/components/BatchEdit/batch-edit.gql.js
@@ -8,7 +8,17 @@ export const BATCH_UPDATE = gql`
     $replace: BatchReplaceInput
   ) {
     batchUpdate(add: $add, delete: $delete, query: $query, replace: $replace) {
-      message
+      id
+      nickname
+      status
+      user
+      started
+      type
+      query
+      add
+      replace
+      delete
+      error
     }
   }
 `;

--- a/lib/meadow/application/children.ex
+++ b/lib/meadow/application/children.ex
@@ -29,6 +29,7 @@ defmodule Meadow.Application.Children do
     [
       EDTF,
       Meadow.BatchDriver,
+      Meadow.BatchNotifier,
       {Meadow.Data.IndexWorker, interval: Config.index_interval()},
       Meadow.IIIF.ManifestListener,
       {Meadow.Ingest.Progress, interval: Config.progress_ping_interval()},

--- a/lib/meadow/batch_notifier.ex
+++ b/lib/meadow/batch_notifier.ex
@@ -1,0 +1,18 @@
+defmodule Meadow.BatchNotifier do
+  @moduledoc """
+  Listens for and handles notifications about updates to batches table
+  """
+  use Meadow.DatabaseNotification, tables: [:batches]
+
+  alias Meadow.Notifications
+  alias Meadow.Batches
+
+  @impl true
+  def handle_notification(:batches, :delete, _key, state), do: {:noreply, state}
+
+  def handle_notification(:batches, _op, %{id: id}, state) do
+    batch = Batches.get_batch!(id)
+    Notifications.batch(batch)
+    {:noreply, state}
+  end
+end

--- a/lib/meadow/batches.ex
+++ b/lib/meadow/batches.ex
@@ -79,6 +79,27 @@ defmodule Meadow.Batches do
   end
 
   @doc """
+  Returns a list of batches matching the given `criteria`.
+
+  Example Criteria:
+
+  [{:limit, 15}, {:order, :asc}]}]
+  """
+
+  def list_batches(criteria) do
+    query = from(Batch)
+
+    Enum.reduce(criteria, query, fn
+      {:limit, limit}, query ->
+        from b in query, limit: ^limit
+
+      {:order, order}, query ->
+        from b in query, order_by: [{^order, :id}]
+    end)
+    |> Repo.all()
+  end
+
+  @doc """
   Gets a batch.
 
   Raises `Ecto.NoResultsError` if the Batch does not exist.

--- a/lib/meadow/database_notification.ex
+++ b/lib/meadow/database_notification.ex
@@ -20,11 +20,11 @@ defmodule Meadow.DatabaseNotification do
   end
   ```
 
-  Add to the list of children in `lib/meadow/application/children.ex`:
+  Add to the list of workers in `lib/meadow/application/children.ex`:
   ```
-  def specs(:dev) do
+  defp workers(nil) do
     [
-      MyDatabaseNotification
+      MyDatabaseWorker
     ]
   end
   ```

--- a/lib/meadow/notifications.ex
+++ b/lib/meadow/notifications.ex
@@ -1,0 +1,28 @@
+defmodule Meadow.Notifications do
+  @moduledoc """
+  functions for notifications to absinthe subscriptions
+  """
+  alias Meadow.Data.Schemas.Batch
+  require Logger
+
+  def batch({:ok, batch}),
+    do: {:ok, batch(batch)}
+
+  def batch(%Batch{} = batch) do
+    Logger.info("Sending notifications for batch: #{batch.id} with status: #{batch.status}")
+
+    Absinthe.Subscription.publish(
+      MeadowWeb.Endpoint,
+      batch,
+      batch_status_update: "batch:" <> batch.id
+    )
+
+    Absinthe.Subscription.publish(
+      MeadowWeb.Endpoint,
+      batch,
+      batches_status_updates: "batches"
+    )
+
+    batch
+  end
+end

--- a/lib/meadow_web/resolvers/batches.ex
+++ b/lib/meadow_web/resolvers/batches.ex
@@ -5,6 +5,14 @@ defmodule MeadowWeb.Resolvers.Data.Batches do
   alias Meadow.Batches
   alias MeadowWeb.Schema.ChangesetErrors
 
+  def batches(_, _args, _) do
+    {:ok, Batches.list_batches()}
+  end
+
+  def batch(_, %{id: id}, _) do
+    {:ok, Batches.get_batch!(id)}
+  end
+
   def update(_, params, %{context: %{current_user: user}}) do
     with query <- Map.get(params, :query),
          delete <- Map.get(params, :delete),
@@ -12,7 +20,7 @@ defmodule MeadowWeb.Resolvers.Data.Batches do
          replace <- Map.get(params, :replace),
          nickname <- Map.get(params, :nickname) do
       if empty_param(add) and empty_param(delete) and empty_param(replace) do
-        {:ok, %{message: "No updates specified"}}
+        {:error, %{message: "No updates specified"}}
       else
         case Batches.create_batch(%{
                nickname: nickname,
@@ -24,7 +32,7 @@ defmodule MeadowWeb.Resolvers.Data.Batches do
                type: "update"
              }) do
           {:ok, batch} ->
-            {:ok, %{message: "Batch: " <> batch.id <> " has been submitted"}}
+            {:ok, batch}
 
           {:error, changeset} ->
             {:error,

--- a/lib/meadow_web/schema/schema.ex
+++ b/lib/meadow_web/schema/schema.ex
@@ -24,6 +24,7 @@ defmodule MeadowWeb.Schema do
 
   query do
     import_fields(:account_queries)
+    import_fields(:batch_queries)
     import_fields(:collection_queries)
     import_fields(:controlled_term_queries)
     import_fields(:field_queries)
@@ -44,6 +45,7 @@ defmodule MeadowWeb.Schema do
   end
 
   subscription do
+    import_fields(:batch_subscriptions)
     import_fields(:ingest_subscriptions)
   end
 

--- a/priv/repo/migrations/20201201141200_batch_notifications.exs
+++ b/priv/repo/migrations/20201201141200_batch_notifications.exs
@@ -1,0 +1,12 @@
+defmodule Meadow.Repo.Migrations.BatchNotifications do
+  use Ecto.Migration
+  import Meadow.DatabaseNotification
+
+  def up do
+    create_notification_trigger(:batches)
+  end
+
+  def down do
+    drop_notification_trigger(:batches)
+  end
+end

--- a/test/gql/BatchFields.frag.gql
+++ b/test/gql/BatchFields.frag.gql
@@ -1,0 +1,12 @@
+fragment BatchFields on Batch {
+  id
+  nickname
+  status
+  started
+  error
+  query
+  add
+  replace
+  delete
+  works_updated
+}

--- a/test/gql/BatchStatusUpdate.gql
+++ b/test/gql/BatchStatusUpdate.gql
@@ -1,0 +1,7 @@
+#import "./BatchFields.frag.gql"
+
+subscription BatchStatusUpdate($id: ID!) {
+  batchStatusUpdate(id: $id) {
+    ...BatchFields
+  }
+}

--- a/test/gql/BatchUpdate.gql
+++ b/test/gql/BatchUpdate.gql
@@ -1,5 +1,7 @@
+#import "./BatchFields.frag.gql"
+
 mutation($query: String!, $delete: BatchDeleteInput, $add: BatchAddInput) {
   batchUpdate(query: $query, delete: $delete, add: $add) {
-    message
+    ...BatchFields
   }
 }

--- a/test/gql/GetBatchById.gql
+++ b/test/gql/GetBatchById.gql
@@ -1,0 +1,7 @@
+#import "./BatchFields.frag.gql"
+
+query GetBatchById($id: ID!) {
+  batch(id: $id) {
+    ...BatchFields
+  }
+}

--- a/test/gql/GetBatches.gql
+++ b/test/gql/GetBatches.gql
@@ -1,0 +1,7 @@
+#import "./BatchFields.frag.gql"
+
+query GetBatches {
+  batches {
+    ...BatchFields
+  }
+}

--- a/test/meadow_web/schema/mutation/batch_update_test.exs
+++ b/test/meadow_web/schema/mutation/batch_update_test.exs
@@ -61,8 +61,8 @@ defmodule MeadowWeb.Schema.Mutation.BatchUpdateTest do
 
     assert {:ok, query_data} = result
 
-    response = get_in(query_data, [:data, "batchUpdate", "message"])
-    assert response =~ "has been submitted"
+    response = get_in(query_data, [:data, "batchUpdate", "status"])
+    assert response =~ "QUEUED"
   end
 
   test "adds only should be a valid mutation" do
@@ -86,8 +86,8 @@ defmodule MeadowWeb.Schema.Mutation.BatchUpdateTest do
 
     assert {:ok, query_data} = result
 
-    response = get_in(query_data, [:data, "batchUpdate", "message"])
-    assert response =~ "has been submitted"
+    response = get_in(query_data, [:data, "batchUpdate", "status"])
+    assert response =~ "QUEUED"
   end
 
   test "no updates should not be a valid mutation" do
@@ -101,12 +101,12 @@ defmodule MeadowWeb.Schema.Mutation.BatchUpdateTest do
 
     assert {:ok, query_data} = result
 
-    response = get_in(query_data, [:data, "batchUpdate", "message"])
-    assert response == "No updates specified"
+    error = List.first(get_in(query_data, [:errors]))
+    assert error.message == "No updates specified"
   end
 
   describe "authorization" do
-    test "viewers are not authorized to update via batch" do
+    test "users are not authorized to update via batch" do
       {:ok, result} =
         query_gql(
           variables: %{

--- a/test/meadow_web/schema/query/get_batch_by_id.exs
+++ b/test/meadow_web/schema/query/get_batch_by_id.exs
@@ -1,0 +1,27 @@
+defmodule MeadowWeb.Schema.Query.GetBatchByIdTest do
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+  alias Meadow.Batches
+
+  load_gql(MeadowWeb.Schema, "test/gql/GetBatchById.gql")
+
+  test "should be a valid query" do
+    batch = batch_fixture()
+
+    result =
+      query_gql(
+        variables: %{"id" => batch.id},
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+
+    batch_status = get_in(query_data, [:data, "batch", "status"])
+    assert batch_status == "QUEUED"
+  end
+
+  test "Should return nil for a non-existent batch" do
+    result = query_gql(variables: %{"id" => Ecto.UUID.generate()})
+    assert {:ok, %{data: %{"batch" => nil}}} = result
+  end
+end

--- a/test/meadow_web/schema/query/get_batches_test.exs
+++ b/test/meadow_web/schema/query/get_batches_test.exs
@@ -1,0 +1,23 @@
+defmodule MeadowWeb.Schema.Query.BatchesTest do
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+
+  load_gql(MeadowWeb.Schema, "test/gql/GetBatches.gql")
+
+  test "should be a valid query" do
+    batch_fixture()
+    batch_fixture()
+    batch_fixture()
+
+    result =
+      query_gql(
+        variables: %{},
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+
+    batches = get_in(query_data, [:data, "batches"])
+    assert length(batches) == 3
+  end
+end

--- a/test/meadow_web/schema/query/get_collection_by_id_test.exs
+++ b/test/meadow_web/schema/query/get_collection_by_id_test.exs
@@ -19,7 +19,7 @@ defmodule MeadowWeb.Schema.Query.GetCollectionByIdTest do
     assert collection_title == collection_fixture.title
   end
 
-  test "Should return nil for a non-existant collection" do
+  test "Should return nil for a non-existent collection" do
     result = query_gql(variables: %{"collectionId" => 100})
     assert {:ok, %{data: %{"collection" => nil}}} = result
   end

--- a/test/meadow_web/schema/subscription/batch_status_update_test.exs
+++ b/test/meadow_web/schema/subscription/batch_status_update_test.exs
@@ -1,0 +1,32 @@
+defmodule MeadowWeb.Schema.Subscription.BatchStatusUpdateTest do
+  use MeadowWeb.SubscriptionCase, async: true
+
+  alias Meadow.Batches
+  alias Meadow.Notifications
+
+  load_gql(MeadowWeb.Schema, "test/gql/BatchStatusUpdate.gql")
+
+  setup %{socket: socket} do
+    batch = batch_fixture()
+
+    {:ok,
+     batch: batch,
+     ref: subscribe_gql(socket, variables: %{"id" => batch.id, context: gql_context()})}
+  end
+
+  test "initiate subscription", %{ref: ref} do
+    assert_reply ref, :ok, %{subscriptionId: subscription_id}
+  end
+
+  test "receive batch status update data", %{ref: ref, batch: batch} do
+    assert_reply ref, :ok, %{subscriptionId: subscription_id}
+    Batches.update_batch!(batch, %{status: "in_progress"})
+    Notifications.batch(Batches.get_batch!(batch.id))
+
+    assert_push "subscription:data", %{
+      result: %{data: %{"batchStatusUpdate" => batch_status_update}}
+    }
+
+    assert get_in(batch_status_update, ["status"]) == "IN_PROGRESS"
+  end
+end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -6,7 +6,7 @@ defmodule Meadow.TestHelpers do
   alias Ecto.Adapters.SQL.Sandbox
 
   alias Meadow.Accounts.{Ldap, User}
-  alias Meadow.Data.Schemas.{Collection, FileSet, Work}
+  alias Meadow.Data.Schemas.{Batch, Collection, FileSet, Work}
   alias Meadow.Data.Works
   alias Meadow.Ingest.Validator
   alias Meadow.Ingest.Schemas.{Project, Sheet}
@@ -117,6 +117,28 @@ defmodule Meadow.TestHelpers do
       |> Repo.insert()
 
     collection
+  end
+
+  @spec batch_fixture(nil | maybe_improper_list | map) :: any
+  def batch_fixture(attrs \\ %{}) do
+    attrs =
+      Enum.into(attrs, %{
+        nickname: attrs[:title] || "batch-#{System.unique_integer([:positive])}",
+        query: ~s'{"query":{"term":{"workType.id": "IMAGE"}}}',
+        replace:
+          Jason.encode!(%{
+            visibility: %{id: "OPEN", scheme: "VISIBILITY"}
+          }),
+        user: "user123",
+        type: "update"
+      })
+
+    {:ok, batch} =
+      %Batch{}
+      |> Batch.changeset(attrs)
+      |> Repo.insert()
+
+    batch
   end
 
   def work_fixture(attrs \\ %{}) do


### PR DESCRIPTION
Adds GraphQL endpoints to power batch dashbaord:

Queries
- `batch` (gets batch by id)
-  `batches` (gets all batches)

Subscriptions
- `batchStatusUpdate` (subscribes to updates for a batch)
- `batchesStatusUpdates` (subscribes to updates for all batches)

Other
- `batchUpdate` mutation now can take a `nickname` argument