### PR TITLE
Better UX for handling Ingest Sheet upload cancel and errors

### DIFF
--- a/assets/js/components/IngestSheet/ingestSheet.gql.js
+++ b/assets/js/components/IngestSheet/ingestSheet.gql.js
@@ -37,7 +37,7 @@ export const CREATE_INGEST_SHEET = gql`
   ) {
     createIngestSheet(
       title: $title
-      project_id: $projectId
+      projectId: $projectId
       filename: $filename
     ) {
       id

--- a/assets/js/screens/IngestSheet/IngestSheet.jsx
+++ b/assets/js/screens/IngestSheet/IngestSheet.jsx
@@ -109,7 +109,7 @@ const ScreensIngestSheet = ({ match }) => {
                       sheetId={sheetId}
                       projectId={id}
                       status={sheetData.ingestSheet.status}
-                      name={sheetData.ingestSheet.title}
+                      title={sheetData.ingestSheet.title}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
Improve the UX for handling the Cancel operation uploading an ingest sheet.  Also supports error handling for grabbing the presigned url for upload location, along with displaying any custom error messages the API provides for errors in the Create Ingest Sheet mutation.

![image](https://user-images.githubusercontent.com/3020266/103581822-5acd3b00-4ea2-11eb-8f5d-2c486cb38150.png)



