### PR TITLE
Store sha1 and sha256 in s3 object metadata

### DIFF
--- a/lib/meadow/pipeline/actions/generate_file_set_digests.ex
+++ b/lib/meadow/pipeline/actions/generate_file_set_digests.ex
@@ -49,7 +49,7 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigests do
     %{host: bucket, path: "/" <> key} = URI.parse(url)
 
     case Lambda.invoke(Config.lambda_config(:digester), %{bucket: bucket, key: key}) do
-      {:ok, result} -> %{sha256: result}
+      {:ok, result} -> %{sha256: result["sha256"], sha1: result["sha1"]}
       {:error, error} -> raise error
     end
   end

--- a/priv/nodejs/digester/index.js
+++ b/priv/nodejs/digester/index.js
@@ -1,24 +1,30 @@
-const AWS = require('aws-sdk');
-const crypto = require('crypto');
+const AWS = require("aws-sdk");
+const crypto = require("crypto");
 
 const handler = async (event, _context, _callback) => {
   return await generateDigest(event.bucket, event.key);
-}
+};
 
 const generateDigest = (bucket, key) => {
-  console.log(`Digesting s3://${bucket}/${key}`)
+  console.log(`Digesting s3://${bucket}/${key}`);
   return new Promise((resolve, reject) => {
-    let sha256 = crypto.createHash('sha256');
+    let sha256 = crypto.createHash("sha256");
+    let sha1 = crypto.createHash("sha1");
 
     let s3Stream = new AWS.S3()
       .getObject({ Bucket: bucket, Key: key })
       .createReadStream();
 
     s3Stream
-      .on('data', (chunk) => sha256.update(chunk))
-      .on('end', () => resolve(sha256.digest('hex')))
-      .on('error', (err) => reject(err));
+      .on("data", (chunk) => {
+        sha256.update(chunk);
+        sha1.update(chunk);
+      })
+      .on("end", () =>
+        resolve({ sha256: sha256.digest("hex"), sha1: sha1.digest("hex") })
+      )
+      .on("error", (err) => reject(err));
   });
-}
+};
 
-module.exports = {handler};
+module.exports = { handler };

--- a/test/pipeline/actions/generate_file_set_digests_test.exs
+++ b/test/pipeline/actions/generate_file_set_digests_test.exs
@@ -10,6 +10,7 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigestsTest do
   @content "test/fixtures/coffee.tif"
   @fixture %{bucket: @bucket, key: @key, content: File.read!(@content)}
   @sha256 "412ca147684a67883226c644ee46b38460b787ec34e5b240983992af4a8c0a90"
+  @sha1 "29b05ca3286e06d1031feb6cef7f623d3efd6986"
 
   setup do
     file_set =
@@ -31,7 +32,7 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigestsTest do
     assert(ActionStates.ok?(file_set_id, GenerateFileSetDigests))
 
     file_set = FileSets.get_file_set!(file_set_id)
-    assert(file_set.metadata.digests == %{"sha256" => @sha256})
+    assert(file_set.metadata.digests == %{"sha256" => @sha256, "sha1" => @sha1})
 
     assert capture_log(fn ->
              GenerateFileSetDigests.process(%{file_set_id: file_set_id}, %{})


### PR DESCRIPTION
- adds `sha1` to digests stored in fileset
- adds `sha1` and `sha256` to s3 object metadata
- fixes but in writing s3 object metadata