### PR TITLE
Wireup relatedUrl batchEdit

### DIFF
--- a/assets/js/components/BatchEdit/About/About.jsx
+++ b/assets/js/components/BatchEdit/About/About.jsx
@@ -14,13 +14,14 @@ import BatchEditAboutModalRemove from "../ModalRemove";
 import {
   useBatchDispatch,
   useBatchState,
-} from "../../../context/batch-edit-context";
+} from "@js/context/batch-edit-context";
 import {
   CONTROLLED_METADATA,
   getBatchMultiValueDataFromForm,
   prepControlledTermInput,
   prepFacetKey,
-} from "../../../services/metadata";
+  prepRelatedUrl,
+} from "@js/services/metadata";
 import { Button } from "@nulib/admin-react-components";
 
 const BatchEditAbout = () => {
@@ -76,6 +77,10 @@ const BatchEditAbout = () => {
       replaceItems.rightsStatement = JSON.parse(
         currentFormValues.rightsStatement
       );
+    }
+
+    if (currentFormValues.relatedUrl) {
+      replaceItems.relatedUrl = prepRelatedUrl(currentFormValues.relatedUrl);
     }
 
     // Update controlled term values to match shape the GraphQL mutation expects

--- a/assets/js/components/BatchEdit/ConfirmationTable.jsx
+++ b/assets/js/components/BatchEdit/ConfirmationTable.jsx
@@ -21,6 +21,7 @@ const displayTable = css`
 export default function BatchEditConfirmationTable({ itemsObj, type = "add" }) {
   const codeLists = useCodeLists();
   const marcRelators = codeLists.marcData.codeList || [];
+  const relatedUrls = codeLists.relatedUrlData.codeList || [];
 
   function getRoleLabel(roleId) {
     let foundItem = marcRelators.find((item) => item.id === roleId);
@@ -30,6 +31,11 @@ export default function BatchEditConfirmationTable({ itemsObj, type = "add" }) {
       );
     }
     return foundItem.label || "No role label found";
+  }
+
+  function getUrlLabel(urlId) {
+    let foundItem = relatedUrls.find((item) => item.id === urlId);
+    return foundItem.label || "No URL label found";
   }
 
   function getIcon() {
@@ -87,6 +93,13 @@ export default function BatchEditConfirmationTable({ itemsObj, type = "add" }) {
               rowKey = `${item.term}-${item.label}`;
               value = `${item.label} | ${item.term} | ${
                 item.role && getRoleLabel(item.role.id)
+              }`;
+            }
+
+            if (typeof item === "object" && item.url) {
+              rowKey = item.url;
+              value = `${item.url} | ${
+                item.label && getUrlLabel(item.label.id)
               }`;
             }
 


### PR DESCRIPTION
Related URL is now wired up and is set to post on batchEdit. Updates might a bit longer but it works.
<img width="993" alt="Screen Shot 2020-12-08 at 2 19 08 PM" src="https://user-images.githubusercontent.com/72217877/101536964-5d4e7a80-3960-11eb-8a3b-620cd2b7f656.png">
