### PR TITLE
Fix NUL Authority create notification bug

### DIFF
--- a/assets/js/components/Dashboards/LocalAuthorities/TitleBar.jsx
+++ b/assets/js/components/Dashboards/LocalAuthorities/TitleBar.jsx
@@ -22,18 +22,13 @@ function DashboardsLocalAuthoritiesTitleBar() {
         if (graphQLErrors.length > 0) {
           errorStrings = graphQLErrors.map(
             ({ message, details }) =>
-              `${message}: ${details && details.title ? details.title : ""}`
+              `${message}: ${details && details.label ? details.label : ""}`
           );
         }
         toastWrapper("is-danger", errorStrings.join(" \n "));
       },
     }
   );
-
-  if (error) {
-    console.error("error", error);
-    return <p className="notification is-danger">{error.toString()}</p>;
-  }
 
   const handleAddLocalAuthority = (formData) => {
     createNulAuthorityRecord({


### PR DESCRIPTION
Now displays the error message, and moves the notification to an alert which doesn't block the UX of re-submitting.

![image](https://user-images.githubusercontent.com/3020266/105218080-53e92e00-5b1a-11eb-9390-24e41ebcd2e8.png)
