### PR TITLE
Support preservation masters (backend)

### DIFF
--- a/assets/js/components/Work/Tabs/Structure/Structure.jsx
+++ b/assets/js/components/Work/Tabs/Structure/Structure.jsx
@@ -7,7 +7,7 @@ import {
   GET_WORK,
   SET_WORK_IMAGE,
   UPDATE_FILE_SETS,
-  UPDATE_FILE_SET_ORDER,
+  UPDATE_ACCESS_MASTER_ORDER,
 } from "@js/components/Work/work.gql.js";
 import { toastWrapper } from "@js/services/helpers";
 import UITabsStickyHeader from "@js/components/UI/Tabs/StickyHeader";
@@ -45,10 +45,10 @@ const WorkTabsStructure = ({ work }) => {
       console.log("onCompleted() updateFileSets", updateFileSets);
     },
   });
-  const [updateFileSetOrder] = useMutation(UPDATE_FILE_SET_ORDER, {
+  const [updateAccessMasterOrder] = useMutation(UPDATE_ACCESS_MASTER_ORDER, {
     onCompleted() {
       setIsReordering(false);
-      toastWrapper("is-success", "Filesets have been successfully reordered.");
+      toastWrapper("is-success", "Access masters have been successfully reordered.");
     },
     onError(error) {
       console.log("error in the updateWork GraphQL mutation :>> ", error);
@@ -66,7 +66,7 @@ const WorkTabsStructure = ({ work }) => {
   };
 
   const handleSaveReorder = (orderedFileSets = []) => {
-    updateFileSetOrder({
+    updateAccessMasterOrder({
       variables: { workId: work.id, fileSetIds: orderedFileSets },
     });
   };
@@ -76,6 +76,10 @@ const WorkTabsStructure = ({ work }) => {
 
     setWorkImageFilesetId(id === workImageFilesetId ? null : id);
     setWorkImage({ variables: { fileSetId: id, workId: work.id } });
+  };
+
+  const filterAccessMasters = (fileSets) => {
+    return fileSets.filter(fs => fs.role == "AM");
   };
 
   const onSubmit = (data) => {
@@ -138,13 +142,13 @@ const WorkTabsStructure = ({ work }) => {
         <div className="mt-4">
           {isReordering ? (
             <WorkTabsStructureFilesetsDragAndDrop
-              fileSets={work.fileSets}
+              fileSets={filterAccessMasters(work.fileSets)}
               handleCancelReorder={handleCancelReorder}
               handleSaveReorder={handleSaveReorder}
             />
           ) : (
             <WorkTabsStructureFilesetList
-              fileSets={work.fileSets}
+              fileSets={filterAccessMasters(work.fileSets)}
               handleDownloadClick={handleDownloadClick}
               handleWorkImageChange={handleWorkImageChange}
               isEditing={isEditing}

--- a/assets/js/components/Work/work.gql.js
+++ b/assets/js/components/Work/work.gql.js
@@ -8,9 +8,9 @@ export const UPDATE_FILE_SETS = gql`
   }
 `;
 
-export const UPDATE_FILE_SET_ORDER = gql`
-  mutation UpdateFileSetOrder($workId: ID!, $fileSetIds: [ID]) {
-    updateFileSetOrder(workId: $workId, fileSetIds: $fileSetIds) {
+export const UPDATE_ACCESS_MASTER_ORDER = gql`
+  mutation UpdateAccessMasterOrder($workId: ID!, $fileSetIds: [ID]) {
+    updateAccessMasterOrder(workId: $workId, fileSetIds: $fileSetIds) {
       id
     }
   }

--- a/config/sequins.exs
+++ b/config/sequins.exs
@@ -33,8 +33,15 @@ config :sequins, CopyFileToPreservation,
 
 config :sequins, CreatePyramidTiff,
   queue_config: [processor_concurrency: 1, visibility_timeout: 300],
-  notify_on: [CopyFileToPreservation: [status: :ok], CreatePyramidTiff: [status: :retry]]
+  notify_on: [
+    CopyFileToPreservation: [status: :ok, role: "am"],
+    CreatePyramidTiff: [status: :retry]
+  ]
 
 config :sequins, FileSetComplete,
   queue_config: [processor_concurrency: 1],
-  notify_on: [CreatePyramidTiff: [status: :ok], FileSetComplete: [status: :retry]]
+  notify_on: [
+    CreatePyramidTiff: [status: :ok],
+    FileSetComplete: [status: :retry],
+    CopyFileToPreservation: [status: :ok, role: "pm"]
+  ]

--- a/lib/meadow/data.ex
+++ b/lib/meadow/data.ex
@@ -32,16 +32,17 @@ defmodule Meadow.Data do
 
   ## Examples
 
-      iex> ranked_file_sets_for_work("01DT7V79D45B8BQMVS6YDRSF9J")
+      iex> ranked_file_sets_for_work("01DT7V79D45B8BQMVS6YDRSF9J", "am")
       [%Meadow.Data.Schemas.FileSet{rank: -100}, %Meadow.Data.Schemas.FileSet{rank: 0}, %Meadow.Data.Schemas.FileSet{rank: 100}]
 
       iex> ranked_file_sets_for_work(Ecto.UUID.generate())
       []
 
   """
-  def ranked_file_sets_for_work(work_id) do
+  def ranked_file_sets_for_work(work_id, role) do
     FileSet
     |> where([fs], fs.work_id == ^work_id)
+    |> where([fs], fs.role == ^role)
     |> order_by(:rank)
     |> Repo.all()
   end

--- a/lib/meadow/data/schemas/file_set.ex
+++ b/lib/meadow/data/schemas/file_set.ex
@@ -43,7 +43,7 @@ defmodule Meadow.Data.Schemas.FileSet do
     |> unsafe_validate_unique([:accession_number], Meadow.Repo)
     |> unique_constraint(:accession_number)
     |> validate_inclusion(:role, @file_set_roles)
-    |> set_rank(scope: :work_id)
+    |> set_rank(scope: [:work_id, :role])
   end
 
   defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.FileSet do

--- a/lib/meadow/iiif/generator.ex
+++ b/lib/meadow/iiif/generator.ex
@@ -11,7 +11,7 @@ defmodule Meadow.IIIF.Generator do
 
   def create_manifest(%Work{id: id}) do
     id
-    |> Works.with_file_sets()
+    |> Works.with_file_sets("am")
     |> encode!()
   end
 

--- a/lib/meadow/ingest/sheets_to_works.ex
+++ b/lib/meadow/ingest/sheets_to_works.ex
@@ -7,6 +7,7 @@ defmodule Meadow.Ingest.SheetsToWorks do
   alias Meadow.Ingest.{Progress, Rows, Sheets, WorkCreator}
   alias Meadow.Ingest.Schemas.{Row, Sheet}
   alias Meadow.Repo
+  alias Meadow.Utils.MapList
 
   def create_works_from_ingest_sheet(%Sheet{} = ingest_sheet, :sync) do
     create_works_from_ingest_sheet(ingest_sheet)
@@ -36,7 +37,9 @@ defmodule Meadow.Ingest.SheetsToWorks do
       |> Enum.flat_map(fn {_, rows} ->
         rows
         |> Enum.with_index()
-        |> Enum.map(fn {row, index} -> {row.id, index == 0} end)
+        |> Enum.map(fn {row, index} ->
+          {row.id, MapList.get(row.fields, :header, :value, :role), index == 0}
+        end)
       end)
       |> Progress.initialize_entries()
 

--- a/lib/meadow/ingest/work_creator.ex
+++ b/lib/meadow/ingest/work_creator.ex
@@ -62,9 +62,10 @@ defmodule Meadow.Ingest.WorkCreator do
   defp send_work_to_pipeline(ingest_sheet, work, file_set_rows) do
     work.file_sets
     |> Enum.zip(file_set_rows)
-    |> Enum.each(fn {%FileSet{id: file_set_id}, %Row{row: row_num}} ->
+    |> Enum.each(fn {%FileSet{id: file_set_id, role: role}, %Row{row: row_num}} ->
       Pipeline.kickoff(file_set_id, %{
         context: "Sheet",
+        role: role,
         ingest_sheet: ingest_sheet.id,
         ingest_sheet_row: row_num
       })

--- a/lib/meadow_web/resolvers/data.ex
+++ b/lib/meadow_web/resolvers/data.ex
@@ -149,8 +149,12 @@ defmodule MeadowWeb.Resolvers.Data do
     end
   end
 
-  def update_file_set_order(_, %{work_id: work_id, file_set_ids: file_set_ids}, _) do
-    case Works.update_file_set_order(work_id, file_set_ids) do
+  def update_access_master_order(
+        _,
+        %{work_id: work_id, file_set_ids: file_set_ids},
+        _
+      ) do
+    case Works.update_file_set_order(work_id, "am", file_set_ids) do
       {:error, message} when is_binary(message) ->
         {
           :error,

--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -67,7 +67,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
       resolve(&Resolvers.Data.update_work/3)
     end
 
-    @desc "Set the representative FileSet for a Work"
+    @desc "Set the representative FileSet (Access Master) for a Work"
     field :set_work_image, :work do
       arg(:work_id, non_null(:id))
       arg(:file_set_id, non_null(:id))
@@ -93,13 +93,13 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
       resolve(&Resolvers.Data.add_work_to_collection/3)
     end
 
-    @desc "Change the order of a work's file sets"
-    field :update_file_set_order, :work do
+    @desc "Change the order of a work's access masters"
+    field :update_access_master_order, :work do
       arg(:work_id, non_null(:id))
       arg(:file_set_ids, list_of(:id))
       middleware(Middleware.Authenticate)
       middleware(Middleware.Authorize, "Editor")
-      resolve(&Resolvers.Data.update_file_set_order/3)
+      resolve(&Resolvers.Data.update_access_master_order/3)
     end
   end
 

--- a/lib/mix/tasks/dc_download.ex
+++ b/lib/mix/tasks/dc_download.ex
@@ -111,7 +111,7 @@ defmodule Mix.Tasks.Meadow.DcDownload do
              "#{work_accession_number}_FILE_#{index}",
              filename,
              doc["label"],
-             "am"
+             Enum.random(["am", "am", "am", "am", "pm"])
            ]}
 
         %{status_code: 403} ->

--- a/priv/repo/migrations/20200507123625_create_dependency_triggers.exs
+++ b/priv/repo/migrations/20200507123625_create_dependency_triggers.exs
@@ -13,7 +13,7 @@ defmodule Meadow.Repo.Migrations.CreateDependencyTriggers do
       :representative_work
     )
 
-    create_parent_trigger(:works, :file_sets, [:metadata])
+    create_parent_trigger(:works, :file_sets, [:metadata, :rank])
   end
 
   def down do

--- a/test/gql/UpdateAccessMasterOrder.gql
+++ b/test/gql/UpdateAccessMasterOrder.gql
@@ -1,5 +1,5 @@
 mutation($workId: ID!, $fileSetIds: [ID!]) {
-  updateFileSetOrder(workId: $workId, fileSetIds: $fileSetIds) {
+  updateAccessMasterOrder(workId: $workId, fileSetIds: $fileSetIds) {
     id
     fileSets {
       id

--- a/test/meadow/data/works_test.exs
+++ b/test/meadow/data/works_test.exs
@@ -113,7 +113,7 @@ defmodule Meadow.Data.WorksTest do
 
   describe "representative images" do
     setup do
-      work = work_with_file_sets_fixture(3)
+      work = work_with_file_sets_fixture(3, %{}, %{role: "am"})
       file_set = work.file_sets |> Enum.at(1)
 
       {:ok, %Work{} = work} = Works.set_representative_image(work, file_set)
@@ -194,6 +194,14 @@ defmodule Meadow.Data.WorksTest do
     } do
       assert(Works.get_work!(work.id) |> Map.get(:representative_image) == image_url)
       FileSets.get_file_set!(image_id) |> FileSets.delete_file_set()
+      assert(is_nil(Works.get_work!(work.id) |> Map.get(:representative_image)))
+    end
+
+    test "set_representative_image/2 with a preservation master does not set the representative image" do
+      work = work_with_file_sets_fixture(1, %{}, %{role: "pm"})
+      file_set = work.file_sets |> Enum.at(1)
+
+      {:ok, %Work{} = work} = Works.set_representative_image(work, file_set)
       assert(is_nil(Works.get_work!(work.id) |> Map.get(:representative_image)))
     end
   end
@@ -383,7 +391,7 @@ defmodule Meadow.Data.WorksTest do
 
   describe "reorder file sets" do
     setup do
-      work = work_with_file_sets_fixture(5)
+      work = work_with_file_sets_fixture(5, %{}, %{role: "am"})
       {:ok, %{work: work, ids: work.file_sets |> Enum.map(& &1.id)}}
     end
 
@@ -397,21 +405,21 @@ defmodule Meadow.Data.WorksTest do
                   index_4: %{id: id_4, position: 4},
                   index_5: %{id: id_5, position: 5},
                   work: %Work{id: ^work_id}
-                }} = Works.update_file_set_order(work_id, Enum.reverse(ids))
+                }} = Works.update_file_set_order(work_id, "am", Enum.reverse(ids))
 
         assert [id_5, id_4, id_3, id_2, id_1] == ids
       end
     end
 
     test "update_file_set_order/1 errors on missing id", %{work: work, ids: [missing_id | ids]} do
-      assert {:error, error_text} = Works.update_file_set_order(work.id, ids)
+      assert {:error, error_text} = Works.update_file_set_order(work.id, "am", ids)
       assert String.contains?(error_text, missing_id)
       assert String.match?(error_text, ~r/missing \[.+\]/)
     end
 
     test "update_file_set_order/1 errors on extra id", %{work: work, ids: ids} do
       with extra_id <- Ecto.UUID.generate() do
-        assert {:error, error_text} = Works.update_file_set_order(work.id, [extra_id | ids])
+        assert {:error, error_text} = Works.update_file_set_order(work.id, "am", [extra_id | ids])
         assert String.contains?(error_text, extra_id)
         assert String.match?(error_text, ~r/^Extra/)
       end
@@ -437,23 +445,24 @@ defmodule Meadow.Data.WorksTest do
         })
       end)
 
-      {:ok, %{work: work, file_set_ids: work.file_sets |> Enum.map(& &1.id)}}
+      {:ok, %{work: work}}
     end
 
     @tag s3: [@fixture]
     test "verify_file_sets/1 verifies file sets are present in preservation location", %{
-      work: work,
-      file_set_ids: file_set_ids
+      work: work
     } do
-      assert Enum.map(file_set_ids, fn id -> %{file_set_id: id, verified: true} end) ==
-               Works.verify_file_sets(work.id)
+      Enum.each(Works.verify_file_sets(work.id), fn result ->
+        assert result.verified == true
+      end)
     end
 
     test "verify_file_sets/1 verifies file sets are not present in preservation location" do
       work = work_with_file_sets_fixture(3)
 
-      assert Enum.map(work.file_sets, fn fs -> %{file_set_id: fs.id, verified: false} end) ==
-               Works.verify_file_sets(work.id)
+      Enum.each(Works.verify_file_sets(work.id), fn result ->
+        assert result.verified == false
+      end)
     end
   end
 end

--- a/test/meadow/data_test.exs
+++ b/test/meadow/data_test.exs
@@ -26,7 +26,7 @@ defmodule Meadow.DataTest do
       assert Data.get_work_by_file_set_id(file_set_id).id == work.id
     end
 
-    test "ranked_file_sets_for_work/1" do
+    test "ranked_file_sets_for_work/2 fetches the ranked file sets for a work and role" do
       work = work_fixture()
 
       %FileSet{}
@@ -48,7 +48,26 @@ defmodule Meadow.DataTest do
       })
       |> Repo.insert!()
 
-      [file_set_1, file_set_2] = Data.ranked_file_sets_for_work(work.id)
+      %FileSet{}
+      |> FileSet.changeset(%{
+        position: 0,
+        work_id: work.id,
+        accession_number: "no",
+        role: "pm",
+        metadata: %{location: "test", original_filename: "test"}
+      })
+      |> Repo.insert!()
+
+      %FileSet{}
+      |> FileSet.changeset(%{
+        position: 0,
+        accession_number: "nono",
+        role: "am",
+        metadata: %{location: "test", original_filename: "test"}
+      })
+      |> Repo.insert!()
+
+      [file_set_1, file_set_2] = Data.ranked_file_sets_for_work(work.id, "am")
       assert file_set_1.rank < file_set_2.rank
     end
 

--- a/test/meadow/iiif/generator_test.exs
+++ b/test/meadow/iiif/generator_test.exs
@@ -11,11 +11,24 @@ defmodule Meadow.IIIF.GeneratorTest do
       file_set =
         file_set_fixture(%{
           work_id: work.id,
+          role: "am",
           metadata: %{
             location: "foo",
             description: "bar",
             original_filename: "something",
             label: "This is the label"
+          }
+        })
+
+      _file_set2 =
+        file_set_fixture(%{
+          work_id: work.id,
+          role: "pm",
+          metadata: %{
+            location: "foo",
+            description: "preservation master",
+            original_filename: "something",
+            label: "This should not be in the manifest"
           }
         })
 

--- a/test/meadow/ingest/work_redriver_test.exs
+++ b/test/meadow/ingest/work_redriver_test.exs
@@ -3,6 +3,7 @@ defmodule Meadow.Ingest.WorkRedriverTest do
   alias Meadow.Ingest.{Progress, Rows, WorkRedriver}
   alias Meadow.Ingest.Schemas.Progress, as: ProgressSchema
   alias Meadow.Repo
+  alias Meadow.Utils.MapList
 
   import ExUnit.CaptureLog
 
@@ -14,7 +15,9 @@ defmodule Meadow.Ingest.WorkRedriverTest do
     with rows <- Rows.list_ingest_sheet_rows(sheet: sheet) do
       rows
       |> Enum.with_index()
-      |> Enum.map(fn {row, index} -> {row.id, rem(index, 4) == 0} end)
+      |> Enum.map(fn {row, index} ->
+        {row.id, MapList.get(row.fields, :header, :value, :role), rem(index, 4) == 0}
+      end)
       |> Progress.initialize_entries()
 
       {:ok, %{worker: worker, ingest_sheet: sheet, rows: rows}}

--- a/test/meadow_web/schema/mutation/set_collection_image_test.exs
+++ b/test/meadow_web/schema/mutation/set_collection_image_test.exs
@@ -9,9 +9,9 @@ defmodule MeadowWeb.Schema.Mutation.SetCollectionImageTest do
     collection = collection_fixture()
 
     works = [
-      work_with_file_sets_fixture(1, %{collection_id: collection.id}),
-      work_with_file_sets_fixture(1, %{collection_id: collection.id}),
-      work_with_file_sets_fixture(1, %{collection_id: collection.id})
+      work_with_file_sets_fixture(1, %{collection_id: collection.id}, %{role: "am"}),
+      work_with_file_sets_fixture(1, %{collection_id: collection.id}, %{role: "am"}),
+      work_with_file_sets_fixture(1, %{collection_id: collection.id}, %{role: "am"})
     ]
 
     expected_work = works |> Enum.at(1)

--- a/test/meadow_web/schema/mutation/set_work_image_test.exs
+++ b/test/meadow_web/schema/mutation/set_work_image_test.exs
@@ -6,7 +6,7 @@ defmodule MeadowWeb.Schema.Mutation.SetWorkImageTest do
   load_gql(MeadowWeb.Schema, "test/gql/SetWorkImage.gql")
 
   test "should be a valid mutation" do
-    work = work_with_file_sets_fixture(3)
+    work = work_with_file_sets_fixture(3, %{}, %{role: "am"})
     expected_file_set = work.file_sets |> Enum.at(1)
     file_set_image = Meadow.Config.iiif_server_url() <> expected_file_set.id
 
@@ -32,7 +32,7 @@ defmodule MeadowWeb.Schema.Mutation.SetWorkImageTest do
 
   describe "authorization" do
     test "viewers are not authorized to set work images" do
-      work = work_with_file_sets_fixture(3)
+      work = work_with_file_sets_fixture(3, %{}, %{role: "am"})
       expected_file_set = work.file_sets |> Enum.at(1)
 
       {:ok, result} =
@@ -48,7 +48,7 @@ defmodule MeadowWeb.Schema.Mutation.SetWorkImageTest do
     end
 
     test "editors and above are authorized to set work images" do
-      work = work_with_file_sets_fixture(3)
+      work = work_with_file_sets_fixture(3, %{}, %{role: "am"})
       expected_file_set = work.file_sets |> Enum.at(1)
 
       {:ok, result} =

--- a/test/meadow_web/schema/mutation/update_access_master_order_test.exs
+++ b/test/meadow_web/schema/mutation/update_access_master_order_test.exs
@@ -1,16 +1,16 @@
-defmodule MeadowWeb.Schema.Mutation.UpdateFileSetOrderTest do
+defmodule MeadowWeb.Schema.Mutation.UpdateAccessMasterOrderTest do
   use MeadowWeb.ConnCase, acync: true
   use Wormwood.GQLCase
 
-  load_gql(MeadowWeb.Schema, "test/gql/UpdateFileSetOrder.gql")
+  load_gql(MeadowWeb.Schema, "test/gql/UpdateAccessMasterOrder.gql")
 
   describe "mutation" do
     setup do
-      work = work_with_file_sets_fixture(5)
+      work = work_with_file_sets_fixture(5, %{}, %{role: "am"})
       {:ok, %{work: work, ids: work.file_sets |> Enum.map(& &1.id)}}
     end
 
-    test "changes the file set order", %{work: work, ids: ids} do
+    test "changes the access master order", %{work: work, ids: ids} do
       new_order = Enum.shuffle(ids)
 
       result =
@@ -22,7 +22,7 @@ defmodule MeadowWeb.Schema.Mutation.UpdateFileSetOrderTest do
       assert {:ok, query_data} = result
 
       with %{"id" => returned_work_id, "fileSets" => returned_file_sets} <-
-             get_in(query_data, [:data, "updateFileSetOrder"]) do
+             get_in(query_data, [:data, "updateAccessMasterOrder"]) do
         assert returned_work_id == work.id
         assert returned_file_sets |> Enum.map(&Map.get(&1, "id")) == new_order
       end

--- a/test/meadow_web/schema/subscription/ingest_progress_test.exs
+++ b/test/meadow_web/schema/subscription/ingest_progress_test.exs
@@ -8,7 +8,7 @@ defmodule MeadowWeb.Schema.Subscription.IngestProgressTest do
   @work_count 2
   @file_set_count 7
   @action_count length(Pipeline.actions())
-  @pct_factor 100 / (@file_set_count * @action_count + @work_count)
+  @pct_factor 100 / (@file_set_count * @action_count - 1 + @work_count)
 
   load_gql(MeadowWeb.Schema, "test/gql/IngestProgress.gql")
 
@@ -39,7 +39,7 @@ defmodule MeadowWeb.Schema.Subscription.IngestProgressTest do
       result: %{data: %{"ingestProgress" => %{"percentComplete" => pct}}}
     }
 
-    assert_in_delta(pct, @pct_factor * 2, 0.10)
+    assert_in_delta(pct, @pct_factor * 2, 0.1)
     sheet = Sheets.get_ingest_sheet!(sheet.id)
     refute(sheet.status == "completed")
   end


### PR DESCRIPTION
- updates `dc_download` task so that PM's are present in the generated ingest sheet
- Reconfigures pipeline so derivatives are not generated for preservation masters
- Updates the front end to only show access masters on structure tab and only allow access masters to participate in file set order.
- excludes PM's from IIIF manifest
- updated db trigger to rewrite manifest if rank is updated
- changes set_representative_image so it only sets image to an access master
- reconfigures `EctoRanked` for FileSets so it is scoped to `work_id` + `role` 
- created issue to refactor code associated with `Pipeline.actions( )` https://github.com/nulib/repodev_planning_and_docs/issues/1323

also fixes https://github.com/nulib/repodev_planning_and_docs/issues/1315


To merger: 
- Please let Divya and Adam know to run a `devstack down -v`
- Please reset staging 