### PR TITLE
Add ordering to file sets in Work Preservation tab by filename

### DIFF
--- a/assets/js/components/Work/Tabs/Preservation.jsx
+++ b/assets/js/components/Work/Tabs/Preservation.jsx
@@ -8,12 +8,18 @@ import { DELETE_WORK, VERIFY_FILE_SETS } from "@js/components/Work/work.gql";
 import UIModalDelete from "@js/components/UI/Modal/Delete";
 import { useHistory } from "react-router-dom";
 import { Button } from "@nulib/admin-react-components";
-import { toastWrapper } from "@js/services/helpers";
+import { sortFileSets, toastWrapper } from "@js/services/helpers";
 import UISkeleton from "@js/components/UI/Skeleton";
 
 const WorkTabsPreservation = ({ work }) => {
+  if (!work) return null;
+
   const history = useHistory();
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [orderedFileSets, setOrderedFileSets] = useState({
+    order: "asc",
+    fileSets: sortFileSets({ fileSets: work.fileSets }),
+  });
 
   const {
     data: verifyFileSetsData,
@@ -64,6 +70,16 @@ const WorkTabsPreservation = ({ work }) => {
   const handleDeleteClick = () => {
     deleteWork({ variables: { workId: work.id } });
   };
+
+  const handleOrderClick = () => {
+    const order = orderedFileSets.order === "asc" ? "desc" : "asc";
+    const fileSets = sortFileSets({
+      order,
+      fileSets: orderedFileSets.fileSets,
+    });
+    setOrderedFileSets({ order, fileSets });
+  };
+
   const onOpenModal = () => {
     setDeleteModalOpen(true);
   };
@@ -84,7 +100,20 @@ const WorkTabsPreservation = ({ work }) => {
             <tr>
               <th className="is-hidden">ID</th>
               <th>Role</th>
-              <th>Filename</th>
+              <th className="is-flex">
+                <FontAwesomeIcon
+                  icon={[
+                    "fas",
+                    orderedFileSets.order === "asc"
+                      ? "sort-alpha-down"
+                      : "sort-alpha-down-alt",
+                  ]}
+                  className="icon"
+                />
+                <a className="ml-2" onClick={handleOrderClick}>
+                  Filename
+                </a>
+              </th>
               <th>Checksum</th>
               <th>s3 Key</th>
               <th className="has-text-centered">Verified</th>
@@ -94,8 +123,8 @@ const WorkTabsPreservation = ({ work }) => {
             </tr>
           </thead>
           <tbody>
-            {work.fileSets &&
-              work.fileSets.map((fileset) => {
+            {orderedFileSets.fileSets.length > 0 &&
+              orderedFileSets.fileSets.map((fileset) => {
                 const metadata = fileset.metadata;
                 return (
                   <tr key={fileset.id} data-testid="preservation-row">

--- a/assets/js/font-awesome-setup.js
+++ b/assets/js/font-awesome-setup.js
@@ -1,5 +1,6 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { fab } from "@fortawesome/free-brands-svg-icons";
+import { fas } from "@fortawesome/free-solid-svg-icons";
 import {
   faAngleDown,
   faBell,
@@ -33,6 +34,8 @@ import {
   faProjectDiagram,
   faSearch,
   faSort,
+  faSortAlphaDown,
+  faSortAlphaDownAlt,
   faSync,
   faThumbsUp,
   faTimes,
@@ -46,6 +49,7 @@ import {
 export default function setupFontAwesome() {
   return library.add(
     fab,
+    fas,
     faAngleDown,
     faBell,
     faCheck,
@@ -77,6 +81,8 @@ export default function setupFontAwesome() {
     faProjectDiagram,
     faSearch,
     faSort,
+    faSortAlphaDown,
+    faSortAlphaDownAlt,
     faSync,
     faThumbsUp,
     faTimes,

--- a/assets/js/services/helpers.js
+++ b/assets/js/services/helpers.js
@@ -68,32 +68,6 @@ export const TEMP_USER_FRIENDLY_STATUS = {
   COMPLETED: "Ingest Complete",
 };
 
-export function toastWrapper(
-  type = "is-info",
-  message = "Whoops, You forgot to include a message!"
-) {
-  return toast({
-    message,
-    type,
-    dismissible: true,
-    duration: 5000,
-    position: "top-center",
-  });
-}
-
-export function setVisibilityClass(visibility = "") {
-  if (visibility.toUpperCase() === "RESTRICTED") {
-    return "is-danger";
-  }
-  if (visibility.toUpperCase() === "AUTHENTICATED") {
-    return "is-primary";
-  }
-  if (visibility.toUpperCase() === "OPEN") {
-    return "is-success";
-  }
-  return "";
-}
-
 export function prepWorkItemForDisplay(res) {
   return {
     id: res._id,
@@ -110,4 +84,57 @@ export function prepWorkItemForDisplay(res) {
     accessionNumber: res.accessionNumber,
     workType: res.workType,
   };
+}
+
+export function setVisibilityClass(visibility = "") {
+  if (visibility.toUpperCase() === "RESTRICTED") {
+    return "is-danger";
+  }
+  if (visibility.toUpperCase() === "AUTHENTICATED") {
+    return "is-primary";
+  }
+  if (visibility.toUpperCase() === "OPEN") {
+    return "is-success";
+  }
+  return "";
+}
+
+/**
+ * Helper function which orders an array of fileset objects by metadata.originalFilename
+ * @param {Object} obj Object map of params
+ * @param {String} obj.order Order preference: "asc" or "desc"
+ * @param {Array} obj.fileSets file sets to order
+ * @returns {Array}
+ */
+export function sortFileSets({ order = "asc", fileSets = [] }) {
+  const orderedFileSets = [...fileSets].sort((a, b) => {
+    const aName = a.metadata.originalFilename;
+    const bName = b.metadata.originalFilename;
+
+    if (aName === bName) return 0;
+
+    switch (order) {
+      case "asc":
+        return aName < bName ? -1 : 1;
+      case "desc":
+        return aName < bName ? 1 : -1;
+      default:
+        break;
+    }
+  });
+
+  return orderedFileSets;
+}
+
+export function toastWrapper(
+  type = "is-info",
+  message = "Whoops, You forgot to include a message!"
+) {
+  return toast({
+    message,
+    type,
+    dismissible: true,
+    duration: 5000,
+    position: "top-center",
+  });
 }

--- a/assets/js/services/helpers.test.js
+++ b/assets/js/services/helpers.test.js
@@ -5,6 +5,7 @@ import {
   getClassFromIngestSheetStatus,
   isUrlValid,
   getImageUrl,
+  sortFileSets,
 } from "./helpers";
 
 it("should escape double quotes", () => {
@@ -79,5 +80,67 @@ describe("IngestSheet status CSS-Class function", () => {
   it("should return empty", () => {
     const actual = getClassFromIngestSheetStatus();
     expect(actual).toBe("");
+  });
+});
+
+describe("Sort file sets", () => {
+  const originalFileSets = [
+    {
+      id: "2357ea03-9dd5-49f2-a88c-dfc9aa88be3c",
+      role: "AM",
+      accessionNumber: "inu-fava-5145080_FILE_0",
+      metadata: {
+        __typename: "FileSetMetadata",
+        description: "inu-fava-5145080-6.tif",
+        originalFilename: "BBBBBBB.jpg",
+        label: "inu-fava-5145080-6.jpg",
+        location:
+          "s3://dev-preservation/23/57/ea/03/83397074acde5c737ede5ea7b09b267940d1ddba93eaef2456ae85c928e7abe2",
+        sha256:
+          "83397074acde5c737ede5ea7b09b267940d1ddba93eaef2456ae85c928e7abe2",
+      },
+    },
+    {
+      id: "26357d25-b5e0-4e27-b683-c6844a13dc6b",
+      role: "AM",
+      accessionNumber: "inu-fava-5145080_FILE_1",
+      metadata: {
+        __typename: "FileSetMetadata",
+        description: "inu-fava-5145080-5.tif",
+        originalFilename: "CCCCCC.jpg",
+        label: "inu-fava-5145080-5.jpg",
+        location:
+          "s3://dev-preservation/26/35/7d/25/033a20e54f4ef254749c0e554e0378ba96242be159c7ed6e8d57810297423f69",
+        sha256:
+          "033a20e54f4ef254749c0e554e0378ba96242be159c7ed6e8d57810297423f69",
+      },
+    },
+    {
+      id: "0607a735-9f99-4d38-b75a-6c10027f0937",
+      role: "AM",
+      accessionNumber: "inu-fava-5145080_FILE_2",
+      metadata: {
+        __typename: "FileSetMetadata",
+        description: "inu-fava-5145080-1.tif",
+        originalFilename: "AAAAA.jpg",
+        label: "inu-fava-5145080-1.jpg",
+        location:
+          "s3://dev-preservation/06/07/a7/35/e3420d439e9770bdc804a19c559ca818120f67e81c303a92a33f774eab199056",
+        sha256:
+          "e3420d439e9770bdc804a19c559ca818120f67e81c303a92a33f774eab199056",
+      },
+    },
+  ];
+
+  it("should order file sets in ascending order", () => {
+    const sorted = sortFileSets({ fileSets: originalFileSets });
+    expect(sorted[0].metadata.originalFilename).toEqual("AAAAA.jpg");
+    expect(sorted[2].metadata.originalFilename).toEqual("CCCCCC.jpg");
+  });
+
+  it("should order file sets in descending order", () => {
+    const sorted = sortFileSets({ order: "desc", fileSets: originalFileSets });
+    expect(sorted[2].metadata.originalFilename).toEqual("AAAAA.jpg");
+    expect(sorted[0].metadata.originalFilename).toEqual("CCCCCC.jpg");
   });
 });


### PR DESCRIPTION
This adds ordering to File sets in the Work Preservation tab.  

- File sets are ordered ascending by default
- Ordering happens on the file set's `metadata.originalFilename` value.


![image](https://user-images.githubusercontent.com/3020266/102642877-f41af400-4123-11eb-815c-ca91a96f8547.png)

![image](https://user-images.githubusercontent.com/3020266/102642915-05640080-4124-11eb-921c-b8bbee9f52f8.png)
