### PR TITLE
Wrap EDTF in a GenServer to avoid spawning an EDTF port per process

### DIFF
--- a/lib/meadow/application.ex
+++ b/lib/meadow/application.ex
@@ -15,6 +15,7 @@ defmodule Meadow.Application do
     # Starts a worker by calling: Meadow.Worker.start_link(arg)
     # {Meadow.Worker, arg},
     base_children = [
+      EDTF,
       {Phoenix.PubSub, [name: Meadow.PubSub, adapter: Phoenix.PubSub.PG2]},
       Meadow.ElasticsearchCluster,
       Meadow.Repo,


### PR DESCRIPTION
Allow local Lambdas to be started explicitly instead of waiting for invoke()
Make local Lambdas less chatty
Clean up tests