### PR TITLE
Add total works to collections queries and clean up placeholder data

### DIFF
--- a/assets/js/components/Collection/Collection.jsx
+++ b/assets/js/components/Collection/Collection.jsx
@@ -23,6 +23,7 @@ const Collection = ({ collection }) => {
     representativeWork,
     findingAidUrl,
     keywords = [],
+    totalWorks,
   } = collection;
 
   const handleViewAllWorksClick = () => {
@@ -53,28 +54,30 @@ const Collection = ({ collection }) => {
               <img src="/images/placeholder.png" />
             )}
           </figure>
-          <AuthDisplayAuthorized>
-            <p className="has-text-centered pt-2">
-              <Button
-                data-testid="button-open-image-modal"
-                isText
-                onClick={handleViewAllWorksClick}
-                className="is-fullwidth"
-              >
-                <span className="icon">
-                  <IconEdit />
-                </span>
-                <span>Update Image</span>
-              </Button>
-            </p>
-          </AuthDisplayAuthorized>
+          {totalWorks > 0 && (
+            <AuthDisplayAuthorized>
+              <p className="has-text-centered pt-2">
+                <Button
+                  data-testid="button-open-image-modal"
+                  isText
+                  onClick={handleViewAllWorksClick}
+                  className="is-fullwidth"
+                >
+                  <span className="icon">
+                    <IconEdit />
+                  </span>
+                  <span>Update Image</span>
+                </Button>
+              </p>
+            </AuthDisplayAuthorized>
+          )}
         </div>
         <div className="column content">
           <dl>
             <dt>
               <strong>Description</strong>
             </dt>
-            <dd>{description}</dd>
+            <dd style={{ whiteSpace: "pre-line" }}>{description}</dd>
             <dt>
               <strong>Admin Email</strong>
             </dt>
