### PR TITLE
Create trigger to update work when file set metadata is updated

### DIFF
--- a/priv/repo/migrations/20200507123625_create_dependency_triggers.exs
+++ b/priv/repo/migrations/20200507123625_create_dependency_triggers.exs
@@ -12,6 +12,8 @@ defmodule Meadow.Repo.Migrations.CreateDependencyTriggers do
       [:representative_file_set_id],
       :representative_work
     )
+
+    create_parent_trigger(:works, :file_sets, [:metadata])
   end
 
   def down do
@@ -19,6 +21,8 @@ defmodule Meadow.Repo.Migrations.CreateDependencyTriggers do
     drop_dependency_trigger(:collections, :works)
     drop_dependency_trigger(:works, :file_sets)
     drop_dependency_trigger(:works, :collections)
+
+    drop_parent_trigger(:works, :file_sets)
   end
 
   defp create_dependency_trigger(parent, child, fields) do
@@ -60,9 +64,51 @@ defmodule Meadow.Repo.Migrations.CreateDependencyTriggers do
     end
   end
 
+  defp create_parent_trigger(parent, child, fields) do
+    with {function_name, trigger_name} <- object_names_for_parent_trigger(parent, child) do
+      condition =
+        fields
+        |> Enum.flat_map(
+          &[
+            "(NEW.#{&1} <> OLD.#{&1})",
+            "(NEW.#{&1} IS NULL AND OLD.#{&1} IS NOT NULL)",
+            "(NEW.#{&1} IS NOT NULL AND OLD.#{&1} IS NULL)"
+          ]
+        )
+        |> Enum.join(" OR ")
+
+      execute """
+      CREATE OR REPLACE FUNCTION #{function_name}()
+        RETURNS trigger AS $$
+      BEGIN
+        IF #{condition} THEN
+          UPDATE #{parent} SET updated_at = NOW() WHERE id = NEW.#{Inflex.singularize(parent)}_id;
+        END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql
+      """
+
+      execute """
+      CREATE TRIGGER #{trigger_name}
+        AFTER UPDATE
+        ON #{child}
+        FOR EACH ROW
+        EXECUTE PROCEDURE #{function_name}()
+      """
+    end
+  end
+
   defp drop_dependency_trigger(parent, child) do
     with {function_name, trigger_name} <- object_names(parent, child) do
       execute("DROP TRIGGER IF EXISTS #{trigger_name} ON #{parent};")
+      execute("DROP FUNCTION IF EXISTS #{function_name};")
+    end
+  end
+
+  defp drop_parent_trigger(parent, child) do
+    with {function_name, trigger_name} <- object_names_for_parent_trigger(parent, child) do
+      execute("DROP TRIGGER IF EXISTS #{trigger_name} ON #{child};")
       execute("DROP FUNCTION IF EXISTS #{function_name};")
     end
   end
@@ -71,6 +117,13 @@ defmodule Meadow.Repo.Migrations.CreateDependencyTriggers do
     {
       "reindex_#{child}_when_#{parent}_changes",
       "#{parent}_#{child}_reindex"
+    }
+  end
+
+  defp object_names_for_parent_trigger(parent, child) do
+    {
+      "reindex_#{parent}_when_#{child}_changes",
+      "#{child}_#{parent}_reindex"
     }
   end
 end


### PR DESCRIPTION
- Create trigger when file set metadata is updated that sets works updated at timestamp so that new manifests can be rewritten (since they contain the file sets' labels and descriptions)

** Please let other devs know when merged - requires `down -v`
** Also please reset staging after merge