### PR TITLE
Add temporary donut_works table for migration

### DIFF
--- a/lib/meadow/data/donut_works.ex
+++ b/lib/meadow/data/donut_works.ex
@@ -1,0 +1,56 @@
+defmodule Meadow.Data.DonutWorks do
+  @moduledoc """
+  The DonutWorks context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Meadow.Data.Schemas.DonutWork
+  alias Meadow.Repo
+
+  def get_donut_work(id) do
+    DonutWork
+    |> Repo.get(id)
+  end
+
+  def get_donut_work!(id) do
+    DonutWork
+    |> Repo.get!(id)
+  end
+
+  def list_donut_works do
+    DonutWork
+    |> Repo.all()
+  end
+
+  def create_donut_work(attrs) do
+    %DonutWork{}
+    |> DonutWork.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def create_donut_work!(attrs) do
+    %DonutWork{}
+    |> DonutWork.changeset(attrs)
+    |> Repo.insert!()
+  end
+
+  def update_donut_work(%DonutWork{} = donut_work, attrs) do
+    donut_work
+    |> DonutWork.changeset(attrs)
+    |> Repo.update()
+  end
+
+  def update_donut_work!(%DonutWork{} = donut_work, attrs) do
+    donut_work
+    |> DonutWork.changeset(attrs)
+    |> Repo.update!()
+  end
+
+  def delete_donut_work(%DonutWork{} = donut_work) do
+    Repo.delete(donut_work)
+  end
+
+  def reset! do
+    Repo.delete_all(DonutWork)
+  end
+end

--- a/lib/meadow/data/schemas/donut_work.ex
+++ b/lib/meadow/data/schemas/donut_work.ex
@@ -1,0 +1,27 @@
+defmodule Meadow.Data.Schemas.DonutWork do
+  @moduledoc """
+  Information about works to migrate from Donut
+  """
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @primary_key false
+  @timestamps_opts [type: :utc_datetime_usec]
+  schema "donut_works" do
+    field :work_id, Ecto.UUID, primary_key: true
+    field :status, :string, default: "pending"
+    field :error, :string
+
+    timestamps()
+  end
+
+  def changeset(donut_work, params \\ %{}) do
+    donut_work
+    |> cast(params, [
+      :work_id,
+      :status,
+      :error
+    ])
+  end
+end

--- a/priv/repo/migrations/20210107210453_create_donut_works.exs
+++ b/priv/repo/migrations/20210107210453_create_donut_works.exs
@@ -1,0 +1,13 @@
+defmodule Meadow.Repo.Migrations.CreateDonutWorks do
+  use Ecto.Migration
+
+  def change do
+    create table(:donut_works, primary_key: false) do
+      add :work_id, :binary_id, primary_key: true
+      add :status, :string
+      add :error, :string
+
+      timestamps()
+    end
+  end
+end

--- a/test/meadow/data/donut_works_test.exs
+++ b/test/meadow/data/donut_works_test.exs
@@ -1,0 +1,45 @@
+defmodule Meadow.Data.DonutWorksTest do
+  use Meadow.DataCase
+
+  alias Meadow.Data.DonutWorks
+  alias Meadow.Data.Schemas.DonutWork
+
+  describe "queries" do
+    @valid_attrs %{
+      work_id: Ecto.UUID.bingenerate()
+    }
+
+    @invalid_attrs %{work_id: "blah"}
+
+    test "create_donut_work/1 with valid data creates a donut_work" do
+      assert {:ok, %DonutWork{} = _donut_work} = DonutWorks.create_donut_work(@valid_attrs)
+    end
+
+    test "create_donut_work/1 with invalid data does not create a donut_work" do
+      assert {:error, %Ecto.Changeset{}} = DonutWorks.create_donut_work(@invalid_attrs)
+    end
+
+    test "delete_donut_work/1 deletes a donut_work" do
+      donut_work = DonutWorks.create_donut_work!(@valid_attrs)
+
+      assert {:ok, %DonutWork{} = _donut_work} = DonutWorks.delete_donut_work(donut_work)
+      assert Enum.empty?(DonutWorks.list_donut_works())
+    end
+
+    test "update_donut_work/2 updates a donut_work" do
+      donut_work = DonutWorks.create_donut_work!(@valid_attrs)
+
+      assert {:ok, %DonutWork{} = donut_work} =
+               DonutWorks.update_donut_work(donut_work, %{status: "error", error: "failed"})
+
+      assert donut_work.status == "error"
+    end
+
+    test "update_donut_work/2 with invalid attributes returns an error" do
+      donut_work = DonutWorks.create_donut_work!(@valid_attrs)
+
+      assert {:error, %Ecto.Changeset{}} =
+               DonutWorks.update_donut_work(donut_work, %{work_id: 123})
+    end
+  end
+end


### PR DESCRIPTION
Migration, Ecto Schema and Phoenix context for the table we are going to store work_ids extracted from Donut for migration