### PR TITLE
Add error boundaries to screen components to protect their child comp…

### DIFF
--- a/assets/js/components/Collection/List.jsx
+++ b/assets/js/components/Collection/List.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import PropTypes from "prop-types";
+import CollectionListRow from "../../components/Collection/ListRow";
+
+function CollectionList({ collections, filteredCollections, onOpenModal }) {
+  return (
+    <div>
+      <ul>
+        {filteredCollections.length > 0 &&
+          filteredCollections.map((collection) => (
+            <CollectionListRow
+              key={collection.id}
+              collection={collection}
+              onOpenModal={onOpenModal}
+            />
+          ))}
+      </ul>
+      {collections.length === 0 && (
+        <div className="content">
+          <p className="notification">No collections returned</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+CollectionList.propTypes = {
+  collections: PropTypes.array,
+  filteredCollections: PropTypes.array,
+  onOpenModal: PropTypes.func,
+};
+
+export default CollectionList;

--- a/assets/js/components/IngestSheet/Completed.jsx
+++ b/assets/js/components/IngestSheet/Completed.jsx
@@ -65,8 +65,8 @@ const IngestSheetCompleted = ({ sheetId, title }) => {
           <div>
             <UIPreviewItems items={works} />
 
-            <div className="mb-4 mt-2">
-              <Button onClick={handleClick} className="is-fullwidth">
+            <div className="my-4 has-text-centered">
+              <Button onClick={handleClick}>
                 <span className="icon">
                   <FontAwesomeIcon icon="eye" />
                 </span>

--- a/assets/js/components/Search/ActionRow.jsx
+++ b/assets/js/components/Search/ActionRow.jsx
@@ -89,7 +89,7 @@ export default function SearchActionRow({
       >
         <Button
           isLight
-          className="is-fullwidth mb-4 is-large"
+          className="is-fullwidth mb-4"
           data-testid="button-batch-all-edit"
           onClick={handleEditAllItemsClick}
         >
@@ -100,7 +100,7 @@ export default function SearchActionRow({
         </Button>
         <Button
           isLight
-          className="is-fullwidth is-large"
+          className="is-fullwidth"
           data-testid="button-csv-all-export"
           onClick={handleCsvExportAllItemsClick}
         >
@@ -118,7 +118,7 @@ export default function SearchActionRow({
       >
         <Button
           isLight
-          className="is-fullwidth mb-4 is-large"
+          className="is-fullwidth mb-4"
           data-testid="button-batch-items-edit"
           onClick={handleEditItemsClick}
         >
@@ -129,7 +129,7 @@ export default function SearchActionRow({
         </Button>
         <Button
           isLight
-          className="is-fullwidth mb-4 is-large"
+          className="is-fullwidth mb-4"
           data-testid="button-view-and-edit"
           onClick={handleViewAndEditClick}
         >
@@ -140,7 +140,7 @@ export default function SearchActionRow({
         </Button>
         <Button
           isLight
-          className="is-fullwidth is-large"
+          className="is-fullwidth"
           data-testid="button-csv-items-export"
           onClick={handleCsvExportItemsClick}
         >

--- a/assets/js/components/UI/FallbackErrorComponent.jsx
+++ b/assets/js/components/UI/FallbackErrorComponent.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+function UIFallbackErrorComponent({ error }) {
+  return (
+    <div
+      role="alert"
+      className="notification is-danger has-text-centered content"
+    >
+      <p>
+        <FontAwesomeIcon icon="exclamation-triangle" /> There was an error
+        rendering
+      </p>
+      <p>
+        <strong>Error</strong>: {error.message}
+      </p>
+    </div>
+  );
+}
+
+UIFallbackErrorComponent.propTypes = {
+  error: PropTypes.object,
+};
+
+export default UIFallbackErrorComponent;

--- a/assets/js/components/Work/ListItem.jsx
+++ b/assets/js/components/Work/ListItem.jsx
@@ -23,14 +23,14 @@ const WorkListItem = ({
     <>
       <article className="media" data-testid="ui-worklist-item">
         <figure className="media-left">
-          <p className="image is-128x128">
+          <div className="image is-128x128">
             <Link to={`/work/${id}`} className="hvr-shrink">
               <UIWorkImage
                 imageUrl={getImageUrl(representativeImage)}
                 size={500}
               />
             </Link>
-          </p>
+          </div>
         </figure>
         <div className="media-content">
           <h3 className="title is-size-5">

--- a/assets/js/screens/BatchEdit/BatchEdit.jsx
+++ b/assets/js/screens/BatchEdit/BatchEdit.jsx
@@ -8,6 +8,8 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useBatchState } from "@js/context/batch-edit-context";
 import { elasticsearchDirectSearch } from "@js/services/elasticsearch";
 import UISkeleton from "@js/components/UI/Skeleton";
+import { ErrorBoundary } from "react-error-boundary";
+import UIFallbackErrorComponent from "@js/components/UI/FallbackErrorComponent";
 
 const ScreensBatchEdit = () => {
   const batchState = useBatchState();
@@ -96,7 +98,9 @@ const ScreensBatchEdit = () => {
                       </span>
                       You are batch editing the following {resultsCount} items.
                     </p>
-                    <UIPreviewItems items={previewItems} />
+                    <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
+                      <UIPreviewItems items={previewItems} />
+                    </ErrorBoundary>
                   </div>
                 )}
               </div>
@@ -122,7 +126,9 @@ const ScreensBatchEdit = () => {
       {isActiveSearch && (
         <section className="section">
           <div className="container" data-testid="tabs-wrapper">
-            <BatchEditTabs />
+            <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
+              <BatchEditTabs />
+            </ErrorBoundary>
           </div>
         </section>
       )}

--- a/assets/js/screens/Collection/Collection.jsx
+++ b/assets/js/screens/Collection/Collection.jsx
@@ -17,6 +17,8 @@ import { toastWrapper } from "../../services/helpers";
 import UIBreadcrumbs from "../../components/UI/Breadcrumbs";
 import Layout from "../Layout";
 import { DisplayAuthorized } from "@js/components/Auth/DisplayAuthorized";
+import { ErrorBoundary } from "react-error-boundary";
+import UIFallbackErrorComponent from "@js/components/UI/FallbackErrorComponent";
 
 const ScreensCollection = () => {
   const { id } = useParams();
@@ -149,8 +151,9 @@ const ScreensCollection = () => {
                     </DisplayAuthorized>
                   </div>
                 </div>
-
-                <Collection collection={data.collection} />
+                <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
+                  <Collection collection={data.collection} />
+                </ErrorBoundary>
               </>
             )}
           </div>

--- a/assets/js/screens/Collection/Form.jsx
+++ b/assets/js/screens/Collection/Form.jsx
@@ -4,10 +4,11 @@ import CollectionForm from "../../components/Collection/Form";
 import Layout from "../Layout";
 import Error from "../../components/UI/Error";
 import UILoadingPage from "../../components/UI/LoadingPage";
-import UISkeleton from "../../components/UI/Skeleton";
 import { GET_COLLECTION } from "../../components/Collection/collection.gql.js";
 import { useQuery } from "@apollo/client";
 import UIBreadcrumbs from "../../components/UI/Breadcrumbs";
+import { ErrorBoundary } from "react-error-boundary";
+import UIFallbackErrorComponent from "@js/components/UI/FallbackErrorComponent";
 
 const ScreensCollectionForm = () => {
   const { id } = useParams();
@@ -60,7 +61,9 @@ const ScreensCollectionForm = () => {
                 <h1 className="title" data-testid="collection-form-title">
                   {collection ? "Edit" : "Add New"} Collection
                 </h1>
-                <CollectionForm collection={collection} />
+                <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
+                  <CollectionForm collection={collection} />
+                </ErrorBoundary>
               </div>
             </div>
           </div>

--- a/assets/js/screens/Collection/List.jsx
+++ b/assets/js/screens/Collection/List.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useRef } from "react";
-import CollectionListRow from "../../components/Collection/ListRow";
 import { useQuery } from "@apollo/client";
 import {
   GET_COLLECTIONS,
@@ -7,7 +6,7 @@ import {
 } from "../../components/Collection/collection.gql.js";
 import Error from "../../components/UI/Error";
 import UISkeleton from "../../components/UI/Skeleton";
-import { Link, useHistory } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useMutation } from "@apollo/client";
 import { toastWrapper } from "../../services/helpers";
 import Layout from "../Layout";
@@ -17,6 +16,9 @@ import UIFormInput from "../../components/UI/Form/Input";
 import UIFormField from "../../components/UI/Form/Field";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { DisplayAuthorized } from "@js/components/Auth/DisplayAuthorized";
+import CollectionsList from "@js/components/Collection/List";
+import { ErrorBoundary } from "react-error-boundary";
+import UIFallbackErrorComponent from "@js/components/UI/FallbackErrorComponent";
 
 const ScreensCollectionList = () => {
   const { data, loading, error } = useQuery(GET_COLLECTIONS);
@@ -130,26 +132,19 @@ const ScreensCollectionList = () => {
                   </span>
                 </UIFormField>
 
-                <ul>
-                  {filteredCollections.length > 0 &&
-                    filteredCollections.map((collection) => (
-                      <CollectionListRow
-                        key={collection.id}
-                        collection={collection}
-                        onOpenModal={onOpenModal}
-                      />
-                    ))}
-                </ul>
-                {data.collections.length === 0 && (
-                  <div className="content">
-                    <p className="notification">No collections returned</p>
-                  </div>
-                )}
+                <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
+                  <CollectionsList
+                    collections={data.collections}
+                    filteredCollections={filteredCollections}
+                    onOpenModal={onOpenModal}
+                  />
+                </ErrorBoundary>
               </>
             )}
           </div>
         </div>
       </section>
+
       <UIModalDelete
         isOpen={modalOpen}
         handleClose={onCloseModal}

--- a/assets/js/screens/Dashboards/BatchEdit/Details.jsx
+++ b/assets/js/screens/Dashboards/BatchEdit/Details.jsx
@@ -3,6 +3,8 @@ import Layout from "@js/screens/Layout";
 import { useParams } from "react-router-dom";
 import UIBreadCrumbs from "@js/components/UI/Breadcrumbs";
 import DashboardsBatchEditDetails from "@js/components/Dashboards/BatchEdit/Details";
+import { ErrorBoundary } from "react-error-boundary";
+import UIFallbackErrorComponent from "@js/components/UI/FallbackErrorComponent";
 
 export default function ScreensDashboardsBatchEditDetails() {
   const params = useParams();
@@ -33,7 +35,9 @@ export default function ScreensDashboardsBatchEditDetails() {
             <h1 className="title" data-testid="page-title">
               Batch Edit Details
             </h1>
-            <DashboardsBatchEditDetails id={params.id} />
+            <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
+              <DashboardsBatchEditDetails id={params.id} />
+            </ErrorBoundary>
           </div>
         </div>
       </section>

--- a/assets/js/screens/Dashboards/BatchEdit/List.jsx
+++ b/assets/js/screens/Dashboards/BatchEdit/List.jsx
@@ -2,6 +2,8 @@ import React from "react";
 import Layout from "@js/screens/Layout";
 import UIBreadCrumbs from "@js/components/UI/Breadcrumbs";
 import DashboardsBatchEditList from "@js/components/Dashboards/BatchEdit/List";
+import { ErrorBoundary } from "react-error-boundary";
+import UIFallbackErrorComponent from "@js/components/UI/FallbackErrorComponent";
 
 function ScreensDashboardsBatchEditList(props) {
   return (
@@ -25,7 +27,9 @@ function ScreensDashboardsBatchEditList(props) {
             <h1 className="title" data-testid="batch-edit-dashboard-title">
               Batch Edit Dashboard
             </h1>
-            <DashboardsBatchEditList />
+            <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
+              <DashboardsBatchEditList />
+            </ErrorBoundary>
           </div>
         </div>
       </section>

--- a/assets/js/screens/Dashboards/LocalAuthorities/List.jsx
+++ b/assets/js/screens/Dashboards/LocalAuthorities/List.jsx
@@ -4,6 +4,7 @@ import UIBreadCrumbs from "@js/components/UI/Breadcrumbs";
 import DashboardsLocalAuthoritiesList from "@js/components/Dashboards/LocalAuthorities/List";
 import DashboardsLocalAuthoritiesTitleBar from "@js/components/Dashboards/LocalAuthorities/TitleBar";
 import { ErrorBoundary } from "react-error-boundary";
+import UIFallbackErrorComponent from "@js/components/UI/FallbackErrorComponent";
 
 function ScreensDashboardsLocalAuthoritiesList() {
   return (
@@ -27,7 +28,7 @@ function ScreensDashboardsLocalAuthoritiesList() {
             ]}
           />
           <div className="box">
-            <ErrorBoundary FallbackComponent={ErrorFallback}>
+            <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
               <DashboardsLocalAuthoritiesTitleBar />
               <DashboardsLocalAuthoritiesList />
             </ErrorBoundary>
@@ -41,14 +42,3 @@ function ScreensDashboardsLocalAuthoritiesList() {
 ScreensDashboardsLocalAuthoritiesList.propTypes = {};
 
 export default ScreensDashboardsLocalAuthoritiesList;
-
-function ErrorFallback({ error }) {
-  return (
-    <div role="alert" className="notification is-danger">
-      <p>There was an error rendering</p>
-      <p>
-        <strong>Error</strong>: {error.message}
-      </p>
-    </div>
-  );
-}

--- a/assets/js/screens/IngestSheet/IngestSheet.jsx
+++ b/assets/js/screens/IngestSheet/IngestSheet.jsx
@@ -13,6 +13,8 @@ import {
 import IngestSheetAlert from "../../components/IngestSheet/Alert";
 import UIBreadcrumbs from "../../components/UI/Breadcrumbs";
 import IngestSheetActionRow from "../../components/IngestSheet/ActionRow";
+import { ErrorBoundary } from "react-error-boundary";
+import UIFallbackErrorComponent from "@js/components/UI/FallbackErrorComponent";
 
 const GET_CRUMB_DATA = gql`
   query GetCrumbData($sheetId: ID!) {
@@ -105,12 +107,14 @@ const ScreensIngestSheet = ({ match }) => {
                     </h1>
                   </div>
                   <div className="column is-half">
-                    <IngestSheetActionRow
-                      sheetId={sheetId}
-                      projectId={id}
-                      status={sheetData.ingestSheet.status}
-                      title={sheetData.ingestSheet.title}
-                    />
+                    <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
+                      <IngestSheetActionRow
+                        sheetId={sheetId}
+                        projectId={id}
+                        status={sheetData.ingestSheet.status}
+                        title={sheetData.ingestSheet.title}
+                      />
+                    </ErrorBoundary>
                   </div>
                 </div>
 
@@ -145,11 +149,13 @@ const ScreensIngestSheet = ({ match }) => {
           {sheetLoading ? (
             <UISkeleton rows={20} />
           ) : (
-            <IngestSheet
-              ingestSheetData={sheetData.ingestSheet}
-              projectId={id}
-              subscribeToIngestSheetUpdates={sheetSubscribeToMore}
-            />
+            <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
+              <IngestSheet
+                ingestSheetData={sheetData.ingestSheet}
+                projectId={id}
+                subscribeToIngestSheetUpdates={sheetSubscribeToMore}
+              />
+            </ErrorBoundary>
           )}
         </div>
       </section>

--- a/assets/js/screens/Layout.jsx
+++ b/assets/js/screens/Layout.jsx
@@ -2,14 +2,20 @@ import React from "react";
 import PropTypes from "prop-types";
 import UILayoutFooter from "../components/UI/Layout/Footer";
 import UILayoutNavBar from "../components/UI/Layout/NavBar";
+import { ErrorBoundary } from "react-error-boundary";
+import UIFallbackErrorComponent from "@js/components/UI/FallbackErrorComponent";
 
 const Layout = ({ children }) => {
   return (
     <div id="root">
-      <UILayoutNavBar />
+      <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
+        <UILayoutNavBar />
+      </ErrorBoundary>
       <div>
         <main>{children}</main>
-        <UILayoutFooter />
+        <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
+          <UILayoutFooter />
+        </ErrorBoundary>
       </div>
     </div>
   );

--- a/assets/js/screens/Project/Form.jsx
+++ b/assets/js/screens/Project/Form.jsx
@@ -1,20 +1,10 @@
 import React from "react";
 import Layout from "../Layout";
 import ProjectForm from "../../components/Project/Form";
+import { ErrorBoundary } from "react-error-boundary";
+import UIFallbackErrorComponent from "@js/components/UI/FallbackErrorComponent";
 
 const ScreensProjectForm = ({}) => {
-  const createCrumbs = () => {
-    return [
-      {
-        title: "Projects",
-        link: "/project/list"
-      },
-      {
-        title: `Create`,
-        link: `/project/create`
-      }
-    ];
-  };
   return (
     <Layout>
       <section className="hero is-light">
@@ -24,7 +14,9 @@ const ScreensProjectForm = ({}) => {
           </div>
         </div>
       </section>
-      <ProjectForm />
+      <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
+        <ProjectForm />
+      </ErrorBoundary>
     </Layout>
   );
 };

--- a/assets/js/screens/Project/List.jsx
+++ b/assets/js/screens/Project/List.jsx
@@ -2,11 +2,12 @@ import React, { useState } from "react";
 import Layout from "../Layout";
 import ProjectList from "../../components/Project/List";
 import ProjectForm from "../../components/Project/Form";
-// import { PrimaryButton } from "nulib-admin-ui-components";
 import UIBreadcrumbs from "../../components/UI/Breadcrumbs";
 import UILevelItem from "../../components/UI/LevelItem";
 import { Button } from "@nulib/admin-react-components";
 import { DisplayAuthorized } from "@js/components/Auth/DisplayAuthorized";
+import { ErrorBoundary } from "react-error-boundary";
+import UIFallbackErrorComponent from "@js/components/UI/FallbackErrorComponent";
 
 const ScreensProjectList = () => {
   const [showForm, setShowForm] = useState();
@@ -48,13 +49,17 @@ const ScreensProjectList = () => {
 
           <div className="box">
             <div data-testid="screen-content">
-              <ProjectList />
+              <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
+                <ProjectList />
+              </ErrorBoundary>
             </div>
           </div>
         </div>
       </section>
 
-      <ProjectForm showForm={showForm} setShowForm={setShowForm} />
+      <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
+        <ProjectForm showForm={showForm} setShowForm={setShowForm} />
+      </ErrorBoundary>
     </Layout>
   );
 };

--- a/assets/js/screens/Project/Project.jsx
+++ b/assets/js/screens/Project/Project.jsx
@@ -16,6 +16,8 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Button } from "@nulib/admin-react-components";
 import { DisplayAuthorized } from "@js/components/Auth/DisplayAuthorized";
 import ProjectIngestSheetModal from "@js/components/Project/IngestSheetModal";
+import { ErrorBoundary } from "react-error-boundary";
+import UIFallbackErrorComponent from "@js/components/UI/FallbackErrorComponent";
 
 const ScreensProject = () => {
   const history = useHistory();
@@ -142,27 +144,31 @@ const ScreensProject = () => {
                 {loading ? (
                   <UISkeleton rows={15} />
                 ) : (
-                  <IngestSheetList
-                    project={data.project}
-                    subscribeToIngestSheetStatusChanges={() =>
-                      subscribeToMore({
-                        document: INGEST_SHEET_STATUS_UPDATES_FOR_PROJECT_SUBSCRIPTION,
-                        variables: { projectId: id },
-                        updateQuery: handleIngestSheetStatusChange,
-                      })
-                    }
-                  />
+                  <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
+                    <IngestSheetList
+                      project={data.project}
+                      subscribeToIngestSheetStatusChanges={() =>
+                        subscribeToMore({
+                          document: INGEST_SHEET_STATUS_UPDATES_FOR_PROJECT_SUBSCRIPTION,
+                          variables: { projectId: id },
+                          updateQuery: handleIngestSheetStatusChange,
+                        })
+                      }
+                    />
+                  </ErrorBoundary>
                 )}
               </div>
             </>
           </div>
         </section>
       </div>
-      <ProjectIngestSheetModal
-        closeModal={() => setIsModalHidden(true)}
-        isHidden={isModalHidden}
-        projectId={id}
-      />
+      <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
+        <ProjectIngestSheetModal
+          closeModal={() => setIsModalHidden(true)}
+          isHidden={isModalHidden}
+          projectId={id}
+        />
+      </ErrorBoundary>
     </Layout>
   );
 };

--- a/assets/js/screens/Search/Search.jsx
+++ b/assets/js/screens/Search/Search.jsx
@@ -4,7 +4,7 @@ import { SelectedFilters } from "@appbaseio/reactivesearch";
 import SearchBar from "../../components/UI/SearchBar";
 import SearchResults from "../../components/Search/Results";
 import SearchFacetSidebar from "../../components/Search/FacetSidebar";
-import { useLocation, useHistory } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import SearchActionRow from "../../components/Search/ActionRow";
 import UIResultsDisplaySwitcher from "../../components/UI/ResultsDisplaySwitcher";
 import {
@@ -15,6 +15,7 @@ import {
 import { useBatchDispatch } from "../../context/batch-edit-context";
 import { ErrorBoundary } from "react-error-boundary";
 import { DisplayAuthorized } from "@js/components/Auth/DisplayAuthorized";
+import UIFallbackErrorComponent from "@js/components/UI/FallbackErrorComponent";
 
 async function getParsedAggregations(query) {
   try {
@@ -173,7 +174,7 @@ const ScreensSearch = () => {
               />
             </div>
 
-            <ErrorBoundary FallbackComponent={ErrorFallback}>
+            <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
               <SearchResults
                 handleOnDataChange={handleOnDataChange}
                 handleQueryChange={handleQueryChange}
@@ -188,16 +189,5 @@ const ScreensSearch = () => {
     </Layout>
   );
 };
-
-function ErrorFallback({ error }) {
-  return (
-    <div role="alert" className="notification is-danger">
-      <p>There was an error displaying Search</p>
-      <p>
-        <strong>Error</strong>: {error.message}
-      </p>
-    </div>
-  );
-}
 
 export default ScreensSearch;

--- a/assets/js/screens/Work/Work.jsx
+++ b/assets/js/screens/Work/Work.jsx
@@ -18,6 +18,7 @@ import WorkSharedLinkNotification from "../../components/Work/SharedLinkNotifica
 import WorkMultiEditBar from "../../components/Work/MultiEditBar";
 import { useBatchState } from "../../context/batch-edit-context";
 import { ErrorBoundary } from "react-error-boundary";
+import UIFallbackErrorComponent from "@js/components/UI/FallbackErrorComponent";
 
 const ScreensWork = () => {
   const params = useParams();
@@ -108,7 +109,7 @@ const ScreensWork = () => {
 
   return (
     <Layout>
-      <ErrorBoundary FallbackComponent={ErrorFallbackHeader}>
+      <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
         <section className="section" data-testid="work-hero">
           <div className="container">
             <UIBreadcrumbs items={breadCrumbs} data-testid="work-breadcrumbs" />
@@ -200,34 +201,12 @@ const ScreensWork = () => {
       {loading ? (
         <UISkeleton rows={20} />
       ) : (
-        <ErrorBoundary FallbackComponent={ErrorFallback}>
+        <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
           <Work work={data.work} />
         </ErrorBoundary>
       )}
     </Layout>
   );
 };
-
-function ErrorFallback({ error }) {
-  return (
-    <div role="alert" className="notification is-danger">
-      <p>There was an error displaying the Work</p>
-      <p>
-        <strong>Error</strong>: {error.message}
-      </p>
-    </div>
-  );
-}
-
-function ErrorFallbackHeader({ error }) {
-  return (
-    <div role="alert" className="notification is-danger">
-      <p>There was an error displaying the header of the Work</p>
-      <p>
-        <strong>Error</strong>: {error.message}
-      </p>
-    </div>
-  );
-}
 
 export default ScreensWork;


### PR DESCRIPTION
…onents.

This adds a new generic component `assets/js/components/UI/FallbackErrorComponent.jsx` which is passed as a prop in the `<ErrorBoundary /`> component.   This `ErrorBoundary` component is used to wrap child components, and if the child components throw any type of non-network error, the `ErrorBoundary` will "catch" the error and prevent the app from crashing. 

![image](https://user-images.githubusercontent.com/3020266/104367244-27ad2c00-54e0-11eb-961d-da05ede6489d.png)
