### PR TITLE
Test db rollback in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,11 @@ jobs:
           name: Test Webpack Build
           command: yarn deploy
           working_directory: ~/meadow/assets
+      - run:
+          name: Test db rollback
+          command: mix ecto.rollback --all
+          environment:
+            MIX_ENV: test
       - store_artifacts:
           path: /tmp/test-results
           destination: tests


### PR DESCRIPTION
- Adds a step to test db rollbacks by running `mix ecto.rollback --all` to ensure we can rollback safely in production if necessary.
![circleci_db_rollback](https://user-images.githubusercontent.com/1395707/108261555-68284700-7129-11eb-9e5b-9ec576d186bc.png)
