### PR TITLE
Refactor FileSetModal

### DIFF
--- a/assets/js/components/Work/Tabs/Preservation.jsx
+++ b/assets/js/components/Work/Tabs/Preservation.jsx
@@ -10,7 +10,7 @@ import { useHistory } from "react-router-dom";
 import { Button } from "@nulib/admin-react-components";
 import { sortFileSets, toastWrapper } from "@js/services/helpers";
 import UISkeleton from "@js/components/UI/Skeleton";
-import FileSetModal from "@js/components/Work/Tabs/Preservation/FileSetModal";
+import WorkTabsPreservationFileSetModal from "@js/components/Work/Tabs/Preservation/FileSetModal";
 
 const WorkTabsPreservation = ({ work }) => {
   if (!work) return null;
@@ -42,6 +42,13 @@ const WorkTabsPreservation = ({ work }) => {
       history.push(`/project/${project.id}/ingest-sheet/${ingestSheet.id}`);
     },
   });
+
+  React.useEffect(() => {
+    setOrderedFileSets({
+      ...orderedFileSets,
+      fileSets: sortFileSets({ fileSets: work.fileSets }),
+    });
+  }, [work.fileSets]);
 
   if (verifyFileSetsError)
     return (
@@ -178,7 +185,7 @@ const WorkTabsPreservation = ({ work }) => {
               })}
           </tbody>
         </table>
-        <FileSetModal
+        <WorkTabsPreservationFileSetModal
           closeModal={() => setIsModalHidden(true)}
           isHidden={isModalHidden}
           workId={work.id}

--- a/assets/js/components/Work/Tabs/Preservation/FileSetDropzone.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/FileSetDropzone.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useDropzone } from "react-dropzone";
+import { formatBytes } from "@js/services/helpers";
 
 /** @jsx jsx */
 import { css, jsx } from "@emotion/core";
@@ -10,7 +11,11 @@ const dropZone = css`
   border: 3px dashed #ccc;
 `;
 
