### PR TITLE
Build source maps for application code

### DIFF
--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -9,7 +9,7 @@ const Webpack = require("webpack");
 module.exports = (env, options) => ({
   optimization: {
     minimizer: [
-      new TerserPlugin({ cache: true, parallel: true, sourceMap: false }),
+      new TerserPlugin({ cache: true, parallel: true, sourceMap: true }),
       new OptimizeCSSAssetsPlugin({}),
     ],
     splitChunks: {
@@ -79,8 +79,12 @@ module.exports = (env, options) => ({
       ),
       __MEADOW_VERSION__: JSON.stringify(process.env.MEADOW_VERSION),
     }),
+    new Webpack.SourceMapDevToolPlugin({
+      filename: "[name].js.map",
+      exclude: ["vendors~app.bundle.js"],
+    }),
   ],
-  devtool: "source-map",
+  devtool: false,
   resolve: {
     extensions: ["*", ".mjs", ".js", ".jsx", ".json"],
     // When testing npm components locally, tell Meadow to only


### PR DESCRIPTION
Because webpack's minimizer has been configured with `sourceMap: false`, maps were only being generated for the vendor bundle, not the app bundle. This change tells webpack to build the source map for the app bundle as well.