### PR TITLE
Change "Undelabelined" to "Undetermined"

### DIFF
--- a/priv/repo/migrations/20210316004128_change_undelabelined_to_undetermined.exs
+++ b/priv/repo/migrations/20210316004128_change_undelabelined_to_undetermined.exs
@@ -1,0 +1,36 @@
+defmodule Meadow.Repo.Migrations.ChangeUndelabelinedToUndetermined do
+  use Ecto.Migration
+  alias Meadow.Data.CodedTerms
+  alias Meadow.Data.Schemas.CodedTerm
+  alias Meadow.Repo
+  import Ecto.Query
+
+  @id "http://rightsstatements.org/vocab/UND/1.0/"
+  @scheme "rights_statement"
+  @wrong "Copyright Undelabelined"
+  @right "Copyright Undetermined"
+  @coded_term_sql "UPDATE coded_terms SET label = $1 WHERE scheme = $2 AND id = $3"
+  @works_sql """
+    UPDATE works
+    SET descriptive_metadata = jsonb_set(descriptive_metadata, '{rights_statement,label}', $1)
+    WHERE descriptive_metadata->'rights_statement'->>'id' = $2
+  """
+
+  def up do
+    update_coded_term(@right)
+    update_existing_work_labels(@right)
+  end
+
+  def down do
+    update_coded_term(@wrong)
+    update_existing_work_labels(@wrong)
+  end
+
+  defp update_coded_term(value) do
+    Repo.query!(@coded_term_sql, [value, @scheme, @id])
+  end
+
+  defp update_existing_work_labels(value) do
+    Repo.query!(@works_sql, [value, @id])
+  end
+end

--- a/priv/repo/seeds/coded_terms/rights_statement.json
+++ b/priv/repo/seeds/coded_terms/rights_statement.json
@@ -5,7 +5,7 @@
   },
   {
     "id": "http://rightsstatements.org/vocab/UND/1.0/",
-    "label": "Copyright Undelabelined"
+    "label": "Copyright Undetermined"
   },
   {
     "id": "http://rightsstatements.org/vocab/InC/1.0/",


### PR DESCRIPTION
The coded term seed file was the only instance of the search/replace error. I ended up writing a migration to change the label in the `coded_terms` table and in every work it's already been used in, which will also trigger a reindex on the next sync.