### PR TITLE
Give meadow lambda role permissions to create and write to CloudWatch log groups

### DIFF
--- a/priv/nodejs/digester/index.js
+++ b/priv/nodejs/digester/index.js
@@ -1,7 +1,8 @@
 const AWS = require("aws-sdk");
 const crypto = require("crypto");
 
-const handler = async (event, _context, _callback) => {
+const handler = async (event, context, _callback) => {
+  context.callbackWaitsForEmptyEventLoop = false;
   return await generateDigest(event.bucket, event.key);
 };
 

--- a/priv/nodejs/exif/index.js
+++ b/priv/nodejs/exif/index.js
@@ -1,6 +1,7 @@
 const exif = require("./exif");
 
-const handler = async (event, _context, _callback) => {
+const handler = async (event, context, _callback) => {
+  context.callbackWaitsForEmptyEventLoop = false;
   return await exif.extractExif(event.source, event.options);
 };
 

--- a/priv/nodejs/lambda/index.js
+++ b/priv/nodejs/lambda/index.js
@@ -37,7 +37,7 @@ const handler = require(script)[lambda];
 process.stdin.resume();
 process.stdin.on("data", (data) => {
   const payload = JSON.parse(data);
-  handler(payload)
+  handler(payload, {})
     .then((result) => writeln("[return] " + JSON.stringify(result)))
     .catch((err) => writeln("[fatal] " + err));
 });

--- a/priv/nodejs/mime-type/index.js
+++ b/priv/nodejs/mime-type/index.js
@@ -2,7 +2,8 @@ const AWS = require("aws-sdk");
 const FileType = require("file-type");
 const { makeTokenizer } = require("@tokenizer/s3");
 
-const handler = async (event, _context, _callback) => {
+const handler = async (event, context, _callback) => {
+  context.callbackWaitsForEmptyEventLoop = false;
   return await extractMimeType(event.bucket, event.key);
 };
 

--- a/priv/nodejs/pyramid-tiff/index.js
+++ b/priv/nodejs/pyramid-tiff/index.js
@@ -2,7 +2,8 @@
 
 const pyramid = require("./pyramid");
 
-const handler = async (event, _context, _callback) => {
+const handler = async (event, context, _callback) => {
+  context.callbackWaitsForEmptyEventLoop = false;
   return await pyramid.createPyramidTiff(event.source, event.target);
 }
 

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -85,6 +85,11 @@ resource "aws_iam_role_policy_attachment" "lambda_bucket_access" {
   policy_arn = aws_iam_policy.this_bucket_policy.arn
 }
 
+resource "aws_iam_role_policy_attachment" "cloudwatch_log_access" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"  
+}
+
 module "digester_function" {
   depends_on  = [aws_iam_role_policy_attachment.lambda_bucket_access]
   source      = "./modules/meadow_lambda"


### PR DESCRIPTION
Also prevents lambdas from waiting for an empty event loop before returning results

Might partially address nulib/repodev_planning_and_docs#1523