### PR TITLE
Get rid of a forced whitespace character in a table, causing console …

### DIFF
--- a/assets/js/components/Work/Tabs/Preservation.jsx
+++ b/assets/js/components/Work/Tabs/Preservation.jsx
@@ -50,7 +50,7 @@ const WorkTabsPreservation = ({ work }) => {
               <th>s3 Key</th>
               <th>Verified</th>
               <DisplayAuthorized action="delete">
-                <th className="has-text-right">Actions</th>{" "}
+                <th className="has-text-right">Actions</th>
               </DisplayAuthorized>
             </tr>
           </thead>


### PR DESCRIPTION
This has been a paper-cut in the browser dev console... Easy, quick fix.