### PR TITLE
update FileSet metadata mutation

### DIFF
--- a/lib/meadow/data/schemas/iiif/work.ex
+++ b/lib/meadow/data/schemas/iiif/work.ex
@@ -19,6 +19,7 @@ defimpl Meadow.IIIF.Resource, for: Meadow.Data.Schemas.Work do
                     resource: %ImageResource{
                       id: IIIF.image_id(file_set.id),
                       label: file_set.metadata.label,
+                      description: file_set.metadata.description,
                       service: %Service{
                         id: IIIF.image_service_id(file_set.id)
                       }

--- a/lib/meadow/iiif/presentation/image_resource.ex
+++ b/lib/meadow/iiif/presentation/image_resource.ex
@@ -6,6 +6,7 @@ defmodule IIIF.Presentation.ImageResource do
 
   defstruct id: nil,
             label: nil,
+            description: nil,
             type: @rdf_type,
             format: nil,
             height: nil,

--- a/lib/meadow_web/resolvers/data.ex
+++ b/lib/meadow_web/resolvers/data.ex
@@ -40,17 +40,6 @@ defmodule MeadowWeb.Resolvers.Data do
   defp set_error_key({:value_id, value}, operation), do: %{operation => value}
   defp set_error_key(property, _), do: property
 
-  def create_file_set(_, args, _) do
-    case FileSets.create_file_set(args) do
-      {:error, changeset} ->
-        {:error,
-         message: "Could not create file set", details: ChangesetErrors.error_details(changeset)}
-
-      {:ok, file_set} ->
-        {:ok, file_set}
-    end
-  end
-
   def update_work(_, %{id: id, work: work_params}, _) do
     work = Works.get_work!(id)
 
@@ -121,6 +110,17 @@ defmodule MeadowWeb.Resolvers.Data do
     {:ok, FileSets.get_file_set_by_accession_number!(accession_number)}
   end
 
+  def create_file_set(_, args, _) do
+    case FileSets.create_file_set(args) do
+      {:error, changeset} ->
+        {:error,
+         message: "Could not create file set", details: ChangesetErrors.error_details(changeset)}
+
+      {:ok, file_set} ->
+        {:ok, file_set}
+    end
+  end
+
   def delete_file_set(_, args, _) do
     file_set = FileSets.get_file_set!(args[:file_set_id])
 
@@ -130,6 +130,19 @@ defmodule MeadowWeb.Resolvers.Data do
           :error,
           message: "Could not delete file_set", details: ChangesetErrors.error_details(changeset)
         }
+
+      {:ok, file_set} ->
+        {:ok, file_set}
+    end
+  end
+
+  def update_file_set(_, %{id: id, metadata: metadata_params}, _) do
+    file_set = FileSets.get_file_set!(id)
+
+    case FileSets.update_file_set(file_set, %{metadata: metadata_params}) do
+      {:error, changeset} ->
+        {:error,
+         message: "Could not update FileSet", details: ChangesetErrors.error_details(changeset)}
 
       {:ok, file_set} ->
         {:ok, file_set}

--- a/lib/meadow_web/schema/types/data/file_set_types.ex
+++ b/lib/meadow_web/schema/types/data/file_set_types.ex
@@ -31,6 +31,15 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
       resolve(&Resolvers.Data.create_file_set/3)
     end
 
+    @desc "Update a FileSet's metadata"
+    field :update_file_set, :file_set do
+      arg(:id, non_null(:id))
+      arg(:metadata, non_null(:file_set_metadata_update))
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Resolvers.Data.update_file_set/3)
+    end
+
     @desc "Delete a FileSet"
     field :delete_file_set, :file_set do
       arg(:file_set_id, non_null(:id))
@@ -62,11 +71,6 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
     field :accession_number, non_null(:string)
     field :role, non_null(:file_set_role)
     field :metadata, :file_set_metadata_input
-  end
-
-  @desc "Input fields for a `file_set` update object "
-  input_object :file_set_update_update do
-    field :metadata, :file_set_metadata_update
   end
 
   #

--- a/test/gql/DeleteFileSet.gql
+++ b/test/gql/DeleteFileSet.gql
@@ -1,0 +1,7 @@
+#import "./FileSetFields.frag.gql"
+
+mutation($fileSetId: ID!) {
+  deleteFileSet(fileSetId: $fileSetId) {
+    ...FileSetFields
+  }
+}

--- a/test/gql/UpdateFileSet.gql
+++ b/test/gql/UpdateFileSet.gql
@@ -1,0 +1,7 @@
+#import "./FileSetFields.frag.gql"
+
+mutation($id: ID!, $metadata: FileSetMetadataUpdate!) {
+  updateFileSet(id: $id, metadata: $metadata) {
+    ...FileSetFields
+  }
+}

--- a/test/meadow/iiif/generator_test.exs
+++ b/test/meadow/iiif/generator_test.exs
@@ -31,6 +31,7 @@ defmodule Meadow.IIIF.GeneratorTest do
                   {
                     \"motivation\": \"sc:painting\",
                     \"resource\": {
+                      \"description\": \"bar\",
                       \"label\": \"This is the label\",
                       \"service\": {
                         \"profile\": \"http://iiif.io/api/image/2/level2.json\",

--- a/test/meadow_web/schema/mutation/delete_file_set_test.exs
+++ b/test/meadow_web/schema/mutation/delete_file_set_test.exs
@@ -1,0 +1,21 @@
+defmodule MeadowWeb.Schema.Mutation.DeleteFileSetTest do
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+
+  alias Meadow.Data.FileSets
+
+  load_gql(MeadowWeb.Schema, "test/gql/DeleteFileSet.gql")
+
+  test "should be a valid mutation" do
+    file_set = file_set_fixture()
+
+    result =
+      query_gql(
+        variables: %{"fileSetId" => file_set.id},
+        context: gql_context()
+      )
+
+    assert {:ok, _query_data} = result
+    assert Enum.empty?(FileSets.list_file_sets())
+  end
+end

--- a/test/meadow_web/schema/mutation/update_file_set_test.exs
+++ b/test/meadow_web/schema/mutation/update_file_set_test.exs
@@ -1,0 +1,24 @@
+defmodule MeadowWeb.Schema.Mutation.UpdateFileSetTest do
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+
+  load_gql(MeadowWeb.Schema, "test/gql/UpdateFileSet.gql")
+
+  test "should be a valid mutation" do
+    file_set = file_set_fixture()
+
+    result =
+      query_gql(
+        variables: %{
+          "id" => file_set.id,
+          "metadata" => %{"label" => "Something"}
+        },
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+
+    label = get_in(query_data, [:data, "updateFileSet", "metadata", "label"])
+    assert label == "Something"
+  end
+end


### PR DESCRIPTION
- implements `updateFileSet` mutation to update a FileSet's metadata (label and description)
- `deleteFileSet` mutation already existed.
- also adds FileSets description to the IIIF manifest (fixes: https://github.com/nulib/repodev_planning_and_docs/issues/768)