### PR TITLE
Lock db when retrieving pending works in WorkCreator

### DIFF
--- a/lib/meadow/batch_notifier.ex
+++ b/lib/meadow/batch_notifier.ex
@@ -4,8 +4,8 @@ defmodule Meadow.BatchNotifier do
   """
   use Meadow.DatabaseNotification, tables: [:batches]
 
-  alias Meadow.Notifications
   alias Meadow.Batches
+  alias Meadow.Notifications
 
   @impl true
   def handle_notification(:batches, :delete, _key, state), do: {:noreply, state}

--- a/lib/meadow/ingest/progress.ex
+++ b/lib/meadow/ingest/progress.ex
@@ -42,17 +42,18 @@ defmodule Meadow.Ingest.Progress do
     |> Repo.one()
   end
 
-  def get_pending_work_entries(sheet_id, limit) do
+  def get_and_lock_pending_work_entries(sheet_id, limit) do
     from(q in pending_work_entry_query(limit),
       join: r in Row,
       on: q.row_id == r.id,
-      where: r.sheet_id == ^sheet_id
+      where: r.sheet_id == ^sheet_id,
+      lock: "FOR UPDATE SKIP LOCKED"
     )
     |> Repo.all()
   end
 
-  def get_pending_work_entries(limit) do
-    pending_work_entry_query(limit)
+  def get_and_lock_pending_work_entries(limit) do
+    from(q in pending_work_entry_query(limit), lock: "FOR UPDATE SKIP LOCKED")
     |> Repo.all()
   end
 

--- a/lib/meadow/ingest/sheets_to_works.ex
+++ b/lib/meadow/ingest/sheets_to_works.ex
@@ -11,7 +11,8 @@ defmodule Meadow.Ingest.SheetsToWorks do
   def create_works_from_ingest_sheet(%Sheet{} = ingest_sheet, :sync) do
     create_works_from_ingest_sheet(ingest_sheet)
 
-    Progress.get_pending_work_entries(ingest_sheet.id, :all)
+    Progress.get_and_lock_pending_work_entries(ingest_sheet.id, :all)
+    |> Progress.update_entries("CreateWork", "processing")
     |> Repo.preload(row: :sheet)
     |> WorkCreator.create_works_from_rows()
 

--- a/test/meadow/ingest/progress_test.exs
+++ b/test/meadow/ingest/progress_test.exs
@@ -39,18 +39,18 @@ defmodule Meadow.Ingest.ProgressTest do
       assert Progress.get_entry(row.id, "CreateWork") |> Map.get(:status) == "pending"
     end
 
-    test "get_pending_work_entries/2", %{ingest_sheet: %{id: sheet_id}, rows: [row | _]} do
-      assert Progress.get_pending_work_entries(sheet_id, :all) |> length() == 2
-      assert Progress.get_pending_work_entries(sheet_id, 1) |> length() == 1
+    test "get_and_lock_pending_work_entries/2", %{ingest_sheet: %{id: sheet_id}, rows: [row | _]} do
+      assert Progress.get_and_lock_pending_work_entries(sheet_id, :all) |> length() == 2
+      assert Progress.get_and_lock_pending_work_entries(sheet_id, 1) |> length() == 1
       Progress.update_entry(row, "CreateWork", "in_process")
-      assert Progress.get_pending_work_entries(sheet_id, :all) |> length() == 1
+      assert Progress.get_and_lock_pending_work_entries(sheet_id, :all) |> length() == 1
     end
 
-    test "get_pending_work_entries/1", %{rows: [row | _]} do
-      assert Progress.get_pending_work_entries(:all) |> length() == 2
-      assert Progress.get_pending_work_entries(1) |> length() == 1
+    test "get_and_lock_pending_work_entries/1", %{rows: [row | _]} do
+      assert Progress.get_and_lock_pending_work_entries(:all) |> length() == 2
+      assert Progress.get_and_lock_pending_work_entries(1) |> length() == 1
       Progress.update_entry(row, "CreateWork", "in_process")
-      assert Progress.get_pending_work_entries(:all) |> length() == 1
+      assert Progress.get_and_lock_pending_work_entries(:all) |> length() == 1
     end
 
     test "get_timed_out_work_entries", %{rows: [row | _]} do

--- a/test/meadow/ingest/work_creator_test.exs
+++ b/test/meadow/ingest/work_creator_test.exs
@@ -1,19 +1,46 @@
 defmodule Meadow.Ingest.WorkCreatorTest do
-  use Meadow.IngestCase
+  use Meadow.IngestCase, async: false
+  alias Ecto.Adapters.SQL.Sandbox
   alias Meadow.Data.Works
   alias Meadow.Ingest.{SheetsToWorks, WorkCreator}
 
+  import Assertions
+  import ExUnit.CaptureLog
+
   @args [works_per_tick: 20, interval: 500]
 
-  setup do
-    worker = start_supervised!({WorkCreator, @args})
-    %{worker: worker}
+  describe "normal operation" do
+    setup do
+      worker = start_supervised!({WorkCreator, @args})
+      %{worker: worker}
+    end
+
+    test "handle_info/2", %{ingest_sheet: sheet} do
+      assert Works.list_works() |> length() == 0
+      SheetsToWorks.create_works_from_ingest_sheet(sheet)
+
+      assert_async(timeout: 1500, sleep_time: 150) do
+        assert Works.list_works() |> length() == 2
+      end
+    end
   end
 
-  test "handle_info/2", %{ingest_sheet: sheet} do
-    assert Works.list_works() |> length() == 0
+  test "concurrency", %{ingest_sheet: sheet} do
+    Sandbox.mode(Meadow.Repo, {:shared, self()})
     SheetsToWorks.create_works_from_ingest_sheet(sheet)
-    :timer.sleep(1000)
-    assert Works.list_works() |> length() == 2
+
+    log =
+      capture_log(fn ->
+        Enum.each(1..5, fn _ ->
+          spawn(fn -> WorkCreator.create_works(%{batch_size: 20}) end)
+        end)
+
+        assert_async(timeout: 1500, sleep_time: 150) do
+          assert Works.list_works() |> length() == 2
+        end
+      end)
+
+    assert Regex.scan(~r/Creating work [A-Z0-9]+_Donohue_001 with 4 file sets/, log)
+           |> length() == 1
   end
 end


### PR DESCRIPTION
- Locks the db row after retrieving `pending` works until they are set to `processing` so that more than one process can't grab them. 