### PR TITLE
Fix cron schedule and redo table unique index

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -106,8 +106,8 @@ config :logger, level: :info
 config :meadow, Meadow.Scheduler,
   overlap: false,
   jobs: [
-    # Runs daily at 2 am
-    {"0 2 * * *", {Meadow.Data.PreservationChecks, :start_job, []}}
+    # Runs daily at 7AM UTC (2 AM)
+    {"0 7 * * *", {Meadow.Data.PreservationChecks, :start_job, []}}
   ]
 
 config :sequins,

--- a/lib/meadow/data/schemas/preservation_check.ex
+++ b/lib/meadow/data/schemas/preservation_check.ex
@@ -22,7 +22,8 @@ defmodule Meadow.Data.Schemas.PreservationCheck do
 
   def changeset(job, attrs) do
     job
-    |> cast(attrs, [:filename, :location, :status, :invalid_rows])
+    |> cast(attrs, [:active, :filename, :location, :status, :invalid_rows])
     |> validate_inclusion(:status, @status)
+    |> unique_constraint(:active)
   end
 end

--- a/priv/repo/migrations/20210325120850_preservation_check_unique_constraint.exs
+++ b/priv/repo/migrations/20210325120850_preservation_check_unique_constraint.exs
@@ -1,0 +1,7 @@
+defmodule Meadow.Repo.Migrations.PreservationCheckUniqueConstraint do
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists(unique_index(:preservation_checks, [:active], where: "active=true"))
+  end
+end

--- a/test/meadow/data/preservation_checks_test.exs
+++ b/test/meadow/data/preservation_checks_test.exs
@@ -3,7 +3,6 @@ defmodule Meadow.Data.PreservationChecksTest do
   use Meadow.DataCase
   use Meadow.S3Case
 
-  import Assertions
   import ExUnit.CaptureLog
 
   alias Meadow.Config
@@ -33,6 +32,8 @@ defmodule Meadow.Data.PreservationChecksTest do
       }
     })
 
+    on_exit(fn -> empty_bucket(@preservation_check_bucket) end)
+
     {:ok, %{}}
   end
 
@@ -50,13 +51,6 @@ defmodule Meadow.Data.PreservationChecksTest do
 
     assert logged |> String.contains?("Starting preservation check")
     assert logged |> String.contains?("Preservation check complete")
-
-    jobs = PreservationChecks.list_jobs()
-
-    on_exit(fn ->
-      jobs
-      |> Enum.each(fn j -> delete_object(@preservation_check_bucket, j.filename) end)
-    end)
   end
 
   test "start_job/0 will not start a new job if one is already active" do
@@ -75,11 +69,5 @@ defmodule Meadow.Data.PreservationChecksTest do
     assert logged |> String.contains?("Active preservation check already running")
 
     assert PreservationChecks.list_jobs() |> length() == 1
-    jobs = PreservationChecks.list_jobs()
-
-    on_exit(fn ->
-      jobs
-      |> Enum.each(fn j -> delete_object(@preservation_check_bucket, j.filename) end)
-    end)
   end
 end


### PR DESCRIPTION
- Fix cron schedule (it's UTC time) so that it runs at 2AM Evanston time
- reinstitute active column unique index in `preservation_checks` table so that a new job cannot be created if there is one already in the 'active' state
- increase "timeout" setting for jobs so that it doesn't get hit on production for a running job (this only needs to be a way outside window since the job runs only once daily)