### PR TITLE
Allow for a non-wildcard certificate to be used on the load balancer

### DIFF
--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -4,7 +4,7 @@ resource "aws_ecs_cluster" "meadow" {
 }
 
 data "aws_acm_certificate" "meadow_cert" {
-  domain = "*.${trimsuffix(data.aws_route53_zone.app_zone.name, ".")}"
+  domain = "${var.certificate_name}.${trimsuffix(data.aws_route53_zone.app_zone.name, ".")}"
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -12,6 +12,11 @@ variable "availability_zones" {
   default = ["us-east-1a", "us-east-1b", "us-east-1c"]
 }
 
+variable "certificate_name" {
+  type    = string
+  default = "*"
+}
+
 variable "digital_collections_url" {
   type    = string
 }


### PR DESCRIPTION
Terraform-only. Already applied to staging and master.