### PR TITLE
Revert ingest sheet title to unique

### DIFF
--- a/lib/meadow/ingest/schemas/sheet.ex
+++ b/lib/meadow/ingest/schemas/sheet.ex
@@ -48,6 +48,7 @@ defmodule Meadow.Ingest.Schemas.Sheet do
     |> cast_assoc(:works)
     |> validate_required([:title, :filename, :project_id])
     |> assoc_constraint(:project)
+    |> unique_constraint(:title)
   end
 
   def status_changeset(ingest_sheet, attrs) do

--- a/priv/repo/migrations/20210305165503_recreate_ingest_sheet_title_index.exs
+++ b/priv/repo/migrations/20210305165503_recreate_ingest_sheet_title_index.exs
@@ -1,0 +1,8 @@
+defmodule Meadow.Repo.Migrations.RecreateIngestSheetTitleIndex do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists index(:ingest_sheets, [:title])
+    create_if_not_exists unique_index(:ingest_sheets, [:title])
+  end
+end


### PR DESCRIPTION
This will require a data migration unless we coordinate with a data reset. 