### PR TITLE
Support updateFileSets mutation on Work Structure tab

### DIFF
--- a/assets/js/components/UI/SearchBar.jsx
+++ b/assets/js/components/UI/SearchBar.jsx
@@ -21,7 +21,7 @@ const UISearchBar = () => {
         fuzziness="AUTO"
         icon={<FontAwesomeIcon icon="search" />}
         innerClass={{ input: "input is-medium" }}
-        queryFormat="and"
+        queryFormat="or"
         queryString={true} // supports complex search, wildcards, etc.
         placeholder="Search all works"
         react={{ and: [RESULT_SENSOR] }}

--- a/assets/js/components/Work/Tabs/Structure/DownloadAll.jsx
+++ b/assets/js/components/Work/Tabs/Structure/DownloadAll.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+function WorkTabsStructureDownloadAll(props) {
+  return (
+    <div className="box">
+      <h3 className="subtitle">Download all files as zip</h3>
+      <div className="columns">
+        <div className="column">
+          <div className="field">
+            <input
+              type="radio"
+              className="is-checkradio"
+              name="downloadsize"
+              id="downloadsize1"
+            />
+            <label htmlFor="downloadsize1"> Full size</label>
+            <input
+              type="radio"
+              className="is-checkradio"
+              name="downloadsize"
+              id="downloadsize2"
+            />
+            <label htmlFor="downloadsize2"> 3000x3000</label>
+            <input
+              type="radio"
+              className="is-checkradio"
+              name="downloadsize"
+              id="downloadsize3"
+            />
+            <label htmlFor="downloadsize3"> 1000x1000</label>
+          </div>
+        </div>
+
+        <div className="column buttons has-text-right">
+          <button className="button">Download Tiffs</button>
+          <button className="button">Download JPGs</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+WorkTabsStructureDownloadAll.propTypes = {};
+
+export default WorkTabsStructureDownloadAll;

--- a/assets/js/components/Work/Tabs/Structure/Fileset.jsx
+++ b/assets/js/components/Work/Tabs/Structure/Fileset.jsx
@@ -35,7 +35,7 @@ function WorkTabsStructureFileset({
                 isReactHookForm
                 required
                 label="Label"
-                name={`label-${fileSet.id}`}
+                name={`${fileSet.id}.label`}
                 data-testid="input-label"
                 placeholder="Label"
                 defaultValue={fileSet.metadata.label}
@@ -49,7 +49,7 @@ function WorkTabsStructureFileset({
             {isEditing ? (
               <UIFormTextarea
                 isReactHookForm
-                name={`metadataDescription-${fileSet.id}`}
+                name={`${fileSet.id}.description`}
                 data-testid="textarea-metadata-description"
                 defaultValue={fileSet.metadata.description}
                 label="Description"

--- a/assets/js/components/Work/work.gql.js
+++ b/assets/js/components/Work/work.gql.js
@@ -1,20 +1,6 @@
 import gql from "graphql-tag";
 
-export const UPDATE_FILE_SETS = gql`
-  mutation UpdateFileSets($id: ID!) {
-    updateFileSets(id: $id) @client {
-      id
-    }
-  }
-`;
 
-export const UPDATE_ACCESS_MASTER_ORDER = gql`
-  mutation UpdateAccessMasterOrder($workId: ID!, $fileSetIds: [ID]) {
-    updateAccessMasterOrder(workId: $workId, fileSetIds: $fileSetIds) {
-      id
-    }
-  }
-`;
 
 export const CREATE_SHARED_LINK = gql`
   mutation CreateSharedLink($workId: ID!) {
@@ -387,6 +373,26 @@ export const DELETE_WORK = gql`
       project {
         id
         title
+      }
+    }
+  }
+`;
+
+export const UPDATE_ACCESS_MASTER_ORDER = gql`
+  mutation UpdateAccessMasterOrder($workId: ID!, $fileSetIds: [ID]) {
+    updateAccessMasterOrder(workId: $workId, fileSetIds: $fileSetIds) {
+      id
+    }
+  }
+`;
+
+export const UPDATE_FILE_SETS = gql`
+  mutation UpdateFileSets($fileSets: [FileSetUpdate]!) {
+    updateFileSets(fileSets: $fileSets) {
+      id
+      metadata {
+        description
+        label
       }
     }
   }


### PR DESCRIPTION
This supports sending data to the `updateFileSets` mutation.  The form only sends file sets which have a "dirty" state, so if there are 100 file sets and the user updated 5 file sets, the incoming array to the mutation would contain 5 records.

Note: creating a new ticket to detangle separate the "update file sets" form from the "re-order file sets" form.  There's some confusion in monitoring form state values trying to combine them.  It works and is functional for now, but should be cleaned up in the future.

![image](https://user-images.githubusercontent.com/3020266/102536486-4a7a2b00-406f-11eb-90ac-d8337194ac8f.png)