-function WorkTabsPreservationFileSetDropzone({ currentFile, handleSetFile }) {
+function WorkTabsPreservationFileSetDropzone({
+  currentFile,
+  handleSetFile,
+  uploadProgress,
+}) {
   // Handle file drop
   const onDrop = React.useCallback((acceptedFiles) => {
     handleSetFile(acceptedFiles[0]);
@@ -23,56 +28,68 @@ function WorkTabsPreservationFileSetDropzone({ currentFile, handleSetFile }) {
     isDragReject,
   } = useDropzone({
     onDrop,
-    accept: "image/tiff, image/jpeg",
-    maxFiles: 1,
+    accept: "image/tiff, image/jpeg, image/jpg",
+    multiple: false,
   });
 
+  const handleDelete = () => {
+    handleSetFile(null);
+  };
+
   return (
-    <div>
-      <div
-        {...getRootProps()}
-        className="p-6 is-clickable has-text-centered"
-        css={dropZone}
-      >
-        <input {...getInputProps()} />
-        <p>
-          <FontAwesomeIcon
-            icon="file-image"
-            size="2x"
-            className="has-text-grey mr-3"
-          />
-          {!isDragActive &&
-            "Drag 'n' drop a file here, or click to select file"}
-          {isDragActive &&
-            !isDragReject &&
-            "Drag 'n' drop a file here, or click to select file"}
-          {isDragReject && "File type not accepted, sorry!"}
-        </p>
-      </div>
-      {currentFile && (
-        <React.Fragment>
-          <p className="mt-5 pb-0 mb-0 subtitle">Current file</p>
-          <table className="table is-fullwidth">
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Path</th>
-                <th>Size</th>
-                <th>Type</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>{currentFile.name}</td>
-                <td>{currentFile.path}</td>
-                <td>{currentFile.size}</td>
-                <td>{currentFile.type}</td>
-              </tr>
-            </tbody>
-          </table>
-        </React.Fragment>
+    <section className="modal-card-body">
+      {!uploadProgress && (
+        <div
+          {...getRootProps()}
+          className="p-6 is-clickable has-text-centered"
+          css={dropZone}
+        >
+          <input {...getInputProps()} />
+          <p>
+            <FontAwesomeIcon
+              icon="file-image"
+              size="2x"
+              className="has-text-grey mr-3"
+            />
+            {!isDragActive &&
+              "Drag 'n' drop a file here, or click to select file"}
+            {isDragActive &&
+              !isDragReject &&
+              "Drag 'n' drop a file here, or click to select file"}
+            {isDragReject && "File type not accepted, sorry!"}
+          </p>
+        </div>
       )}
-    </div>
+
+      {currentFile && uploadProgress === 100 && (
+        <div className="notification is-light is-success">
+          <button onClick={handleDelete} className="delete"></button>
+          <p>
+            <strong>{currentFile.name}</strong>
+            <br />
+            <small>{formatBytes(currentFile.size)}</small>
+            <br />
+            File uploaded successfully
+          </p>
+        </div>
+      )}
+
+      {currentFile && uploadProgress < 100 && (
+        <div className="notification is-light">
+          <p>
+            <strong>{currentFile.name}</strong>
+            <br />
+            <small>Uploading {formatBytes(currentFile.size)}</small>
+          </p>
+          <progress
+            className="progress is-primary is-small"
+            value={uploadProgress}
+            max="100"
+          ></progress>
+          <p>({Math.round(Number(uploadProgress))}%)</p>
+        </div>
+      )}
+    </section>
   );
 }
 

--- a/assets/js/components/Work/Tabs/Preservation/FileSetForm.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/FileSetForm.jsx
@@ -1,0 +1,66 @@
+import React from "react";
+import PropTypes from "prop-types";
+import UIFormInput from "@js/components/UI/Form/Input.jsx";
+import UIFormField from "@js/components/UI/Form/Field.jsx";
+import UIFormSelect from "@js/components/UI/Form/Select.jsx";
+import { FILE_SET_ROLES } from "@js/services/global-vars";
+import Error from "@js/components/UI/Error";
+
+function WorkTabsPreservationFileSetForm({ s3UploadLocation }) {
+  return (
+    <>
+      {s3UploadLocation && (
+        <div>
+          <UIFormField label="Accession number">
+            <UIFormInput
+              isReactHookForm
+              required
+              label="FileSet label"
+              data-testid="fileset-accession-number-input"
+              name="accessionNumber"
+              placeholder="accession number"
+            />
+          </UIFormField>
+
+          <UIFormField label="Label">
+            <UIFormInput
+              isReactHookForm
+              required
+              label="FileSet label"
+              data-testid="fileset-label-input"
+              name="label"
+              placeholder="Fileset label"
+            />
+          </UIFormField>
+
+          <UIFormField label="Description">
+            <UIFormInput
+              isReactHookForm
+              required
+              label="FileSet description"
+              data-testid="fileset-description-input"
+              name="description"
+              placeholder="Description of the Fileset"
+            />
+          </UIFormField>
+
+          <UIFormField label="Role">
+            <UIFormSelect
+              isReactHookForm
+              name="role"
+              label="Fileset Role"
+              options={FILE_SET_ROLES}
+              data-testid="fileset-role-input"
+            />
+          </UIFormField>
+        </div>
+      )}
+    </>
+  );
+}
+
+WorkTabsPreservationFileSetForm.propTypes = {
+  s3UploadLocation: PropTypes.string,
+};
+
+export default WorkTabsPreservationFileSetForm;

--- a/assets/js/components/Work/Tabs/Preservation/FileSetModal.test.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/FileSetModal.test.jsx
@@ -37,14 +37,4 @@ describe("Add fileset to work modal", () => {
   it("renders fileset form", async () => {
     expect(await screen.findByTestId("fileset-form"));
   });
-
-  it("displays input error when the required fields label and description have no value", async () => {
-    await waitFor(() => {
-      const el = screen.getByTestId("fileset-accession-number-input");
-      expect(el);
-      userEvent.type(el, "abc124");
-      userEvent.click(screen.getByTestId("submit-button"));
-    });
-    expect(screen.getAllByTestId("input-errors")).toHaveLength(2);
-  });
 });

--- a/assets/js/services/helpers.js
+++ b/assets/js/services/helpers.js
@@ -142,3 +142,12 @@ export function toastWrapper(
 export function s3Location(presignedUrl) {
   return `s3://${presignedUrl.split("?")[0].split("/").slice(-3).join("/")}`;
 }
+
+export function formatBytes(bytes, decimals) {
+  if (bytes == 0) return "0 Bytes";
+  var k = 1024,
+    dm = decimals || 2,
+    sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"],
+    i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
+}


### PR DESCRIPTION
Refactors the FileSetModal
- breaks out into components
- Changes the flow:
   - uploads the file (with progress bar) immediately when dropped
   - hides the drop zone once a file has been dropped
   - shows the input fields once the upload is successful
   - handles aborting the upload (if someone closes the modal with the upload in progress)
   - displays GraphQL errors and file Upload errors (as well as an unlikely presigned url error)


<img width="963" alt="Screen Shot 2020-12-23 at 11 19 35 AM" src="https://user-images.githubusercontent.com/6372022/103033942-fd8bce00-4520-11eb-9a93-e809bfc5f1c7.png">


<img width="788" alt="Screen Shot 2020-12-23 at 11 18 20 AM" src="https://user-images.githubusercontent.com/6372022/103033965-0c728080-4521-11eb-9052-07ac71d10a5f.png">
