### PR TITLE
Use advisory locks in ingest sheet progress trigger

### DIFF
--- a/priv/repo/migrations/20200925213350_create_ingest_sheet_update_trigger.exs
+++ b/priv/repo/migrations/20200925213350_create_ingest_sheet_update_trigger.exs
@@ -7,22 +7,31 @@ defmodule Meadow.Repo.Migrations.CreateIngestSheetUpdateTrigger do
       RETURNS trigger AS $$
     DECLARE
       current_sheet_id ingest_sheets.id%TYPE;
+      lock_id bigint;
       pending integer;
     BEGIN
       SELECT ingest_sheet_rows.sheet_id INTO current_sheet_id
       FROM ingest_sheet_rows WHERE ingest_sheet_rows.id = NEW.row_id;
 
+      SELECT ('x'||TRANSLATE(current_sheet_id::VARCHAR,'-',''))::BIT(64)::BIGINT INTO lock_id;
+
+      SET LOCAL lock_timeout = '10s';
+      PERFORM pg_advisory_lock(lock_id);
+
       SELECT COUNT(*) INTO pending
-      FROM ingest_progress
-      JOIN ingest_sheet_rows ON ingest_progress.row_id = ingest_sheet_rows.id
-      WHERE ingest_sheet_rows.sheet_id = current_sheet_id
-      AND ingest_progress.status NOT IN ('ok', 'error');
+        FROM ingest_progress
+        JOIN ingest_sheet_rows ON ingest_progress.row_id = ingest_sheet_rows.id
+        WHERE ingest_sheet_rows.sheet_id = current_sheet_id
+        AND ingest_progress.status NOT IN ('ok', 'error');
 
       IF pending = 0 THEN
         UPDATE ingest_sheets
         SET status = 'completed', updated_at = NOW() AT TIME ZONE 'utc'
         WHERE ingest_sheets.id = current_sheet_id;
       END IF;
+
+      PERFORM pg_advisory_unlock(lock_id);
+
       RETURN NEW;
     END;
     $$ LANGUAGE plpgsql


### PR DESCRIPTION
This should resolve the race condition that sometimes prevents the ingest sheet from being marked `completed`.