### PR TITLE
Upload source maps to honeybadger after phx.digest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,7 @@ jobs:
           image: nulib/meadow
           tag: ${DEPLOY_TAG}
       - run:
+          name: Tag Deps Image
           command: |
             DEPS_IMAGE=$(docker image ls --filter "label=edu.northwestern.library.app=meadow" --filter "label=edu.northwestern.library.stage=deps" --format '{{.CreatedAt}}\t{{.ID}}' | sort -nr | cut -f2 | head -1)
             docker tag ${DEPS_IMAGE} nulib/meadow-deps:${DEPLOY_TAG}
@@ -155,14 +156,16 @@ jobs:
       - docker/push:
           image: nulib/meadow
           tag: ${DEPLOY_TAG}
+      - run:
+          name: Upload Source Maps to Honeybadger
+          command: ./.circleci/scripts/upload_source_maps.sh
       - when:
           condition:
             equal: [ master, << pipeline.git.branch >> ]
           steps:
             - run:
                 name: "Push release tag"
-                command: |
-                  git push origin v${MEADOW_VERSION}
+                command: git push origin v${MEADOW_VERSION}
           
   deploy:
     executor: aws-cli/default
@@ -188,19 +191,10 @@ jobs:
             ECS_SERVICE: meadow
             ECS_TASK: meadow-all
             ECS_CONTAINER: meadow-all
-          command: |
-            networkconfig=$(aws ecs describe-services --cluster ${ECS_CLUSTER} --service ${ECS_SERVICE} | jq -cM '.services[0].networkConfiguration')
-            overrides='{"containerOverrides":[{"name":"'${ECS_CONTAINER}'","environment": [{"name": "MEADOW_PROCESSES", "value": "none"}, {"name": "DB_POOL_SIZE", "value": "10"}],"command":["eval","Meadow.ReleaseTasks.migrate()"]}]}'
-            aws ecs run-task --platform-version 1.4.0 --cluster ${ECS_CLUSTER} --task-definition ${ECS_TASK} --overrides "${overrides}" --launch-type FARGATE --network-configuration ${networkconfig}
-            for service in $(aws ecs list-services --cluster meadow | jq -r '.serviceArns[] | split("/") | last'); do
-              aws ecs update-service --cluster ${ECS_CLUSTER} --service ${service} --force-new-deployment
-            done
+          command: ./.circleci/scripts/update_ecs_service.sh
       - run:
           name: Notify Honeybadger
-          command: |
-            curl \
-              --data "deploy[environment]=${DEPLOY_TAG}&deploy[local_username]=&deploy[revision]=${CIRCLE_SHA1}&api_key=${HONEYBADGER_API_KEY}" \
-              https://api.honeybadger.io/v1/deploys
+          command: ./.circleci/scripts/honeybadger_deploy_notification.sh
 workflows:
   ci:
     jobs:

--- a/.circleci/scripts/honeybadger_deploy_notification.sh
+++ b/.circleci/scripts/honeybadger_deploy_notification.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+curl \
+  --data "deploy[environment]=${DEPLOY_TAG}&deploy[local_username]=&deploy[revision]=${CIRCLE_SHA1}&api_key=${HONEYBADGER_API_KEY}" \
+  https://api.honeybadger.io/v1/deploys

--- a/.circleci/scripts/update_ecs_service.sh
+++ b/.circleci/scripts/update_ecs_service.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+networkconfig=$(aws ecs describe-services --cluster ${ECS_CLUSTER} --service ${ECS_SERVICE} | jq -cM '.services[0].networkConfiguration')
+overrides='{"containerOverrides":[{"name":"'${ECS_CONTAINER}'","environment": [{"name": "MEADOW_PROCESSES", "value": "none"}, {"name": "DB_POOL_SIZE", "value": "10"}],"command":["eval","Meadow.ReleaseTasks.migrate()"]}]}'
+aws ecs run-task --platform-version 1.4.0 --cluster ${ECS_CLUSTER} --task-definition ${ECS_TASK} --overrides "${overrides}" --launch-type FARGATE --network-configuration ${networkconfig}
+for service in $(aws ecs list-services --cluster meadow | jq -r '.serviceArns[] | split("/") | last'); do
+  aws ecs update-service --cluster ${ECS_CLUSTER} --service ${service} --force-new-deployment
+done

