### PR TITLE
Call Ecto.Changeset.no_assoc_constraint/2 when deleting a collection

### DIFF
--- a/lib/meadow/data/collections.ex
+++ b/lib/meadow/data/collections.ex
@@ -31,7 +31,10 @@ defmodule Meadow.Data.Collections do
   end
 
   def delete_collection(%Collection{} = collection) do
-    Repo.delete(collection)
+    collection
+    |> Collection.changeset()
+    |> no_assoc_constraint(:works, message: "Works are still associated with this collection.")
+    |> Repo.delete()
   end
 
   def create_collection(attrs \\ %{}) do

--- a/test/meadow_web/schema/mutation/delete_collection_test.exs
+++ b/test/meadow_web/schema/mutation/delete_collection_test.exs
@@ -16,6 +16,26 @@ defmodule MeadowWeb.Schema.Mutation.DeleteCollectionTest do
     assert {:ok, _query_data} = result
   end
 
+  test "should not allow non-empty collections to be deleted" do
+    collection = collection_fixture()
+    work_fixture(%{collection_id: collection.id})
+
+    {:ok, result} =
+      query_gql(
+        variables: %{"collectionId" => collection.id},
+        context: gql_context()
+      )
+
+    assert %{
+             errors: [
+               %{
+                 message: "Could not delete collection",
+                 details: %{"works" => "Works are still associated with this collection."}
+               }
+             ]
+           } = result
+  end
+
   describe "authorization" do
     test "viewers and editors are not authorized to delete collections" do
       collection_fixture = collection_fixture()


### PR DESCRIPTION
- Proper error handling when deleting a collection with works still associated. The current behavior is to raise an error due to the foreign key constraint, this change makes for a proper changeset error during deletion.
- Update `MeadowWeb.Schema.Mutation.DeleteCollectionTest` to include a test for the change