### PR TITLE
Change file set role to coded term

### DIFF
--- a/assets/js/components/IngestSheet/ingestSheet.gql.js
+++ b/assets/js/components/IngestSheet/ingestSheet.gql.js
@@ -179,7 +179,10 @@ export const INGEST_SHEET_WORKS = gql`
       }
       fileSets {
         id
-        role
+        role {
+          id
+          label
+        }
         accessionNumber
         metadata {
           description

--- a/assets/js/components/Work/Tabs/Preservation.jsx
+++ b/assets/js/components/Work/Tabs/Preservation.jsx
@@ -241,7 +241,7 @@ const WorkTabsPreservation = ({ work }) => {
                 return (
                   <tr key={fileset.id} data-testid="preservation-row">
                     <td className="is-hidden">{fileset.id}</td>
-                    <td>{fileset.role}</td>
+                    <td>{fileset.role && fileset.role.label}</td>
                     <td className="break-word">
                       {metadata ? metadata.originalFilename : " "}
                     </td>

--- a/assets/js/components/Work/Tabs/Preservation.test.js
+++ b/assets/js/components/Work/Tabs/Preservation.test.js
@@ -53,7 +53,7 @@ describe("WorkTabsPreservation component", () => {
     const td = await screen.findByText(mockWork.fileSets[0].id);
     const row = td.closest("tr");
     const utils = within(row);
-    expect(utils.getByText(/AM/i));
+    expect(utils.getByText("Access"));
     expect(utils.getByText(/coffee.jpg/i));
     expect(utils.getByText("s3://bucket/foo/bar"));
   });

--- a/assets/js/components/Work/Tabs/Preservation/FileSetForm.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/FileSetForm.jsx
@@ -3,10 +3,11 @@ import PropTypes from "prop-types";
 import UIFormInput from "@js/components/UI/Form/Input.jsx";
 import UIFormField from "@js/components/UI/Form/Field.jsx";
 import UIFormSelect from "@js/components/UI/Form/Select.jsx";
-import { FILE_SET_ROLES } from "@js/services/global-vars";
-import Error from "@js/components/UI/Error";
+import { useCodeLists } from "@js/context/code-list-context";
 
 function WorkTabsPreservationFileSetForm({ s3UploadLocation }) {
+  const codeLists = useCodeLists();
+
   return (
     <>
       {s3UploadLocation && (
@@ -48,9 +49,10 @@ function WorkTabsPreservationFileSetForm({ s3UploadLocation }) {
             <UIFormSelect
               isReactHookForm
               name="role"
+              showHelper={true}
               label="Fileset Role"
-              options={FILE_SET_ROLES}
-              data-testid="fileset-role-input"
+              options={codeLists.fileSetRoleData.codeList}
+              required
             />
           </UIFormField>
         </div>

--- a/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
@@ -27,7 +27,7 @@ function WorkTabsPreservationFileSetModal({ closeModal, isVisible, workId }) {
     accessionNumber: "",
     label: "",
     description: "",
-    role: "PM",
+    role: { id: "A", scheme: "FILE_SET_ROLE" },
   };
 
   const methods = useForm({
@@ -73,7 +73,7 @@ function WorkTabsPreservationFileSetModal({ closeModal, isVisible, workId }) {
       variables: {
         accession_number: data.accessionNumber,
         workId,
-        role: data.role,
+        role: { id: data.role, scheme: "FILE_SET_ROLE" },
         metadata: {
           description: data.description,
           label: data.label,

--- a/assets/js/components/Work/Tabs/Preservation/FileSetModal.test.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/FileSetModal.test.jsx
@@ -10,6 +10,8 @@ import { mockWork } from "@js/components/Work/work.gql.mock.js";
 import { screen, waitFor } from "@testing-library/react";
 import { getCurrentUserMock } from "@js/components/Auth/auth.gql.mock";
 import userEvent from "@testing-library/user-event";
+import { CodeListProvider } from "@js/context/code-list-context";
+import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
 
 let isModalOpen = true;
 
@@ -26,10 +28,16 @@ describe("Add fileset to work modal", () => {
     });
     return renderWithRouterApollo(
       <AuthProvider>
-        <Wrapped />
+        <CodeListProvider>
+          <Wrapped />
+        </CodeListProvider>
       </AuthProvider>,
       {
-        mocks: [getPresignedUrlForFileSetMock, getCurrentUserMock],
+        mocks: [
+          getPresignedUrlForFileSetMock,
+          getCurrentUserMock,
+          ...allCodeListMocks,
+        ],
       }
     );
   });

--- a/assets/js/components/Work/Tabs/Structure/Structure.jsx
+++ b/assets/js/components/Work/Tabs/Structure/Structure.jsx
@@ -103,7 +103,7 @@ const WorkTabsStructure = ({ work }) => {
   };
 
   const filterAccessMasters = (fileSets) => {
-    return fileSets.filter((fs) => fs.role == "AM");
+    return fileSets.filter((fs) => fs.role.id == "A");
   };
 
   const onSubmit = (data) => {

--- a/assets/js/components/Work/controlledVocabulary.gql.mock.js
+++ b/assets/js/components/Work/controlledVocabulary.gql.mock.js
@@ -289,8 +289,32 @@ export const codeListVisibilityMock = {
   },
 };
 
+export const codeListFileSetRoleMock = {
+  request: {
+    query: CODE_LIST_QUERY,
+    variables: { scheme: "FILE_SET_ROLE" },
+  },
+  result: {
+    data: {
+      codeList: [
+        {
+          id: "A",
+          label: "Access",
+          __typename: "CodedTerm",
+        },
+        {
+          id: "P",
+          label: "Preservation",
+          __typename: "CodedTerm",
+        },
+      ],
+    },
+  },
+};
+
 export const allCodeListMocks = [
   codeListAuthorityMock,
+  codeListFileSetRoleMock,
   codeListLibraryUnitMock,
   codeListLicenseMock,
   codeListMarcRelatorMock,

--- a/assets/js/components/Work/work.gql.js
+++ b/assets/js/components/Work/work.gql.js
@@ -198,7 +198,10 @@ export const GET_WORK = gql`
       }
       fileSets {
         id
-        role
+        role {
+          id
+          label
+        }
         accessionNumber
         metadata {
           description
@@ -245,7 +248,10 @@ export const GET_WORKS = gql`
       }
       fileSets {
         id
-        role
+        role {
+          id
+          label
+        }
         accessionNumber
         metadata {
           description
@@ -416,7 +422,10 @@ export const INGEST_FILE_SET = gql`
     ) {
       id
       accession_number
-      role
+      role {
+        id
+        label
+      }
       work {
         id
       }

--- a/assets/js/components/Work/work.gql.mock.js
+++ b/assets/js/components/Work/work.gql.mock.js
@@ -143,7 +143,7 @@ export const mockWork = {
     {
       accessionNumber: "Donohue_001_04",
       id: "01E08T3EXBJX3PWDG22NSRE0BS",
-      role: "AM",
+      role: { id: "A", label: "Access" },
       metadata: {
         description: "Letter, page 2, If these papers, verso, blank",
         exif:
@@ -157,7 +157,7 @@ export const mockWork = {
     {
       accessionNumber: "Donohue_001_01",
       id: "01E08T3EW3TQ9T0AXCR6X9QDJW",
-      role: "AM",
+      role: { id: "A", label: "Access" },
       metadata: {
         description: "Letter, page 1, Dear Sir, recto",
         exif:
@@ -172,7 +172,7 @@ export const mockWork = {
     {
       accessionNumber: "Donohue_001_03",
       id: "01E08T3EWRPXMWW0B1NHZ56AW6",
-      role: "AM",
+      role: { id: "A", label: "Access" },
       metadata: {
         description: "Letter, page 2, If these papers, recto",
         originalFilename: "coffee.jpg",
@@ -184,7 +184,7 @@ export const mockWork = {
     {
       accessionNumber: "Donohue_001_02",
       id: "01E08T3EWFJB35RY3RVR65AXMK",
-      role: "AM",
+      role: { id: "A", label: "Access" },
       metadata: {
         description: "Letter, page 1, Dear Sir, verso, blank",
         originalFilename: "coffee.jpg",
@@ -308,7 +308,7 @@ const mockWork2 = {
         sha256:
           "6b94a88f3a357a1fabec803412ebfaa8972c8f8784e25b723898035b3863f303",
       },
-      role: "AM",
+      role: { id: "A", label: "Access" },
     },
     {
       accessionNumber: "Donohue_002_01b",
@@ -322,7 +322,7 @@ const mockWork2 = {
         sha256:
           "a2fe39ca86723eaecb9a6e2557c3daf4698e2e5d4b124c81ad557b5854376a5b",
       },
-      role: "AM",
+      role: { id: "A", label: "Access" },
     },
     {
       accessionNumber: "Donohue_002_02b",
@@ -336,7 +336,7 @@ const mockWork2 = {
         sha256:
           "7c69abf311b0da097edc8c54d30e27b41b8fcbca7b5e962c86b8604c5072cfb6",
       },
-      role: "AM",
+      role: { id: "A", label: "Access" },
     },
   ],
   ingestSheet: {

--- a/assets/js/context/code-list-context.js
+++ b/assets/js/context/code-list-context.js
@@ -117,10 +117,22 @@ function CodeListProvider({ children }) {
     throw new Error("Error getting visibility data");
   }
 
+  // GET FILE SET ROLES
+  const {
+    data: fileSetRoleData,
+    error: fileSetRoleError,
+    loading: fileSetRoleLoading,
+  } = useQuery(CODE_LIST_QUERY, { variables: { scheme: "FILE_SET_ROLE" } });
+
+  if (fileSetRoleError) {
+    throw new Error("Error getting file set role data");
+  }
+
   return (
     <CodeListContext.Provider
       value={{
         authorityData,
+        fileSetRoleData,
         libraryUnitData,
         licenseData,
         marcData,
@@ -131,7 +143,8 @@ function CodeListProvider({ children }) {
         subjectRoleData,
         visibilityData,
         isLoading: Boolean(
-          authorityLoading ||
+          fileSetRoleLoading ||
+            authorityLoading ||
             libraryUnitLoading ||
             licenseLoading ||
             marcLoading ||

--- a/assets/js/mock-data/filesets.js
+++ b/assets/js/mock-data/filesets.js
@@ -1,7 +1,7 @@
 export const mockFileSets = [
   {
     id: "45226a50-87ca-443e-bc05-f47884e14505",
-    role: "AM",
+    role: { id: "A", scheme: "FILE_SET_ROLE" },
     accessionNumber: "Voyager:2569254_FILE_0",
     metadata: {
       description: "inu-dil-9d35d0ba-a84b-4e0a-99e6-9c6b548a46db.tif",
@@ -16,7 +16,7 @@ export const mockFileSets = [
   {
     __typename: "FileSet",
     id: "109b9a5c-3c6f-4a98-b98b-12402b871dc7",
-    role: "AM",
+    role: { id: "A", scheme: "FILE_SET_ROLE" },
     accessionNumber: "Voyager:2572813_FILE_0",
     metadata: {
       __typename: "FileSetMetadata",
@@ -32,7 +32,7 @@ export const mockFileSets = [
   {
     __typename: "FileSet",
     id: "d414d3d4-b72c-49cc-b7cc-faa9bc0f256e",
-    role: "AM",
+    role: { id: "A", scheme: "FILE_SET_ROLE" },
     accessionNumber: "Voyager:2553177_FILE_0",
     metadata: {
       __typename: "FileSetMetadata",

--- a/assets/js/services/global-vars.js
+++ b/assets/js/services/global-vars.js
@@ -3,15 +3,6 @@ export const COLLECTION_TYPES = [
   { label: "NUL Theme", id: "NUL Theme", value: "NUL Theme" },
 ];
 
-export const FILE_SET_ROLES = [
-  { label: "Access Master (AM)", id: "AM", value: "Access Master (AM)" },
-  {
-    label: "Preservation Master (PM)",
-    id: "PM",
-    value: "Preservation Master (PM)",
-  },
-];
-
 export const REACTIVESEARCH_SORT_OPTIONS = [
   {
     sortBy: "desc",

--- a/assets/js/services/helpers.test.js
+++ b/assets/js/services/helpers.test.js
@@ -115,7 +115,7 @@ describe("Sort file sets", () => {
   const originalFileSets = [
     {
       id: "2357ea03-9dd5-49f2-a88c-dfc9aa88be3c",
-      role: "AM",
+      role: { id: "A", scheme: "FILE_SET_ROLE" },
       accessionNumber: "inu-fava-5145080_FILE_0",
       metadata: {
         __typename: "FileSetMetadata",
@@ -130,7 +130,7 @@ describe("Sort file sets", () => {
     },
     {
       id: "26357d25-b5e0-4e27-b683-c6844a13dc6b",
-      role: "AM",
+      role: { id: "A", scheme: "FILE_SET_ROLE" },
       accessionNumber: "inu-fava-5145080_FILE_1",
       metadata: {
         __typename: "FileSetMetadata",
@@ -145,7 +145,7 @@ describe("Sort file sets", () => {
     },
     {
       id: "0607a735-9f99-4d38-b75a-6c10027f0937",
-      role: "AM",
+      role: { id: "A", scheme: "FILE_SET_ROLE" },
       accessionNumber: "inu-fava-5145080_FILE_2",
       metadata: {
         __typename: "FileSetMetadata",

--- a/config/sequins.exs
+++ b/config/sequins.exs
@@ -67,7 +67,7 @@ config :sequins, CreatePyramidTiff,
     visibility_timeout: 300
   ],
   notify_on: [
-    ExtractExifMetadata: [status: :ok, role: "am"],
+    ExtractExifMetadata: [status: :ok, role: "A"],
     CreatePyramidTiff: [status: :retry]
   ]
 
@@ -76,5 +76,5 @@ config :sequins, FileSetComplete,
   notify_on: [
     CreatePyramidTiff: [status: :ok],
     FileSetComplete: [status: :retry],
-    ExtractExifMetadata: [status: :ok, role: "pm"]
+    ExtractExifMetadata: [status: :ok, role: "P"]
   ]

--- a/lib/meadow/constants.ex
+++ b/lib/meadow/constants.ex
@@ -3,11 +3,6 @@ defmodule Meadow.Constants do
 
   defmacro __using__(_) do
     quote do
-      @work_types ~w[image audio video document]
-      @ingest_statuses ~w[pending processing complete error]
-      @visibility ~w[open authenticated restricted]
-      @default_visibility "restricted"
-      @file_set_roles ~w[am pm]
       @ingest_sheet_headers ~w(accession_number description filename role work_accession_number)
       @role_priority ~w[Administrators Managers Editors Users]
     end

--- a/lib/meadow/data.ex
+++ b/lib/meadow/data.ex
@@ -32,19 +32,22 @@ defmodule Meadow.Data do
 
   ## Examples
 
-      iex> ranked_file_sets_for_work("01DT7V79D45B8BQMVS6YDRSF9J", "am")
+      iex> ranked_file_sets_for_work("01DT7V79D45B8BQMVS6YDRSF9J", "A")
       [%Meadow.Data.Schemas.FileSet{rank: -100}, %Meadow.Data.Schemas.FileSet{rank: 0}, %Meadow.Data.Schemas.FileSet{rank: 100}]
 
       iex> ranked_file_sets_for_work(Ecto.UUID.generate())
       []
 
   """
-  def ranked_file_sets_for_work(work_id, role) do
-    FileSet
-    |> where([fs], fs.work_id == ^work_id)
-    |> where([fs], fs.role == ^role)
-    |> order_by(:rank)
-    |> Repo.all()
+  def ranked_file_sets_for_work(work_id, role_id) do
+    map = %{"id" => role_id}
+
+    Repo.all(
+      from f in FileSet,
+        where: f.work_id == ^work_id,
+        where: fragment("role @> ?::jsonb", ^map),
+        order_by: :rank
+    )
   end
 
   # Dataloader

--- a/lib/meadow/data/works.ex
+++ b/lib/meadow/data/works.ex
@@ -116,10 +116,12 @@ defmodule Meadow.Data.Works do
   end
 
   def get_access_masters(work_id) do
+    map = %{"id" => "A"}
+
     Repo.all(
       from f in FileSet,
-        where: f.role == "am",
         where: f.work_id == ^work_id,
+        where: fragment("role @> ?::jsonb", ^map),
         order_by: :rank,
         limit: 1
     )
@@ -143,12 +145,18 @@ defmodule Meadow.Data.Works do
 
   """
   def with_file_sets(id, role) do
+    map = %{"id" => role}
+
     Work
     |> Repo.get!(id)
     |> Repo.preload([
       :ingest_sheet,
       :project,
-      file_sets: from(f in FileSet, where: f.role == ^role, order_by: [asc: :role, asc: :rank])
+      file_sets:
+        from(f in FileSet,
+          where: fragment("role @> ?::jsonb", ^map),
+          order_by: [asc: :role, asc: :rank]
+        )
     ])
     |> add_representative_image()
   end
@@ -533,9 +541,9 @@ defmodule Meadow.Data.Works do
   @doc """
   Update the order of the file sets attached to a work
   """
-  def update_file_set_order(work_id, role, ordered_file_set_ids) do
+  def update_file_set_order(work_id, role_id, ordered_file_set_ids) do
     ensure_file_set_list_unique(ordered_file_set_ids)
-    |> ensure_file_set_list_complete(work_id, role, ordered_file_set_ids)
+    |> ensure_file_set_list_complete(work_id, role_id, ordered_file_set_ids)
     |> reorder_file_sets(ordered_file_set_ids)
   end
 
@@ -547,12 +555,14 @@ defmodule Meadow.Data.Works do
 
   defp ensure_file_set_list_complete({:error, msg}, _, _, _), do: {:error, msg}
 
-  defp ensure_file_set_list_complete(:ok, work_id, role, file_set_ids) do
+  defp ensure_file_set_list_complete(:ok, work_id, role_id, file_set_ids) do
+    map = %{"id" => role_id}
+
     work =
       from(w in Work,
         join: f in assoc(w, :file_sets),
         where: w.id == ^work_id,
-        where: f.role == ^role,
+        where: fragment("role @> ?::jsonb", ^map),
         preload: [file_sets: f]
       )
       |> Repo.one()

--- a/lib/meadow/iiif/generator.ex
+++ b/lib/meadow/iiif/generator.ex
@@ -11,7 +11,7 @@ defmodule Meadow.IIIF.Generator do
 
   def create_manifest(%Work{id: id}) do
     id
-    |> Works.with_file_sets("am")
+    |> Works.with_file_sets("A")
     |> encode!()
   end
 

--- a/lib/meadow/ingest/progress.ex
+++ b/lib/meadow/ingest/progress.ex
@@ -210,7 +210,7 @@ defmodule Meadow.Ingest.Progress do
     |> Repo.aggregate(:count)
   end
 
-  defp row_actions("pm", include_work) do
+  defp row_actions("P", include_work) do
     actions = List.delete(Pipeline.actions(), Meadow.Pipeline.Actions.CreatePyramidTiff)
 
     if include_work do

--- a/lib/meadow/ingest/validator.ex
+++ b/lib/meadow/ingest/validator.ex
@@ -4,7 +4,7 @@ defmodule Meadow.Ingest.Validator do
   """
 
   alias Meadow.Config
-  alias Meadow.Data.{FileSets, Works}
+  alias Meadow.Data.{CodedTerms, FileSets, Works}
   alias Meadow.Ingest.{Rows, Sheets}
   alias Meadow.Ingest.Schemas.{Row, Sheet}
   alias Meadow.Repo
@@ -205,11 +205,11 @@ defmodule Meadow.Ingest.Validator do
     do: {:error, field_name, "#{field_name} cannot be blank"}
 
   defp validate_value({"role", value}, _existing_files) do
-    case Enum.member?(@file_set_roles, value) do
-      true ->
+    case CodedTerms.get_coded_term(value, "file_set_role") do
+      {{:ok, _}, _term} ->
         :ok
 
-      false ->
+      nil ->
         {:error, "role", "role: #{value} is invalid"}
     end
   end

--- a/lib/meadow/ingest/work_creator.ex
+++ b/lib/meadow/ingest/work_creator.ex
@@ -77,7 +77,7 @@ defmodule Meadow.Ingest.WorkCreator do
     |> Enum.each(fn {%FileSet{id: file_set_id, role: role}, %Row{row: row_num}} ->
       Pipeline.kickoff(file_set_id, %{
         context: "Sheet",
-        role: role,
+        role: role.id,
         ingest_sheet: ingest_sheet.id,
         ingest_sheet_row: row_num
       })
@@ -102,7 +102,7 @@ defmodule Meadow.Ingest.WorkCreator do
 
           %{
             accession_number: row |> Row.field_value(:accession_number),
-            role: row |> Row.field_value(:role),
+            role: %{scheme: "file_set_role", id: row |> Row.field_value(:role)},
             metadata: %{
               description: row |> Row.field_value(:description),
               location: location,

--- a/lib/meadow/migration.ex
+++ b/lib/meadow/migration.ex
@@ -241,7 +241,7 @@ defmodule Meadow.Migration do
 
     file_sets
     |> Enum.each(fn file_set ->
-      Pipeline.kickoff(file_set, %{overwrite: "false", role: file_set.role})
+      Pipeline.kickoff(file_set, %{overwrite: "false", role: file_set.role.id})
     end)
   end
 
@@ -251,6 +251,7 @@ defmodule Meadow.Migration do
     |> update_digests()
     |> update_original_filename()
     |> update_label()
+    |> update_role()
   end
 
   defp update_location(%{metadata: %{location: location}} = file_set) do
@@ -295,6 +296,10 @@ defmodule Meadow.Migration do
       "" -> put_in(file_set, [:metadata, :label], original_filename)
       _ -> file_set
     end
+  end
+
+  defp update_role(%{role: _role} = file_set) do
+    put_in(file_set.role, %{id: "A", scheme: "FILE_SET_ROLE"})
   end
 
   defp update_original_filename(%{metadata: %{original_filename: original_filename}} = file_set) do

--- a/lib/meadow/pipeline.ex
+++ b/lib/meadow/pipeline.ex
@@ -10,7 +10,7 @@ defmodule Meadow.Pipeline do
   def ingest_file_set(attrs \\ %{}) do
     case FileSets.create_file_set(attrs) do
       {:ok, file_set} ->
-        kickoff(file_set, %{role: file_set.role})
+        kickoff(file_set, %{role: file_set.role.id})
         {:ok, file_set}
 
       {:error, changeset} ->

--- a/lib/meadow_web/resolvers/data.ex
+++ b/lib/meadow_web/resolvers/data.ex
@@ -169,7 +169,7 @@ defmodule MeadowWeb.Resolvers.Data do
         %{work_id: work_id, file_set_ids: file_set_ids},
         _
       ) do
-    case Works.update_file_set_order(work_id, "am", file_set_ids) do
+    case Works.update_file_set_order(work_id, "A", file_set_ids) do
       {:error, message} when is_binary(message) ->
         {
           :error,

--- a/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
+++ b/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
@@ -106,6 +106,7 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
   @desc "Schemes for code list table. (Ex: Subjects, MARC relators, prevervation levels, etc)"
   enum :code_list_scheme do
     value(:authority, as: "authority", description: "Authority")
+    value(:file_set_role, as: "file_set_role", description: "File Set Role")
     value(:library_unit, as: "library_unit", description: "Library Unit")
     value(:license, as: "license", description: "License")
     value(:marc_relator, as: "marc_relator", description: "MARC Relator")

--- a/lib/meadow_web/schema/types/data/file_set_types.ex
+++ b/lib/meadow_web/schema/types/data/file_set_types.ex
@@ -23,7 +23,7 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
     @desc "Ingests a new FileSet for a work"
     field :ingest_file_set, :file_set do
       arg(:accession_number, non_null(:string))
-      arg(:role, non_null(:file_set_role))
+      arg(:role, non_null(:coded_term_input))
       arg(:work_id, non_null(:id))
       arg(:metadata, non_null(:file_set_metadata_input))
       middleware(Middleware.Authenticate)
@@ -84,7 +84,7 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
   @desc "Input fields for a `file_set` creation object "
   input_object :file_set_input do
     field :accession_number, non_null(:string)
-    field :role, non_null(:file_set_role)
+    field :role, non_null(:coded_term_input)
     field :metadata, :file_set_metadata_input
   end
 
@@ -96,7 +96,7 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
   object :file_set do
     field :id, non_null(:id)
     field :accession_number, non_null(:string)
-    field :role, non_null(:file_set_role)
+    field :role, non_null(:coded_term)
     field :position, :string
     field :rank, :integer
     field :work, :work, resolve: dataloader(Data)
@@ -128,11 +128,5 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
         end
       end)
     end
-  end
-
-  @desc "A `file_set_role` designates whether the file is an access or preservation master and will determine how the file is processed and stored."
-  enum :file_set_role do
-    value(:am, as: "am", description: "Access Master")
-    value(:pm, as: "pm", description: "Preservaton Master")
   end
 end

--- a/lib/mix/tasks/dc_download.ex
+++ b/lib/mix/tasks/dc_download.ex
@@ -111,7 +111,7 @@ defmodule Mix.Tasks.Meadow.DcDownload do
              "#{work_accession_number}_FILE_#{index}",
              filename,
              doc["label"],
-             Enum.random(["am", "am", "am", "am", "pm"])
+             Enum.random(["A", "A", "A", "A", "P"])
            ]}
 
         %{status_code: 403} ->

--- a/priv/repo/migrations/20190920155454_create_file_sets.exs
+++ b/priv/repo/migrations/20190920155454_create_file_sets.exs
@@ -4,7 +4,7 @@ defmodule Meadow.Repo.Migrations.CreateFileSets do
   def change do
     create table("file_sets") do
       add(:accession_number, :string)
-      add(:role, :string)
+      add(:role, :map)
       add(:metadata, :map, default: %{})
       add(:work_id, references(:works, null: false, on_delete: :delete_all))
       add(:rank, :integer)

--- a/priv/repo/seeds/coded_terms/file_set_role.json
+++ b/priv/repo/seeds/coded_terms/file_set_role.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "A",
+    "label": "Access"
+  },
+  {
+    "id": "P",
+    "label": "Preservation"
+  }
+]

--- a/test/fixtures/ingest_sheet.csv
+++ b/test/fixtures/ingest_sheet.csv
@@ -1,8 +1,8 @@
 work_accession_number,accession_number,filename,description,role
-Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",am
-Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",pm
-Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",am
-Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",am
-Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",am
-Donohue_002,Donohue_002_02,coffee.tif,Verso,am
-Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",am
+Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A
+Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P
+Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A
+Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A
+Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A
+Donohue_002,Donohue_002_02,coffee.tif,Verso,A
+Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A

--- a/test/fixtures/ingest_sheet_duplicate_accession.csv
+++ b/test/fixtures/ingest_sheet_duplicate_accession.csv
@@ -1,8 +1,8 @@
 work_accession_number,accession_number,filename,description,role
-Donohue_001,6777,Donohue_001_01.tif,"Letter, page 1, Dear Sir, recto",am
-Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",pm
-Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",am
-Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",am
-Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",am
-Donohue_002,Donohue_002_02,coffee.tif,Verso,am
-Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",am
+Donohue_001,6777,Donohue_001_01.tif,"Letter, page 1, Dear Sir, recto",A
+Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P
+Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A
+Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A
+Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A
+Donohue_002,Donohue_002_02,coffee.tif,Verso,A
+Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A

--- a/test/fixtures/ingest_sheet_duplicate_work_accession.csv
+++ b/test/fixtures/ingest_sheet_duplicate_work_accession.csv
@@ -1,8 +1,8 @@
 work_accession_number,accession_number,filename,description,role
-6779,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",am
-Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",pm
-Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",am
-Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",am
-Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",am
-Donohue_002,Donohue_002_02,coffee.tif,Verso,am
-Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",am
+6779,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A
+Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P
+Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A
+Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A
+Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A
+Donohue_002,Donohue_002_02,coffee.tif,Verso,A
+Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A

--- a/test/fixtures/ingest_sheet_incorrect_role.csv
+++ b/test/fixtures/ingest_sheet_incorrect_role.csv
@@ -1,8 +1,8 @@
 work_accession_number,accession_number,filename,description,role
-Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",hm
-Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",pm
-Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",am
-Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",am
-Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",am
-Donohue_002,Donohue_002_02,coffee.tif,Verso,am
-Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",am
+Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",H
+Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P
+Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A
+Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A
+Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A
+Donohue_002,Donohue_002_02,coffee.tif,Verso,A
+Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A

--- a/test/fixtures/ingest_sheet_missing_field.csv
+++ b/test/fixtures/ingest_sheet_missing_field.csv
@@ -1,8 +1,8 @@
 work_accession_number,accession_number,filename,description,role
-Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",am
-Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",am
-Donohue_001,,coffee.tif,"Letter, page 2, If these papers, recto",am
-Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",am
-Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",am
-Donohue_002,Donohue_002_02,coffee.tif,Verso,am
-Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",am
+Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A
+Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",A
+Donohue_001,,coffee.tif,"Letter, page 2, If these papers, recto",A
+Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A
+Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A
+Donohue_002,Donohue_002_02,coffee.tif,Verso,A
+Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A

--- a/test/fixtures/ingest_sheet_missing_file.csv
+++ b/test/fixtures/ingest_sheet_missing_file.csv
@@ -1,8 +1,8 @@
 work_accession_number,accession_number,filename,description,role
-Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",am
-Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",am
-Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",am
-Donohue_001,Donohue_001_04,Missing_001_04.tif,"Letter, page 2, If these papers, verso, blank",am
-Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",am
-Donohue_002,Donohue_002_02,coffee.tif,Verso,am
-Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",am
+Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A
+Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",A
+Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A
+Donohue_001,Donohue_001_04,Missing_001_04.tif,"Letter, page 2, If these papers, verso, blank",A
+Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A
+Donohue_002,Donohue_002_02,coffee.tif,Verso,A
+Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A

--- a/test/fixtures/ingest_sheet_wrong_headers.csv
+++ b/test/fixtures/ingest_sheet_wrong_headers.csv
@@ -1,8 +1,8 @@
 work_accession_number,not_the_accession_number,filename,description,role
-Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",am
-Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",am
-Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",am
-Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",am
-Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",am
-Donohue_002,Donohue_002_02,coffee.tif,Verso,am
-Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",am
+Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A
+Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",A
+Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A
+Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A
+Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A
+Donohue_002,Donohue_002_02,coffee.tif,Verso,A
+Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A

--- a/test/fixtures/migration/manifests/3a618a95-fa7e-4bec-b9c1-ac781b64cc56.json
+++ b/test/fixtures/migration/manifests/3a618a95-fa7e-4bec-b9c1-ac781b64cc56.json
@@ -1,1 +1,72 @@
-{"id":"3a618a95-fa7e-4bec-b9c1-ac781b64cc56","accession_number":"Voyager:2564924","published":false,"visibility":{"id":"OPEN","scheme":"visibility"},"work_type":{"id":"IMAGE","scheme":"work_type"},"collection_id":"faf4f60e-78e0-4fbf-96ce-4ca8b4df597a","administrative_metadata":{"library_unit":{"id":"GOVERNMENT_AND_GEOGRAPHIC_INFORMATION_COLLECTION","scheme":"library_unit"},"status":{"id":"DONE","scheme":"status"},"preservation_level":{"id":"1","scheme":"preservation_level"}},"descriptive_metadata":{"date_created":[{"edtf":"1942"}],"contributor":[{"role":{"id":"ctb","scheme":"marc_relator"},"term":{"id":"http://id.worldcat.org/fast/515187"}},{"role":{"id":"ill","scheme":"marc_relator"},"term":{"id":"http://id.worldcat.org/fast/1898537"}}],"subject":[{"role":{"id":"TOPICAL","scheme":"subject_role"},"term":{"id":"info:nul/c9a4c048-64a2-4ba1-a31f-fbfd907c440e"}},{"role":{"id":"TOPICAL","scheme":"subject_role"},"term":{"id":"http://id.loc.gov/authorities/subjects/sh85148522"}},{"role":{"id":"TOPICAL","scheme":"subject_role"},"term":{"id":"http://id.worldcat.org/fast/1170615"}}],"ark":"ark:/99999/fk4001cr0p","terms_of_use":"Materials published by the U.S. Government Printing Office are in the public domain and, as such, not subject to copyright restriction. However, the Libraries request users to cite the URL and Northwestern University Libraries if they wish to reproduce images from this site.","title":"He's a fighting fool : give him the best you've got : more production","catalog_key":["9969583494202441"],"description":["A fully outfitted soldier in a helmet with a pack holds his rifle and charges. ; [illustrated by] Fred Ludekens"],"identifier":["Object no. IIIC.32.","\"A1\""],"legacy_identifier":["inu:dil-b800f3ef-a1ea-478b-a6b4-0a199191f6e0"],"physical_description_material":["1 black and white and blue poster"],"physical_description_size":["101 x 72 cm"],"publisher":["U.S. G.P.O."],"location":[{"term":{"id":"https://sws.geonames.org/4138106/"}}],"genre":[{"term":{"id":"http://vocab.getty.edu/aat/300027221"}}],"language":[{"term":{"id":"http://id.loc.gov/vocabulary/languages/eng"}}]},"file_sets":[{"id":"ca7cf0dd-f0ae-4973-8376-4780eadbca15","accession_number":"Voyager:2564924_donut_01","role":"am","metadata":{"location":"s3://stack-p-fedora-binaries/b6328aba898c4274711c65a3453830720efdfa3a","original_filename":"inu-dil-b800f3ef-a1ea-478b-a6b4-0a199191f6e0.tif?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=ASIA4JS3A4DQ36RH66RB%2F20190325%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20190325T230336Z\u0026X-Amz-Expires=604800\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Security-Token=FQoGZXIvYXdzEEgaDK2tw6jBwmGeDSa%2B5CK3AxBRyY%2BnBE6oOZpyc%2Fs2fnnhOQNGzijijzX8L6MCOWYX3iZ7w3N8We8cv25GQr95vLUOSomNP3bYq3PzR8m1sTi1%2B0ZJtndRQfewg5g4PJ%2BDgBrsux%2BORwsyyMXP0R8Tqmqrpw5q6KbdaPQyiIFXdPakWMd41nSQ6Tb%2Fbfg%2Bg7F8iJSz%2B80KqeYTE%2FRLZNDrORezPiQ6Hbqef%2BqYRqd9Dd%2FNFD1rL5NjUlOIkwLpF4rTwfWoxcYDjjlzgHItmvAJSikz9PqsEfkSKNlsrX4blvRUQQfiMRDU4IlrK39E4k1h8nQSi2Hi15%2BS7Vg9TmOV7FuVH8%2FiY2CgFeOPJRABTRL%2FkAQs15cJe3qPCst2rCuV1Z%2FGhCQf67PydCURh3S1mKrqgc0iS3j3NgHavLmE52nXMg3%2Fbp960qYNCQAWObDWAF835lElofbv1T0OQsat%2BHOq9cWMh2jPpXU6dWmlrsAU8VbwGiXM7FBmjFHqOqe83WOLR6ppEnUbhQNI5zjWQyaBSK8MWlOjMygfNoZA8YpD3gRyF8o4GhX0%2BHJVk0FXOUxCiX%2BwxUumWpUMh8ArTSHza4glnQooorPl5AU%3D\u0026X-Amz-Signature=d1644e7af61dfa2c802d5df46b594711b3899cbe69dfeb8fbbffd744167b3191"}}],"representative_file_set_id":"ca7cf0dd-f0ae-4973-8376-4780eadbca15"}
+{
+  "id": "3a618a95-fa7e-4bec-b9c1-ac781b64cc56",
+  "accession_number": "Voyager:2564924",
+  "published": false,
+  "visibility": { "id": "OPEN", "scheme": "visibility" },
+  "work_type": { "id": "IMAGE", "scheme": "work_type" },
+  "collection_id": "faf4f60e-78e0-4fbf-96ce-4ca8b4df597a",
+  "administrative_metadata": {
+    "library_unit": {
+      "id": "GOVERNMENT_AND_GEOGRAPHIC_INFORMATION_COLLECTION",
+      "scheme": "library_unit"
+    },
+    "status": { "id": "DONE", "scheme": "status" },
+    "preservation_level": { "id": "1", "scheme": "preservation_level" }
+  },
+  "descriptive_metadata": {
+    "date_created": [{ "edtf": "1942" }],
+    "contributor": [
+      {
+        "role": { "id": "ctb", "scheme": "marc_relator" },
+        "term": { "id": "http://id.worldcat.org/fast/515187" }
+      },
+      {
+        "role": { "id": "ill", "scheme": "marc_relator" },
+        "term": { "id": "http://id.worldcat.org/fast/1898537" }
+      }
+    ],
+    "subject": [
+      {
+        "role": { "id": "TOPICAL", "scheme": "subject_role" },
+        "term": { "id": "info:nul/c9a4c048-64a2-4ba1-a31f-fbfd907c440e" }
+      },
+      {
+        "role": { "id": "TOPICAL", "scheme": "subject_role" },
+        "term": { "id": "http://id.loc.gov/authorities/subjects/sh85148522" }
+      },
+      {
+        "role": { "id": "TOPICAL", "scheme": "subject_role" },
+        "term": { "id": "http://id.worldcat.org/fast/1170615" }
+      }
+    ],
+    "ark": "ark:/99999/fk4001cr0p",
+    "terms_of_use": "Materials published by the U.S. Government Printing Office are in the public domain and, as such, not subject to copyright restriction. However, the Libraries request users to cite the URL and Northwestern University Libraries if they wish to reproduce images from this site.",
+    "title": "He's a fighting fool : give him the best you've got : more production",
+    "catalog_key": ["9969583494202441"],
+    "description": [
+      "A fully outfitted soldier in a helmet with a pack holds his rifle and charges. ; [illustrated by] Fred Ludekens"
+    ],
+    "identifier": ["Object no. IIIC.32.", "\"A1\""],
+    "legacy_identifier": ["inu:dil-b800f3ef-a1ea-478b-a6b4-0a199191f6e0"],
+    "physical_description_material": ["1 black and white and blue poster"],
+    "physical_description_size": ["101 x 72 cm"],
+    "publisher": ["U.S. G.P.O."],
+    "location": [{ "term": { "id": "https://sws.geonames.org/4138106/" } }],
+    "genre": [{ "term": { "id": "http://vocab.getty.edu/aat/300027221" } }],
+    "language": [
+      { "term": { "id": "http://id.loc.gov/vocabulary/languages/eng" } }
+    ]
+  },
+  "file_sets": [
+    {
+      "id": "ca7cf0dd-f0ae-4973-8376-4780eadbca15",
+      "accession_number": "Voyager:2564924_donut_01",
+      "role": "am",
+      "metadata": {
+        "location": "s3://stack-p-fedora-binaries/b6328aba898c4274711c65a3453830720efdfa3a",
+        "original_filename": "inu-dil-b800f3ef-a1ea-478b-a6b4-0a199191f6e0.tif?X-Amz-Algorithm=AWS4-HMAC-SHA256\u0026X-Amz-Credential=ASIA4JS3A4DQ36RH66RB%2F20190325%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Date=20190325T230336Z\u0026X-Amz-Expires=604800\u0026X-Amz-SignedHeaders=host\u0026X-Amz-Security-Token=FQoGZXIvYXdzEEgaDK2tw6jBwmGeDSa%2B5CK3AxBRyY%2BnBE6oOZpyc%2Fs2fnnhOQNGzijijzX8L6MCOWYX3iZ7w3N8We8cv25GQr95vLUOSomNP3bYq3PzR8m1sTi1%2B0ZJtndRQfewg5g4PJ%2BDgBrsux%2BORwsyyMXP0R8Tqmqrpw5q6KbdaPQyiIFXdPakWMd41nSQ6Tb%2Fbfg%2Bg7F8iJSz%2B80KqeYTE%2FRLZNDrORezPiQ6Hbqef%2BqYRqd9Dd%2FNFD1rL5NjUlOIkwLpF4rTwfWoxcYDjjlzgHItmvAJSikz9PqsEfkSKNlsrX4blvRUQQfiMRDU4IlrK39E4k1h8nQSi2Hi15%2BS7Vg9TmOV7FuVH8%2FiY2CgFeOPJRABTRL%2FkAQs15cJe3qPCst2rCuV1Z%2FGhCQf67PydCURh3S1mKrqgc0iS3j3NgHavLmE52nXMg3%2Fbp960qYNCQAWObDWAF835lElofbv1T0OQsat%2BHOq9cWMh2jPpXU6dWmlrsAU8VbwGiXM7FBmjFHqOqe83WOLR6ppEnUbhQNI5zjWQyaBSK8MWlOjMygfNoZA8YpD3gRyF8o4GhX0%2BHJVk0FXOUxCiX%2BwxUumWpUMh8ArTSHza4glnQooorPl5AU%3D\u0026X-Amz-Signature=d1644e7af61dfa2c802d5df46b594711b3899cbe69dfeb8fbbffd744167b3191"
+      }
+    }
+  ],
+  "representative_file_set_id": "ca7cf0dd-f0ae-4973-8376-4780eadbca15"
+}

--- a/test/fixtures/missing_ingest_sheet.csv
+++ b/test/fixtures/missing_ingest_sheet.csv
@@ -1,8 +1,8 @@
 work_accession_number,accession_number,filename,description,role
-Donohue_001,6777,Donohue_001_01.tif,"Letter, page 1, Dear Sir, recto",am
-Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",pm
-Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",am
-Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",am
-Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",am
-Donohue_002,Donohue_002_02,coffee.tif,Verso,am
-Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",am
+Donohue_001,6777,Donohue_001_01.tif,"Letter, page 1, Dear Sir, recto",A
+Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P
+Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A
+Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A
+Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A
+Donohue_002,Donohue_002_02,coffee.tif,Verso,A
+Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A

--- a/test/fixtures/seed_data.csv
+++ b/test/fixtures/seed_data.csv
@@ -1,3 +1,3 @@
 work_accession_number,accession_number,filename,description,role
-Donohue_001,Donohue_001_01,seed_data/coffee.tif,"Letter, page 1, Dear Sir, recto",am
-Donohue_001,Donohue_001_02,seed_data/coffee.tif,"Letter, page 1, Dear Sir, verso, blank",pm
+Donohue_001,Donohue_001_01,seed_data/coffee.tif,"Letter, page 1, Dear Sir, recto",A
+Donohue_001,Donohue_001_02,seed_data/coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P

--- a/test/gql/FileSetFields.frag.gql
+++ b/test/gql/FileSetFields.frag.gql
@@ -1,7 +1,11 @@
 fragment FileSetFields on FileSet {
   id
   accessionNumber
-  role
+  role {
+    id
+    label
+    scheme
+  }
   rank
   position
   metadata {

--- a/test/meadow/data/coded_terms_test.exs
+++ b/test/meadow/data/coded_terms_test.exs
@@ -5,6 +5,7 @@ defmodule Meadow.Data.CodedTermsTest do
 
   @schemes [
     "authority",
+    "file_set_role",
     "library_unit",
     "license",
     "marc_relator",

--- a/test/meadow/data/file_sets_test.exs
+++ b/test/meadow/data/file_sets_test.exs
@@ -8,7 +8,7 @@ defmodule Meadow.Data.FileSetsTest do
   describe "queries" do
     @valid_attrs %{
       accession_number: "12345",
-      role: "am",
+      role: %{id: "A", scheme: "FILE_SET_ROLE"},
       metadata: %{
         description: "yes",
         location: "https://example.com",
@@ -53,18 +53,18 @@ defmodule Meadow.Data.FileSetsTest do
     end
 
     test "updating rank, role or accession_number with update_file_set/2 is not allowed" do
-      file_set = file_set_fixture(%{role: "am"})
+      file_set = file_set_fixture(%{role: %{id: "A", scheme: "FILE_SET_ROLE"}})
 
       assert {:ok, %FileSet{} = updated_file_set} =
                FileSets.update_file_set(file_set, %{
                  rank: 123,
                  metadata: %{label: "New label"},
                  accession_number: "Unsupported",
-                 role: "pm"
+                 role: %{id: "P", scheme: "FILE_SET_ROLE"}
                })
 
       assert updated_file_set.metadata.label == "New label"
-      assert updated_file_set.role == "am"
+      assert updated_file_set.role.id == "A"
       assert updated_file_set.accession_number == file_set.accession_number
       assert updated_file_set.rank == file_set.rank
     end

--- a/test/meadow/data/schemas/file_set_test.exs
+++ b/test/meadow/data/schemas/file_set_test.exs
@@ -6,7 +6,7 @@ defmodule Meadow.Data.Schemas.FileSetTest do
   describe "file_sets" do
     @valid_attrs %{
       accession_number: "12345",
-      role: "am",
+      role: %{id: "A", scheme: "FILE_SET_ROLE"},
       metadata: %{
         description: "yes",
         location: "https://example.com",

--- a/test/meadow/data/works_test.exs
+++ b/test/meadow/data/works_test.exs
@@ -113,7 +113,7 @@ defmodule Meadow.Data.WorksTest do
 
   describe "representative images" do
     setup do
-      work = work_with_file_sets_fixture(3, %{}, %{role: "am"})
+      work = work_with_file_sets_fixture(3, %{}, %{role: %{id: "A", scheme: "FILE_SET_ROLE"}})
       file_set = work.file_sets |> Enum.at(1)
 
       {:ok, %Work{} = work} = Works.set_representative_image(work, file_set)
@@ -198,7 +198,7 @@ defmodule Meadow.Data.WorksTest do
     end
 
     test "set_representative_image/2 with a preservation master does not set the representative image" do
-      work = work_with_file_sets_fixture(1, %{}, %{role: "pm"})
+      work = work_with_file_sets_fixture(1, %{}, %{role: %{id: "P", scheme: "FILE_SET_ROLE"}})
       file_set = work.file_sets |> Enum.at(1)
 
       {:ok, %Work{} = work} = Works.set_representative_image(work, file_set)
@@ -391,7 +391,7 @@ defmodule Meadow.Data.WorksTest do
 
   describe "reorder file sets" do
     setup do
-      work = work_with_file_sets_fixture(5, %{}, %{role: "am"})
+      work = work_with_file_sets_fixture(5, %{}, %{role: %{id: "A", scheme: "FILE_SET_ROLE"}})
       {:ok, %{work: work, ids: work.file_sets |> Enum.map(& &1.id)}}
     end
 
@@ -405,21 +405,21 @@ defmodule Meadow.Data.WorksTest do
                   index_4: %{id: id_4, position: 4},
                   index_5: %{id: id_5, position: 5},
                   work: %Work{id: ^work_id}
-                }} = Works.update_file_set_order(work_id, "am", Enum.reverse(ids))
+                }} = Works.update_file_set_order(work_id, "A", Enum.reverse(ids))
 
         assert [id_5, id_4, id_3, id_2, id_1] == ids
       end
     end
 
     test "update_file_set_order/1 errors on missing id", %{work: work, ids: [missing_id | ids]} do
-      assert {:error, error_text} = Works.update_file_set_order(work.id, "am", ids)
+      assert {:error, error_text} = Works.update_file_set_order(work.id, "A", ids)
       assert String.contains?(error_text, missing_id)
       assert String.match?(error_text, ~r/missing \[.+\]/)
     end
 
     test "update_file_set_order/1 errors on extra id", %{work: work, ids: ids} do
       with extra_id <- Ecto.UUID.generate() do
-        assert {:error, error_text} = Works.update_file_set_order(work.id, "am", [extra_id | ids])
+        assert {:error, error_text} = Works.update_file_set_order(work.id, "A", [extra_id | ids])
         assert String.contains?(error_text, extra_id)
         assert String.match?(error_text, ~r/^Extra/)
       end

--- a/test/meadow/data_test.exs
+++ b/test/meadow/data_test.exs
@@ -10,7 +10,7 @@ defmodule Meadow.DataTest do
       file_sets: [
         %{
           accession_number: "1234",
-          role: "am",
+          role: %{id: "A", scheme: "FILE_SET_ROLE"},
           metadata: %{
             description: "This is the description",
             location: "https://www.library.northwestern.edu",
@@ -33,7 +33,7 @@ defmodule Meadow.DataTest do
       |> FileSet.changeset(%{
         work_id: work.id,
         accession_number: "2222",
-        role: "am",
+        role: %{id: "A", scheme: "FILE_SET_ROLE"},
         metadata: %{location: "test", original_filename: "test"}
       })
       |> Repo.insert!()
@@ -43,7 +43,7 @@ defmodule Meadow.DataTest do
         position: 0,
         work_id: work.id,
         accession_number: "1111",
-        role: "am",
+        role: %{id: "A", scheme: "FILE_SET_ROLE"},
         metadata: %{location: "test", original_filename: "test"}
       })
       |> Repo.insert!()
@@ -53,7 +53,7 @@ defmodule Meadow.DataTest do
         position: 0,
         work_id: work.id,
         accession_number: "no",
-        role: "pm",
+        role: %{id: "P", scheme: "FILE_SET_ROLE"},
         metadata: %{location: "test", original_filename: "test"}
       })
       |> Repo.insert!()
@@ -62,12 +62,13 @@ defmodule Meadow.DataTest do
       |> FileSet.changeset(%{
         position: 0,
         accession_number: "nono",
-        role: "am",
+        role: %{id: "A", scheme: "FILE_SET_ROLE"},
         metadata: %{location: "test", original_filename: "test"}
       })
       |> Repo.insert!()
 
-      [file_set_1, file_set_2] = Data.ranked_file_sets_for_work(work.id, "am")
+      [file_set_1, file_set_2] = Data.ranked_file_sets_for_work(work.id, "A")
+
       assert file_set_1.rank < file_set_2.rank
     end
 

--- a/test/meadow/iiif/generator_test.exs
+++ b/test/meadow/iiif/generator_test.exs
@@ -11,7 +11,7 @@ defmodule Meadow.IIIF.GeneratorTest do
       file_set =
         file_set_fixture(%{
           work_id: work.id,
-          role: "am",
+          role: %{id: "A", scheme: "FILE_SET_ROLE"},
           metadata: %{
             location: "foo",
             description: "bar",
@@ -23,7 +23,7 @@ defmodule Meadow.IIIF.GeneratorTest do
       _file_set2 =
         file_set_fixture(%{
           work_id: work.id,
-          role: "pm",
+          role: %{id: "P", scheme: "FILE_SET_ROLE"},
           metadata: %{
             location: "foo",
             description: "preservation master",

--- a/test/meadow/ingest/progress_test.exs
+++ b/test/meadow/ingest/progress_test.exs
@@ -30,11 +30,11 @@ defmodule Meadow.Ingest.ProgressTest do
         Progress.initialize_entry(row, true)
 
         case MapList.get(row.fields, :header, :value, :role) do
-          "am" ->
+          "A" ->
             assert Progress.get_entry(row, Actions.CreatePyramidTiff) |> Map.get(:status) ==
                      "pending"
 
-          "pm" ->
+          "P" ->
             assert is_nil(Progress.get_entry(row, Actions.CreatePyramidTiff))
         end
       end)

--- a/test/meadow/pipeline_test.exs
+++ b/test/meadow/pipeline_test.exs
@@ -12,7 +12,7 @@ defmodule Meadow.Data.PipelineTest do
   describe "ingesting file set" do
     @valid_attrs %{
       accession_number: "12345",
-      role: "am",
+      role: %{id: "A", scheme: "FILE_SET_ROLE"},
       metadata: %{
         description: "yes",
         location: "https://example.com",

--- a/test/meadow_web/schema/mutation/ingest_file_set_test.exs
+++ b/test/meadow_web/schema/mutation/ingest_file_set_test.exs
@@ -18,7 +18,7 @@ defmodule MeadowWeb.Schema.Mutation.IngestFileSetTest do
       query_gql(
         variables: %{
           "accession_number" => "99999",
-          "role" => "AM",
+          "role" => %{"id" => "A", "scheme" => "FILE_SET_ROLE"},
           "work_id" => work.id,
           "metadata" => %{
             "description" => "Something",
@@ -41,7 +41,7 @@ defmodule MeadowWeb.Schema.Mutation.IngestFileSetTest do
         query_gql(
           variables: %{
             "accession_number" => "99999",
-            "role" => "AM",
+            "role" => %{"id" => "A", "scheme" => "FILE_SET_ROLE"},
             "work_id" => work.id,
             "metadata" => %{
               "description" => "Something",

--- a/test/meadow_web/schema/mutation/set_collection_image_test.exs
+++ b/test/meadow_web/schema/mutation/set_collection_image_test.exs
@@ -9,9 +9,15 @@ defmodule MeadowWeb.Schema.Mutation.SetCollectionImageTest do
     collection = collection_fixture()
 
     works = [
-      work_with_file_sets_fixture(1, %{collection_id: collection.id}, %{role: "am"}),
-      work_with_file_sets_fixture(1, %{collection_id: collection.id}, %{role: "am"}),
-      work_with_file_sets_fixture(1, %{collection_id: collection.id}, %{role: "am"})
+      work_with_file_sets_fixture(1, %{collection_id: collection.id}, %{
+        role: %{id: "A", scheme: "FILE_SET_ROLE"}
+      }),
+      work_with_file_sets_fixture(1, %{collection_id: collection.id}, %{
+        role: %{id: "A", scheme: "FILE_SET_ROLE"}
+      }),
+      work_with_file_sets_fixture(1, %{collection_id: collection.id}, %{
+        role: %{id: "A", scheme: "FILE_SET_ROLE"}
+      })
     ]
 
     expected_work = works |> Enum.at(1)

--- a/test/meadow_web/schema/mutation/set_work_image_test.exs
+++ b/test/meadow_web/schema/mutation/set_work_image_test.exs
@@ -6,7 +6,7 @@ defmodule MeadowWeb.Schema.Mutation.SetWorkImageTest do
   load_gql(MeadowWeb.Schema, "test/gql/SetWorkImage.gql")
 
   test "should be a valid mutation" do
-    work = work_with_file_sets_fixture(3, %{}, %{role: "am"})
+    work = work_with_file_sets_fixture(3, %{}, %{role: %{id: "A", scheme: "FILE_SET_ROLE"}})
     expected_file_set = work.file_sets |> Enum.at(1)
     file_set_image = Meadow.Config.iiif_server_url() <> expected_file_set.id
 
@@ -32,7 +32,7 @@ defmodule MeadowWeb.Schema.Mutation.SetWorkImageTest do
 
   describe "authorization" do
     test "viewers are not authorized to set work images" do
-      work = work_with_file_sets_fixture(3, %{}, %{role: "am"})
+      work = work_with_file_sets_fixture(3, %{}, %{role: %{id: "A", scheme: "FILE_SET_ROLE"}})
       expected_file_set = work.file_sets |> Enum.at(1)
 
       {:ok, result} =
@@ -48,7 +48,7 @@ defmodule MeadowWeb.Schema.Mutation.SetWorkImageTest do
     end
 
     test "editors and above are authorized to set work images" do
-      work = work_with_file_sets_fixture(3, %{}, %{role: "am"})
+      work = work_with_file_sets_fixture(3, %{}, %{role: %{id: "A", scheme: "FILE_SET_ROLE"}})
       expected_file_set = work.file_sets |> Enum.at(1)
 
       {:ok, result} =

--- a/test/meadow_web/schema/mutation/update_access_master_order_test.exs
+++ b/test/meadow_web/schema/mutation/update_access_master_order_test.exs
@@ -6,7 +6,7 @@ defmodule MeadowWeb.Schema.Mutation.UpdateAccessMasterOrderTest do
 
   describe "mutation" do
     setup do
-      work = work_with_file_sets_fixture(5, %{}, %{role: "am"})
+      work = work_with_file_sets_fixture(5, %{}, %{role: %{id: "A", scheme: "FILE_SET_ROLE"}})
       {:ok, %{work: work, ids: work.file_sets |> Enum.map(& &1.id)}}
     end
 

--- a/test/pipeline/actions/copy_file_to_preservation_test.exs
+++ b/test/pipeline/actions/copy_file_to_preservation_test.exs
@@ -20,7 +20,7 @@ defmodule Meadow.Pipeline.Actions.CopyFileToPreservationTest do
       file_set_fixture(%{
         id: @id,
         accession_number: "123",
-        role: "am",
+        role: %{id: "A", scheme: "FILE_SET_ROLE"},
         metadata: %{
           digests: %{
             "sha256" => @sha256,

--- a/test/pipeline/actions/create_pyramid_tiff_test.exs
+++ b/test/pipeline/actions/create_pyramid_tiff_test.exs
@@ -18,7 +18,7 @@ defmodule Meadow.Pipeline.Actions.CreatePyramidTiffTest do
       file_set_fixture(%{
         id: "6caf2759-c476-46ae-9c40-ec58cf44c704",
         accession_number: "123",
-        role: "am",
+        role: %{id: "A", scheme: "FILE_SET_ROLE"},
         metadata: %{
           location: "s3://#{@ingest_bucket}/#{@key}",
           original_filename: "coffee.tif"
@@ -29,7 +29,7 @@ defmodule Meadow.Pipeline.Actions.CreatePyramidTiffTest do
       file_set_fixture(%{
         id: "5915fe2b-6b66-4373-b69a-e13f765dc2a4",
         accession_number: "1234",
-        role: "am",
+        role: %{id: "A", scheme: "FILE_SET_ROLE"},
         metadata: %{
           location: "invalid",
           original_filename: "coffee.tif"

--- a/test/pipeline/actions/extract_exif_metadata_test.exs
+++ b/test/pipeline/actions/extract_exif_metadata_test.exs
@@ -58,7 +58,7 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadataTest do
       file_set_fixture(%{
         id: "cecb1180-054e-4764-8d2b-8a46c6b777b2",
         accession_number: "1234",
-        role: "am",
+        role: %{id: "A", scheme: "FILE_SET_ROLE"},
         metadata: %{
           location: "s3://#{@bucket}/#{@exif_key}",
           original_filename: "test.tif"
@@ -69,7 +69,7 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadataTest do
       file_set_fixture(%{
         id: "bbcb54da-fb1d-48ed-8438-99a030431086",
         accession_number: "2314",
-        role: "am",
+        role: %{id: "A", scheme: "FILE_SET_ROLE"},
         metadata: %{
           location: "s3://#{@bucket}/#{@no_exif_key}",
           original_filename: "test.tif"
@@ -80,7 +80,7 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadataTest do
       file_set_fixture(%{
         id: "979d3570-9dc9-4d3b-ac1b-ee5524ee0bd3",
         accession_number: "4321",
-        role: "am",
+        role: %{id: "A", scheme: "FILE_SET_ROLE"},
         metadata: %{
           location: "invalid",
           original_filename: "test.tif"

--- a/test/pipeline/actions/extract_mime_type_test.exs
+++ b/test/pipeline/actions/extract_mime_type_test.exs
@@ -14,7 +14,7 @@ defmodule Meadow.Pipeline.Actions.ExtractMimeTypeTest do
     file_set =
       file_set_fixture(%{
         accession_number: "123",
-        role: "pm",
+        role: %{id: "P", scheme: "FILE_SET_ROLE"},
         metadata: %{
           location: "s3://#{@bucket}/#{@key}",
           original_filename: "test.tif"

--- a/test/pipeline/actions/generate_file_set_digests_test.exs
+++ b/test/pipeline/actions/generate_file_set_digests_test.exs
@@ -16,7 +16,7 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigestsTest do
     file_set =
       file_set_fixture(%{
         accession_number: "123",
-        role: "am",
+        role: %{id: "A", scheme: "FILE_SET_ROLE"},
         metadata: %{
           location: "s3://#{@bucket}/#{@key}",
           original_filename: "test.tif"

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -16,8 +16,6 @@ defmodule Meadow.TestHelpers do
 
   alias NimbleCSV.RFC4180, as: CSV
 
-  use Meadow.Constants
-
   @test_users %{
     "TestAdmins" => ~w[auy5400 auk0124 auh7250 aud6389],
     "TestManagers" => ~w[aut2418 aum1701 auf2249 aua6615],
@@ -193,7 +191,7 @@ defmodule Meadow.TestHelpers do
   def file_set_fixture_attrs(attrs \\ %{}) do
     Enum.into(attrs, %{
       accession_number: attrs[:accession_number] || Faker.String.base64(),
-      role: attrs[:role] || Faker.Util.pick(@file_set_roles),
+      role: attrs[:role] || %{id: Faker.Util.pick(["A", "P"]), scheme: "FILE_SET_ROLE"},
       metadata:
         attrs[:metadata] ||
           %{


### PR DESCRIPTION
- Change file set roles to coded terms rather than strings
- "am" and "pm" changed to "A" and "P" in the ingest sheet's role column. 
- updated pipeline, migration, dc_download, ingest
-  was concerned about file set ordering but it still seems to work

`devstack down -v` required and also your current dc_downloads won't work, you'll need to redo them (or manually change "am" -> "A" and "pm" -> "P" - but it would be great if you help me test this)