--- a/.circleci/scripts/upload_source_maps.sh
+++ b/.circleci/scripts/upload_source_maps.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+container_id=$(docker create nulib/meadow:${DEPLOY_TAG})
+docker cp ${container_id}:/app/lib/meadow-${MEADOW_VERSION}/priv/static/js sources
+for source in app vendors~app; do
+  js_file=$(ls sources/${source}.bundle-*.js)
+  source_map=$(ls sources/${source}.js-*.map)
+  echo curl https://api.honeybadger.io/v1/source_maps \
+      -F api_key=${HONEYBADGER_API_KEY_FRONTEND} \
+      -F revision=${CIRCLE_SHA1} \
+      -F minified_url="http*://meadow*.library.northwestern.edu/$(basename ${js_file})" \
+      -F source_map=@${source_map} \
+      -F minified_file=@${js_file}
+done

--- a/assets/package.json
+++ b/assets/package.json
@@ -63,7 +63,6 @@
     "@creativebulma/bulma-divider": "^1.1.0",
     "@creativebulma/bulma-tooltip": "^1.2.0",
     "@elastic/elasticsearch-mock": "^0.3.0",
-    "@honeybadger-io/webpack": "^1.2.0",
     "@nulib/prettier-config": "^1.2.0",
     "@svgr/webpack": "^5.5.0",
     "@testing-library/dom": "^7.30.3",

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -1,46 +1,9 @@
 const path = require("path");
-const glob = require("glob");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
-const HoneybadgerSourceMapPlugin = require("@honeybadger-io/webpack");
 const Webpack = require("webpack");
