### PR TITLE
Add search to NUL Authority dashboard

### DIFF
--- a/assets/js/components/Dashboards/LocalAuthorities/List.jsx
+++ b/assets/js/components/Dashboards/LocalAuthorities/List.jsx
@@ -10,12 +10,15 @@ import { Button } from "@nulib/admin-react-components";
 import UIModalDelete from "@js/components/UI/Modal/Delete";
 import { toastWrapper } from "@js/services/helpers";
 import DashboardsLocalAuthoritiesModalEdit from "@js/components/Dashboards/LocalAuthorities/ModalEdit";
+import UISearchBarRow from "@js/components/UI/SearchBarRow";
+import UIFormInput from "@js/components/UI/Form/Input";
 
 const colHeaders = ["Label", "Hint"];
 
 export default function DashboardsLocalAuthoritiesList() {
   const client = useApolloClient();
   const [currentAuthority, setCurrentAuthority] = React.useState();
+  const [filteredAuthorities, setFilteredAuthorities] = React.useState([]);
   const [modalsState, setModalsState] = React.useState({
     delete: {
       isOpen: false,
@@ -72,6 +75,17 @@ export default function DashboardsLocalAuthoritiesList() {
     },
   });
 
+  React.useEffect(() => {
+    if (!data) {
+      return;
+    }
+    setFilteredAuthorities(
+      data.nulAuthorityRecords && data.nulAuthorityRecords.length > 0
+        ? data.nulAuthorityRecords
+        : []
+    );
+  }, [data]);
+
   if (loading || deleteAuthorityLoading || updateLoading) return null;
   if (error)
     return <p className="notification is-danger">{error.toString()}</p>;
@@ -98,6 +112,17 @@ export default function DashboardsLocalAuthoritiesList() {
     });
   };
 
