### PR TITLE
Redact sensitive cookies before sending reports to honeybadger

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -109,6 +109,7 @@ config :honeybadger,
   revision: System.get_env("HONEYBADGER_REVISION", nil),
   repos: [Meadow.Repo],
   breadcrumbs_enabled: true,
+  notice_filter: Meadow.Error.Filter,
   exclude_envs: [:dev, :test]
 
 aws_env =

--- a/lib/meadow/error.ex
+++ b/lib/meadow/error.ex
@@ -38,3 +38,45 @@ defmodule Meadow.Error do
     Map.put(metadata, :tags, tag_list)
   end
 end
+
+defmodule Meadow.Error.Filter do
+  @moduledoc """
+  Honeybadger message filter for NU-specific sensitive data
+  """
+  @behaviour Honeybadger.NoticeFilter
+
+  alias Plug.Conn.Cookies
+
+  @redact [~r/^nusso/i, ~r/^_meadow_key$/, ~r/^dcApi/]
+  @redacted "[REDACTED]"
+
+  def filter(message) do
+    with result <- Honeybadger.NoticeFilter.Default.filter(message) do
+      Map.put(result, :request, filter_request(result.request))
+    end
+  end
+
+  defp filter_request(%{cgi_data: cgi_data} = request) when is_map(cgi_data) do
+    request |> Map.put(:cgi_data, filter_cgi_data(cgi_data))
+  end
+
+  defp filter_request(request), do: request
+
+  defp filter_cgi_data(cgi_data) do
+    cgi_data
+    |> Map.put("HTTP_COOKIE", cgi_data |> Map.get("HTTP_COOKIE") |> filter_cookie())
+  end
+
+  def filter_cookie(cookie) when is_binary(cookie) do
+    cookie
+    |> Cookies.decode()
+    |> Enum.map(fn {name, value} ->
+      if Enum.any?(@redact, &Regex.match?(&1, name)),
+        do: "#{name}=#{@redacted}",
+        else: "#{name}=#{value}"
+    end)
+    |> Enum.join("; ")
+  end
+
+  def filter_cookie(cookie), do: cookie
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Meadow.MixProject do
   use Mix.Project
 
-  @app_version "1.4.0"
+  @app_version "1.4.1"
 
   def project do
     [

--- a/test/meadow/error_test.exs
+++ b/test/meadow/error_test.exs
@@ -1,7 +1,15 @@
 defmodule Meadow.ErrorTest do
   use Honeybadger.Case
+  use MeadowWeb.ConnCase, async: true
 
   alias Meadow.Config
+  alias Plug.Conn.Cookies
+
+  import Plug.Conn
+
+  @cookie "dcApiToken=PLEASE_REDACT; dcApiUser=PLEASE_REDACT; amlbcookie=01; nusso=PLEASE_REDACT; _meadow_key=PLEASE_REDACT; PS_DEVICEFEATURES=width:2560 height:1440 pixelratio:1 touch:0 geolocation:1 websockets:1 webworkers:1 datepicker:0 dtpicker:0 timepicker:0 dnd:1 sessionstorage:1 localstorage:1 history:1 canvas:1 svg:1 postmessage:1 hc:0 maf:0"
+  @expect_redacted ~w(dcApiToken dcApiUser nusso _meadow_key)
+  @expect_unredacted ~w(amlbcookie PS_DEVICEFEATURES)
 
   setup do
     {:ok, _} = Honeybadger.API.start(self())
@@ -30,6 +38,41 @@ defmodule Meadow.ErrorTest do
         assert request_context |> Map.get("meadow_version") == Config.meadow_version()
         assert request_context |> Map.get("notifier") == __MODULE__ |> to_string()
         assert request_context |> Map.get("tags") == "backend"
+      end
+    end
+  end
+
+  describe "phoenix error" do
+    test "sends error notifications" do
+      restart_with_config(exclude_envs: [])
+
+      user = user_fixture("TestAdmins")
+
+      conn =
+        build_conn()
+        |> auth_user(user)
+        |> put_req_header("cookie", @cookie)
+        |> put_req_header("content-type", "application/json")
+
+      assert_raise Ecto.Query.CastError, fn ->
+        post(
+          conn,
+          "/api/graphql",
+          ~s'{"query":"query{ work(id:\\"this-is-not-a-uuid\\"){ id } }","variables":null}'
+        )
+      end
+
+      assert_receive {:api_request, report}, 1000
+
+      with cookies <- report |> get_in(["request", "cgi_data", "HTTP_COOKIE"]) |> Cookies.decode() do
+        (@expect_redacted ++ @expect_unredacted)
+        |> Enum.each(fn key -> assert cookies |> Map.has_key?(key) end)
+
+        @expect_redacted
+        |> Enum.each(fn key -> assert cookies |> Map.get(key) == "[REDACTED]" end)
+
+        @expect_unredacted
+        |> Enum.each(fn key -> refute cookies |> Map.get(key) == "[REDACTED]" end)
       end
     end
   end


### PR DESCRIPTION
I created this issue as high priority and pulled it in after I noticed that `dcAPI` (elastic proxy), NUSSO login, and Meadow session tokens were being sent to Honeybadger as part of the cookie header in error reports. There's no way the tokens that have already been reported can be used maliciously, because they have expired, but it's fairly urgent that we keep new ones from getting through, since they (especially NUSSO) can be used to impersonate the user who was logged in at the time until the token expires.

It _should_ have been possible to write this much more simply using the `Honeybadger.Filter` behaviour, but it didn't work due to a bug (honeybadger-io/honeybadger-elixir#350) so it had to be a higher-level `Honeybadger.NoticeFilter`.