### PR TITLE
Allow batch deleting - backend

### DIFF
--- a/lib/meadow_web/resolvers/batches.ex
+++ b/lib/meadow_web/resolvers/batches.ex
@@ -40,6 +40,24 @@ defmodule MeadowWeb.Resolvers.Data.Batches do
     end
   end
 
+  def delete(_, params, %{context: %{current_user: user}}) do
+    with query <- Map.get(params, :query),
+         nickname <- Map.get(params, :nickname) do
+      case Batches.create_batch(%{
+             nickname: nickname,
+             user: user.username,
+             query: query,
+             type: "delete"
+           }) do
+        {:ok, batch} ->
+          {:ok, batch}
+
+        {:error, changeset} ->
+          {:error, message: "Could not create batch", details: parse_batch_errors(changeset)}
+      end
+    end
+  end
+
   defp parse_batch_errors(changeset) do
     %{
       add: parse_batch_errors(changeset, :add),

--- a/lib/meadow_web/schema/types/data/batch_types.ex
+++ b/lib/meadow_web/schema/types/data/batch_types.ex
@@ -39,6 +39,15 @@ defmodule MeadowWeb.Schema.Data.BatchTypes do
       middleware(Middleware.Authorize, "Editor")
       resolve(&Batches.update/3)
     end
+
+    @desc "Start a batch delete operation"
+    field :batch_delete, :batch do
+      arg(:nickname, :string)
+      arg(:query, non_null(:string))
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Manager")
+      resolve(&Batches.delete/3)
+    end
   end
 
   #

--- a/test/gql/BatchDelete.gql
+++ b/test/gql/BatchDelete.gql
@@ -1,0 +1,7 @@
+#import "./BatchFields.frag.gql"
+
+mutation($query: String!, $nickname: String) {
+  batchDelete(query: $query, nickname: $nickname) {
+    ...BatchFields
+  }
+}

--- a/test/gql/BatchUpdate.gql
+++ b/test/gql/BatchUpdate.gql
@@ -1,7 +1,19 @@
 #import "./BatchFields.frag.gql"
 
-mutation($query: String!, $delete: BatchDeleteInput, $add: BatchAddInput) {
-  batchUpdate(query: $query, delete: $delete, add: $add) {
+mutation(
+  $query: String!
+  $delete: BatchDeleteInput
+  $add: BatchAddInput
+  $replace: BatchReplaceInput
+  $nickname: String
+) {
+  batchUpdate(
+    query: $query
+    delete: $delete
+    add: $add
+    replace: $replace
+    nickname: $nickname
+  ) {
     ...BatchFields
   }
 }

--- a/test/meadow/batches_test.exs
+++ b/test/meadow/batches_test.exs
@@ -113,6 +113,29 @@ defmodule Meadow.BatchesTest do
       assert batch.works_updated == 3
     end
 
+    test "process_batch/1 runs and completes a batch delete" do
+      query = ~s'{"query":{"term":{"workType.id": "IMAGE"}}}'
+      type = "delete"
+      user = "user123"
+
+      attrs = %{
+        query: query,
+        type: type,
+        user: user
+      }
+
+      assert Works.list_works() |> length() == 3
+
+      {:ok, batch} = Batches.create_batch(attrs)
+      assert {:ok, _result} = Batches.process_batch(batch)
+      assert Batches.list_batches() |> length() == 1
+      batch = Batches.get_batch!(batch.id)
+      assert batch.status == "complete"
+      assert batch.active == false
+      assert batch.works_updated == 3
+      assert Works.list_works() |> length() == 0
+    end
+
     test "process_batch/1 does not start a batch if another batch is running" do
       query = ~s'{"query":{"term":{"workType.id": "IMAGE"}}}'
       type = "update"

--- a/test/meadow_web/schema/mutation/batch_delete_test.exs
+++ b/test/meadow_web/schema/mutation/batch_delete_test.exs
@@ -1,0 +1,59 @@
+defmodule MeadowWeb.Schema.Mutation.BatchDeleteTest do
+  use MeadowWeb.ConnCase, async: true
+  use Meadow.DataCase
+  use Wormwood.GQLCase
+  alias Meadow.Data.Indexer
+
+  load_gql(MeadowWeb.Schema, "test/gql/BatchDelete.gql")
+
+  setup do
+    work_fixture()
+
+    Indexer.reindex_all!()
+    :ok
+  end
+
+  test "should be a valid mutation" do
+    result =
+      query_gql(
+        variables: %{
+          "query" => ~s'{"query":{"term":{"workType.id": "IMAGE"}}}',
+          "nickname" => "This is a batch delete"
+        },
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+
+    response = get_in(query_data, [:data, "batchDelete", "status"])
+    assert response =~ "QUEUED"
+  end
+
+  describe "authorization" do
+    test "editors are not authorized to perform a batch delete" do
+      {:ok, result} =
+        query_gql(
+          variables: %{
+            "query" => ~s'{"query":{"term":{"workType.id": "IMAGE"}}}',
+            "nickname" => "This is a batch delete"
+          },
+          context: %{current_user: %{username: "abc123", role: "Editors"}}
+        )
+
+      assert %{errors: [%{message: "Forbidden", status: 403}]} = result
+    end
+
+    test "managers and above are authorized to perform a batch delete" do
+      {:ok, result} =
+        query_gql(
+          variables: %{
+            "query" => ~s'{"query":{"term":{"workType.id": "IMAGE"}}}',
+            "nickname" => "This is a batch delete"
+          },
+          context: %{current_user: %{username: "abc123", role: "Manager"}}
+        )
+
+      assert result.data["batchDelete"]
+    end
+  end
+end


### PR DESCRIPTION
- adds `batchDelete` mutation which takes an Elasticsearch query for works to be deleted.
- Uses the same batch infrastructure as batchUpdate, (`type` = `update` or `delete`)