### PR TITLE
Rescue Ecto.NoResultsError in modules using Meadow.DatabaseNotification

### DIFF
--- a/lib/meadow/iiif/manifest_listener.ex
+++ b/lib/meadow/iiif/manifest_listener.ex
@@ -14,5 +14,7 @@ defmodule Meadow.IIIF.ManifestListener do
     Logger.info("Writing manifest for #{id}")
     id |> IIIF.write_manifest()
     {:noreply, state}
+  rescue
+    Ecto.NoResultsError -> {:noreply, state}
   end
 end

--- a/lib/meadow/ingest/sheet_notifier.ex
+++ b/lib/meadow/ingest/sheet_notifier.ex
@@ -14,5 +14,7 @@ defmodule Meadow.Ingest.SheetNotifier do
     sheet = Sheets.get_ingest_sheet!(id)
     Notifications.ingest_sheet(sheet)
     {:noreply, state}
+  rescue
+    Ecto.NoResultsError -> {:noreply, state}
   end
 end

--- a/test/meadow/iiif/manifest_listener_test.exs
+++ b/test/meadow/iiif/manifest_listener_test.exs
@@ -20,6 +20,10 @@ defmodule Meadow.IIIF.ManifestListenerTest do
       end)
     end
 
+    test "fails gracefully when work is not found" do
+      assert {:noreply, nil} == ManifestListener.handle_notification(:works, :insert, %{id: Ecto.UUID.generate()}, nil)
+    end
+
     test "ignores DELETE notification" do
       work = work_fixture()
       Repo.delete(work)

--- a/test/meadow/ingest/sheet_notifier_test.exs
+++ b/test/meadow/ingest/sheet_notifier_test.exs
@@ -1,0 +1,10 @@
+defmodule Meadow.Ingest.SheetNotifierTest do
+  use Meadow.DataCase
+  alias Meadow.Ingest.SheetNotifier
+
+  describe "handle_notification/4" do
+    test "fails gracefully when sheet is not found" do
+      assert {:noreply, nil} == SheetNotifier.handle_notification(:ingest_sheets, :insert, %{id: Ecto.UUID.generate()}, nil)
+    end
+  end
+end


### PR DESCRIPTION
- Rescue `Ecto.NoResultsError` in modules using `Meadow.DatabaseNotification`
- End result is avoiding unnecessary Honeybadger errors