### PR TITLE
Fix bug where resolver calls create_project on update

### DIFF
--- a/lib/meadow_web/resolvers/ingest.ex
+++ b/lib/meadow_web/resolvers/ingest.ex
@@ -34,7 +34,9 @@ defmodule MeadowWeb.Resolvers.Ingest do
   end
 
   def update_project(_, args, _) do
-    case Projects.create_project(args) do
+    project = Projects.get_project!(args[:id])
+
+    case Projects.update_project(project, args) do
       {:error, changeset} ->
         {:error,
          message: "Could not update project", details: ChangesetErrors.humanize_errors(changeset)}

--- a/test/meadow_web/schema/mutation/update_project_test.exs
+++ b/test/meadow_web/schema/mutation/update_project_test.exs
@@ -19,8 +19,8 @@ defmodule MeadowWeb.Schema.Mutation.UpdateProjectTest do
 
       assert {:ok, query_data} = result
 
-      title = get_in(query_data, [:data, "updateProject", "title"])
-      assert title == "The New Title"
+      assert project.id == get_in(query_data, [:data, "updateProject", "id"])
+      assert "The New Title" == get_in(query_data, [:data, "updateProject", "title"])
     end
   end
 


### PR DESCRIPTION
- fix mistake in Ingest resolver. `update_project` should call `update_project`, not `create_project`