### PR TITLE
Use the command line to configure which processes to start

### DIFF
--- a/lib/meadow/application/children.ex
+++ b/lib/meadow/application/children.ex
@@ -7,40 +7,87 @@ defmodule Meadow.Application.Children do
   alias Meadow.Utils.ArkClient
   require Logger
 
+  @basic_processes %{
+    "batch_driver" => Meadow.BatchDriver,
+    "index_worker" => {Meadow.Data.IndexWorker, interval: Config.index_interval()},
+    "manifest_listener" => Meadow.IIIF.ManifestListener,
+    "work_creator" => [Meadow.Ingest.WorkCreator, Meadow.Ingest.WorkRedriver]
+  }
+
+  @pipeline_processes Meadow.Pipeline.children()
+                      |> Enum.map(fn {action, _} = spec ->
+                        key =
+                          "pipeline." <>
+                            (action |> Module.split() |> List.last() |> Inflex.underscore())
+
+                        {key, spec}
+                      end)
+                      |> Enum.into(%{})
+
+  @web_processes %{
+    "web.server" => [
+      MeadowWeb.Endpoint,
+      {Absinthe.Subscription, MeadowWeb.Endpoint}
+    ],
+    "web.notifiers" => [
+      {Meadow.Ingest.Progress, interval: Config.progress_ping_interval()},
+      Meadow.Ingest.SheetNotifier
+    ]
+  }
+
+  @all_processes @basic_processes |> Map.merge(@pipeline_processes) |> Map.merge(@web_processes)
+
+  @process_aliases %{
+    "all" => @all_processes |> Enum.map(fn {key, _} -> key end),
+    "none" => [],
+    "basic" => @basic_processes |> Enum.map(fn {key, _} -> key end),
+    "pipeline" => @pipeline_processes |> Enum.map(fn {key, _} -> key end),
+    "web" => @web_processes |> Enum.map(fn {key, _} -> key end)
+  }
+
+  @doc """
+  Produce a list of child specs to start under the main supervisor based
+  on the current environment
+  """
   def specs do
-    (Caches.specs(Config.environment()) ++
-       specs(Config.environment()))
-    |> Enum.reject(&is_nil/1)
+    with env <- Config.environment() do
+      (Caches.specs(env) ++ specs(env))
+      |> Enum.reject(&is_nil/1)
+    end
   end
 
   defp specs(:dev) do
-    [mock_ark_server(3943) | workers(System.get_env("NO_WORKERS", nil))]
+    [mock_ark_server(3943) | workers(Config.workers())]
   end
 
   defp specs(:test) do
-    [EDTF, mock_ark_server(3944)]
+    [mock_ark_server(3944) | workers(["web.server"])]
   end
 
   defp specs(:prod) do
-    workers(System.get_env("NO_WORKERS", nil))
+    workers(Config.workers())
   end
 
-  defp workers(nil) do
-    [
-      EDTF,
-      Meadow.BatchDriver,
-      {Meadow.Data.IndexWorker, interval: Config.index_interval()},
-      Meadow.IIIF.ManifestListener,
-      {Meadow.Ingest.Progress, interval: Config.progress_ping_interval()},
-      Meadow.Ingest.SheetNotifier,
-      Meadow.Ingest.WorkCreator,
-      Meadow.Ingest.WorkRedriver
-    ]
+  def processes("aliases"), do: @process_aliases
+  def processes("all"), do: @all_processes
+  def processes("basic"), do: @basic_processes
+  def processes("pipeline"), do: @pipeline_processes
+  def processes("web"), do: @web_processes
+  def processes(_), do: []
+
+  defp expand_workers(workers) do
+    workers
+    |> Enum.map(fn worker -> Map.get(@process_aliases, worker, worker) end)
+    |> List.flatten()
+    |> Enum.uniq()
   end
 
-  defp workers(_) do
-    Logger.warn("Skipping background workers because NO_WORKERS is set")
-    []
+  defp workers(workers) do
+    workers
+    |> expand_workers()
+    |> Enum.map(fn worker -> Map.get(@all_processes, worker) end)
+    |> Enum.reject(&is_nil/1)
+    |> List.flatten()
   end
 
   defp mock_ark_server(port) do

--- a/lib/meadow/config.ex
+++ b/lib/meadow/config.ex
@@ -151,6 +151,12 @@ defmodule Meadow.Config do
   def validation_ping_interval,
     do: configured_integer_value(:validation_ping_interval, :timer.seconds(15))
 
+  def workers do
+    System.get_env("MEADOW_PROCESSES", "ALL")
+    |> String.split(~r/\s*,\s*/)
+    |> Enum.map(&Inflex.underscore/1)
+  end
+
   defp configured_integer_value(key, default \\ 0) do
     case Application.get_env(:meadow, key, default) do
       n when is_binary(n) -> String.to_integer(n)

--- a/lib/meadow/release_tasks.ex
+++ b/lib/meadow/release_tasks.ex
@@ -15,7 +15,7 @@ defmodule Meadow.ReleaseTasks do
 
   def migrate do
     Logger.info("Starting Meadow")
-    System.put_env("NO_WORKERS", "true")
+    System.put_env("MEADOW_PROCESSES", "none")
     Application.ensure_all_started(@app)
     pause!()
 

--- a/lib/mix/tasks/meadow.ex
+++ b/lib/mix/tasks/meadow.ex
@@ -93,3 +93,27 @@ defmodule Mix.Tasks.Meadow.Seed do
     end)
   end
 end
