### PR TITLE
Include controlled term cache in seed export/import

### DIFF
--- a/lib/meadow/seed/export.ex
+++ b/lib/meadow/seed/export.ex
@@ -14,7 +14,7 @@ defmodule Meadow.Seed.Export do
 
   require Logger
 
-  @common_exports ~w(collections nul_authorities)a
+  @common_exports ~w(collections controlled_term_cache nul_authorities)a
   @ingest_sheet_exports ~w(ingest_sheet_projects ingest_sheets ingest_sheet_rows ingest_sheet_progress
     ingest_sheet_works ingest_sheet_file_sets ingest_sheet_action_states)a
   @standalone_exports ~w(standalone_works standalone_file_sets standalone_action_states)a
@@ -149,7 +149,7 @@ defmodule Meadow.Seed.Export do
   defp dump_data(queryable) do
     query = "COPY (#{interpolate_params(queryable)}) TO STDOUT WITH (FORMAT CSV, HEADER)"
 
-    SQL.query!(Repo, query)
+    SQL.query!(Repo, query, [], timeout: :infinity)
     |> Map.get(:rows)
   end
 

--- a/lib/meadow/seed/queries.ex
+++ b/lib/meadow/seed/queries.ex
@@ -3,13 +3,17 @@ defmodule Meadow.Seed.Queries do
   Module providing the composable query functions used by Meadow.Seed.Export
   """
 
-  alias Meadow.Data.Schemas.{ActionState, Collection, FileSet, Work}
+  alias Meadow.Data.Schemas.{ActionState, Collection, ControlledTermCache, FileSet, Work}
   alias Meadow.Ingest.Schemas.{Progress, Project, Row, Sheet}
 
   import Ecto.Query
 
   def collections(_) do
     from(c in Collection, select: c)
+  end
+
+  def controlled_term_cache(_) do
+    from(ct in ControlledTermCache, select: ct)
   end
 
   def nul_authorities(_) do

--- a/priv/repo/migrations/20210316004128_change_undelabelined_to_undetermined.exs
+++ b/priv/repo/migrations/20210316004128_change_undelabelined_to_undetermined.exs
@@ -1,9 +1,6 @@
 defmodule Meadow.Repo.Migrations.ChangeUndelabelinedToUndetermined do
   use Ecto.Migration
-  alias Meadow.Data.CodedTerms
-  alias Meadow.Data.Schemas.CodedTerm
   alias Meadow.Repo
-  import Ecto.Query
 
   @id "http://rightsstatements.org/vocab/UND/1.0/"
   @scheme "rights_statement"


### PR DESCRIPTION
Also:

* Use `Repo.stream()` instead of `Repo.all()` to post-process data sets (because they might be large)
* Clean up unused alias/import warnings in a migration