### PR TITLE
Create meadow upload user with access keys

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -97,10 +97,13 @@ resource "aws_instance" "this_ec2_instance" {
   user_data                     = data.template_file.ec2_user_data.rendered
 
   lifecycle {
-    ignore_changes = [ user_data, instance_type ]
+    ignore_changes = [ ami, user_data, instance_type ]
   }
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    { Name = "${var.stack_name}-console" }
+  )
 }
 
 resource "aws_route53_record" "ec2_hostname" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -12,7 +12,7 @@ module "rds" {
   allocated_storage         = "5"
   backup_window             = "04:00-05:00"
   engine                    = "postgres"
-  engine_version            = "11.2"
+  engine_version            = "11.8"
   final_snapshot_identifier = "meadow-final"
   identifier                = "${var.stack_name}-db"
   instance_class            = "db.t3.medium"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -5,3 +5,10 @@ output "ec2_instance" {
 output "endpoint" {
   value = "https://${aws_route53_record.app_hostname.fqdn}/"
 }
+
+output "upload_user_key_id" {
+  value = {
+    aws_access_key_id = aws_iam_access_key.upload_user_access_key.id,
+    aws_secret_access_key = aws_iam_access_key.upload_user_access_key.secret
+  }
+}

--- a/terraform/upload_user.tf
+++ b/terraform/upload_user.tf
@@ -1,0 +1,66 @@
+data "aws_iam_policy_document" "upload_bucket_access" {
+  statement {
+    effect    = "Allow"
+    actions   = [
+      "s3:ListAllMyBuckets"
+    ]
+    resources = ["arn:aws:s3:::*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:DeleteObjectTagging",
+      "s3:DeleteObjectVersion",
+      "s3:ListBucketVersions",
+      "s3:PutObjectVersionTagging",
+      "s3:ListBucket",
+      "s3:DeleteObjectVersionTagging",
+      "s3:PutObject",
+      "s3:GetObjectAcl",
+      "s3:GetObject",
+      "s3:AbortMultipartUpload",
+      "s3:PutObjectTagging",
+      "s3:DeleteObject",
+      "s3:PutObjectAcl",
+      "s3:GetObjectVersion"
+    ]
+
+    resources = [
+      aws_s3_bucket.meadow_ingest.arn,
+      aws_s3_bucket.meadow_uploads.arn,
+      "${aws_s3_bucket.meadow_ingest.arn}/*",
+      "${aws_s3_bucket.meadow_uploads.arn}/*"
+    ]
+  }  
+}
+
+resource "aws_iam_policy" "upload_bucket_policy" {
+  name          = "${var.stack_name}-upload-policy"
+  description   = "Read-write access to Meadow ingest and upload buckets"
+  policy        = data.aws_iam_policy_document.upload_bucket_access.json
+}
+
+resource "aws_iam_group" "upload_group" {
+  name   = "${var.stack_name}-uploaders"
+}
+
+resource "aws_iam_group_policy_attachment" "upload_group_policy" {
+  group      = aws_iam_group.upload_group.name
+  policy_arn = aws_iam_policy.upload_bucket_policy.arn
+}
+
+resource "aws_iam_user" "upload_user" {
+  name   = "${var.stack_name}-uploader"
+  tags   = var.tags
+}
+
+resource "aws_iam_user_group_membership" "upload_user_group_membership" {
+  user = aws_iam_user.upload_user.name
+  groups = [aws_iam_group.upload_group.name]
+}
+
+resource "aws_iam_access_key" "upload_user_access_key" {
+  user = aws_iam_user.upload_user.name
+}


### PR DESCRIPTION
Terraform-only change.
Changes have already been applied on staging and production, with the generated access keys stored in CyberArk.