### PR TITLE
Encode and decode ark attributes to prevent ANVL parsing errors

### DIFF
--- a/lib/meadow/ark.ex
+++ b/lib/meadow/ark.ex
@@ -165,7 +165,7 @@ defmodule Meadow.Ark do
       |> String.split("\n")
       |> Enum.map(fn attribute ->
         [key, value] = String.split(attribute, ": ")
-        {Map.get(field_map, key), value}
+        {Map.get(field_map, key), URI.decode(value)}
       end)
       |> Enum.reject(fn {key, _} -> is_nil(key) end)
     )
@@ -183,5 +183,5 @@ defmodule Meadow.Ark do
     |> Enum.join("\n")
   end
 
-  defp serialize({key, value}) when is_atom(key), do: Map.get(@datacite_map, key) <> ": " <> value
+  defp serialize({key, value}) when is_atom(key), do: Map.get(@datacite_map, key) <> ": " <> URI.encode(value)
 end

--- a/test/meadow/ark_test.exs
+++ b/test/meadow/ark_test.exs
@@ -108,7 +108,7 @@ defmodule Meadow.ArkTest do
     end
 
     test "valid ARK", %{fixture: fixture} do
-      update = Map.put(fixture, :title, "A New Title for This ARK")
+      update = Map.put(fixture, :title, "A 100% New Title for This ARK!")
       assert {:ok, update} == Ark.put(update)
       assert {:ok, update} == Ark.get(fixture.ark)
       assert_received({:put, :credentials, {"mockuser", "mockpassword"}})
@@ -118,7 +118,7 @@ defmodule Meadow.ArkTest do
           "_profile: datacite",
           "datacite.creator: Lovelace, Ada",
           "_target: http://example.edu/work",
-          "datacite.title: A New Title for This ARK"
+          "datacite.title: A 100% New Title for This ARK!"
         ]
         |> Enum.join("\n")
 


### PR DESCRIPTION
- `URI.encode/1` and `URI.decode/1` the values sent and received from the EZID Ark minting API
- Updates the ark mock server to reproduce the percent-encoding API functionality