### PR TITLE
Add robust semantic versioning support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,10 +125,14 @@ jobs:
             else
               echo "export DEPLOY_TAG=$(echo $CIRCLE_BRANCH | awk -F/ '{print $NF}')" >> $BASH_ENV
             fi
+      - run:
+          name: Extract MEADOW_VERSION from mix.exs
+          command: |
+            echo "export MEADOW_VERSION=$(grep '@app_version "' mix.exs | sed -n 's/^.*"\(.*\)".*/\1/p')" >> $BASH_ENV
       - docker/check
       - docker/build:
           cache_from: nulib/meadow-deps:${DEPLOY_TAG}
-          extra_build_args: --build-arg HONEYBADGER_API_KEY=${HONEYBADGER_API_KEY} --build-arg HONEYBADGER_ENVIRONMENT=${DEPLOY_TAG} --build-arg HONEYBADGER_REVISION=${CIRCLE_SHA1}
+          extra_build_args: --build-arg HONEYBADGER_API_KEY=${HONEYBADGER_API_KEY} --build-arg HONEYBADGER_ENVIRONMENT=${DEPLOY_TAG} --build-arg HONEYBADGER_REVISION=${CIRCLE_SHA1} --build-arg MEADOW_VERSION=${MEADOW_VERSION}
           image: nulib/meadow
           tag: ${DEPLOY_TAG}
       - run:
@@ -141,6 +145,16 @@ jobs:
       - docker/push:
           image: nulib/meadow
           tag: ${DEPLOY_TAG}
