### PR TITLE
Update dev bg toggle for staging environment

### DIFF
--- a/assets/js/components/UI/DevBgToggle.jsx
+++ b/assets/js/components/UI/DevBgToggle.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 // Default color light blue
 // You can update this in your browser's console by setting a new hex value for "devBg" property
-const BG_HEX_VALUE = "#eff5fa";
+const BG_HEX_VALUE = "#7fcecd";
 function UIDevBgToggle(props) {
   const toggleRef = React.useRef();
   const [devBg, setDevBg] = React.useState(localStorage.getItem("devBg") || "");

--- a/assets/js/components/UI/Layout/Main.jsx
+++ b/assets/js/components/UI/Layout/Main.jsx
@@ -12,7 +12,7 @@ function UILayoutMain({ children }) {
 
   // Sets bg color for the DEV environment only
   const wrapper = css`
-    background: ${(env === "DEV" && devBg) || false};
+    background: ${(env !== "PRODUCTION" && devBg) || false};
   `;
 
   return (

--- a/assets/js/components/UI/Layout/NavBar.jsx
+++ b/assets/js/components/UI/Layout/NavBar.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect } from "react";
+import React, { useContext, useState } from "react";
 import { Link } from "react-router-dom";
 import { useLocation } from "react-router-dom";
 import { AuthContext } from "../../Auth/Auth";
@@ -81,7 +81,10 @@ const UILayoutNavBar = () => {
 
                 <div className="level-item is-family-secondary is-size-4">
                   <div>
-                    <Link to="/">Meadow</Link>{" "}
+                    <Link to="/">Meadow</Link>
+                    {env !== "PRODUCTION" && (
+                      <span className="mx-2">{env}</span>
+                    )}
                     <span className="has-text-grey is-size-6">
                       <UIMeadowVersion />
                     </span>
@@ -235,7 +238,7 @@ const UILayoutNavBar = () => {
                   </Link>
                 </div>
 
-                {env === "DEV" && <UIDevBgToggle />}
+                {env !== "PRODUCTION" && <UIDevBgToggle />}
               </div>
             </>
           )}


### PR DESCRIPTION
Default bg color, but a user can update this in their `localStorage.devBg` property to any color they like.

Also adds either "DEV" or "STAGING" to the header next to the Meadow logo.

![image](https://user-images.githubusercontent.com/3020266/113896869-f3b86e80-978f-11eb-88e9-f3545cd12445.png)
