### PR TITLE
Deploy NodeJS lambdas via Terraform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,9 @@ jobs:
             networkconfig=$(aws ecs describe-services --cluster ${ECS_CLUSTER} --service ${ECS_SERVICE} | jq -cM '.services[0].networkConfiguration')
             overrides="{\"containerOverrides\":[{\"name\":\"${ECS_CONTAINER}\",\"environment\": [{\"name\": \"MEADOW_PROCESSES\", \"value\": \"none\"}],\"command\":[\"eval\",\"Meadow.ReleaseTasks.migrate()\"]}]}"
             aws ecs run-task --platform-version 1.4.0 --cluster ${ECS_CLUSTER} --task-definition ${ECS_TASK} --overrides "${overrides}" --launch-type FARGATE --network-configuration ${networkconfig}
-            aws ecs update-service --cluster ${ECS_CLUSTER} --service ${ECS_SERVICE} --force-new-deployment
+            for service in $(aws ecs list-services --cluster meadow | jq -r '.serviceArns[] | split("/") | last'); do
+              aws ecs update-service --cluster ${ECS_CLUSTER} --service ${service} --force-new-deployment
+            end
 workflows:
   ci:
     jobs:

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -5,6 +5,8 @@
 # file to your .gitignore.
 import Config
 
+alias Meadow.Pipeline.Actions
+
 get_required_var = fn var ->
   System.get_env(var) || raise "environment variable #{var} is missing."
 end
@@ -105,3 +107,10 @@ config :ueberauth, Ueberauth,
 
 config :hackney,
   max_connections: System.get_env("HACKNEY_MAX_CONNECTIONS", "1000") |> String.to_integer()
+
+# Configure Lambda-based actions
+
+config :meadow, :lambda, digester: {:lambda, "meadow-digester"}
+
+config :sequins, Actions.GenerateFileSetDigests,
+  queue_config: [processor_concurrency: 50, visibility_timeout: 300]

--- a/priv/nodejs/digester/yarn.lock
+++ b/priv/nodejs/digester/yarn.lock
@@ -3,9 +3,9 @@
 
 
 aws-sdk@^2.808.0:
-  version "2.813.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.813.0.tgz#16104b91a286c1fc8ca6480ac32ccebb955f6148"
-  integrity sha512-uOeJ6DgsImQLv0eC0KHloFgDP788A1MEYTKdSV+1Bjv1iqQHH3bJcH5DPPX2NSyeaXJAjkVSVT2Fqe4s5Vf9TA==
+  version "2.829.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.829.0.tgz#da70407a8bddc21b1dc1c9ba61ac3daea39b9364"
+  integrity sha512-0LV0argbcE1HhOeCeCZWUbpP4rWzwqe+0WmnR+jCJPY0w0n/ntGU/GW8obzhhhUej8pS4AkuAJNgzbwlTnxUmw==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"

