### PR TITLE
Iron out bugs with Related URL controlled term filed in single work a…

### DIFF
--- a/assets/js/components/BatchEdit/About/About.jsx
+++ b/assets/js/components/BatchEdit/About/About.jsx
@@ -52,15 +52,12 @@ const BatchEditAbout = () => {
 
   // Handle About tab form submit (Core and Descriptive metadata)
   const onSubmit = (data) => {
-    console.log("data", data);
-
     // "data" here returns everything (which was set above in the useEffect()),
     // including fields that are either outdated or which no values were ever registered
     // with React Hook Form's register().   So, we'll use getValues() to get the real data
     // updated.
 
     let currentFormValues = methods.getValues();
-    console.log("currentFormValues", currentFormValues);
     let addItems = {};
     let deleteReadyItems = {};
     let replaceItems = {};

--- a/assets/js/components/BatchEdit/ConfirmationTable.jsx
+++ b/assets/js/components/BatchEdit/ConfirmationTable.jsx
@@ -33,8 +33,8 @@ export default function BatchEditConfirmationTable({ itemsObj, type = "add" }) {
     return foundItem.label || "No role label found";
   }
 
-  function getUrlLabel(urlId) {
-    let foundItem = relatedUrls.find((item) => item.id === urlId);
+  function getUrlLabel(url) {
+    let foundItem = relatedUrls.find((item) => item.id === url);
     return foundItem.label || "No URL label found";
   }
 
@@ -96,6 +96,7 @@ export default function BatchEditConfirmationTable({ itemsObj, type = "add" }) {
               }`;
             }
 
+            // Related URL.  TODO: Could find a better way to cue on this than "url"
             if (typeof item === "object" && item.url) {
               rowKey = item.url;
               value = `${item.url} | ${

--- a/assets/js/components/UI/Form/RelatedURL.jsx
+++ b/assets/js/components/UI/Form/RelatedURL.jsx
@@ -7,6 +7,9 @@ import { isUrlValid } from "../../../services/helpers";
 import { Button } from "@nulib/admin-react-components";
 import { useFormContext } from "react-hook-form";
 
+// Final shape of the Related URL input to API is
+// relatedUrl: { label: { id: "ABC123", scheme: "RELATED_URL" }, url: "http://yo.com"}
+
 const UIFormRelatedURL = ({
   codeLists = [],
   label,
@@ -39,8 +42,13 @@ const UIFormRelatedURL = ({
                   data-testid="legend"
                 >{`${label} #${index + 1}`}</legend>
 
-                {/* Existing values are NOT editable, so we save form data needed in the POST update, in hidden fields here */}
-                {!item.new && (
+                {/* 
+                Existing values are NOT editable, so we save form data needed in the POST update, in hidden fields here 
+                item.label - comes from the API as a previously existing value
+                item.labelId is a new entry in the form  
+                */}
+
+                {(item.label || item.labelId) && (
                   <div data-testid="related-url-existing-value">
                     <p>
                       {item.url}
@@ -50,17 +58,19 @@ const UIFormRelatedURL = ({
                       type="hidden"
                       name={`${itemName}.url`}
                       ref={register()}
+                      value={item.url}
                     />
                     <input
                       type="hidden"
-                      name={`${itemName}.label`}
+                      name={`${itemName}.labelId`}
                       ref={register()}
+                      value={item.label ? item.label.id : null}
                     />
                   </div>
                 )}
 
                 {/* New form entries */}
-                {item.new && (
+                {!item.labelId && !item.label && (
                   <div data-testid="related-url-form-item">
                     <div className="field">
                       <label className="label">URL</label>
@@ -68,7 +78,9 @@ const UIFormRelatedURL = ({
                         type="text"
                         name={`${itemName}.url`}
                         className={`input ${
-                          errors[name] && errors[name][index].url
+                          errors[name] &&
+                          errors[name][index] &&
+                          errors[name][index].url
                             ? "is-danger"
                             : ""
                         }`}
@@ -80,25 +92,32 @@ const UIFormRelatedURL = ({
                         defaultValue=""
                         data-testid={`related-url-url-input`}
                       />
-                      {errors[name] && errors[name][index].url && (
-                        <p
-                          data-testid={`relatedURL-input-errors-${index}`}
-                          className="help is-danger"
-                        >
-                          {errors[name][index].url.message}
-                        </p>
-                      )}
+                      {errors[name] &&
+                        errors[name][index] &&
+                        errors[name][index].url && (
+                          <p
+                            data-testid={`relatedURL-input-errors-${index}`}
+                            className="help is-danger"
+                          >
+                            {errors[name][index].url.message}
+                          </p>
+                        )}
                     </div>
                     <div className="field">
+                      <label className="label">Label</label>
                       <UIFormSelect
                         isReactHookForm
-                        name={`${itemName}.label`}
+                        name={`${itemName}.labelId`}
                         label="Label"
                         showHelper={true}
                         data-testid={`related-url-select`}
                         options={codeLists}
                         hasErrors={
-                          !!(errors[name] && errors[name][index].label)
+                          !!(
+                            errors[name] &&
+                            errors[name][index] &&
+                            errors[name][index].labelId
+                          )
                         }
                         required
                       />
@@ -126,7 +145,7 @@ const UIFormRelatedURL = ({
       <Button
         isLight
         onClick={() => {
-          append({ new: true, url: "", label: "" });
+          append({ url: "", labelId: "" });
         }}
         data-testid="button-add-field-array-row"
       >

--- a/assets/js/components/Work/Tabs/About.jsx
+++ b/assets/js/components/Work/Tabs/About.jsx
@@ -27,7 +27,7 @@ import {
   RIGHTS_METADATA,
   UNCONTROLLED_METADATA,
   deleteKeyFromObject,
-} from "../../../services/metadata";
+} from "@js/services/metadata";
 import UIError from "../../UI/Error";
 
 function prepFormData(work) {
@@ -114,6 +114,7 @@ const WorkTabsAbout = ({ work }) => {
     // with React Hook Form's register().   So, we'll use getValues() to get the real data
     // updated.
     let currentFormValues = methods.getValues();
+    console.log("currentFormValues", currentFormValues);
 
     const { title = "" } = currentFormValues;
     let workUpdateInput = {
@@ -126,6 +127,7 @@ const WorkTabsAbout = ({ work }) => {
         license: data.license
           ? deleteKeyFromObject(JSON.parse(data.license))
           : {},
+        relatedUrl: prepRelatedUrl(currentFormValues.relatedUrl),
         rightsStatement: data.rightsStatement
           ? {
               id: data.rightsStatement,
@@ -159,10 +161,7 @@ const WorkTabsAbout = ({ work }) => {
       );
     }
 
-    // Update Related Url, which is a unique controlled term
-    workUpdateInput.descriptiveMetadata.relatedUrl = prepRelatedUrl(
-      currentFormValues.relatedUrl
-    );
+    console.log("workUpdateInput", workUpdateInput);
 
     updateWork({
       variables: {

--- a/assets/js/services/metadata.js
+++ b/assets/js/services/metadata.js
@@ -389,25 +389,18 @@ export function prepFacetKey(controlledTerm = {}, keyItems = []) {
  * @returns {Array} of properly shaped values for Related Url
  */
 export function prepRelatedUrl(items = []) {
-  let returnArray = [];
-
-  returnArray = items.map((item) => {
-    return {
+  try {
+    return items.map((item) => ({
       url: item.url,
       label: {
         scheme: "RELATED_URL",
-        id: item.label,
+        id: item.labelId,
       },
-    };
-  });
-
-  // Check for empty values caused by any kind of error
-  const badData = returnArray.find((item) => !item.url || !item.label.id);
-  if (badData) {
-    console.log("Error preparing Related Url value for form post");
+    }));
+  } catch (e) {
+    console.error("Error preparing Related Url value for form post");
+    return [];
   }
-
-  return badData ? [] : returnArray;
 }
 
 /**

--- a/assets/js/services/metadata.test.js
+++ b/assets/js/services/metadata.test.js
@@ -179,11 +179,11 @@ describe("prepRelatedUrl()", () => {
   var relatedUrlFormValues = [
     {
       url: "http://google.com",
-      label: "HATHI_TRUST_DIGITAL_LIBRARY",
+      labelId: "HATHI_TRUST_DIGITAL_LIBRARY",
     },
     {
       url: "http://northwestern.edu",
-      label: "RESEARCH_GUIDE",
+      labelId: "RESEARCH_GUIDE",
     },
   ];
 
@@ -206,15 +206,5 @@ describe("prepRelatedUrl()", () => {
       },
     ];
     expect(results).toEqual(expectedResults);
-  });
-
-  it("returns an empty array when bad data is passed in", () => {
-    let results = metadata.prepRelatedUrl([
-      {
-        foo: "http://google.com",
-        bar: "HATHI_TRUST_DIGITAL_LIBRARY",
-      },
-    ]);
-    expect(results).toEqual([]);
   });
 });


### PR DESCRIPTION
…nd batch

This should now behave better.  Previously it was not guarding against certain field array properties being set, which caused the original bug in the issue.  Then the data preparation for posting back to the API was sending an empty array if any errors in the form data were present (for whatever reason), thereby potentially clearing out any previous values, not intended for deletion. 

If someone wants to double check I'm not missing anything playing with this in the UI, that'd be great.