+  const handleFilterChange = (e) => {
+    const filterValue = e.target.value.toUpperCase();
+    if (!filterValue) {
+      return setFilteredAuthorities(data.nulAuthorityRecords);
+    }
+    const filteredList = filteredAuthorities.filter((item) => {
+      return item.label.toUpperCase().indexOf(filterValue) > -1;
+    });
+    setFilteredAuthorities(filteredList);
+  };
+
   const handleUpdateButtonClick = (record) => {
     setCurrentAuthority({ ...record });
     setModalsState({
@@ -117,6 +142,15 @@ export default function DashboardsLocalAuthoritiesList() {
 
   return (
     <React.Fragment>
+      <UISearchBarRow>
+        <UIFormInput
+          placeholder="Search"
+          name="localAuthoritiesSearch"
+          label="Filter NUL local authorities"
+          onChange={handleFilterChange}
+          data-testid="input-local-authorities-filter"
+        />
+      </UISearchBarRow>
       <table
         className="table is-striped is-fullwidth"
         data-testid="local-authorities-dashboard-table"
@@ -131,7 +165,7 @@ export default function DashboardsLocalAuthoritiesList() {
           </tr>
         </thead>
         <tbody data-testid="local-authorities-table-body">
-          {data.nulAuthorityRecords.map((record) => {
+          {filteredAuthorities.map((record) => {
             const { id, hint = "", label = "" } = record;
 
             return (

--- a/assets/js/components/Dashboards/LocalAuthorities/List.test.jsx
+++ b/assets/js/components/Dashboards/LocalAuthorities/List.test.jsx
@@ -7,6 +7,7 @@ import {
   getNulAuthorityRecordsMock,
   updateNulAuthorityRecordMock,
 } from "@js/components/Dashboards/dashboards.gql.mock";
+import userEvent from "@testing-library/user-event";
 
 describe("DashboardsLocalAuthoritiesList component", () => {
   beforeEach(() => {
@@ -21,6 +22,23 @@ describe("DashboardsLocalAuthoritiesList component", () => {
 
   it("renders", async () => {
     expect(await screen.findByTestId("local-authorities-dashboard-table"));
+  });
+
+  describe("Search filter", () => {
+    it("renders a search input", async () => {
+      expect(await screen.findByTestId("search-bar-row"));
+    });
+
+    it("filters NUL authorities list", async () => {
+      const el = await screen.findByPlaceholderText("Search");
+      expect(await screen.findAllByTestId("nul-authorities-row")).toHaveLength(
+        2
+      );
+      userEvent.type(el, "2");
+      expect(await screen.findAllByTestId("nul-authorities-row")).toHaveLength(
+        1
+      );
+    });
   });
 
   it("renders the correct number of nul authority rows", async () => {

--- a/assets/js/components/Project/List.jsx
+++ b/assets/js/components/Project/List.jsx
@@ -2,18 +2,17 @@ import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { useQuery } from "@apollo/client";
 import Error from "../UI/Error";
-import Loading from "../UI/Loading";
 import { useMutation, useApolloClient } from "@apollo/client";
 import { DELETE_PROJECT, GET_PROJECTS } from "./project.gql.js";
 import UIModalDelete from "../UI/Modal/Delete";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { formatDate, toastWrapper } from "@js/services/helpers";
 import UISkeleton from "../UI/Skeleton";
-import UIFormField from "@js/components/UI/Form/Field";
 import UIFormInput from "@js/components/UI/Form/Input";
 import { Button } from "@nulib/admin-react-components";
 import { DisplayAuthorized } from "@js/components/Auth/DisplayAuthorized";
 import ProjectForm from "@js/components/Project/Form";
+import UISearchBarRow from "@js/components/UI/SearchBarRow";
 
 const ProjectList = () => {
   const [modalOpen, setModalOpen] = useState(false);
@@ -90,7 +89,7 @@ const ProjectList = () => {
 
   return (
     <>
-      <UIFormField childClass="has-icons-left">
+      <UISearchBarRow>
         <UIFormInput
           placeholder="Search projects"
           name="projectsSearch"
@@ -98,10 +97,8 @@ const ProjectList = () => {
           onChange={handleFilterChange}
           data-testid="input-project-filter"
         />
-        <span className="icon is-small is-left">
-          <FontAwesomeIcon icon="search" />
-        </span>
-      </UIFormField>
+      </UISearchBarRow>
+
       <table
         data-testid="project-list"
         className="table is-striped is-hoverable is-fullwidth"

--- a/assets/js/components/UI/SearchBarRow.jsx
+++ b/assets/js/components/UI/SearchBarRow.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+import PropTypes from "prop-types";
+import UIFormField from "@js/components/UI/Form/Field";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+function UISearchBarRow({ isCentered, children }) {
+  return (
+    <div
+      className={`columns ${isCentered ? "is-centered" : ""}`}
+      data-testid="search-bar-row"
+    >
+      <div className="column is-half-desktop">
+        <UIFormField childClass="has-icons-left">
+          {children}
+          <span className="icon is-small is-left" data-testid="icon-search">
+            <FontAwesomeIcon icon="search" />
+          </span>
+        </UIFormField>
+      </div>
+    </div>
+  );
+}
+
+UISearchBarRow.propTypes = {
+  children: PropTypes.node,
+  isCentered: PropTypes.bool,
+};
+
+export default UISearchBarRow;

--- a/assets/js/components/UI/SearchBarRow.test.js
+++ b/assets/js/components/UI/SearchBarRow.test.js
@@ -1,0 +1,22 @@
+import React from "react";
+import { screen, render } from "@testing-library/react";
+import UISearchBarRow from "@js/components/UI/SearchBarRow";
+
+describe("UISearchBarRow component", () => {
+  beforeEach(() => {
+    render(
+      <UISearchBarRow>
+        <div>Foobar</div>
+      </UISearchBarRow>
+    );
+  });
+
+  it("renders main components", () => {
+    expect(screen.getByTestId("search-bar-row"));
+    expect(screen.getByTestId("icon-search"));
+  });
+
+  it("renders child content", () => {
+    expect(screen.getByText("Foobar"));
+  });
+});


### PR DESCRIPTION
Adds search to NUL Dashboard, and created a generic search component wrapper which is being re-used on the Project search as well...and any we want to implement in the future.

![image](https://user-images.githubusercontent.com/3020266/105369614-5904b680-5bc8-11eb-8ff5-7adf252a4c66.png)

![image](https://user-images.githubusercontent.com/3020266/105369765-789bdf00-5bc8-11eb-9ab8-52ec32335567.png)
