### PR TITLE
Switch default search bar operator to AND instead of OR

### DIFF
--- a/assets/js/components/UI/SearchBar.jsx
+++ b/assets/js/components/UI/SearchBar.jsx
@@ -14,14 +14,14 @@ const UISearchBar = () => {
         componentId={SEARCH_SENSOR}
         autosuggest={false}
         dataField={ELASTICSEARCH_FIELDS_TO_SEARCH}
-        debounce={100}
+        debounce={500}
         defaultValue={queryParts ? queryParts.search : null}
         fieldWeights={[5, 2]}
         filterLabel="Search"
         fuzziness={0}
         icon={<FontAwesomeIcon icon="search" />}
         innerClass={{ input: "input is-medium" }}
-        queryFormat="or"
+        queryFormat="and"
         queryString={true} // supports complex search, wildcards, etc.
         placeholder="Search all works"
         react={{ and: [RESULT_SENSOR] }}


### PR DESCRIPTION
Now searches in the search bar will use `AND` instead of `OR` on multi word searches.

![image](https://user-images.githubusercontent.com/3020266/102115539-52349800-3e01-11eb-9d0c-95d2319b87f7.png)
