### PR TITLE
Block Published facet from allowing a None value

### DIFF
--- a/assets/js/components/Search/FacetSidebar.jsx
+++ b/assets/js/components/Search/FacetSidebar.jsx
@@ -121,7 +121,9 @@ export default function SearchFacetSidebar() {
           react={{
             and: filterList(sensor.componentId),
           }}
-          showMissing={true}
+          showMissing={
+            ["Published"].indexOf(sensor.componentId) > -1 ? false : true
+          }
           showFilter={true}
           URLParams={true}
         />


### PR DESCRIPTION
Nice call @kdid  on proposed solution.  Seems to work well and now Published is faceting properly.