### PR TITLE
Use SSO test server instead of prod in developer environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   - `assets.install` looks for all `yarn.lock` files project-wide and runs `yarn install` in each directory found, so you don't need to run `yarn install` in individual directories.
 - `cd` back to the `meadow` project folder and start the Phoenix endpoint with `mix phx.server` or `iex -S mix phx.server` if you want to an interactive shell.
 
-Now you can visit [`https://devbox.library.northwestern.edu/`](https://devbox.library.northwestern.edu/) from your browser.
+Now you can visit [`https://devbox.library.northwestern.edu:3001/`](https://devbox.library.northwestern.edu:3001/) from your browser.
 
 ## Running the application
 
@@ -89,7 +89,7 @@ See your local "s3" buckets.
 
 ### GraphQL API
 
-You can visit the GraphiQL interface at: [`https://devbox.library.northwestern.edu/api/graphiql`](https://devbox.library.northwestern.edu/api/graphiql)
+You can visit the GraphiQL interface at: [`https://devbox.library.northwestern.edu:3001/api/graphiql`](https://devbox.library.northwestern.edu:3001/api/graphiql)
 
 ### IIIF Server
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -19,7 +19,7 @@ config :meadow, Meadow.Repo,
 config :meadow, MeadowWeb.Endpoint,
   http: [port: 3000],
   https: [
-    port: 443,
+    port: 3001,
     cipher_suite: :strong,
     certfile: "/usr/local/etc/devbox_ssl/devbox.library.full.pem",
     keyfile: "/usr/local/etc/devbox_ssl/devbox.library.key.pem"
@@ -165,7 +165,7 @@ config :ueberauth, Ueberauth,
     nusso:
       {Ueberauth.Strategy.NuSSO,
        [
-         base_url: "https://northwestern-prod.apigee.net/agentless-websso/",
+         base_url: System.get_env("SETTINGS__NUSSO__BASE_URL"),
          callback_path: "/auth/nusso/callback",
          consumer_key: System.get_env("SETTINGS__NUSSO__CONSUMER_KEY"),
          include_attributes: true,


### PR DESCRIPTION
**Note: This PR reverts #2079, moving Meadow back to https://devstack.library.northwestern.edu:3001/ in the dev environment.**

This update involves changes to ~four~ three components of our stack/app ecosystem:

* [devstack](https://github.com/nulib/devstack/commit/0528f34564db53927d88632040aba4cae8141dfa) (pushed)
* [miscellany](https://github.com/nulib/miscellany/commit/8ce917fe8e78eb1e03d12c0200325830adf24762) (pushed)
* ~[digital collections](https://github.com/nulib/digital-collections/commit/bb13b5adbce0ccd1f2fffeb997be8d1c93391ef6) ([PR](https://github.com/nulib/digital-collections/pull/648))~
* meadow (this PR)

In order to get this all straight, you should do the following:

1. Update `miscellany`
    ```
    cd /path/to/miscellany/repo
    git fetch origin
    git pull origin
    ```
2. Quit and restart your terminal
3. Update `devstack`
    ```
    devstack update
    ```
    You might need to stop and restart your devstack environment, but there's no `down -v` required.

You should now be able to use Meadow, DC, and Elastic Proxy in the dev environment, with successful login/logout via the WebSSO test server.