### PR TITLE
Add id to collection changeset cast

### DIFF
--- a/lib/meadow/data/schemas/collection.ex
+++ b/lib/meadow/data/schemas/collection.ex
@@ -35,6 +35,7 @@ defmodule Meadow.Data.Schemas.Collection do
   def changeset(collection, params \\ %{}) do
     collection
     |> cast(params, [
+      :id,
       :admin_email,
       :description,
       :featured,

--- a/test/meadow/data/collections/collection_test.exs
+++ b/test/meadow/data/collections/collection_test.exs
@@ -28,5 +28,16 @@ defmodule Meadow.Data.Schemas.CollectionTest do
       assert {:error, changeset} = Repo.insert(collection2)
       assert {"has already been taken", _} = changeset.errors[:title]
     end
+
+    test "you can supply an id when you create a collection" do
+      uuid = Ecto.UUID.bingenerate()
+
+      {:ok, collection} =
+        %Collection{}
+        |> Collection.changeset(Map.merge(@valid_attrs, %{id: uuid}))
+        |> Repo.insert()
+
+      assert {:ok, collection.id} == Ecto.UUID.load(uuid)
+    end
   end
 end


### PR DESCRIPTION
For migration we need to be able to pass in the id in order to preserve donut url's