### PR TITLE
Change batch query_string to search non-tokenized id field

### DIFF
--- a/assets/js/components/Dashboards/dashboards.gql.mock.js
+++ b/assets/js/components/Dashboards/dashboards.gql.mock.js
@@ -17,7 +17,7 @@ export const mockGetBatchesResults = [
     id: "f97d222b-3cf6-45ff-98c6-d09a3261964f",
     nickname: null,
     query:
-      '{"query":{"bool":{"must":[{"match":{"model.name":"Image"}},{"query_string":{"query":" id:(aceee345-4fc9-4917-a499-7f9e0379231d OR 620cbd4f-7e44-45bc-aab9-0b0fb97ff2ea)"}}]}}}',
+      '{"query":{"bool":{"must":[{"match":{"model.name":"Image"}},{"query_string":{"query":" id.keyword:(aceee345-4fc9-4917-a499-7f9e0379231d OR 620cbd4f-7e44-45bc-aab9-0b0fb97ff2ea)"}}]}}}',
     replace:
       '{"administrative_metadata":{},"descriptive_metadata":{"title":"Yo Ima Batch Title"}}',
     started: "2020-12-08T15:27:13.396560Z",
@@ -34,7 +34,7 @@ export const mockGetBatchesResults = [
     id: "7b9fa4c5-fa97-46e8-8fd7-db0001dc76c3",
     nickname: "My Batch Job",
     query:
-      '{"query":{"bool":{"must":[{"match":{"model.name":"Image"}},{"query_string":{"query":" id:(aceee345-4fc9-4917-a499-7f9e0379231d OR 620cbd4f-7e44-45bc-aab9-0b0fb97ff2ea)"}}]}}}',
+      '{"query":{"bool":{"must":[{"match":{"model.name":"Image"}},{"query_string":{"query":" id.keyword:(aceee345-4fc9-4917-a499-7f9e0379231d OR 620cbd4f-7e44-45bc-aab9-0b0fb97ff2ea)"}}]}}}',
     replace:
       '{"administrative_metadata":{},"descriptive_metadata":{"description":["Description replacer"],"rights_statement":{"id":"http://rightsstatements.org/vocab/InC/1.0/","scheme":"rights_statement"}}}',
     started: "2020-12-08T17:24:49.278717Z",
@@ -50,7 +50,7 @@ export const mockGetBatchesResults = [
     id: "ABC-f97d222b-3cf6-45ff-98c6",
     nickname: null,
     query:
-      '{"query":{"bool":{"must":[{"match":{"model.name":"Image"}},{"query_string":{"query":" id:(aceee345-4fc9-4917-a499-7f9e0379231d OR 620cbd4f-7e44-45bc-aab9-0b0fb97ff2ea)"}}]}}}',
+      '{"query":{"bool":{"must":[{"match":{"model.name":"Image"}},{"query_string":{"query":" id.keyword:(aceee345-4fc9-4917-a499-7f9e0379231d OR 620cbd4f-7e44-45bc-aab9-0b0fb97ff2ea)"}}]}}}',
     replace:
       '{"administrative_metadata":{},"descriptive_metadata":{"title":"Yo Ima Batch Title"}}',
     started: "2020-12-09T15:27:13.396560Z",
@@ -66,7 +66,7 @@ export const mockGetBatchesResults = [
     id: "ZYZ-f97d222b-3cf6-45ff-98c6",
     nickname: null,
     query:
-      '{"query":{"bool":{"must":[{"match":{"model.name":"Image"}},{"query_string":{"query":" id:(aceee345-4fc9-4917-a499-7f9e0379231d OR 620cbd4f-7e44-45bc-aab9-0b0fb97ff2ea)"}}]}}}',
+      '{"query":{"bool":{"must":[{"match":{"model.name":"Image"}},{"query_string":{"query":" id.keyword:(aceee345-4fc9-4917-a499-7f9e0379231d OR 620cbd4f-7e44-45bc-aab9-0b0fb97ff2ea)"}}]}}}',
     replace:
       '{"administrative_metadata":{},"descriptive_metadata":{"title":"Yo Ima Batch Title"}}',
     started: "2020-12-09T15:27:13.396560Z",

--- a/assets/js/services/reactive-search.js
+++ b/assets/js/services/reactive-search.js
@@ -41,7 +41,7 @@ export function buildSelectedItemsQuery(selectedItems = []) {
         },
         {
           query_string: {
-            query: ` id:(${selectedItems.join(" OR ")})`,
+            query: ` id.keyword:(${selectedItems.join(" OR ")})`,
           },
         },
       ],


### PR DESCRIPTION
The batch edit/delete query (in select works mode), searches on the `id` field, which is tokenized. So a search for an id of 
bdfa8b37-5f43-4594-a8f4-4bd26a27900e

would also match this id because it contains a8f4
7916a549-b921-4318-a8f4-3f2386732bb5

This would lead someone to edit or delete more works than they thought they were. 