### PR TITLE
Report Lambda errors to Honeybadger as LambdaError instead of RuntimeError

### DIFF
--- a/lib/meadow/error.ex
+++ b/lib/meadow/error.ex
@@ -1,3 +1,6 @@
+defmodule Meadow.TimeoutError, do: defexception([:message])
+defmodule Meadow.LambdaError, do: defexception([:message])
+
 defmodule Meadow.Error do
   @moduledoc """
   Convenience module for error reporting via Honeybadger

--- a/lib/meadow/pipeline/actions/generate_file_set_digests.ex
+++ b/lib/meadow/pipeline/actions/generate_file_set_digests.ex
@@ -53,7 +53,7 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigests do
           raise error
       end
     rescue
-      Meadow.Utils.Stream.Timeout ->
+      Meadow.TimeoutError ->
         ActionStates.set_state!(file_set, __MODULE__, "pending")
         :retry
 

--- a/lib/meadow/utils/lambda.ex
+++ b/lib/meadow/utils/lambda.ex
@@ -94,16 +94,16 @@ defmodule Meadow.Utils.Lambda do
     case ExAws.Lambda.invoke(lambda, payload, %{})
          |> ExAws.request(http_opts: [recv_timeout: timeout], retries: [max_attempts: 1]) do
       {:ok, %{"errorType" => _, "errorMessage" => error_message, "trace" => trace}} ->
-        Meadow.Error.report(error_message, __MODULE__, [], %{
+        Meadow.Error.report(%Meadow.LambdaError{message: error_message}, __MODULE__, [], %{
           lambda: lambda,
           payload: payload,
-          trace: trace |> Enum.join("\n")
+          trace: trace
         })
 
         {:error, error_message}
 
       {:error, {:http_error, status, %{body: message}}} = result ->
-        Meadow.Error.report(message, __MODULE__, [], %{
+        Meadow.Error.report(%Meadow.LambdaError{message: message}, __MODULE__, [], %{
           http_status: status,
           lambda: lambda,
           payload: payload

--- a/lib/meadow/utils/stream.ex
+++ b/lib/meadow/utils/stream.ex
@@ -3,10 +3,6 @@ defmodule Meadow.Utils.Stream do
   Functions to provide chunk streams from http:// and s3:// URLs
   """
 
-  defmodule Timeout do
-    defexception [:message]
-  end
-
   require Logger
 
   def exists?("s3://" <> _ = url) do
@@ -65,7 +61,7 @@ defmodule Meadow.Utils.Stream do
       5_000 ->
         with msg <- "No message received from #{inspect(resp)} in 5 seconds." do
           Logger.warn(msg)
-          raise __MODULE__.Timeout, message: msg
+          raise Meadow.TimeoutError, message: msg
         end
     end
   end

--- a/test/support/honeybadger_case.ex
+++ b/test/support/honeybadger_case.ex
@@ -43,8 +43,8 @@ defmodule Honeybadger.API do
   """
   import Plug.Conn
 
-  alias Plug.Conn
   alias Plug.Adapters.Cowboy
+  alias Plug.Conn
 
   def start(pid) do
     Cowboy.http(__MODULE__, [test: pid], port: 4444)


### PR DESCRIPTION
- Don't concatenate the stack trace; Honeybadger can handle an array and it looks better
- Additional small changes to make `mix.credo --strict` happy

![image](https://user-images.githubusercontent.com/196872/110178323-e47a8580-7dcb-11eb-9a43-859847a2fd4b.png)
