### PR TITLE
Don't error on tech metadata fields with null value

### DIFF
--- a/assets/js/components/Work/Tabs/Preservation/Technical.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/Technical.jsx
@@ -14,7 +14,11 @@ const modalCloseButton = css`
 
 function TechDataDisplay({ value }) {
   if (typeof value === "object") {
-    return Object.keys(value).join(", ");
+    if (value === null) {
+      return "--";
+    } else {
+      return Object.keys(value).join(", ");
+    }
   }
   return value;
 }


### PR DESCRIPTION
- Does not throw error if a technical metadata field has a null value.
- 



<img width="743" alt="Screen Shot 2021-03-11 at 1 01 23 PM" src="https://user-images.githubusercontent.com/6372022/110847557-4c1c4f00-826a-11eb-899a-821b4f47c26d.png">
