### PR TITLE
Set the BatchDriver timeout to 10 minutes.

### DIFF
--- a/lib/meadow/batch_driver.ex
+++ b/lib/meadow/batch_driver.ex
@@ -12,7 +12,7 @@ defmodule Meadow.BatchDriver do
 
   require Logger
 
-  @timeout 360
+  @timeout 600
 
   @doc """
   If no batches are currently running, find the next one and start it


### PR DESCRIPTION
Sets the BatchDriver to 10 minutes (up from 6 minutes)