+      - when:
+          condition:
+            equal: [ master, << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: "Tag release"
+                command: |
+                  git tag v${MEADOW_VERSION}
+                  git push --tags origin v${MEADOW_VERSION}
+          
   deploy:
     executor: aws-cli/default
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ FROM nulib/elixir-phoenix-base:1.11.1 AS release
 ARG HONEYBADGER_API_KEY=
 ARG HONEYBADGER_ENVIRONMENT=
 ARG HONEYBADGER_REVISION=
+ARG MEADOW_VERSION=
 ENV MIX_ENV=prod
 COPY . /app
 COPY --from=deps /app/_build /app/_build

--- a/assets/js/app.jsx
+++ b/assets/js/app.jsx
@@ -12,12 +12,14 @@ import { ApolloProvider } from "@apollo/client";
 import client from "./client";
 
 const config = {
-  apiKey: process.env.HONEYBADGER_API_KEY || "DO_NOT_REPORT",
-  environment: process.env.HONEYBADGER_ENVIRONMENT || "dev",
-  revision: process.env.HONEYBADGER_REVISION || "1.0",
+  apiKey: __HONEYBADGER_API_KEY__,
+  environment: __HONEYBADGER_ENVIRONMENT__,
+  revision: __HONEYBADGER_REVISION__,
 };
 
-const honeybadger = Honeybadger.configure(config);
+const honeybadger = Honeybadger
+  .configure(config)
+  .setContext({ meadow_version: __MEADOW_VERSION__ });
 
 setupFontAwesome();
 

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -4,6 +4,7 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
+const Webpack = require("webpack");
 
 module.exports = (env, options) => ({
   optimization: {
@@ -76,6 +77,20 @@ module.exports = (env, options) => ({
     new MiniCssExtractPlugin({ filename: "../css/app.css" }),
     new CopyWebpackPlugin({
       patterns: [{ from: "static/", to: "../" }],
+    }),
+    new Webpack.DefinePlugin({
+      __HONEYBADGER_API_KEY__: JSON.stringify(
+        process.env.HONEYBADGER_API_KEY || "DO_NOT_REPORT"
+      ),
+      __HONEYBADGER_ENVIRONMENT__: JSON.stringify(
+        process.env.HONEYBADGER_ENVIRONMENT || "dev"
+      ),
+      __HONEYBADGER_REVISION__: JSON.stringify(
+        process.env.HONEYBADGER_REVISION || "unknown"
+      ),
+      __MEADOW_VERSION__: JSON.stringify(
+        process.env.MEADOW_VERSION || "unknown"
+      ),
     }),
   ],
   devtool: "source-map",

--- a/config/test.exs
+++ b/config/test.exs
@@ -105,3 +105,9 @@ config :logger, level: :info
 
 config :ex_unit,
   assert_receive_timeout: 500
+
+config :honeybadger,
+  environment_name: :test,
+  exclude_envs: [:dev, :test],
+  api_key: "abc123",
+  origin: "http://localhost:4444"

--- a/doc/architecture/decisions/0027-semantic-versioning.md
+++ b/doc/architecture/decisions/0027-semantic-versioning.md
@@ -1,0 +1,30 @@
+# 27. Semantic Versioning
+
+Date: 2021-03-03
+
+## Status
+
+Accepted
+
+## Context
+
+Simplify versioning.
+
+Supersedes [24. Version Management](0024-version-management.md)
+
+## Decision
+
+When merging from staging to master:
+
+- Update the `@app_version` attribute in `mix.exs` on the staging branch:
+  - Major version: Backward-incompatible database and/or API changes
+  - Minor version: New features or backward-compatible database and/or API changes
+  - Point version: All other changes
+- PR staging to master
+- After CircleCI is finished building and deploying the new version, it will
+  automatically tag the correct revision with the version number and push
+  the tag to Github
+
+## Consequences
+
+- Tagging is consistent and easy

--- a/lib/meadow/config.ex
+++ b/lib/meadow/config.ex
@@ -3,6 +3,8 @@ defmodule Meadow.Config do
   Convenience methods for retrieving Meadow configuration
   """
 
+  @meadow_version Mix.Project.config() |> Keyword.get(:version)
+
   @doc "Retrieve the environment specific URL for the Digital Collections website"
   def digital_collections_url do
     Application.get_env(:meadow, :digital_collections_url)
@@ -161,6 +163,8 @@ defmodule Meadow.Config do
     |> String.split(~r/\s*,\s*/)
     |> Enum.map(&Inflex.underscore/1)
   end
+
+  def meadow_version, do: @meadow_version
 
   defp configured_integer_value(key, default \\ 0) do
     case Application.get_env(:meadow, key, default) do

--- a/lib/meadow/database_notification.ex
+++ b/lib/meadow/database_notification.ex
@@ -106,11 +106,7 @@ defmodule Meadow.DatabaseNotification do
             {:noreply, state}
           rescue
             exception ->
-              Honeybadger.notify(exception,
-                metadata: %{notifier: __MODULE__},
-                stacktrace: __STACKTRACE__
-              )
-
+              Meadow.Error.report(exception, __MODULE__, __STACKTRACE__)
               reraise(exception, __STACKTRACE__)
           end
         end

--- a/lib/meadow/error.ex
+++ b/lib/meadow/error.ex
@@ -1,0 +1,18 @@
+defmodule Meadow.Error do
+  @moduledoc """
+  Convenience module for error reporting via Honeybadger
+  """
+  alias Meadow.Config
+
+  def report(exception, module, stacktrace) do
+    Honeybadger.notify(exception,
+      metadata:
+        Honeybadger.context()
+        |> Map.merge(%{
+          meadow_version: Config.meadow_version(),
+          notifier: module
+        }),
+      stacktrace: stacktrace
+    )
+  end
+end

--- a/lib/meadow/interval_task.ex
+++ b/lib/meadow/interval_task.ex
@@ -110,11 +110,7 @@ defmodule Meadow.IntervalTask do
         end
       rescue
         exception ->
-          Honeybadger.notify(exception,
-            metadata: %{task: __MODULE__},
-            stacktrace: __STACKTRACE__
-          )
-
+          Meadow.Error.report(exception, __MODULE__, __STACKTRACE__)
           reraise(exception, __STACKTRACE__)
       end
 

--- a/lib/meadow/pipeline/actions/common.ex
+++ b/lib/meadow/pipeline/actions/common.ex
@@ -9,6 +9,14 @@ defmodule Meadow.Pipeline.Actions.Common do
 
       def process(data, attrs) do
         Logger.info("Beginning #{__MODULE__} for file set: #{data.file_set_id}")
+
+        Honeybadger.add_breadcrumb(to_string(__MODULE__),
+          metadata: %{
+            data: data,
+            attrs: attrs
+          }
+        )
+
         file_set = FileSets.get_file_set!(data.file_set_id)
         precheck(file_set, attrs)
 
@@ -21,11 +29,7 @@ defmodule Meadow.Pipeline.Actions.Common do
         end
       rescue
         exception ->
-          Honeybadger.notify(exception,
-            metadata: %{action: __MODULE__},
-            stacktrace: __STACKTRACE__
-          )
-
+          Meadow.Error.report(exception, __MODULE__, __STACKTRACE__)
           reraise(exception, __STACKTRACE__)
       end
 

--- a/lib/meadow_web/error_metadata.ex
+++ b/lib/meadow_web/error_metadata.ex
@@ -1,0 +1,12 @@
+defmodule MeadowWeb.ErrorMetadata do
+  @moduledoc """
+  Honeybadger plug_data module to inject the meadow version into Honeybadger's context
+  """
+  alias Honeybadger.PlugData
+  alias Meadow.Config
+
+  def metadata(conn, module) do
+    PlugData.metadata(conn, module)
+    |> Map.merge(%{meadow_version: Config.meadow_version()})
+  end
+end

--- a/lib/meadow_web/router.ex
+++ b/lib/meadow_web/router.ex
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Router do
   use MeadowWeb, :router
-  use Honeybadger.Plug
+  use Honeybadger.Plug, plug_data: MeadowWeb.ErrorMetadata
   import Phoenix.LiveDashboard.Router
 
   pipeline :browser do

--- a/test/meadow/config_test.exs
+++ b/test/meadow/config_test.exs
@@ -70,6 +70,10 @@ defmodule Meadow.ConfigTest do
     end
   end
 
+  test "meadow_version/0" do
+    assert Config.meadow_version() == Mix.Project.config() |> Keyword.get(:version)
+  end
+
   describe "IIIF configs" do
     setup do
       prior_values = %{

--- a/test/meadow/error_test.exs
+++ b/test/meadow/error_test.exs
@@ -1,0 +1,33 @@
+defmodule Meadow.ErrorTest do
+  use Honeybadger.Case
+
+  alias Meadow.Config
+
+  setup do
+    {:ok, _} = Honeybadger.API.start(self())
+
+    on_exit(&Honeybadger.API.stop/0)
+  end
+
+  describe "report/3" do
+    test "sends error notifications" do
+      restart_with_config(exclude_envs: [])
+
+      bad_function = fn denominator ->
+        try do
+          107 / denominator
+        rescue
+          exception -> Meadow.Error.report(exception, __MODULE__, __STACKTRACE__)
+        end
+      end
+
+      bad_function.(0)
+      assert_receive {:api_request, report}, 1000
+
+      with request_context <- report |> get_in(["request", "context"]) do
+        assert request_context |> Map.get("meadow_version") == Config.meadow_version()
+        assert request_context |> Map.get("notifier") == __MODULE__ |> to_string()
+      end
+    end
+  end
+end

--- a/test/support/honeybadger_case.ex
+++ b/test/support/honeybadger_case.ex
@@ -1,0 +1,74 @@
+defmodule Honeybadger.Case do
+  @moduledoc """
+  Case template for capturing and testing Honeybadger notifications.
+  Copied with minor changes from https://github.com/honeybadger-io/honeybadger-elixir/blob/master/test/test_helper.exs
+  """
+  use ExUnit.CaseTemplate
+
+  using(_) do
+    quote do
+      import unquote(__MODULE__)
+    end
+  end
+
+  def restart_with_config(opts) do
+    :ok = Application.stop(:honeybadger)
+    original = take_original_env(opts)
+
+    put_all_env(opts)
+
+    on_exit(fn ->
+      :ok = Application.stop(:honeybadger)
+      put_all_env(original)
+      :ok = Application.ensure_started(:honeybadger)
+    end)
+
+    :ok = Application.ensure_started(:honeybadger)
+  end
+
+  defp take_original_env(opts) do
+    Keyword.take(Application.get_all_env(:honeybadger), Keyword.keys(opts))
+  end
+
+  defp put_all_env(opts) do
+    Enum.each(opts, fn {key, val} ->
+      Application.put_env(:honeybadger, key, val)
+    end)
+  end
+end
+
+defmodule Honeybadger.API do
+  @moduledoc """
+  Mock API for Honeybadger testing
+  """
+  import Plug.Conn
+
+  alias Plug.Conn
+  alias Plug.Adapters.Cowboy
+
+  def start(pid) do
+    Cowboy.http(__MODULE__, [test: pid], port: 4444)
+  end
+
+  def stop do
+    :timer.sleep(100)
+    Cowboy.shutdown(__MODULE__.HTTP)
+    :timer.sleep(100)
+  end
+
+  def init(opts) do
+    Keyword.fetch!(opts, :test)
+  end
+
+  def call(%Conn{method: "POST"} = conn, test) do
+    {:ok, body, conn} = read_body(conn)
+
+    send(test, {:api_request, Jason.decode!(body)})
+
+    send_resp(conn, 200, "{}")
+  end
+
+  def call(conn, _test) do
+    send_resp(conn, 404, "Not Found")
+  end
+end


### PR DESCRIPTION
- Integrate Meadow version with Honeybadger
- Include version in context on all Honeybadger notifications
- Update CircleCI to pass meadow version to Docker
- Update Dockerfile to pass meadow version to webpack
- Update webpack config to include version
- Configure CircleCI to tag master branch with version and push to github
- Create ADR for semantic versioning

While checking to see if webpack handled the `MEADOW_VERSION` properly, I found that it wasn't precompiling any of the `process.env.*` variables, which led me to the [`DefinePlugin`](https://webpack.js.org/plugins/define-plugin/) solution. Apparently `webpack` handles the build-time environment differently from however `react-scripts` does it.