### PR TITLE
Increase authority cache transaction timeout for migration

### DIFF
--- a/lib/meadow/migration.ex
+++ b/lib/meadow/migration.ex
@@ -37,13 +37,16 @@ defmodule Meadow.Migration do
   """
   def cache_authorities do
     {:ok, terms} =
-      Repo.transaction(fn ->
-        from(dw in DonutWork, where: dw.status == "pending")
-        |> Repo.stream()
-        |> Stream.map(fn %{manifest: source} -> source end)
-        |> Stream.map(&Meadow.Migration.read_manifest/1)
-        |> ControlledTerms.extract_unique_terms()
-      end)
+      Repo.transaction(
+        fn ->
+          from(dw in DonutWork, where: dw.status == "pending")
+          |> Repo.stream()
+          |> Stream.map(fn %{manifest: source} -> source end)
+          |> Stream.map(&Meadow.Migration.read_manifest/1)
+          |> ControlledTerms.extract_unique_terms()
+        end,
+        timeout: :infinity
+      )
 
     Logger.info("Pre-caching #{length(terms)} unique terms")
 


### PR DESCRIPTION
I got a timeout when trying to run `mix migration.precache` on 32,000+ records

```
[error] Postgrex.Protocol (#PID<0.498.0>) disconnected: ** (DBConnection.ConnectionError) client #PID<0.94.0> timed out because it queued and checked out the connection for longer than 15000ms

#PID<0.94.0> was at location:

    (elixir 1.11.1) lib/task/supervised.ex:252: Task.Supervised.stream_reduce/7
    (elixir 1.11.1) lib/stream.ex:1609: Enumerable.Stream.do_each/4
    (elixir 1.11.1) lib/enum.ex:3461: Enum.into/4
    (meadow 0.1.0) lib/meadow/migration.ex:107: Meadow.Migration.read_manifest/1
    (elixir 1.11.1) lib/stream.ex:572: anonymous fn/4 in Stream.map/2
    (elixir 1.11.1) lib/enum.ex:3764: Enumerable.List.reduce/3
    (elixir 1.11.1) lib/stream.ex:931: Stream.do_list_transform/7
    (elixir 1.11.1) lib/stream.ex:1609: Enumerable.Stream.do_each/4
    (elixir 1.11.1) lib/stream.ex:880: Stream.do_transform/5
    (elixir 1.11.1) lib/enum.ex:3461: Enum.reverse/1
    (elixir 1.11.1) lib/enum.ex:3054: Enum.to_list/1
    (meadow 0.1.0) lib/meadow/data/controlled_terms.ex:224: Meadow.Data.ControlledTerms.extract_unique_terms/1
    (ecto_sql 3.5.4) lib/ecto/adapters/sql.ex:1027: anonymous fn/3 in Ecto.Adapters.SQL.checkout_or_transaction/4
    (db_connection 2.3.1) lib/db_connection.ex:1444: DBConnection.run_transaction/4
    (meadow 0.1.0) lib/meadow/migration.ex:40: Meadow.Migration.cache_authorities/0
    (mix 1.11.1) lib/mix/task.ex:394: Mix.Task.run_task/3
    (mix 1.11.1) lib/mix/cli.ex:84: Mix.CLI.run_task/2
    (elixir 1.11.1) src/elixir_compiler.erl:75: :elixir_compiler.dispatch/4
    (elixir 1.11.1) src/elixir_compiler.erl:60: :elixir_compiler.compile/3
    (elixir 1.11.1) src/elixir_lexical.erl:15: :elixir_lexical.run/3
```