### PR TITLE
Consider pipeline actions that have errored complete

### DIFF
--- a/lib/meadow/pipeline/actions/common.ex
+++ b/lib/meadow/pipeline/actions/common.ex
@@ -10,7 +10,9 @@ defmodule Meadow.Pipeline.Actions.Common do
       def process(data, attrs) do
         Logger.info("Beginning #{__MODULE__} for file set: #{data.file_set_id}")
 
-        with complete <- ActionStates.ok?(data.file_set_id, __MODULE__) do
+        with complete <-
+               ActionStates.ok?(data.file_set_id, __MODULE__) ||
+                 ActionStates.error?(data.file_set_id, __MODULE__) do
           result = process(data, attrs, complete)
           unless complete, do: update_progress(data, attrs, result)
           result


### PR DESCRIPTION
What we observed during an ingest yesterday while we were dealing with scaling issues (we had lambda timeouts set lower than required for the task at hand and our EFS was having performance issues) was that file sets that had `action_state` `outcome` and `ingest_progress` `status` of `error`  we're being retried and those states overwritten.

While successful retries are good, this is not our mechanism for retrying. When we set an action_state and ingest_progress to error, that is a permanent error, and the action should be considered complete and should not be retried. 