+
+defmodule Mix.Tasks.Meadow.Processes do
+  @moduledoc """
+  Display a list of available processes
+  """
+
+  alias Meadow.Application.Children
+
+  def run(_) do
+    [
+      {"Web processes", Children.processes("web")},
+      {"Basic processes", Children.processes("basic")},
+      {"Pipeline processes", Children.processes("pipeline")},
+      {"Aliases", Children.processes("aliases")}
+    ]
+    |> Enum.map(fn {label, workers} ->
+      ["#{label}:", workers |> Enum.map(fn {name, _} -> "  #{name}" end), ""]
+    end)
+    |> List.flatten()
+    |> Enum.join("\n")
+    |> String.trim()
+    |> IO.puts()
+  end
+end

--- a/test/meadow/application/children_test.exs
+++ b/test/meadow/application/children_test.exs
@@ -1,0 +1,50 @@
+defmodule Meadow.Application.ChildrenTest do
+  use ExUnit.Case
+
+  alias Meadow.Application.Children
+  alias Meadow.Config
+
+  describe "specs/0" do
+    setup tags do
+      with old_env <- Config.environment() do
+        Application.put_env(:meadow, :environment, Map.get(tags, :environment, old_env))
+
+        on_exit(fn ->
+          Application.put_env(:meadow, :environment, old_env)
+        end)
+      end
+    end
+
+    @tag environment: :dev
+    test "dev processes" do
+      assert Children.specs() |> length() >= 10
+    end
+
+    @tag environment: :test
+    test "test processes" do
+      assert Children.specs() |> length() <= 10
+    end
+
+    @tag environment: :prod
+    test "prod processes" do
+      with specs <- Children.specs() do
+        assert specs |> length() >= 10
+
+        refute Enum.find(specs, fn
+                 {_, args} when is_list(args) ->
+                   args[:plug] == Meadow.Utils.ArkClient.MockServer
+
+                 _ ->
+                   false
+               end)
+      end
+    end
+  end
+
+  test "processes/1" do
+    ~w(aliases all basic pipeline web)
+    |> Enum.each(fn group ->
+      assert is_map(Children.processes(group))
+    end)
+  end
+end

--- a/test/mix/tasks/meadow_test.exs
+++ b/test/mix/tasks/meadow_test.exs
@@ -1,0 +1,14 @@
+defmodule Mix.Tasks.Meadow.ProcessesTest do
+  use ExUnit.Case
+
+  import ExUnit.CaptureIO
+
+  test "mix meadow.processes" do
+    with output <- capture_io(fn -> Mix.Task.run("meadow.processes") end) do
+      assert output =~ ~r/Web processes:/
+      assert output =~ ~r/Basic processes:/
+      assert output =~ ~r/Pipeline processes:/
+      assert output =~ ~r/Aliases:/
+    end
+  end
+end


### PR DESCRIPTION
## Description

Allows granular selection of which Meadow processes to run on startup using the command line

## Mix Task

```
$ mix meadow.processes
Web processes:
  web.notifiers
  web.server

Basic processes:
  batch_driver
  index_worker
  manifest_listener
  work_creator

Pipeline processes:
  pipeline.copy_file_to_preservation
  pipeline.create_pyramid_tiff
  pipeline.file_set_complete
  pipeline.generate_file_set_digests
  pipeline.ingest_file_set

Aliases:
  all
  basic
  none
  pipeline
  web
```

## Startup

Use the `MEADOW_PROCESSES` variable to supply a comma-delimited list of processes to start. The default is `all`.

Examples:

```
# Start the web server
$ MEADOW_PROCESSES=web iex -S mix phx.server

# Start the background tasks but not the ingest pipeline
$ MEADOW_PROCESSES=basic iex -S mix phx.server

# Start the background tasks and the ingest pipeline
$ MEADOW_PROCESSES=basic,pipeline iex -S mix phx.server

# Start the background tasks and only the low-footprint parts of the ingest pipeline.
$ MEADOW_PROCESSES=basic,pipeline.ingest_file_set,pipeline.copy_file_to_preservation,pipeline.file_set_complete iex -S mix phx.server

# Start a dedicated process just to generate file set digests
$ MEADOW_PROCESSES=pipeline.generate_file_set_digests iex -S mix phx.server

# Start a dedicated process just to create pyramid TIFFs
$ MEADOW_PROCESSES=pipeline.generate_file_set_digests iex -S mix phx.server
```

## Testing

(The following will be incredibly resource-hungry. Close any unnecessary processes before you try it.)

1. In separate tabs or windows, start instances with different sets of processes, e.g.:

      ```
      $ MEADOW_PROCESSES=web iex -S mix phx.server
      $ MEADOW_PROCESSES=basic iex -S mix phx.server
      $ MEADOW_PROCESSES=pipeline.ingest_file_set,pipeline.copy_file_to_preservation,pipeline.file_set_complete iex -S mix phx.server
      $ MEADOW_PROCESSES=pipeline.generate_file_set_digests iex -S mix phx.server
      $ MEADOW_PROCESSES=pipeline.create_pyramid_tiff iex -S mix phx.server
      ```

2. Start an ingest from the front end UI.
3. Watch the progress indicator in the UI and the logs of the terminal instances until the ingest is complete.

## Notes

- The `web.server` and `web.notifiers` tasks aren't really severable, and you'll get errors if you try to run one without the other. They're only separated in the code to make testing easier. Just use `web` to be safe.
- Everything should be scalable and behave well when run concurrently (e.g., same process is started in more than one instance). But this is very hard to test on a laptop.