### PR TITLE
Give meadow the ability to set ACLs on bucket objects

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -130,6 +130,7 @@ data "aws_iam_policy_document" "this_bucket_access" {
 
     actions = [
       "s3:PutObject",
+      "s3:PutObjectAcl",
       "s3:GetObject",
       "s3:DeleteObject",
     ]


### PR DESCRIPTION
Terraform only. Already applied to both environments.