--- a/terraform/ecs_services.tf
+++ b/terraform/ecs_services.tf
@@ -65,6 +65,10 @@ resource "aws_ecs_service" "meadow_all" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
   network_configuration {
     subnets          = data.aws_subnet_ids.private_subnets.ids
     security_groups  = [aws_security_group.meadow.id]
@@ -107,6 +111,10 @@ resource "aws_ecs_service" "meadow_web" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
   network_configuration {
     subnets          = data.aws_subnet_ids.private_subnets.ids
     security_groups  = [aws_security_group.meadow.id]
@@ -120,6 +128,7 @@ module "meadow_task_workers" {
   source              = "./modules/meadow_task"
   container_config    = local.container_config
   cpu                 = 1024
+  db_pool_size        = 10
   file_system_id      = aws_efs_file_system.meadow_working.id
   meadow_processes    = "basic,pipeline.ingest_file_set,pipeline.copy_file_to_preservation,pipeline.file_set_complete"
   memory              = 2048
@@ -137,6 +146,10 @@ resource "aws_ecs_service" "meadow_workers" {
   launch_type                         = "FARGATE"
   platform_version                    = "1.4.0"
 
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
   network_configuration {
     subnets          = data.aws_subnet_ids.private_subnets.ids
     security_groups  = [aws_security_group.meadow.id]
@@ -150,6 +163,7 @@ module "meadow_task_digests" {
   source              = "./modules/meadow_task"
   container_config    = local.container_config
   cpu                 = 2048
+  db_pool_size        = 2
   file_system_id      = aws_efs_file_system.meadow_working.id
   meadow_processes    = "pipeline.generate_file_set_digests"
   memory              = 4096
@@ -167,6 +181,10 @@ resource "aws_ecs_service" "meadow_digests" {
   launch_type                         = "FARGATE"
   platform_version                    = "1.4.0"
 
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
   network_configuration {
     subnets          = data.aws_subnet_ids.private_subnets.ids
     security_groups  = [aws_security_group.meadow.id]
@@ -180,8 +198,9 @@ module "meadow_task_tiffs" {
   source              = "./modules/meadow_task"
   container_config    = local.container_config
   cpu                 = 2048
+  db_pool_size        = 2
   file_system_id      = aws_efs_file_system.meadow_working.id
-  meadow_processes    = "pipeline.generate_file_set_tiffs"
+  meadow_processes    = "pipeline.create_pyramid_tiff"
   memory              = 4096
   name                = "tiffs"
   role_arn            = aws_iam_role.meadow_role.arn
@@ -196,6 +215,10 @@ resource "aws_ecs_service" "meadow_tiffs" {
   desired_count                       = 0
   launch_type                         = "FARGATE"
   platform_version                    = "1.4.0"
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
 
   network_configuration {
     subnets          = data.aws_subnet_ids.private_subnets.ids

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -1,0 +1,87 @@
+resource "aws_efs_access_point" "meadow_working_access_point" {
+  file_system_id    = aws_efs_file_system.meadow_working.id
+  tags              = var.tags
+
+  posix_user {
+    uid = 1000
+    gid = 1000
+  }
+
+  root_directory {
+    path = "/working"
+    creation_info {
+      owner_uid   = 1000
+      owner_gid   = 1000
+      permissions = 777
+    }
+  }
+}
+
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_iam_policy_document" "lambda_access_point_policy_document" {
+  statement {
+    sid       = "efslist"
+    effect    = "Allow"
+    actions   = [
+      "elasticfilesystem:DescribeAccessPoints"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid       = "efsaccess"
+    effect    = "Allow"
+    actions   = [
+      "elasticfilesystem:ClientMount",
+      "elasticfilesystem:ClientWrite"
+    ]
+    resources = [aws_efs_file_system.meadow_working.arn]
+  }
+}
+
+resource "aws_iam_policy" "lambda_access_point_policy" {
+  name = "${var.stack_name}-lambda-working-access"
+  policy = data.aws_iam_policy_document.lambda_access_point_policy_document.json
+}
+
+resource "aws_iam_role" "lambda_role" {
+  name               = "${var.stack_name}-lambda-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_working_access" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = aws_iam_policy.lambda_access_point_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_bucket_access" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = aws_iam_policy.this_bucket_policy.arn
+}
+
+module "digester_function" {
+  depends_on    = [ aws_iam_role_policy_attachment.lambda_bucket_access ]
+  source        = "./modules/meadow_lambda"
+  name          = "digester"
+  description   = "Function to calcuate the sha256 digest of an S3 object"
+  role          = aws_iam_role.lambda_role.arn
+  stack_name    = var.stack_name
+  memory_size   = 1024
+  timeout       = 60
+
+  tags          = var.tags
+}
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,7 +15,7 @@ module "rds" {
   engine_version            = "11.2"
   final_snapshot_identifier = "meadow-final"
   identifier                = "${var.stack_name}-db"
-  instance_class            = "db.t3.micro"
+  instance_class            = "db.t3.medium"
   maintenance_window        = "Sun:01:00-Sun:02:00"
   password                  = random_string.db_password.result
   port                      = "5432"
@@ -244,7 +244,7 @@ resource "aws_security_group" "meadow_working_access" {
 }
 
 resource "aws_efs_file_system" "meadow_working" {
-  tags = var.tags
+  tags = merge(var.tags, {Name = "${var.stack_name}-working"})
 }
 
 resource "aws_efs_mount_target" "meadow_working_mount" {

--- a/terraform/modules/meadow_lambda/main.tf
+++ b/terraform/modules/meadow_lambda/main.tf
@@ -1,0 +1,58 @@
+locals {
+  dest_path   = abspath("${path.module}/_build")
+  source_path = abspath("${path.module}/../../../priv/nodejs")
+}
+
+data "archive_file" "source" {
+  type          = "zip"
+  source_dir    = "${local.source_path}/${var.name}"
+  excludes      = [ "node_modules" ]
+  output_path   = "${local.dest_path}/${var.name}.src.zip"
+}
+
+resource "null_resource" "this_zip" {
+  triggers = {
+    source_code = data.archive_file.source.output_sha
+  }
+
+  provisioner "local-exec" {
+    command = "docker run -v ${local.source_path}:/src -v ${local.dest_path}:/dest nulib/lambda-build ${var.name}"
+  }
+}
+
+resource "aws_lambda_function" "this_lambda_function" {
+  depends_on    = [ null_resource.this_zip ]
+  function_name = "${var.stack_name}-${var.name}"
+  filename      = "${local.dest_path}/${var.name}.zip"
+  description   = var.description
+  handler       = var.handler
+  memory_size   = var.memory_size
+  runtime       = "nodejs12.x"
+  timeout       = var.timeout
+  role          = var.role
+  tags          = var.tags
+
+  dynamic "environment" {
+    for_each = length(var.environment) > 0 ? [1] : []
+    content {
+      variables = var.environment
+    }
+  }
+
+  dynamic "file_system_config" {
+    for_each = var.access_point_arn != "" ? [1] : []
+    content {
+      arn                 = var.access_point_arn
+      local_mount_path    = "/mnt/working"
+    }
+  }
+
+  dynamic "vpc_config" {
+    for_each = length(var.subnet_ids) > 0 ? [1] : []
+    content {
+      subnet_ids = var.subnet_ids
+      security_group_ids = var.security_group_ids
+    }
+  }
+}
+

--- a/terraform/modules/meadow_lambda/variables.tf
+++ b/terraform/modules/meadow_lambda/variables.tf
@@ -1,0 +1,55 @@
+variable "access_point_arn" {
+  type    = string
+  default = ""
+}
+
+variable "name" {
+  type    = string
+}
+
+variable "description" {
+  type    = string
+}
+
+variable "environment" {
+  type    = map
+  default = {}
+}
+
+variable "handler" {
+  type    = string
+  default = "index.handler"
+}
+
+variable "memory_size" {
+  type    = number
+  default = 128
+}
+
+variable "timeout" {
+  type    = number
+  default = 3
+}
+
+variable "role" {
+  type    = string
+}
+
+variable "stack_name" {
+  type    = string
+}
+
+variable "tags" {
+  type    = map
+  default = {}
+}
+
+variable "subnet_ids" {
+  type    = list
+  default = []
+}
+
+variable "security_group_ids" {
+  type    = list
+  default = []
+}

--- a/terraform/modules/meadow_task/main.tf
+++ b/terraform/modules/meadow_task/main.tf
@@ -26,6 +26,7 @@ locals {
     var.container_config,
     {
       cpu_reservation       = var.cpu * 0.9765625,
+      db_pool_size          = var.db_pool_size,
       memory_reservation    = var.memory * 0.9765625,
       name                  = var.name,
       processes             = var.meadow_processes

--- a/terraform/modules/meadow_task/variables.tf
+++ b/terraform/modules/meadow_task/variables.tf
@@ -6,6 +6,11 @@ variable "cpu" {
   type    = number
 }
 
+variable "db_pool_size" {
+  type    = number
+  default = 10
+}
+
 variable "file_system_id" {
   type    = string
 }

--- a/terraform/task-definitions/meadow_app.json
+++ b/terraform/task-definitions/meadow_app.json
@@ -101,6 +101,10 @@
         "value": "${host_name}"
       },
       {
+        "name": "POOL_SIZE",
+        "value": "${db_pool_size}"
+      },
+      {
         "name": "PRESERVATION_BUCKET",
         "value": "${preservation_bucket}"
       },


### PR DESCRIPTION
* Create reusable terraform module/manifest for NodeJS lambda deployment
* Deploy `meadow-digester` lambda via terraform
* Configure meadow to use `meadow-digester` lambda in prod with 50 concurrent processors