### PR TITLE
Delete a fileset functionality from Work Preservation tab

### DIFF
--- a/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
@@ -16,7 +16,7 @@ const modalCss = css`
   z-index: 100;
 `;
 
-function WorkTabsPreservationFileSetModal({ closeModal, isHidden, workId }) {
+function WorkTabsPreservationFileSetModal({ closeModal, isVisible, workId }) {
   const [currentFile, setCurrentFile] = useState();
   const [uploadProgress, setUploadProgress] = useState();
   const [s3UploadLocation, setS3UploadLocation] = useState();
@@ -144,7 +144,7 @@ function WorkTabsPreservationFileSetModal({ closeModal, isHidden, workId }) {
   if (urlLoading) return <p>Presigned URL Loading</p>;
 
   return (
-    <div className={`modal ${isHidden ? "" : "is-active"}`} css={modalCss}>
+    <div className={`modal ${isVisible ? "is-active" : ""}`} css={modalCss}>
       <div className="modal-background"></div>
 
       {urlError ? (
@@ -216,7 +216,7 @@ function WorkTabsPreservationFileSetModal({ closeModal, isHidden, workId }) {
 
 WorkTabsPreservationFileSetModal.propTypes = {
   closeModal: PropTypes.func,
-  isHidden: PropTypes.bool,
+  isVisible: PropTypes.bool,
   workId: PropTypes.string,
 };
 

--- a/assets/js/components/Work/work.gql.js
+++ b/assets/js/components/Work/work.gql.js
@@ -1,31 +1,9 @@
 import gql from "graphql-tag";
 
-export const INGEST_FILE_SET = gql`
-  mutation IngestFileSet(
-    $accession_number: String!
-    $role: FileSetRole!
-    $metadata: FileSetMetadataInput!
-    $workId: ID!
-  ) {
-    ingestFileSet(
-      accessionNumber: $accession_number
-      role: $role
-      metadata: $metadata
-      workId: $workId
-    ) {
+export const ADD_WORK_TO_COLLECTION = gql`
+  mutation addWorkToCollection($workId: ID!, $collectionId: ID!) {
+    addWorkToCollection(workId: $workId, collectionId: $collectionId) {
       id
-      accession_number
-      role
-      work {
-        id
-      }
-      metadata {
-        location
-        label
-        description
-        original_filename
-        sha256
-      }
     }
   }
 `;
@@ -52,6 +30,33 @@ export const CREATE_WORK = gql`
         title
       }
       id
+    }
+  }
+`;
+
+export const DELETE_FILESET = gql`
+  mutation DeleteFileSet($fileSetId: ID!) {
+    deleteFileSet(fileSetId: $fileSetId) {
+      id
+    }
+  }
+`;
+
+export const DELETE_WORK = gql`
+  mutation deleteWork($workId: ID!) {
+    deleteWork(workId: $workId) {
+      id
+      descriptiveMetadata {
+        title
+      }
+      ingestSheet {
+        id
+        title
+      }
+      project {
+        id
+        title
+      }
     }
   }
 `;
@@ -396,28 +401,31 @@ export const UPDATE_WORK = gql`
   }
 `;
 
-export const ADD_WORK_TO_COLLECTION = gql`
-  mutation addWorkToCollection($workId: ID!, $collectionId: ID!) {
-    addWorkToCollection(workId: $workId, collectionId: $collectionId) {
+export const INGEST_FILE_SET = gql`
+  mutation IngestFileSet(
+    $accession_number: String!
+    $role: FileSetRole!
+    $metadata: FileSetMetadataInput!
+    $workId: ID!
+  ) {
+    ingestFileSet(
+      accessionNumber: $accession_number
+      role: $role
+      metadata: $metadata
+      workId: $workId
+    ) {
       id
-    }
-  }
-`;
-
-export const DELETE_WORK = gql`
-  mutation deleteWork($workId: ID!) {
-    deleteWork(workId: $workId) {
-      id
-      descriptiveMetadata {
-        title
-      }
-      ingestSheet {
+      accession_number
+      role
+      work {
         id
-        title
       }
-      project {
-        id
-        title
+      metadata {
+        location
+        label
+        description
+        original_filename
+        sha256
       }
     }
   }

--- a/assets/js/components/Work/work.gql.mock.js
+++ b/assets/js/components/Work/work.gql.mock.js
@@ -1,7 +1,8 @@
 import {
+  CREATE_WORK,
+  DELETE_FILESET,
   GET_WORK,
   VERIFY_FILE_SETS,
-  CREATE_WORK,
 } from "../../components/Work/work.gql.js";
 import { mockVisibility, mockWorkType } from "../../client-local";
 
@@ -392,6 +393,22 @@ export const createWorkMock = {
         descriptiveMetadata: {
           title: "New mock work title",
         },
+        id: "ABC123",
+      },
+    },
+  },
+};
+
+export const deleteFilesetMock = {
+  request: {
+    query: DELETE_FILESET,
+    variables: {
+      fileSetId: "ABC123",
+    },
+  },
+  result: {
+    data: {
+      deleteFileSet: {
         id: "ABC123",
       },
     },

--- a/assets/js/services/helpers.js
+++ b/assets/js/services/helpers.js
@@ -149,7 +149,7 @@ export function toastWrapper(
     message,
     type,
     dismissible: true,
-    duration: 5000,
+    duration: 8000,
     position: "top-center",
   });
 }


### PR DESCRIPTION
Delete functionality now wired up.  Handles errors and updates the Apollo Client cache after a delete.

![image](https://user-images.githubusercontent.com/3020266/108261186-e0dad380-7128-11eb-9c67-6c8ebfe200dc.png)
