### PR TITLE
Fix test flappiness caused by side effects of the assumeRole mutation test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,9 @@ jobs:
           environment:
             MIX_ENV: test
       - run:
+          name: Wait for db
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+      - run:
           name: Elixir Tests
           command: mix coveralls.circle
       - run:

--- a/test/meadow_web/schema/mutation/assume_role_test.exs
+++ b/test/meadow_web/schema/mutation/assume_role_test.exs
@@ -1,5 +1,5 @@
 defmodule MeadowWeb.Schema.Mutation.AssumeRoleTest do
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/AssumeRole.gql")
@@ -7,6 +7,7 @@ defmodule MeadowWeb.Schema.Mutation.AssumeRoleTest do
   describe "assumeRole mutation" do
     setup do
       user = user_fixture("TestAdmins")
+      on_exit(fn -> Cachex.clear!(Meadow.Cache.Users) end)
       {:ok, %{user: user}}
     end
 


### PR DESCRIPTION
Also have CircleCI wait on the postgres port before running Elixir tests