### PR TITLE
Use AWS.S3.getObject events to handle downloads from S3

### DIFF
--- a/lib/meadow/utils/lambda.ex
+++ b/lib/meadow/utils/lambda.ex
@@ -92,7 +92,10 @@ defmodule Meadow.Utils.Lambda do
     Logger.metadata(lambda: lambda)
 
     case ExAws.Lambda.invoke(lambda, payload, %{})
-         |> ExAws.request(http_opts: [recv_timeout: timeout], retries: [max_attempts: 1]) do
+         |> ExAws.request(
+           http_opts: [recv_timeout: timeout, pool: false],
+           retries: [max_attempts: 1]
+         ) do
       {:ok, %{"errorType" => _, "errorMessage" => error_message}} -> {:error, error_message}
       other -> other
     end

--- a/priv/nodejs/exif/index.js
+++ b/priv/nodejs/exif/index.js
@@ -1,7 +1,6 @@
 const exif = require("./exif");
 
 const handler = async (event, context, _callback) => {
-  context.callbackWaitsForEmptyEventLoop = false;
   return await exif.extractExif(event.source, event.options);
 };
 

--- a/priv/nodejs/exif/working-copy.js
+++ b/priv/nodejs/exif/working-copy.js
@@ -1,0 +1,46 @@
+const AWS = require("aws-sdk");
+const URI = require("uri-js");
+const fs = require("fs");
+const tempy = require("tempy");
+
+AWS.config.update({httpOptions: {timeout: 600000}});
+
+const getS3Key = uri => {
+  return uri.path.replace(/^\/+/, "");
+};
+
+const cacheWorkingCopy = async (location) => {
+  const filename = tempy.file();
+
+  return new Promise((resolve, reject) => {
+    let uri = URI.parse(location);
+    let writable = fs
+      .createWriteStream(filename)
+      .on("error", err => reject(err));
+
+    const errorHandler = (err) => {
+      writable.end();
+      fs.unlinkSync(filename);
+      reject(err);
+    }
+
+    console.info(`Creating working copy of ${location} at ${filename}`);
+    new AWS.S3()
+      .getObject({Bucket: uri.host, Key: getS3Key(uri)})
+      .on("httpData", (chunk) => {
+        writable.write(chunk);
+      })
+      .on("httpDownloadProgress", ({loaded, total}) => {
+        console.debug(`Retrieved ${loaded}/${total}`)
+      })
+      .on("httpDone", () => {
+        writable.end();
+        resolve(filename);
+      })
+      .on("httpError", errorHandler)
+      .on("error", errorHandler)
+      .send();
+  });
+}
+
+module.exports = cacheWorkingCopy;

--- a/priv/nodejs/mime-type/index.js
+++ b/priv/nodejs/mime-type/index.js
@@ -3,7 +3,6 @@ const FileType = require("file-type");
 const { makeTokenizer } = require("@tokenizer/s3");
 
 const handler = async (event, context, _callback) => {
-  context.callbackWaitsForEmptyEventLoop = false;
   return await extractMimeType(event.bucket, event.key);
 };
 

--- a/priv/nodejs/pyramid-tiff/index.js
+++ b/priv/nodejs/pyramid-tiff/index.js
@@ -3,7 +3,6 @@
 const pyramid = require("./pyramid");
 
 const handler = async (event, context, _callback) => {
-  context.callbackWaitsForEmptyEventLoop = false;
   return await pyramid.createPyramidTiff(event.source, event.target);
 }
 

--- a/priv/nodejs/pyramid-tiff/working-copy.js
+++ b/priv/nodejs/pyramid-tiff/working-copy.js
@@ -1,0 +1,46 @@
+const AWS = require("aws-sdk");
+const URI = require("uri-js");
+const fs = require("fs");
+const tempy = require("tempy");
+
+AWS.config.update({httpOptions: {timeout: 600000}});
+
+const getS3Key = uri => {
+  return uri.path.replace(/^\/+/, "");
+};
+
+const cacheWorkingCopy = async (location) => {
+  const filename = tempy.file();
+
+  return new Promise((resolve, reject) => {
+    let uri = URI.parse(location);
+    let writable = fs
+      .createWriteStream(filename)
+      .on("error", err => reject(err));
+
+    const errorHandler = (err) => {
+      writable.end();
+      fs.unlinkSync(filename);
+      reject(err);
+    }
+
+    console.info(`Creating working copy of ${location} at ${filename}`);
+    new AWS.S3()
+      .getObject({Bucket: uri.host, Key: getS3Key(uri)})
+      .on("httpData", (chunk) => {
+        writable.write(chunk);
+      })
+      .on("httpDownloadProgress", ({loaded, total}) => {
+        console.debug(`Retrieved ${loaded}/${total}`)
+      })
+      .on("httpDone", () => {
+        writable.end();
+        resolve(filename);
+      })
+      .on("httpError", errorHandler)
+      .on("error", errorHandler)
+      .send();
+  });
+}
+
+module.exports = cacheWorkingCopy;


### PR DESCRIPTION
`AWS.S3.getObject().createReadStream()` seems not to be completely reliable. This PR changes the lambdas to use `AWS.Request` events directly (`httpData`, `httpDone`, `httpError`, and `error`) directly, while logging actual progress instead of just `ping`s.