### PR TITLE
Remove unique constraint on ingest sheet titles

### DIFF
--- a/lib/meadow/ingest/schemas/sheet.ex
+++ b/lib/meadow/ingest/schemas/sheet.ex
@@ -48,7 +48,6 @@ defmodule Meadow.Ingest.Schemas.Sheet do
     |> cast_assoc(:works)
     |> validate_required([:title, :filename, :project_id])
     |> assoc_constraint(:project)
-    |> unique_constraint(:title)
   end
 
   def status_changeset(ingest_sheet, attrs) do

--- a/priv/repo/migrations/20210304122111_drop_ingest_sheet_title_index.exs
+++ b/priv/repo/migrations/20210304122111_drop_ingest_sheet_title_index.exs
@@ -1,0 +1,8 @@
+defmodule Meadow.Repo.Migrations.DropIngestSheetTitleIndex do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists unique_index(:ingest_sheets, [:title])
+    create_if_not_exists index(:ingest_sheets, [:title])
+  end
+end


### PR DESCRIPTION
After thinking about this a lot, I'm proposing this change instead of the full changing of 'title' to 'filename' described in the issue (which would also necessitate changing 'filename' to something else). It seemed to be a whole lot of changes for not really any functional benefit, (if one was creating an ingest sheet straight through the API, you still need to provide a "title" because the sheet name cannot be derived from the presigned url.) The front end is enforcing filename as title and I think that's good enough. The column names are close enough to what they are functionally, that the full renaming seems, after reflection,  unnecessary.


This just removes the unique constraint on ingest sheet title. 