### PR TITLE
Fix error path bug for CFTP action and provide failure test

### DIFF
--- a/lib/meadow/pipeline/actions/copy_file_to_preservation.ex
+++ b/lib/meadow/pipeline/actions/copy_file_to_preservation.ex
@@ -18,7 +18,7 @@ defmodule Meadow.Pipeline.Actions.CopyFileToPreservation do
 
   @actiondoc "Copy File to Preservation"
 
-  defp process(data, attributes, _) do
+  defp process(data, _attributes, _) do
     file_set = FileSets.get_file_set!(data.file_set_id)
     ActionStates.set_state!(file_set, __MODULE__, "started")
 
@@ -32,7 +32,7 @@ defmodule Meadow.Pipeline.Actions.CopyFileToPreservation do
 
       {:error, err} ->
         ActionStates.set_state!(file_set, __MODULE__, "error", err)
-        {:error, data, attributes |> Map.put(:error, err)}
+        {:error, err}
     end
   end
 


### PR DESCRIPTION
This error seen on staging (the actual file set is one from yesterday's ingest that didn't get the digests - it's still retrying in the CFTP queue.) I'm not sure why the CFTP action was returning something different in an error case than the other actions so I changed it to match. 

I think that will address this problem... right?

PR also adds failure test


<img width="1462" alt="Screen Shot 2021-02-04 at 4 23 13 PM" src="https://user-images.githubusercontent.com/6372022/106972292-ceff3680-670d-11eb-98e0-20fb56922536.png">

```
23:21:23.124 [error] ** (Protocol.UndefinedError) protocol String.Chars not implemented for {:error, %{file_set_id: "51ac17f3-16fd-4c8a-ad3e-33e8f022d993"}, %{context: "Sheet", error: "Error creating preservation path", ingest_sheet: "61451ecc-cafb-4fe9-99f4-9a8dbe7ff1ad", ingest_sheet_row: "3783", process: "GenerateFileSetDigests", role: "pm", status: "ok"}} of type Tuple. This protocol is implemented for the following type(s): Phoenix.LiveComponent.CID, Postgrex.Copy, Postgrex.Query, Decimal, BitString, List, Version, DateTime, Integer, Time, Float, Date, NaiveDateTime, Version.Requirement, URI, Atom
```
