### PR TITLE
Add and configure NUL.Authority, a local Authoritex module for NUL Authority Records

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -87,7 +87,8 @@ config :authoritex,
     Authoritex.Getty,
     Authoritex.LOC.Languages,
     Authoritex.LOC.Names,
-    Authoritex.LOC.SubjectHeadings
+    Authoritex.LOC.SubjectHeadings,
+    NUL.Authority
   ]
 
 config :honeybadger,

--- a/config/test.exs
+++ b/config/test.exs
@@ -51,7 +51,7 @@ config :meadow,
     url: "http://localhost:3944/"
   }
 
-config :authoritex, authorities: [Authoritex.Mock]
+config :authoritex, authorities: [Authoritex.Mock, NUL.Authority]
 
 config :ueberauth, Ueberauth,
   providers: [

--- a/lib/meadow_web/resolvers/nul_authority_records.ex
+++ b/lib/meadow_web/resolvers/nul_authority_records.ex
@@ -1,0 +1,58 @@
+defmodule MeadowWeb.Resolvers.NULAuthorityRecords do
+  @moduledoc """
+  Resolver for NUL.AuthorityRecords
+  """
+
+  alias Meadow.Utils.ChangesetErrors
+  alias NUL.AuthorityRecords
+
+  def nul_authority_records(_, _args, _) do
+    {:ok, AuthorityRecords.list_authority_records()}
+  end
+
+  def nul_authority_record(_, %{id: id}, _) do
+    {:ok, AuthorityRecords.get_authority_record!(id)}
+  end
+
+  def create_nul_authority_record(_, args, _) do
+    case AuthorityRecords.create_authority_record(args) do
+      {:error, changeset} ->
+        {:error,
+         message: "Could not create authority record",
+         details: ChangesetErrors.humanize_errors(changeset)}
+
+      {:ok, authority_record} ->
+        {:ok, authority_record}
+    end
+  end
+
+  def update_nul_authority_record(_, %{id: id, label: label, hint: hint}, _) do
+    authority_record = AuthorityRecords.get_authority_record!(id)
+
+    case AuthorityRecords.update_authority_record(authority_record, %{label: label, hint: hint}) do
+      {:error, changeset} ->
+        {:error,
+         message: "Could not update authority record",
+         details: ChangesetErrors.humanize_errors(changeset)}
+
+      {:ok, authority_record} ->
+        {:ok, authority_record}
+    end
+  end
+
+  def delete_nul_authority_record(_, args, _) do
+    authority_record = AuthorityRecords.get_authority_record!(args[:nul_authority_record_id])
+
+    case AuthorityRecords.delete_authority_record(authority_record) do
+      {:error, changeset} ->
+        {
+          :error,
+          message: "Could not delete Authority Record",
+          details: ChangesetErrors.humanize_errors(changeset)
+        }
+
+      {:ok, authority_record} ->
+        {:ok, authority_record}
+    end
+  end
+end

--- a/lib/meadow_web/schema/schema.ex
+++ b/lib/meadow_web/schema/schema.ex
@@ -21,6 +21,7 @@ defmodule MeadowWeb.Schema do
   import_types(__MODULE__.Data.FieldTypes)
   import_types(__MODULE__.Data.SharedLinkTypes)
   import_types(__MODULE__.HelperTypes)
+  import_types(__MODULE__.NULAuthorityTypes)
 
   query do
     import_fields(:account_queries)
@@ -31,6 +32,7 @@ defmodule MeadowWeb.Schema do
     import_fields(:file_set_queries)
     import_fields(:helper_queries)
     import_fields(:ingest_queries)
+    import_fields(:nul_authority_queries)
     import_fields(:work_queries)
   end
 
@@ -40,6 +42,7 @@ defmodule MeadowWeb.Schema do
     import_fields(:collection_mutations)
     import_fields(:file_set_mutations)
     import_fields(:ingest_mutations)
+    import_fields(:nul_authority_mutations)
     import_fields(:shared_link_mutations)
     import_fields(:work_mutations)
   end

--- a/lib/meadow_web/schema/types/nul_authority_types.ex
+++ b/lib/meadow_web/schema/types/nul_authority_types.ex
@@ -1,0 +1,63 @@
+defmodule MeadowWeb.Schema.NULAuthorityTypes do
+  @moduledoc """
+  GraphQL schema types for NUL AuthorityRecords
+  """
+
+  use Absinthe.Schema.Notation
+  alias MeadowWeb.Resolvers
+  alias MeadowWeb.Schema.Middleware
+
+  object :nul_authority_queries do
+    @desc "Get a list of NUL AuthorityRecords"
+    field :nul_authority_records, list_of(:nul_authority_record) do
+      middleware(Middleware.Authenticate)
+      resolve(&Resolvers.NULAuthorityRecords.nul_authority_records/3)
+    end
+
+    @desc "Get an NUL AuthorityRecord by ID"
+    field :nul_authority_record, :nul_authority_record do
+      arg(:id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      resolve(&Resolvers.NULAuthorityRecords.nul_authority_record/3)
+    end
+  end
+
+  object :nul_authority_mutations do
+    @desc "Create a new NUL AuthorityRecord"
+    field :create_nul_authority_record, :nul_authority_record do
+      arg(:label, non_null(:string))
+      arg(:hint, :string)
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Manager")
+      resolve(&Resolvers.NULAuthorityRecords.create_nul_authority_record/3)
+    end
+
+    @desc "Update an NUL AuthorityRecord"
+    field :update_nul_authority_record, :nul_authority_record do
+      arg(:id, non_null(:id))
+      arg(:label, non_null(:string))
+      arg(:hint, :string)
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Manager")
+      resolve(&Resolvers.NULAuthorityRecords.update_nul_authority_record/3)
+    end
+
+    @desc "Delete an AuthorityRecord"
+    field :delete_nul_authority_record, :nul_authority_record do
+      arg(:nul_authority_record_id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Resolvers.NULAuthorityRecords.delete_nul_authority_record/3)
+    end
+  end
+
+  #
+  # Object Types
+  #
+
+  object :nul_authority_record do
+    field :id, non_null(:id)
+    field :label, non_null(:string)
+    field :hint, :string
+  end
+end

--- a/lib/nul/authority.ex
+++ b/lib/nul/authority.ex
@@ -1,0 +1,59 @@
+defmodule NUL.Authority do
+  @moduledoc "Authoritex implementation for Northwestern University Libraries local authority"
+  @behaviour Authoritex
+
+  import Ecto.Query
+
+  alias Meadow.Repo
+  alias NUL.Schemas.AuthorityRecord
+
+  @id_prefix "info:nul"
+
+  @impl Authoritex
+  def can_resolve?(@id_prefix <> _), do: true
+  def can_resolve?(_), do: false
+
+  @impl Authoritex
+  def code, do: "nul-authority"
+
+  @impl Authoritex
+  def description, do: "Northwestern University Libraries local authority"
+
+  @impl Authoritex
+  def fetch(id) do
+    case get_record(id) do
+      %{} = record -> {:ok, record}
+      _ -> {:error, 404}
+    end
+  end
+
+  @impl Authoritex
+  def search(query, max_results \\ 30) do
+    case get_records(query, max_results) do
+      [] -> {:ok, []}
+      [_ | _] = results -> {:ok, results}
+      _ -> {:error, :nul_authority_search_error}
+    end
+  end
+
+  defp get_record(id) do
+    from(a in AuthorityRecord,
+      select: %{
+        id: a.id,
+        label: a.label,
+        qualified_label: fragment("concat_ws(' ', ?, ?)", a.label, a.hint),
+        hint: a.hint
+      }
+    )
+    |> Repo.get(id)
+  end
+
+  defp get_records(query, max_results) do
+    from(a in AuthorityRecord,
+      where: ilike(a.label, ^"%#{query}%"),
+      limit: ^max_results,
+      select: %{id: a.id, label: a.label, hint: a.hint}
+    )
+    |> Repo.all()
+  end
+end

--- a/lib/nul/authority_records.ex
+++ b/lib/nul/authority_records.ex
@@ -1,0 +1,110 @@
+defmodule NUL.AuthorityRecords do
+  @moduledoc """
+  The NUL.AuthorityRecords context.
+  """
+
+  alias Meadow.Repo
+  alias NUL.Schemas.AuthorityRecord
+
+  import Ecto.Query
+
+  @doc """
+  Returns the list of AuthorityRecords.
+
+  ## Examples
+
+      iex> list_authority_records()
+      [%NUL.Schemas.AuthorityRecord{}, %NUL.Schemas.AuthorityRecord{}]
+
+  """
+  def list_authority_records do
+    from(a in AuthorityRecord, order_by: [desc: a.inserted_at, desc: a.id], limit: 100)
+    |> Repo.all()
+  end
+
+  @doc """
+  Gets an AuthorityRecord.
+
+  Raises `Ecto.NoResultsError` if the AuthorityRecord does not exist.
+
+  ## Examples
+
+      iex> get_authority_record!("info:nul/123")
+      %NUL.Schemas.AuthorityRecord{}
+
+      iex> get_authority_record!("456")
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_authority_record!(id) do
+    Repo.get!(AuthorityRecord, id)
+  end
+
+  @doc """
+  Gets an AuthorityRecord.
+
+  ## Examples
+
+      iex> get_authority_record("info:nul/123")
+      %NUL.Schemas.AuthorityRecord{}
+
+      iex> get_authority_record("456")
+      nil
+
+  """
+  def get_authority_record(id) do
+    Repo.get(AuthorityRecord, id)
+  end
+
+  @doc """
+  Creates an AuthorityRecord.
+
+  ## Examples
+
+      iex> create_authority_record(%{id: "info:nul/123", label: "test label", hint: "test hint"})
+      {:ok, %NUL.Schemas.AuthorityRecord{}}
+
+      iex> create_authority_record(%{id: 123})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_authority_record(attrs \\ %{}) do
+    %AuthorityRecord{}
+    |> AuthorityRecord.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Same as create_authority_record/1 but raises on error
+  """
+  def create_authority_record!(attrs \\ %{}) do
+    %AuthorityRecord{}
+    |> AuthorityRecord.changeset(attrs)
+    |> Repo.insert!()
+  end
+
+  @doc """
+  Updates an AuthorityRecord.
+
+  ## Examples
+
+      iex> update_authority_record(authority_record, %{label: "new label"})
+      {:ok, %AuthorityRecord{}}
+
+      iex> update_authority_record(authority_record, %{id: "not allowed"})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_authority_record(%AuthorityRecord{} = authority_record, attrs) do
+    authority_record
+    |> AuthorityRecord.update_changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes an AuthorityRecord.
+  """
+  def delete_authority_record(%AuthorityRecord{} = authority_record) do
+    Repo.delete(authority_record)
+  end
+end

--- a/lib/nul/schemas/authority_record.ex
+++ b/lib/nul/schemas/authority_record.ex
@@ -1,0 +1,32 @@
+defmodule NUL.Schemas.AuthorityRecord do
+  @moduledoc """
+  AuthorityRecords are used to describe local controlled vocabulary entries.
+  """
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @primary_key {:id, :string, []}
+  schema "authority_records" do
+    field :label, :string
+    field :hint, :string
+
+    timestamps()
+  end
+
+  def changeset(record, params) do
+    record
+    |> cast(params, [:label, :hint])
+    |> validate_required([:label])
+    |> put_change(:id, generate_nul_id())
+  end
+
+  def update_changeset(record, params) do
+    record
+    |> cast(params, [:label, :hint])
+  end
+
+  defp generate_nul_id do
+    "info:nul/" <> Ecto.UUID.generate()
+  end
+end

--- a/priv/repo/migrations/20201214202206_add_authority_records_table.exs
+++ b/priv/repo/migrations/20201214202206_add_authority_records_table.exs
@@ -1,0 +1,16 @@
+defmodule Meadow.Repo.Migrations.AddAuthorityRecordsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:authority_records, primary_key: false) do
+      add :id, :string, primary_key: true
+      add :label, :string, null: false
+      add :hint, :string
+
+      timestamps()
+    end
+
+    create(index(:authority_records, ["lower(label)"]))
+    create(index(:authority_records, [:inserted_at, :id]))
+  end
+end

--- a/priv/repo/seeds/coded_terms/authority.json
+++ b/priv/repo/seeds/coded_terms/authority.json
@@ -62,5 +62,9 @@
   {
     "id": "lcsh",
     "label": "Library of Congress Subject Headings"
+  },
+  {
+    "id": "nul-authority",
+    "label": "Northwestern University Libraries local authority"
   }
 ]

--- a/test/gql/CreateNULAuthorityRecord.gql
+++ b/test/gql/CreateNULAuthorityRecord.gql
@@ -1,0 +1,7 @@
+mutation($label: String!, $hint: String!) {
+  createNULAuthorityRecord(label: $label, hint: $hint) {
+    id
+    label
+    hint
+  }
+}

--- a/test/gql/DeleteNULAuthorityRecord.gql
+++ b/test/gql/DeleteNULAuthorityRecord.gql
@@ -1,0 +1,7 @@
+mutation($nulAuthorityRecordId: ID!) {
+  deleteNULAuthorityRecord(nulAuthorityRecordId: $nulAuthorityRecordId) {
+    id
+    label
+    hint
+  }
+}

--- a/test/gql/GetNULAuthorityRecordById.gql
+++ b/test/gql/GetNULAuthorityRecordById.gql
@@ -1,0 +1,7 @@
+query GetNULAuthorityRecord($id: ID!) {
+  nulAuthorityRecord(id: $id) {
+    id
+    label
+    hint
+  }
+}

--- a/test/gql/GetNULAuthorityRecords.gql
+++ b/test/gql/GetNULAuthorityRecords.gql
@@ -1,0 +1,7 @@
+query GetNULAuthorityRecords {
+  nulAuthorityRecords {
+    id
+    label
+    hint
+  }
+}

--- a/test/gql/UpdateNULAuthorityRecord.gql
+++ b/test/gql/UpdateNULAuthorityRecord.gql
@@ -1,0 +1,7 @@
+mutation($id: ID!, $label: String!, $hint: String!) {
+  updateNULAuthorityRecord(id: $id, label: $label, hint: $hint) {
+    id
+    label
+    hint
+  }
+}

--- a/test/meadow_web/schema/mutation/create_nul_authority_record.exs
+++ b/test/meadow_web/schema/mutation/create_nul_authority_record.exs
@@ -1,0 +1,39 @@
+defmodule MeadowWeb.Schema.Mutation.CreateNULAuthorityRecordTest do
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+
+  load_gql(MeadowWeb.Schema, "test/gql/CreateNULAuthorityRecord.gql")
+
+  test "should be a valid mutation" do
+    {:ok, result} =
+      query_gql(
+        variables: %{"label" => "test label", "hint" => "test hint"},
+        context: gql_context()
+      )
+
+    assert "test label" == get_in(result, [:data, "createNULAuthorityRecord", "label"])
+    assert "test hint" == get_in(result, [:data, "createNULAuthorityRecord", "hint"])
+  end
+
+  describe "authorization" do
+    test "viewers and editors are not authorized to create NUL AuthorityRecords" do
+      {:ok, result} =
+        query_gql(
+          variables: %{"label" => "test label", "hint" => "test hint"},
+          context: %{current_user: %{role: "Editor"}}
+        )
+
+      assert %{errors: [%{message: "Forbidden", status: 403}]} = result
+    end
+
+    test "managers and above are authorized to create NUL AuthorityRecords" do
+      {:ok, result} =
+        query_gql(
+          variables: %{"label" => "test label", "hint" => "test hint"},
+          context: %{current_user: %{role: "Manager"}}
+        )
+
+      assert result.data["createNULAuthorityRecord"]
+    end
+  end
+end

--- a/test/meadow_web/schema/mutation/delete_nul_authority_record_test.exs
+++ b/test/meadow_web/schema/mutation/delete_nul_authority_record_test.exs
@@ -1,0 +1,25 @@
+defmodule MeadowWeb.Schema.Mutation.DeleteNULAuthorityRecordTest do
+  use Meadow.DataCase
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+
+  alias NUL.AuthorityRecords
+
+  load_gql(MeadowWeb.Schema, "test/gql/DeleteNULAuthorityRecord.gql")
+
+  setup do
+    {:ok, authority_record: AuthorityRecords.create_authority_record!(%{label: "test label"})}
+  end
+
+  test "should be a valid mutation", %{authority_record: authority_record} do
+    {:ok, _result} =
+      query_gql(
+        variables: %{
+          "nulAuthorityRecordId" => authority_record.id
+        },
+        context: gql_context()
+      )
+
+    assert Enum.empty?(AuthorityRecords.list_authority_records())
+  end
+end

--- a/test/meadow_web/schema/mutation/udpate_nul_authority_record.exs
+++ b/test/meadow_web/schema/mutation/udpate_nul_authority_record.exs
@@ -1,0 +1,63 @@
+defmodule MeadowWeb.Schema.Mutation.UpdateNULAuthorityRecordTest do
+  use Meadow.DataCase
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+
+  alias NUL.AuthorityRecords
+
+  load_gql(MeadowWeb.Schema, "test/gql/UpdateNULAuthorityRecord.gql")
+
+  test "should be a valid mutation" do
+    authority_record =
+      AuthorityRecords.create_authority_record!(%{label: "test label", hint: "test hint"})
+
+    {:ok, result} =
+      query_gql(
+        variables: %{
+          "id" => authority_record.id,
+          "label" => "new test label",
+          "hint" => "new test hint"
+        },
+        context: gql_context()
+      )
+
+    assert "new test label" == get_in(result, [:data, "updateNULAuthorityRecord", "label"])
+    assert "new test hint" == get_in(result, [:data, "updateNULAuthorityRecord", "hint"])
+  end
+
+  describe "authorization" do
+    test "viewers and editors are not authorized to update NUL AuthorityRecords" do
+      authority_record =
+        AuthorityRecords.create_authority_record!(%{label: "test label", hint: "test hint"})
+
+      {:ok, result} =
+        query_gql(
+          variables: %{
+            "id" => authority_record.id,
+            "label" => "test label",
+            "hint" => "test hint"
+          },
+          context: %{current_user: %{role: "Editor"}}
+        )
+
+      assert %{errors: [%{message: "Forbidden", status: 403}]} = result
+    end
+
+    test "managers and above are authorized to update NUL AuthorityRecords" do
+      authority_record =
+        AuthorityRecords.create_authority_record!(%{label: "test label", hint: "test hint"})
+
+      {:ok, result} =
+        query_gql(
+          variables: %{
+            "id" => authority_record.id,
+            "label" => "test label",
+            "hint" => "test hint"
+          },
+          context: %{current_user: %{role: "Manager"}}
+        )
+
+      assert result.data["updateNULAuthorityRecord"]
+    end
+  end
+end

--- a/test/meadow_web/schema/query/get_nul_authority_record_by_id_test.exs
+++ b/test/meadow_web/schema/query/get_nul_authority_record_by_id_test.exs
@@ -1,0 +1,23 @@
+defmodule MeadowWeb.Schema.Query.NULAuthorityRecordByIdTest do
+  use Meadow.DataCase
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+
+  alias NUL.AuthorityRecords
+
+  load_gql(MeadowWeb.Schema, "test/gql/GetNULAuthorityRecordById.gql")
+
+  test "should be a valid query" do
+    authority_record =
+      AuthorityRecords.create_authority_record!(%{label: "test label", hint: "test hint"})
+
+    {:ok, result} =
+      query_gql(
+        variables: %{"id" => authority_record.id},
+        context: gql_context()
+      )
+
+    assert "test label" == get_in(result, [:data, "nulAuthorityRecord", "label"])
+    assert "test hint" == get_in(result, [:data, "nulAuthorityRecord", "hint"])
+  end
+end

--- a/test/meadow_web/schema/query/get_nul_authority_records_test.exs
+++ b/test/meadow_web/schema/query/get_nul_authority_records_test.exs
@@ -1,0 +1,24 @@
+defmodule MeadowWeb.Schema.Query.NULAuthorityRecordsTest do
+  use Meadow.DataCase
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+
+  alias NUL.AuthorityRecords
+
+  load_gql(MeadowWeb.Schema, "test/gql/GetNULAuthorityRecords.gql")
+
+  test "should be a valid query" do
+    AuthorityRecords.create_authority_record!(%{label: "one"})
+    AuthorityRecords.create_authority_record!(%{label: "two"})
+    AuthorityRecords.create_authority_record!(%{label: "three"})
+
+    {:ok, result} =
+      query_gql(
+        variables: %{},
+        context: gql_context()
+      )
+
+    nul_authority_records = get_in(result, [:data, "nulAuthorityRecords"])
+    assert length(nul_authority_records) == 3
+  end
+end

--- a/test/nul/authority_records_test.exs
+++ b/test/nul/authority_records_test.exs
@@ -1,0 +1,77 @@
+defmodule NUL.AuthorityRecordsTest do
+  use Meadow.DataCase
+
+  alias NUL.AuthorityRecords
+  alias NUL.Schemas.AuthorityRecord
+
+  setup do
+    authority_records = [
+      authority_record_fixture(%{label: "Ver Steeg, Clarence L.", hint: "(The Legend)"}),
+      authority_record_fixture(%{label: "Ver Steeg, Dorothy A."}),
+      authority_record_fixture(%{label: "Netsch, Walter A."})
+    ]
+
+    {:ok, authority_record: List.first(authority_records)}
+  end
+
+  def authority_record_fixture(attrs \\ %{}) do
+    attrs =
+      Enum.into(attrs, %{
+        label: attrs[:label] || Faker.Person.name(),
+        hint: attrs[:hint] || Faker.Lorem.sentence(2)
+      })
+
+    {:ok, authority_record} =
+      %AuthorityRecord{}
+      |> AuthorityRecord.changeset(attrs)
+      |> Repo.insert()
+
+    authority_record
+  end
+
+  test "list_authority_records/0" do
+    assert AuthorityRecords.list_authority_records() |> length() == 3
+  end
+
+  test "get_authority_record!/1", %{authority_record: authority_record} do
+    assert AuthorityRecords.get_authority_record!(authority_record.id)
+    assert_raise Ecto.NoResultsError, fn -> AuthorityRecords.get_authority_record!("M1SS1NG") end
+  end
+
+  test "get_authority_record/1", %{authority_record: authority_record} do
+    assert AuthorityRecords.get_authority_record(authority_record.id)
+    assert is_nil(AuthorityRecords.get_authority_record("M1SS1NG"))
+  end
+
+  test "create_authority_record/1" do
+    assert {:ok, _authority_record} =
+             AuthorityRecords.create_authority_record(%{
+               label: "test label",
+               hint: "test hint"
+             })
+
+    assert {:error, %Ecto.Changeset{}} =
+             AuthorityRecords.create_authority_record(%{hint: "test hint"})
+  end
+
+  test "create_authority_record!/1" do
+    assert %NUL.Schemas.AuthorityRecord{} =
+             AuthorityRecords.create_authority_record!(%{
+               label: "test label",
+               hint: "test hint"
+             })
+
+    assert_raise Ecto.InvalidChangesetError, fn ->
+      AuthorityRecords.create_authority_record!(%{hint: "test hint"})
+    end
+  end
+
+  test "update_authority_record/2", %{authority_record: authority_record} do
+    assert {:ok, %NUL.Schemas.AuthorityRecord{label: "new label"}} =
+             AuthorityRecords.update_authority_record(authority_record, %{label: "new label"})
+  end
+
+  test "delete_authority_record/1", %{authority_record: authority_record} do
+    assert {:ok, _authority_record} = AuthorityRecords.delete_authority_record(authority_record)
+  end
+end

--- a/test/nul/authority_test.exs
+++ b/test/nul/authority_test.exs
@@ -1,0 +1,80 @@
+defmodule NUL.AuthorityTest do
+  use Meadow.DataCase
+
+  alias NUL.{Authority, AuthorityRecords}
+
+  setup do
+    authority_records = [
+      AuthorityRecords.create_authority_record!(%{
+        label: "Ver Steeg, Clarence L.",
+        hint: "(The Legend)"
+      }),
+      AuthorityRecords.create_authority_record!(%{
+        label: "Ver Steeg, Dorothy A."
+      }),
+      AuthorityRecords.create_authority_record!(%{
+        label: "steering committee"
+      }),
+      AuthorityRecords.create_authority_record!(%{label: "Netsch, Walter A."})
+    ]
+
+    {:ok, authority_record: List.first(authority_records)}
+  end
+
+  test "implements the Authoritex behaviour" do
+    assert Authority.__info__(:attributes)
+           |> get_in([:behaviour])
+           |> Enum.member?(Authoritex)
+  end
+
+  test "can_resolve?/1" do
+    assert Authority.can_resolve?("info:nul")
+    refute Authority.can_resolve?("info:fake/uri")
+  end
+
+  describe "introspection" do
+    test "code/0" do
+      assert Authority.code() == "nul-authority"
+    end
+
+    test "description/0" do
+      assert Authority.description() == "Northwestern University Libraries local authority"
+    end
+  end
+
+  describe "fetch/1" do
+    test "success", %{authority_record: authority_record} do
+      assert {:ok,
+              %{
+                label: "Ver Steeg, Clarence L.",
+                qualified_label: "Ver Steeg, Clarence L. (The Legend)",
+                hint: "(The Legend)"
+              }} = Authority.fetch(authority_record.id)
+    end
+
+    test "failure" do
+      assert {:error, 404} = Authority.fetch("info:nul/wrong")
+    end
+  end
+
+  describe "search/2" do
+    test "results" do
+      with {:ok, results} <- Authority.search("Ver Steeg") do
+        assert length(results) == 2
+      end
+
+      with {:ok, results} <-
+             Authority.search("Ver Steeg", 1) do
+        assert length(results) == 1
+      end
+
+      with {:ok, results} <- Authority.search("stee") do
+        assert Enum.all?(results, fn result -> String.match?(result.label, ~r/stee/i) end)
+      end
+    end
+
+    test "no results" do
+      assert {:ok, []} = Authority.search("M1551ng")
+    end
+  end
+end


### PR DESCRIPTION
- Adds NUL.Authority, a local Authoritex module for Northwestern University Libraries authority records. 
  - Includes a schema, migration, and tests. 
  - Adds the "nul-authority" to the authority.json file which wires up the authority search.
  - Adds the module to Meadow's `Authoritex` configs
  - Search functionality uses PostgresQL `ilike` query with wildcards

- Adds CRUD actions for NUL.Schema.AuthorityRecord to Meadow's GraphQL schema with queries and mutations, with tests.
  - Create NUL Authority Record GraphQL example:
```graphql
mutation {
  createNulAuthorityRecord(label:"Ver Steeg, Clarence L.", hint:"(The Legend)") {
    id
    hint
    label
  }
}
```

**Search:**
<img width="678" alt="search_results" src="https://user-images.githubusercontent.com/1395707/102407933-7e434b00-3fb2-11eb-8c0c-215895c08b55.png">

**Work Record:**
<img width="611" alt="work_with_nul_authority_record" src="https://user-images.githubusercontent.com/1395707/102407970-8e5b2a80-3fb2-11eb-89d3-36704bb3b267.png">

**Facet:**
<img width="836" alt="facet" src="https://user-images.githubusercontent.com/1395707/102407985-94510b80-3fb2-11eb-8507-50be0f9c5463.png">