-
-const buildPlugins = (env, options) => {
-  let result = [
-    new MiniCssExtractPlugin({ filename: "../css/app.css" }),
-    new CopyWebpackPlugin({
-      patterns: [{ from: "static/", to: "../" }],
-    }),
-    new Webpack.DefinePlugin({
-      __HONEYBADGER_API_KEY__: JSON.stringify(
-        process.env.HONEYBADGER_API_KEY_FRONTEND
-      ),
-      __HONEYBADGER_ENVIRONMENT__: JSON.stringify(
-        process.env.HONEYBADGER_ENVIRONMENT
-      ),
-      __HONEYBADGER_REVISION__: JSON.stringify(
-        process.env.HONEYBADGER_REVISION
-      ),
-      __MEADOW_VERSION__: JSON.stringify(process.env.MEADOW_VERSION),
-    }),
-    new Webpack.SourceMapDevToolPlugin({
-      filename: "[name].js.map",
-    }),
-  ];
-
-  if (typeof process.env.HONEYBADGER_API_KEY_FRONTEND === "string") {
-    result.push(
-      new HoneybadgerSourceMapPlugin({
-        apiKey: process.env.HONEYBADGER_API_KEY_FRONTEND,
-        assetsUrl: "http*://meadow*.library.northwestern.edu",
-        revision: process.env.HONEYBADGER_REVISION,
-      })
-    );
-  }
-  return result;
-};
 
 module.exports = (env, options) => ({
   optimization: {
@@ -100,7 +63,27 @@ module.exports = (env, options) => ({
       },
     ],
   },
-  plugins: buildPlugins(env, options),
+  plugins: [
+    new MiniCssExtractPlugin({ filename: "../css/app.css" }),
+    new CopyWebpackPlugin({
+      patterns: [{ from: "static/", to: "../" }],
+    }),
+    new Webpack.DefinePlugin({
+      __HONEYBADGER_API_KEY__: JSON.stringify(
+        process.env.HONEYBADGER_API_KEY_FRONTEND
+      ),
+      __HONEYBADGER_ENVIRONMENT__: JSON.stringify(
+        process.env.HONEYBADGER_ENVIRONMENT
+      ),
+      __HONEYBADGER_REVISION__: JSON.stringify(
+        process.env.HONEYBADGER_REVISION
+      ),
+      __MEADOW_VERSION__: JSON.stringify(process.env.MEADOW_VERSION),
+    }),
+    new Webpack.SourceMapDevToolPlugin({
+      filename: "[name].js.map",
+    }),
+  ],
   devtool: false,
   resolve: {
     extensions: ["*", ".mjs", ".js", ".jsx", ".json"],

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -1019,7 +1019,7 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.1", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.1", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
   integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
@@ -1260,19 +1260,6 @@
   integrity sha512-jTdoaPO+/XgTIY1X4eFSOAi7xNnye/BUOvlyMqIJBTOmX8gL+5OtzVsS2HzQSHq3rutARYWasiYQJLSOFGj5MA==
   dependencies:
     "@honeybadger-io/js" "^3.0.1"
-
-"@honeybadger-io/webpack@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@honeybadger-io/webpack/-/webpack-1.2.0.tgz#d058f5bb87e8f69ca9c8721d4aa5cb226e8604e7"
-  integrity sha512-kPhoE41KncSw5V20uYn7xPhQWUvBChPIIPG/8/TkeXbse6LLQtLpHgvwsAcN8jMiULM+8DcLKfkdOubkvkYb0g==
-  dependencies:
-    "@babel/runtime" "^7.7.6"
-    async "^3.0.0"
-    lodash.find "^4.3.0"
-    lodash.foreach "^4.2.0"
-    lodash.reduce "^4.3.0"
-    request "^2.87.0"
-    verror "^1.6.1"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -2359,11 +2346,6 @@ async-limiter@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
-
-async@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
-  integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -6095,16 +6077,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.find@^4.3.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
-  integrity sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=
-
-lodash.foreach@^4.2.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
-  integrity sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=
-
 lodash.isnull@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash.isnull/-/lodash.isnull-3.0.0.tgz#fafbe59ea1dca27eed786534039dd84c2e07c56e"
@@ -6124,11 +6096,6 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
-lodash.reduce@^4.3.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
-  integrity sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs=
 
 lodash.throttle@^4.1.1:
   version "4.1.1"
@@ -8165,7 +8132,7 @@ request-promise-native@^1.0.9:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.87.0, request@^2.88.0, request@^2.88.2:
+request@^2.88.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -9557,7 +9524,7 @@ vendors@^1.0.0:
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.4.tgz#e2b800a53e7a29b93506c3cf41100d16c4c4ad8e"
   integrity sha512-/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w==
 
-verror@1.10.0, verror@^1.6.1:
+verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
   integrity sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=

--- a/mix.exs
+++ b/mix.exs
@@ -140,7 +140,7 @@ defmodule Meadow.MixProject do
 
   def build_assets(release) do
     System.cmd("yarn", ["deploy"], cd: "assets")
-    Mix.Tasks.Phx.Digest.run([])
+    Mix.Task.run("phx.digest")
     release
   end
 end


### PR DESCRIPTION
The minified URLs for Meadow's source maps in Honeybadger don't include the Phoenix digests:

![image](https://user-images.githubusercontent.com/196872/113595683-f5066180-95fe-11eb-8ccd-05425c7ce22b.png)

(Those should be `vendors~app.bundle-7b5fbdaaf3c862113bdfe4e2fbf33d79.js` and `app.bundle-55fb79a6f44cbbf586da786ab53c5a1e.js` to match what's in staging.)

The `@honeybadger-io/webpack` plugin doesn't know about Phoenix digests, so we have to change things up and upload source maps manually.

This PR also includes a little bit of refactoring to make the CircleCI build config easier to read by moving large, multi-line `run` commands to separate bash scripts.