### PR TITLE
Set Cowboy2 idle timeout to inifinity in staging/production

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -43,7 +43,13 @@ port = String.to_integer(System.get_env("PORT", "4000"))
 
 config :meadow, MeadowWeb.Endpoint,
   url: [host: host, port: port],
-  http: [:inet6, port: port],
+  http: [
+    :inet6,
+    port: port,
+    protocol_options: [
+      idle_timeout: :infinity
+    ]
+  ],
   check_origin: System.get_env("ALLOWED_ORIGINS", "") |> String.split(~r/,\s*/),
   secret_key_base: get_required_var.("SECRET_KEY_BASE"),
   live_view: [signing_salt: get_required_var.("SECRET_KEY_BASE")]


### PR DESCRIPTION
The `[:http, :protocol_options, :idle_timeout]` configuration option controls how long Phoenix (via Plug/Cowboy/Ranch) holds open a connection before closing it. There's an argument to be made that a connection that has data flowing through it is not “idle,” but that seems to be how Cowboy works. It's also a startup-time config value that can't be changed on a per-request or per-route basis. Instead of trying to guess at a better maximum timeout, I think it's best just to set it to `:infinity` to let downloads take as long as they need to. This is safe to do in the AWS environment because the load balancer will still enforce a 60-second timeout on connections that are _actually_ idle (i.e., not sending data in either direction).