### PR TITLE
Batch id search results bug

### DIFF
--- a/assets/js/components/Dashboards/BatchEdit/Details.jsx
+++ b/assets/js/components/Dashboards/BatchEdit/Details.jsx
@@ -77,7 +77,7 @@ function DashboardsBatchEditDetails({ id }) {
           className="button"
           to={{
             pathname: "/search",
-            state: { passedInSearchTerm: id },
+            state: { passedInSearchTerm: `batches:${id}` },
           }}
         >
           <span className="icon">

--- a/assets/js/components/Dashboards/BatchEdit/List.jsx
+++ b/assets/js/components/Dashboards/BatchEdit/List.jsx
@@ -96,17 +96,19 @@ export default function DashboardsBatchEditTable() {
                 >
                   <FontAwesomeIcon icon="eye" />
                 </Link>
-                <Link
-                  data-testid="button-to-search"
-                  className="button is-small"
-                  title="View updated works"
-                  to={{
-                    pathname: "/search",
-                    state: { passedInSearchTerm: id },
-                  }}
-                >
-                  <FontAwesomeIcon icon="share" />
-                </Link>
+                {type == "UPDATE" && (
+                  <Link
+                    data-testid="button-to-search"
+                    className="button is-small"
+                    title="View updated works"
+                    to={{
+                      pathname: "/search",
+                      state: { passedInSearchTerm: id },
+                    }}
+                  >
+                    <FontAwesomeIcon icon="share" />
+                  </Link>
+                )}
               </td>
             </tr>
           );


### PR DESCRIPTION
- fix the search term passed in to view works affected by a batch update
- don't show link to view affected works from the list page if it's a batch delete 