### PR TITLE
Bumped up the count from 10 (default) to 60 items on Search screen

### DIFF
--- a/assets/js/components/Search/Results.jsx
+++ b/assets/js/components/Search/Results.jsx
@@ -101,6 +101,7 @@ const SearchResults = ({
               );
             }}
             showResultStats={true}
+            size={60}
             sortOptions={REACTIVESEARCH_SORT_OPTIONS}
             URLParams={true}
           />


### PR DESCRIPTION
This should be a little zippier now.  Loads up to 60 images (a multiple of 4) by default instead of 10 on the main Search screen.