### PR TITLE
Allow bastion to connect to Meadow DB instance for backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ npm-debug.log
 
 /terraform/.terraform/
 /terraform/**/_build/
+/terraform/**/*.plan
 
 /tmp/
 


### PR DESCRIPTION
Terraform-only. Changes already applied to both staging and production.