### PR TITLE
Read pipeline configs at runtime instead of compile time

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -5,6 +5,8 @@
 # file to your .gitignore.
 import Config
 
+alias Meadow.Pipeline.Actions
+
 get_required_var = fn var ->
   case System.get_env("__COMPILE_CHECK__") do
     nil -> System.get_env(var) || raise "environment variable #{var} is missing."
@@ -118,3 +120,35 @@ config :meadow, :lambda,
   mime_type: {:lambda, "meadow-mime-type"},
   tiff: {:lambda, "meadow-pyramid-tiff"},
   exif: {:lambda, "meadow-exif"}
+
+config :sequins, Actions.GenerateFileSetDigests,
+  queue_config: [
+    producer_concurrency: 10,
+    max_number_of_messages: 10,
+    processor_concurrency: 100,
+    visibility_timeout: 600
+  ]
+
+config :sequins, Actions.ExtractExifMetadata,
+  queue_config: [
+    producer_concurrency: 10,
+    max_number_of_messages: 10,
+    processor_concurrency: 100,
+    visibility_timeout: 600
+  ]
+
+config :sequins, Actions.ExtractMimeType,
+  queue_config: [
+    producer_concurrency: 10,
+    max_number_of_messages: 10,
+    processor_concurrency: 100,
+    visibility_timeout: 120
+  ]
+
+config :sequins, Actions.CreatePyramidTiff,
+  queue_config: [
+    producer_concurrency: 10,
+    max_number_of_messages: 10,
+    processor_concurrency: 100,
+    visibility_timeout: 600
+  ]

--- a/config/sequins.exs
+++ b/config/sequins.exs
@@ -28,23 +28,23 @@ config :sequins, Meadow.Pipeline,
 config :sequins, IngestFileSet, queue_config: [processor_concurrency: 10]
 
 config :sequins, ExtractMimeType,
-  queue_config: [producer_concurrency: 10, processor_concurrency: 100, visibility_timeout: 120],
+  queue_config: [processor_concurrency: 1, visibility_timeout: 300],
   notify_on: [IngestFileSet: [status: :ok], ExtractMimeType: [status: :retry]]
 
 config :sequins, GenerateFileSetDigests,
-  queue_config: [producer_concurrency: 10, processor_concurrency: 100, visibility_timeout: 600],
+  queue_config: [processor_concurrency: 1, visibility_timeout: 300],
   notify_on: [ExtractMimeType: [status: :ok], GenerateFileSetDigests: [status: :retry]]
 
 config :sequins, CopyFileToPreservation,
-  queue_config: [producer_concurrency: 10, processor_concurrency: 100],
+  queue_config: [visibility_timeout: 300],
   notify_on: [GenerateFileSetDigests: [status: :ok], CopyFileToPreservation: [status: :retry]]
 
 config :sequins, ExtractExifMetadata,
-  queue_config: [producer_concurrency: 10, processor_concurrency: 100, visibility_timeout: 600],
+  queue_config: [processor_concurrency: 1, visibility_timeout: 300],
   notify_on: [CopyFileToPreservation: [status: :ok], ExtractExifMetadata: [status: :retry]]
 
 config :sequins, CreatePyramidTiff,
-  queue_config: [producer_concurrency: 10, processor_concurrency: 100, visibility_timeout: 600],
+  queue_config: [processor_concurrency: 1, visibility_timeout: 300],
   notify_on: [
     ExtractExifMetadata: [status: :ok, role: "am"],
     CreatePyramidTiff: [status: :retry]


### PR DESCRIPTION
The compile-time concurrency settings were happening in `Meadow.Application.Children`, not in `Sequins`. Changing the relevant configs from `@attribute`s to functions cleared it right up, and overrides can now be in `releases.exs`.