### PR TITLE
expose verify FileSet API

### DIFF
--- a/lib/meadow/batch_notifier.ex
+++ b/lib/meadow/batch_notifier.ex
@@ -4,8 +4,8 @@ defmodule Meadow.BatchNotifier do
   """
   use Meadow.DatabaseNotification, tables: [:batches]
 
-  alias Meadow.Notifications
   alias Meadow.Batches
+  alias Meadow.Notifications
 
   @impl true
   def handle_notification(:batches, :delete, _key, state), do: {:noreply, state}

--- a/lib/meadow_web/resolvers/data.ex
+++ b/lib/meadow_web/resolvers/data.ex
@@ -168,4 +168,8 @@ defmodule MeadowWeb.Resolvers.Data do
         {:ok, work}
     end
   end
+
+  def verify_file_sets(_, %{work_id: work_id}, _) do
+    {:ok, Works.verify_file_sets(work_id)}
+  end
 end

--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -34,6 +34,13 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
       middleware(Middleware.Authenticate)
       resolve(&MeadowWeb.Resolvers.Data.work/3)
     end
+
+    @desc "Get verification status for a work's fileSets"
+    field :verify_file_sets, list_of(:file_set_verification_status) do
+      arg(:work_id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      resolve(&MeadowWeb.Resolvers.Data.verify_file_sets/3)
+    end
   end
 
   object :work_mutations do
@@ -204,6 +211,12 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
   object :work_sheet do
     field :id, :id
     field :title, :string
+  end
+
+  @desc "Whether or not a file set's presence in preservation location is verified"
+  object :file_set_verification_status do
+    field :file_set_id, :id
+    field :verified, :boolean
   end
 
   #

--- a/test/gql/VerifyFileSets.gql
+++ b/test/gql/VerifyFileSets.gql
@@ -1,0 +1,6 @@
+query VerifyFleSets($workId: ID!) {
+  verifyFileSets(workId: $workId) {
+    fileSetId
+    verified
+  }
+}

--- a/test/meadow_web/schema/query/verifiy_file_sets_test.exs
+++ b/test/meadow_web/schema/query/verifiy_file_sets_test.exs
@@ -1,0 +1,22 @@
+defmodule MeadowWeb.Schema.Query.VerifyFileSets do
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+
+  load_gql(MeadowWeb.Schema, "test/gql/VerifyFileSets.gql")
+
+  test "should be a valid query" do
+    work = work_with_file_sets_fixture(1)
+
+    result =
+      query_gql(
+        variables: %{"workId" => work.id},
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+
+    file_sets = get_in(query_data, [:data, "verifyFileSets"])
+    assert get_in(List.first(file_sets), ["fileSetId"]) == List.first(work.file_sets).id
+    assert get_in(List.first(file_sets), ["verified"]) == false
+  end
+end

--- a/test/support/s3_case.ex
+++ b/test/support/s3_case.ex
@@ -10,8 +10,8 @@ defmodule Meadow.S3Case do
         use Meadow.S3Case
 
         @bucket "test-ingest"
-        @key: "file_checker_test/path/to/file.tif"
-        @content: "test/fixtures/file.tif"
+        @key "file_checker_test/path/to/file.tif"
+        @content "test/fixtures/file.tif"
         @fixture %{
           bucket: @bucket,
           key: @key,


### PR DESCRIPTION
@adamjarling - ended up implementing this so it takes a work id rather than just an array of file set ids. When I started working on it that seemed to make sense - that way you could make the request on page load rather having to make a second request after load by sending back the file set id's in an array. Let me know if that doesn't seem right to you.  

<img width="1497" alt="Screen Shot 2020-12-07 at 5 22 45 PM" src="https://user-images.githubusercontent.com/6372022/101483766-e2f90880-3915-11eb-92b1-35b2be440f6a.png">
