### PR TITLE
Don't update "started" field when setting batch complete/error

### DIFF
--- a/lib/meadow/batches.ex
+++ b/lib/meadow/batches.ex
@@ -198,7 +198,6 @@ defmodule Meadow.Batches do
 
   defp set_complete!(batch) do
     update_batch!(batch, %{
-      started: DateTime.utc_now(),
       status: "complete",
       active: false
     })
@@ -206,7 +205,6 @@ defmodule Meadow.Batches do
 
   defp set_error!(batch, message) do
     update_batch!(batch, %{
-      started: DateTime.utc_now(),
       status: "error",
       active: false,
       error: message


### PR DESCRIPTION
There's no good way to add a test for this without creating a test batch that reliably takes more than a second or two to run. But the fix is straightforward enough that I'm comfortable not jumping through extra hoops to test it.