@@ -91,20 +94,26 @@ const Collection = ({ collection }) => {
               <strong>Keywords</strong>
             </dt>
             <dd>{keywords.join(", ")}</dd>
+            <dt>
+              <strong>Total Works</strong>
+            </dt>
+            <dd>{totalWorks}</dd>
           </dl>
-          <AuthDisplayAuthorized>
-            <div className="pt-3">
-              <Button
-                onClick={handleViewAllWorksClick}
-                data-testid="view-works-button"
-              >
-                <span className="icon">
-                  <IconImages />
-                </span>
-                <span>View collection works</span>
-              </Button>
-            </div>
-          </AuthDisplayAuthorized>
+          {totalWorks > 0 && (
+            <AuthDisplayAuthorized>
+              <div className="pt-3">
+                <Button
+                  onClick={handleViewAllWorksClick}
+                  data-testid="view-works-button"
+                >
+                  <span className="icon">
+                    <IconImages />
+                  </span>
+                  <span>View collection works</span>
+                </Button>
+              </div>
+            </AuthDisplayAuthorized>
+          )}
         </div>
       </div>
     </div>

--- a/assets/js/components/Collection/ListRow.jsx
+++ b/assets/js/components/Collection/ListRow.jsx
@@ -7,9 +7,12 @@ import CollectionImage from "@js/components/Collection/Image";
 import IconEdit from "@js/components/Icon/Edit";
 import IconDelete from "@js/components/Icon/Delete";
 import IconTrashCan from "@js/components/Icon/TrashCan";
+import useTruncateText from "@js/hooks/useTruncateText";
 
 const CollectionListRow = ({ collection, onOpenModal }) => {
-  const { id, title = "", keywords = [] } = collection;
+  const { id, title = "", description, totalWorks } = collection;
+  const { truncate } = useTruncateText();
+
   return (
     <li data-testid="collection-list-row" className="mb-6">
       <article className="media">
@@ -24,23 +27,12 @@ const CollectionListRow = ({ collection, onOpenModal }) => {
               <Link to={`/collection/${id}`}>{title}</Link>
             </h4>
             <CollectionTags collection={collection} />
-            {/* <p>{description}</p> */}
-            <table className="table is-fullwidth is-narrow">
-              <thead>
-                <tr>
-                  <th>Keywords</th>
-                  <th>Works [not yet supported]</th>
-                  <th>Assets [not yet supported]</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>{keywords.join(", ")}</td>
-                  <td>3810 works, 2010 public, 700 netid, 100 private</td>
-                  <td>100,000 preserved files</td>
-                </tr>
-              </tbody>
-            </table>
+
+            <div>
+              <strong>Works:</strong> {totalWorks}
+              <br />
+              {description && truncate(description, 350)}
+            </div>
           </div>
         </div>
         <div className="media-right">

--- a/assets/js/components/Collection/collection.gql.js
+++ b/assets/js/components/Collection/collection.gql.js
@@ -94,6 +94,7 @@ export const GET_COLLECTION = gql`
       published
       title
       description
+      totalWorks
       representativeWork {
         id
         representativeImage
@@ -127,6 +128,7 @@ export const GET_COLLECTIONS = gql`
       description
       id
       keywords
+      totalWorks
       representativeWork {
         id
         representativeImage

--- a/assets/js/components/Collection/collection.gql.mock.js
+++ b/assets/js/components/Collection/collection.gql.mock.js
@@ -13,6 +13,7 @@ export const collectionMock = {
   title: "Great collection",
   published: false,
   //visibility: published,
+  totalWorks: 2,
   works: [
     {
       id: "1id-23343432",

--- a/assets/js/hooks/useTruncateText.js
+++ b/assets/js/hooks/useTruncateText.js
@@ -1,0 +1,9 @@
+export default function useTruncateText() {
+  function truncate(text = "", number) {
+    if (text.length <= number) {
+      return text;
+    }
+    return text.slice(0, number) + "...";
+  }
+  return { truncate };
+}

--- a/lib/meadow/data/collections.ex
+++ b/lib/meadow/data/collections.ex
@@ -48,6 +48,14 @@ defmodule Meadow.Data.Collections do
     |> add_representative_image()
   end
 
+  def get_work_count(collection_id) do
+    count =
+      from(w in Work, where: w.collection_id == ^collection_id)
+      |> Repo.aggregate(:count)
+
+    {:ok, count}
+  end
+
   def add_works(%Collection{} = collection, work_ids) do
     from(w in Work, where: w.id in ^work_ids)
     |> Repo.update_all(set: [collection_id: collection.id, updated_at: DateTime.utc_now()])

--- a/lib/meadow_web/schema/types/data/collection_types.ex
+++ b/lib/meadow_web/schema/types/data/collection_types.ex
@@ -112,5 +112,10 @@ defmodule MeadowWeb.Schema.Data.CollectionTypes do
     end
 
     field :representative_work, :work
+
+    field :total_works, :integer,
+      resolve: fn query, _, _ ->
+        Meadow.Data.Collections.get_work_count(query.id)
+      end
   end
 end

--- a/test/gql/CollectionFields.frag.gql
+++ b/test/gql/CollectionFields.frag.gql
@@ -6,6 +6,7 @@ fragment CollectionFields on Collection {
   findingAidUrl
   adminEmail
   featured
+  totalWorks
   representativeWork {
     id
     representativeImage

--- a/test/meadow/data/collections_test.exs
+++ b/test/meadow/data/collections_test.exs
@@ -74,6 +74,12 @@ defmodule Meadow.Data.CollectionsTest do
       end
     end
 
+    test "get_work_count/2", %{collection: collection, works: _works} do
+      assert length(collection.works) == 2
+
+      assert {:ok, 2} = Collections.get_work_count(collection.id)
+    end
+
     test "remove_works/2", %{collection: collection, works: works} do
       assert length(collection.works) == 2
 


### PR DESCRIPTION
- Adds totalWorks to GraphQL collection queries
- Add total works and truncated description to collection list page, clean up placeholder data
- On individual collection pages:
  - display total works
  - don't display view all works button or update image link if the collection has no works
  - respect newlines in description text


<hr>
<img width="1422" alt="Screen Shot 2021-03-05 at 2 49 32 PM" src="https://user-images.githubusercontent.com/6372022/110177941-fc99d700-7dc2-11eb-870b-9062cfbf2861.png">

<img width="1456" alt="Screen Shot 2021-03-05 at 2 58 26 PM" src="https://user-images.githubusercontent.com/6372022/110178145-45ea2680-7dc3-11eb-8456-a2c6990cad6d.png">


<img width="1383" alt="Screen Shot 2021-03-05 at 1 41 56 PM" src="https://user-images.githubusercontent.com/6372022/110178016-12a79780-7dc3-11eb-9f60-e6dc408892d0.png">



