### PR TITLE
Use a separate Honeybadger API Key for the front-end

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,7 +142,7 @@ jobs:
       - docker/check
       - docker/build:
           cache_from: nulib/meadow-deps:${DEPLOY_TAG}
-          extra_build_args: --build-arg HONEYBADGER_API_KEY=${HONEYBADGER_API_KEY} --build-arg HONEYBADGER_ENVIRONMENT=${DEPLOY_TAG} --build-arg HONEYBADGER_REVISION=${CIRCLE_SHA1} --build-arg MEADOW_VERSION=${MEADOW_VERSION}
+          extra_build_args: --build-arg HONEYBADGER_API_KEY=${HONEYBADGER_API_KEY} --build-arg HONEYBADGER_API_KEY_FRONTEND=${HONEYBADGER_API_KEY_FRONTEND} --build-arg HONEYBADGER_ENVIRONMENT=${DEPLOY_TAG} --build-arg HONEYBADGER_REVISION=${CIRCLE_SHA1} --build-arg MEADOW_VERSION=${MEADOW_VERSION}
           image: nulib/meadow
           tag: ${DEPLOY_TAG}
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN for flag in $(find . -name .docker-yarn); do \
 # Create elixir release
 FROM nulib/elixir-phoenix-base:1.11.1 AS release
 ARG HONEYBADGER_API_KEY=
+ARG HONEYBADGER_API_KEY_FRONTEND=
 ARG HONEYBADGER_ENVIRONMENT=
 ARG HONEYBADGER_REVISION=
 ARG MEADOW_VERSION=

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -14,7 +14,9 @@ const buildPlugins = (env, options) => {
       patterns: [{ from: "static/", to: "../" }],
     }),
     new Webpack.DefinePlugin({
-      __HONEYBADGER_API_KEY__: JSON.stringify(process.env.HONEYBADGER_API_KEY),
+      __HONEYBADGER_API_KEY__: JSON.stringify(
+        process.env.HONEYBADGER_API_KEY_FRONTEND
+      ),
       __HONEYBADGER_ENVIRONMENT__: JSON.stringify(
         process.env.HONEYBADGER_ENVIRONMENT
       ),
@@ -28,10 +30,10 @@ const buildPlugins = (env, options) => {
     }),
   ];
 
-  if (typeof process.env.HONEYBADGER_API_KEY === "string") {
+  if (typeof process.env.HONEYBADGER_API_KEY_FRONTEND === "string") {
     result.push(
       new HoneybadgerSourceMapPlugin({
-        apiKey: process.env.HONEYBADGER_API_KEY,
+        apiKey: process.env.HONEYBADGER_API_KEY_FRONTEND,
         assetsUrl: "http*://meadow*.library.northwestern.edu",
         revision: process.env.HONEYBADGER_REVISION,
       })

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Meadow.MixProject do
   use Mix.Project
 
-  @app_version "1.4.1"
+  @app_version "1.5.0"
 
   def project do
     [


### PR DESCRIPTION
This update includes a minor version bump to make it clearer where the split happened when filtering in Honeybadger.