### PR TITLE
Add file-based CloudWatch Agent logging to EC2 console

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -71,6 +71,7 @@ defmodule Meadow.MixProject do
       {:honeybadger, "~> 0.7"},
       {:inflex, "~> 2.1.0"},
       {:jason, "~> 1.0"},
+      {:logger_file_backend, "~> 0.0.11"},
       {:mox, "~> 1.0", only: :test},
       {:nimble_csv, "~> 1.1.0"},
       {:phoenix, "~> 1.5.1"},

--- a/mix.lock
+++ b/mix.lock
@@ -48,6 +48,7 @@
   "inflex": {:hex, :inflex, "2.1.0", "a365cf0821a9dacb65067abd95008ca1b0bb7dcdd85ae59965deef2aa062924c", [:mix], [], "hexpm", "14c17d05db4ee9b6d319b0bff1bdf22aa389a25398d1952c7a0b5f3d93162dd8"},
   "jason": {:hex, :jason, "1.2.2", "ba43e3f2709fd1aa1dce90aaabfd039d000469c05c56f0b8e31978e03fa39052", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "18a228f5f0058ee183f29f9eae0805c6e59d61c3b006760668d8d18ff0d12179"},
   "jumper": {:hex, :jumper, "1.0.1", "3c00542ef1a83532b72269fab9f0f0c82bf23a35e27d278bfd9ed0865cecabff", [:mix], [], "hexpm", "318c59078ac220e966d27af3646026db9b5a5e6703cb2aa3e26bcfaba65b7433"},
+  "logger_file_backend": {:hex, :logger_file_backend, "0.0.11", "3bbc5f31d3669e8d09d7a9443e86056fae7fc18e45c6f748c33b8c79a7e147a1", [:mix], [], "hexpm", "62be826f04644c62b0a2bc98a13e2e7ae52c0a4eda020f4c59d7287356d5e445"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mime": {:hex, :mime, "1.5.0", "203ef35ef3389aae6d361918bf3f952fa17a09e8e43b5aa592b93eba05d0fb8d", [:mix], [], "hexpm", "55a94c0f552249fc1a3dd9cd2d3ab9de9d3c89b559c2bd01121f824834f24746"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -87,8 +87,10 @@ data "template_file" "ec2_meadow_config" {
   vars = merge(
     local.container_config,
     {
-      meadow_ec2_hostname   = "${var.stack_name}-console.${data.aws_route53_zone.app_zone.name}",
-      meadow_hostname       = aws_route53_record.app_hostname.fqdn
+      meadow_ec2_hostname       = "${var.stack_name}-console.${data.aws_route53_zone.app_zone.name}",
+      meadow_hostname           = aws_route53_record.app_hostname.fqdn,
+      migration_binary_bucket   = var.migration_binary_bucket,
+      migration_manifest_bucket = var.migration_manifest_bucket
     }
   )
 }
@@ -103,6 +105,7 @@ resource "aws_instance" "this_ec2_instance" {
   user_data                     = data.template_file.ec2_user_data.rendered
 
   lifecycle {
+    create_before_destroy = true
     ignore_changes = [ ami, user_data, instance_type ]
   }
 

--- a/terraform/ec2_files/dev.local.exs
+++ b/terraform/ec2_files/dev.local.exs
@@ -78,9 +78,22 @@ config :exldap, :settings,
   password: System.get_env("LDAP_BIND_PASSWORD", "d0ck3rAdm1n!"),
   ssl: System.get_env("LDAP_SSL", "false") == "true"
 
+config :logger,
+  backends: [
+    :console,
+    {LoggerFileBackend, :cloudwatch}
+  ]
+
 config :logger, :console,
   format: "$metadata[$level] $levelpad$message\n",
   metadata: [:action]
+
+config :logger, :cloudwatch,
+  path: "/var/log/meadow/meadow.log",
+  format: "$date $time [$level] $metadata $levelpad$message\n",
+  metadata: [:action],
+  level: :info,
+  colors: [enabled: false]
 
 config :ueberauth, Ueberauth,
   providers: [

--- a/terraform/ec2_files/meadowrc
+++ b/terraform/ec2_files/meadowrc
@@ -32,6 +32,8 @@ export RELEASE_DISTRIBUTION="name"
 export RELEASE_NODE="meadow@${host_name}"
 export SECRET_KEY_BASE="${secret_key_base}"
 export UPLOAD_BUCKET="${upload_bucket}"
+export MIGRATION_BINARY_BUCKET="${migration_binary_bucket}"
+export MIGRATION_MANIFEST_BUCKET="${migration_manifest_bucket}"
 
 cd ~/meadow
 git fetch -pa origin


### PR DESCRIPTION
This is mostly a terraform PR, and the changes have already been applied. But there is one addition to `mix.exs` that will have to be merged before it works.