### PR TITLE
Create a more robust mechanism for Indexing and updating IndexTimes

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -33,8 +33,10 @@ config :meadow, MeadowWeb.Endpoint,
 # Configures the ElasticsearchCluster
 config :meadow, Meadow.ElasticsearchCluster,
   api: Elasticsearch.API.HTTP,
-  timeout: 15_000,
-  recv_timeout: 15_000,
+  default_options: [
+    timeout: 20_000,
+    recv_timeout: 30_000
+  ],
   json_library: Jason,
   indexes: %{
     meadow: %{

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -56,7 +56,9 @@ config :meadow, Meadow.ElasticsearchCluster,
       region: get_required_var.("AWS_REGION"),
       access_key: get_required_var.("ELASTICSEARCH_KEY"),
       secret: get_required_var.("ELASTICSEARCH_SECRET")
-    ]
+    ],
+    timeout: 20_000,
+    recv_timeout: 30_000
   ],
   json_library: Jason,
   indexes: %{
@@ -65,7 +67,7 @@ config :meadow, Meadow.ElasticsearchCluster,
       store: Meadow.ElasticsearchStore,
       sources: [Meadow.Data.Schemas.Work, Meadow.Data.Schemas.Collection],
       bulk_page_size: 500,
-      bulk_wait_interval: 2_000
+      bulk_wait_interval: 1_000
     }
   }
 

--- a/lib/meadow/data/index_times.ex
+++ b/lib/meadow/data/index_times.ex
@@ -6,9 +6,52 @@ defmodule Meadow.Data.IndexTimes do
   alias Meadow.Data.Schemas.IndexTime
   alias Meadow.Repo
 
+  import Ecto.Query
+
   require Logger
+
+  def change(index_ids, delete_ids) do
+    with {add_ids, update_ids} <- touch(index_ids) do
+      delete(delete_ids)
+      {add_ids, update_ids, delete_ids}
+    end
+  end
+
+  def delete(ids) do
+    with {_count, deleted_ids} <-
+           from(t in IndexTime, where: t.id in ^ids, select: t.id)
+           |> Repo.delete_all() do
+      deleted_ids
+    end
+  end
 
   def reset_all! do
     Repo.delete_all(IndexTime)
+  end
+
+  def touch(ids, timestamp \\ DateTime.utc_now()) do
+    with ids <- Enum.uniq(ids) do
+      result =
+        Repo.transaction(fn ->
+          {_count, update_ids} =
+            from(t in IndexTime, where: t.id in ^ids, select: t.id)
+            |> Repo.update_all(set: [indexed_at: timestamp])
+
+          with add_ids <- ids -- update_ids,
+               changesets <- add_ids |> Enum.map(&%{id: &1, indexed_at: timestamp}) do
+            Repo.insert_all(IndexTime, changesets,
+              on_conflict: :nothing,
+              conflict_target: [:id]
+            )
+
+            {add_ids, update_ids}
+          end
+        end)
+
+      case result do
+        {:ok, counts} -> counts
+        other -> other
+      end
+    end
   end
 end

--- a/lib/meadow/elasticsearch_diff_store.ex
+++ b/lib/meadow/elasticsearch_diff_store.ex
@@ -10,7 +10,7 @@ defmodule Meadow.ElasticsearchDiffStore do
   alias Meadow.Repo
   import Ecto.Query
 
-  @chunk_size 100
+  @chunk_size 500
   @tracked_schemas [Schemas.Collection, Schemas.Work, Schemas.FileSet]
 
   @impl true

--- a/terraform/ec2_files/dev.local.exs
+++ b/terraform/ec2_files/dev.local.exs
@@ -21,7 +21,9 @@ config :meadow, Meadow.ElasticsearchCluster,
       region: get_required_var.("AWS_REGION"),
       access_key: get_required_var.("ELASTICSEARCH_KEY"),
       secret: get_required_var.("ELASTICSEARCH_SECRET")
-    ]
+    ],
+    timeout: 20_000,
+    recv_timeout: 30_000
   ],
   json_library: Jason,
   indexes: %{

--- a/test/meadow/data/index_times_test.exs
+++ b/test/meadow/data/index_times_test.exs
@@ -4,22 +4,56 @@ defmodule Meadow.Data.IndexTimesTest do
   alias Meadow.Data.IndexTimes
   alias Meadow.Data.Schemas.IndexTime
 
-  @valid_attrs %{
-    id: Ecto.UUID.generate(),
-    indexed_at: DateTime.utc_now()
-  }
+  setup tags do
+    with count <- Map.get(tags, :count, 1) do
+      index_time_ids =
+        1..count
+        |> Enum.map(fn _ ->
+          with {:ok, index_time} <-
+                 %IndexTime{}
+                 |> IndexTime.changeset(%{
+                   id: Ecto.UUID.generate(),
+                   indexed_at: DateTime.utc_now()
+                 })
+                 |> Repo.insert() do
+            index_time.id
+          end
+        end)
 
-  setup do
-    {:ok, index_time} =
-      %IndexTime{}
-      |> IndexTime.changeset(@valid_attrs)
-      |> Repo.insert()
-
-    {:ok, index_time: index_time}
+      {:ok, index_time_ids: index_time_ids}
+    end
   end
 
+  @tag count: 50
+  test "change/2", %{index_time_ids: index_time_ids} do
+    [update | [delete | _]] = index_time_ids |> Enum.chunk_every(40)
+    add = Enum.map(1..20, fn _ -> Ecto.UUID.generate() end)
+    assert {added, updated, deleted} = IndexTimes.change(add ++ update, delete)
+    assert length(added) == 20
+    assert length(updated) == 40
+    assert length(deleted) == 10
+    assert Repo.aggregate(IndexTime, :count) == 60
+  end
+
+  @tag count: 30
+  test "touch/1", %{index_time_ids: update} do
+    add = Enum.map(1..20, fn _ -> Ecto.UUID.generate() end)
+    assert {added, updated} = IndexTimes.touch(add ++ update)
+    assert length(added) == 20
+    assert length(updated) == 30
+    assert Repo.aggregate(IndexTime, :count) == 50
+  end
+
+  @tag count: 25
+  test "delete/1", %{index_time_ids: index_time_ids} do
+    delete = index_time_ids |> Enum.take(10)
+    assert IndexTimes.delete(delete) |> length() == 10
+    assert Repo.aggregate(IndexTime, :count) == 15
+  end
+
+  @tag count: 25
   test "reset_all!/0" do
-    IndexTimes.reset_all!()
+    assert IndexTimes.reset_all!() == {25, nil}
     assert Repo.aggregate(IndexTime, :count) == 0
   end
 end


### PR DESCRIPTION
- Update and Insert separately instead of trying to use `insert_all` with `on_conflict: update`
- Add index count logging to Indexer
- Increase chunk size
- Reduce wait interval
- Increase timeouts
- Handle Elasticsearch upload failures (trap, warn, move on)

I ran a full `Indexer.reindex_all()` on staging with these changes and it ran through just fine (78 Collections + 80,541 Works + 81,284 FileSets = 161,903 IndexTime records)