### PR TITLE
Refactor logging

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -75,7 +75,7 @@ end
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $levelpad$message\n",
-  metadata: [:request_id, :action]
+  metadata: [:request_id, :context, :id]
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -151,7 +151,7 @@ config :exldap, :settings,
 # Do not include metadata nor timestamps in development logs
 config :logger, :console,
   format: "$metadata[$level] $levelpad$message\n",
-  metadata: [:action]
+  metadata: [:context, :id]
 
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.

--- a/lib/meadow/accounts/user.ex
+++ b/lib/meadow/accounts/user.ex
@@ -19,8 +19,8 @@ defmodule Meadow.Accounts.User do
       end)
 
     case status do
-      :ok -> Logger.info("User #{username} found in cache")
-      :commit -> Logger.info("User #{username} found in LDAP and added to cache")
+      :ok -> Logger.debug("User #{username} found in cache")
+      :commit -> Logger.debug("User #{username} found in LDAP and added to cache")
       :ignore -> Logger.warn("User #{username} not found")
     end
 

--- a/lib/meadow/batches.ex
+++ b/lib/meadow/batches.ex
@@ -135,7 +135,7 @@ defmodule Meadow.Batches do
         try do
           case do_update(batch) do
             {:ok, _any} ->
-              Logger.info("Setting batch to complete")
+              Logger.info("Batch #{batch.id} complete")
               {:ok, set_complete!(batch)}
 
             {:error, any} ->
@@ -152,7 +152,7 @@ defmodule Meadow.Batches do
         end
 
       {:error, %Ecto.Changeset{}} ->
-        Logger.info("Couldn't start batch. Active batch already exists")
+        Logger.info("Couldn't start batch #{batch.id}. Active batch already exists.")
         {:ok, batch}
     end
   end
@@ -279,7 +279,7 @@ defmodule Meadow.Batches do
     delete = prepare_controlled_field_list(delete)
     add = prepare_controlled_field_list(add)
 
-    Logger.info("Batch updating controlled fields")
+    Logger.debug("Batch updating controlled fields")
 
     from(w in Work, where: w.id in ^work_ids)
     |> Works.replace_controlled_value(
@@ -376,7 +376,7 @@ defmodule Meadow.Batches do
   defp update_top_level_field(work_ids, _field, :not_present), do: work_ids
 
   defp update_top_level_field(work_ids, field, value) do
-    Logger.info("Batch updating #{field}")
+    Logger.debug("Batch updating #{field}")
 
     update_args = Keyword.new([{field, value}, {:updated_at, DateTime.utc_now()}])
 
@@ -393,7 +393,7 @@ defmodule Meadow.Batches do
   defp update_collection(work_ids, :not_present), do: work_ids
 
   defp update_collection(work_ids, value) do
-    Logger.info("Batch updating collection_id: #{value}")
+    Logger.debug("Batch updating collection_id: #{value}")
 
     from(w in Work, where: w.id in ^work_ids)
     |> Repo.update_all(
@@ -407,7 +407,7 @@ defmodule Meadow.Batches do
   end
 
   defp apply_batch_association(work_ids, batch_id) do
-    Logger.info("Associating batch_id: #{batch_id} with works")
+    Logger.debug("Associating batch_id: #{batch_id} with works")
     {:ok, b_id} = Ecto.UUID.dump(batch_id)
 
     entries =
@@ -457,7 +457,7 @@ defmodule Meadow.Batches do
 
     total = Map.get(hits, "total")
 
-    Logger.info(
+    Logger.debug(
       "Indexing for batch update scroll_id: #{scroll_id}, hits: #{length(current_hits)}, total: #{
         total
       }"
@@ -477,8 +477,8 @@ defmodule Meadow.Batches do
       |> Map.put("_source", "")
       |> Jason.encode!()
 
-    Logger.info("Starting Elasticsearch scroll for batch update")
-    Logger.info("query #{inspect(query)}")
+    Logger.debug("Starting Elasticsearch scroll for batch update")
+    Logger.debug("query #{inspect(query)}")
 
     Meadow.ElasticsearchCluster
     |> Elasticsearch.post("/meadow/_search?scroll=10m", query)
@@ -513,8 +513,8 @@ defmodule Meadow.Batches do
       |> Map.put("_source", "")
       |> Jason.encode!()
 
-    Logger.info("Starting Elasticsearch scroll for batch delete")
-    Logger.info("query #{inspect(query)}")
+    Logger.debug("Starting Elasticsearch scroll for batch delete")
+    Logger.debug("query #{inspect(query)}")
 
     Meadow.ElasticsearchCluster
     |> Elasticsearch.post("/meadow/_search?scroll=10m", query)
@@ -539,9 +539,9 @@ defmodule Meadow.Batches do
 
   defp log_batch_info(batch) do
     Logger.info("Processing batch #{batch.type} for batch_id: #{batch.id}")
-    Logger.info("query: #{batch.query}")
-    Logger.info("delete: #{inspect(batch.delete)}")
-    Logger.info("add: #{inspect(batch.add)}")
-    Logger.info("replace: #{inspect(batch.replace)}")
+    Logger.debug("query: #{batch.query}")
+    Logger.debug("delete: #{inspect(batch.delete)}")
+    Logger.debug("add: #{inspect(batch.add)}")
+    Logger.debug("replace: #{inspect(batch.replace)}")
   end
 end

--- a/lib/meadow/csv_metadata_update_driver.ex
+++ b/lib/meadow/csv_metadata_update_driver.ex
@@ -9,6 +9,7 @@ defmodule Meadow.CSVMetadataUpdateDriver do
   alias Meadow.IntervalTask
 
   use IntervalTask, default_interval: 5_000, function: :drive_update_job
+  use Meadow.Utils.Logging
 
   require Logger
 
@@ -27,7 +28,10 @@ defmodule Meadow.CSVMetadataUpdateDriver do
 
       job ->
         Logger.info("Starting CSV update job #{job.id}")
-        MetadataUpdateJobs.apply_job(job)
+
+        with_log_metadata(context: MetadataUpdateJobs, id: job.id) do
+          MetadataUpdateJobs.apply_job(job)
+        end
     end
 
     {:noreply, state}

--- a/lib/meadow/data/indexer.ex
+++ b/lib/meadow/data/indexer.ex
@@ -2,6 +2,8 @@ defmodule Meadow.Data.Indexer do
   @moduledoc """
   Indexes individual structs into Elasticsearch, preloading if necessary.
   """
+  use Meadow.Utils.Logging
+
   alias Meadow.Config
   alias Meadow.Data.IndexTimes
   alias Meadow.Data.Schemas.{Collection, FileSet, Work}
@@ -11,10 +13,12 @@ defmodule Meadow.Data.Indexer do
   require Logger
 
   def synchronize_index do
-    [:deleted, FileSet, Work, Collection]
-    |> Enum.each(&synchronize_schema/1)
+    with_log_metadata(context: __MODULE__) do
+      [:deleted, FileSet, Work, Collection]
+      |> Enum.each(&synchronize_schema/1)
 
-    Elasticsearch.Index.refresh(Cluster, to_string(index()))
+      Elasticsearch.Index.refresh(Cluster, to_string(index()))
+    end
   end
 
   def reindex_all! do
@@ -171,9 +175,8 @@ defmodule Meadow.Data.Indexer do
   end
 
   defp log_update_count({add_ids, update_ids, delete_ids}) do
-    Logger.info(
-      "Index updates: +#{length(add_ids)} ~#{length(update_ids)} -#{length(delete_ids)}"
-    )
+    "Index updates: +#{length(add_ids)} ~#{length(update_ids)} -#{length(delete_ids)}"
+    |> Logger.info()
   end
 
   defp config do

--- a/lib/meadow/ingest/notifications.ex
+++ b/lib/meadow/ingest/notifications.ex
@@ -9,11 +9,9 @@ defmodule Meadow.Ingest.Notifications do
     do: {:ok, ingest_sheet(sheet)}
 
   def ingest_sheet(%Sheet{} = sheet) do
-    Logger.info(
-      "Sending notifications for ingest sheet: #{sheet.id}, in project: #{sheet.project_id} with status: #{
-        sheet.status
-      }"
-    )
+    ("Sending notifications for ingest sheet: #{sheet.id} " <>
+       "in project: #{sheet.project_id} with status: #{sheet.status}")
+    |> Logger.info()
 
     Absinthe.Subscription.publish(
       MeadowWeb.Endpoint,

--- a/lib/meadow/ingest/progress.ex
+++ b/lib/meadow/ingest/progress.ex
@@ -2,6 +2,8 @@ defmodule Meadow.Ingest.Progress do
   @moduledoc """
   Translate action state notifications into ingest sheet progress notifications
   """
+  use Meadow.Utils.Logging
+
   alias Meadow.Ingest.Schemas.{Progress, Row, Sheet}
   alias Meadow.Ingest.{Rows, Sheets}
   alias Meadow.IntervalTask
@@ -11,7 +13,6 @@ defmodule Meadow.Ingest.Progress do
 
   import Ecto.Query
   import Meadow.Utils.Atoms
-  import Meadow.Utils.Logging
 
   use IntervalTask, default_interval: 500, function: :send_progress_notifications
   require Logger
@@ -281,7 +282,10 @@ defmodule Meadow.Ingest.Progress do
   end
 
   def send_progress_notifications(state) do
-    with_log_level(:info, &send_notifications/0)
+    with_log_level :info do
+      send_notifications()
+    end
+
     {:noreply, state}
   end
 end

--- a/lib/meadow/ingest/validator.ex
+++ b/lib/meadow/ingest/validator.ex
@@ -206,7 +206,7 @@ defmodule Meadow.Ingest.Validator do
           {:ok, sheet}
 
         {:error, sheet} ->
-          Logger.info("Ingest sheet: #{sheet.id} has failing rows")
+          Logger.warn("Ingest sheet: #{sheet.id} has failing rows")
           Sheets.update_ingest_sheet_status(sheet, "row_fail")
           {:error, sheet}
       end
@@ -325,7 +325,7 @@ defmodule Meadow.Ingest.Validator do
   end
 
   defp add_file_errors(sheet, messages) do
-    Logger.info("Ingest sheet: #{sheet.id} has file errors")
+    Logger.warn("Ingest sheet: #{sheet.id} has file errors")
 
     sheet
     |> Sheets.add_file_validation_errors_to_ingest_sheet(messages)

--- a/lib/meadow/ingest/work_creator.ex
+++ b/lib/meadow/ingest/work_creator.ex
@@ -2,8 +2,9 @@ defmodule Meadow.Ingest.WorkCreator do
   @moduledoc """
   IntervalTask to create works from pending ingest sheet rows
   """
+  use Meadow.Utils.Logging
+
   import Ecto.Query, warn: false
-  import Meadow.Utils.Logging
 
   alias Meadow.Config
   alias Meadow.Data.{ActionStates, Works}
@@ -27,11 +28,11 @@ defmodule Meadow.Ingest.WorkCreator do
   Turn a batch of pending work rows into works
   """
   def create_works(state) do
-    with_log_level(:info, fn ->
+    with_log_level :info do
       state
       |> get_and_update_pending_work_rows()
       |> handle_result()
-    end)
+    end
 
     {:noreply, state}
   end

--- a/lib/meadow/ingest/work_redriver.ex
+++ b/lib/meadow/ingest/work_redriver.ex
@@ -2,8 +2,9 @@ defmodule Meadow.Ingest.WorkRedriver do
   @moduledoc """
   IntervalTask to create works from pending ingest sheet rows
   """
+  use Meadow.Utils.Logging
+
   import Ecto.Query, warn: false
-  import Meadow.Utils.Logging
 
   alias Meadow.Ingest.Progress
   alias Meadow.IntervalTask
@@ -20,14 +21,14 @@ defmodule Meadow.Ingest.WorkRedriver do
   reset them to pending
   """
   def redrive_works(state) do
-    with_log_level(:info, fn ->
+    with_log_level :info do
       {count, _} =
         Progress.works_processing_longer_than(@timeout)
         |> Repo.update_all(set: [status: "pending", updated_at: DateTime.utc_now()])
 
       if count > 0,
-        do: Logger.info("Redriving #{count} works processing longer than #{@timeout} seconds")
-    end)
+        do: Logger.warn("Redriving #{count} works processing longer than #{@timeout} seconds")
+    end
 
     {:noreply, state}
   end

--- a/lib/meadow/interval_task.ex
+++ b/lib/meadow/interval_task.ex
@@ -63,9 +63,8 @@ defmodule Meadow.IntervalTask do
       def init(args) do
         interval = Keyword.get(args, :interval, unquote(default_interval))
 
-        Logger.info(
-          "IntervalTask: Invoking #{__MODULE__}.#{unquote(function)} every #{interval}ms"
-        )
+        "IntervalTask: Invoking #{__MODULE__}.#{unquote(function)} every #{interval}ms"
+        |> Logger.info()
 
         state =
           initial_state(args)

--- a/lib/meadow/pipeline/actions/create_pyramid_tiff.ex
+++ b/lib/meadow/pipeline/actions/create_pyramid_tiff.ex
@@ -16,7 +16,6 @@ defmodule Meadow.Pipeline.Actions.CreatePyramidTiff do
   end
 
   defp process(file_set, _, _) do
-    Logger.info("Beginning #{__MODULE__} for FileSet #{file_set.id}")
     source = file_set.metadata.location
     target = FileSets.pyramid_uri_for(file_set.id)
 

--- a/lib/meadow/pipeline/actions/extract_exif_metadata.ex
+++ b/lib/meadow/pipeline/actions/extract_exif_metadata.ex
@@ -29,7 +29,6 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadata do
   end
 
   defp process(file_set, _attributes, _) do
-    Logger.info("Beginning #{__MODULE__} for FileSet #{file_set.id}")
     ActionStates.set_state!(file_set, __MODULE__, "started")
     source = file_set.metadata.location
 

--- a/lib/meadow/pipeline/actions/extract_mime_type.ex
+++ b/lib/meadow/pipeline/actions/extract_mime_type.ex
@@ -27,7 +27,6 @@ defmodule Meadow.Pipeline.Actions.ExtractMimeType do
   end
 
   defp process(file_set, _attributes, _) do
-    Logger.info("Beginning #{__MODULE__} for FileSet #{file_set.id}")
     ActionStates.set_state!(file_set, __MODULE__, "started")
     source = file_set.metadata.location
 

--- a/lib/meadow/utils/logging.ex
+++ b/lib/meadow/utils/logging.ex
@@ -1,30 +1,54 @@
 defmodule Meadow.Utils.Logging do
   @moduledoc "Logging utilities"
 
+  defmacro __using__(_) do
+    quote do
+      require Meadow.Utils.Logging
+      import Meadow.Utils.Logging
+    end
+  end
+
   @doc """
   Transparently change the logging level around a function
 
   Examples:
-    iex> Meadow.Utils.Logging.with_log_level(:warn, fn ->
+    iex> Meadow.Utils.Logging.with_log_level :warn do
     ...>   8 * 8
-    ...> end)
+    ...> end
     64
   """
-  def with_log_level(level, fun) do
-    case Logger.level() do
-      ^level -> fun.()
-      _ -> temp_change_log_level(level, fun)
+  defmacro with_log_level(level, do: block) do
+    quote do
+      case Logger.level() do
+        unquote(level) ->
+          unquote(block)
+
+        _ ->
+          with old_level <- Logger.level() do
+            try do
+              Logger.configure(level: unquote(level))
+              unquote(block)
+            after
+              Logger.configure(level: old_level)
+            end
+          end
+      end
     end
   end
 
-  defp temp_change_log_level(level, fun) do
-    old_level = Logger.level()
+  defmacro with_log_metadata(metadata, do: block) do
+    quote do
+      old_metadata =
+        unquote(metadata)
+        |> Enum.map(fn {key, _} -> {key, nil} end)
+        |> Keyword.merge(Logger.metadata())
 
-    try do
-      Logger.configure(level: level)
-      fun.()
-    after
-      Logger.configure(level: old_level)
+      try do
+        Logger.metadata(unquote(metadata))
+        unquote(block)
+      after
+        Logger.metadata(old_metadata)
+      end
     end
   end
 end

--- a/lib/mix/tasks/meadow.ex
+++ b/lib/mix/tasks/meadow.ex
@@ -73,7 +73,8 @@ defmodule Mix.Tasks.Meadow.Seed do
   Run database seeds
   """
   use Mix.Task
-  alias Meadow.Utils.Logging
+
+  use Meadow.Utils.Logging
 
   def run([]), do: run("seeds.exs")
   def run([name | []]), do: run("seeds/#{name}.exs")
@@ -84,13 +85,13 @@ defmodule Mix.Tasks.Meadow.Seed do
   end
 
   def run(name) do
-    Logging.with_log_level(:info, fn ->
+    with_log_level :info do
       Ecto.Migrator.with_repo(Meadow.Repo, fn _ ->
         Path.expand("priv/repo/#{name}")
         |> Code.compile_file()
         |> Enum.each(fn {module, _} -> module.run() end)
       end)
-    end)
+    end
   end
 end
 

--- a/test/meadow/accounts/user_test.exs
+++ b/test/meadow/accounts/user_test.exs
@@ -8,7 +8,11 @@ defmodule Meadow.Accounts.User.Test do
 
   describe "Meadow.Accounts.User.find/1" do
     setup do
+      old_level = Logger.level()
+      Logger.configure(level: :debug)
+      on_exit(fn -> Logger.configure(level: old_level) end)
       Cachex.clear!(Meadow.Cache.Users)
+
       :ok
     end
 

--- a/test/meadow/batch_driver_test.exs
+++ b/test/meadow/batch_driver_test.exs
@@ -62,6 +62,6 @@ defmodule Meadow.BatchDriverTest do
       assert work.descriptive_metadata.alternate_title == ["First", "Second"]
     end)
 
-    assert logged |> String.contains?("Found next batch to start")
+    assert logged |> String.contains?("Starting batch")
   end
 end

--- a/test/meadow/utils/logging_test.exs
+++ b/test/meadow/utils/logging_test.exs
@@ -1,28 +1,37 @@
 defmodule Meadow.Utils.LoggingTest do
   use ExUnit.Case
-  import ExUnit.CaptureLog
-  require Logger
-  alias Meadow.Utils.Logging
+  use Meadow.Utils.Logging
 
-  doctest Logging
+  import ExUnit.CaptureLog
+
+  require Logger
+
+  doctest Meadow.Utils.Logging
 
   test "log level is only changed within the passed fn" do
-    logged = capture_log(fn ->
-               assert Logger.level() == :info
-               Logger.debug("This is a debug message")
-             end)
-    refute String.match?(logged , ~r/This is a debug message/)
+    logged =
+      capture_log(fn ->
+        assert Logger.level() == :info
+        Logger.debug("This is a debug message")
+      end)
 
-    logged = capture_log([level: :debug], fn ->
-               assert Logger.level() == :info
-               result = Logging.with_log_level(:debug, fn ->
-                 assert Logger.level() == :debug
-                 Logger.debug("This is a debug message")
-                 {:ok, :inner_fn_result}
-               end)
-               assert result == {:ok, :inner_fn_result}
-               assert Logger.level() == :info
-             end)
+    refute String.match?(logged, ~r/This is a debug message/)
+
+    logged =
+      capture_log([level: :debug], fn ->
+        assert Logger.level() == :info
+
+        result =
+          with_log_level :debug do
+            assert Logger.level() == :debug
+            Logger.debug("This is a debug message")
+            {:ok, :inner_fn_result}
+          end
+
+        assert result == {:ok, :inner_fn_result}
+        assert Logger.level() == :info
+      end)
+
     assert String.match?(logged, ~r/This is a debug message/)
   end
 end


### PR DESCRIPTION
- Change Meadow.Utils.Logging.with_log_level from function to macro
- Add Meadow.Utils.Logging.with_log_metadata macro
- Update log message levels throughout
- Add `context` and `id` metadata to actions, batches, csv updates, indexing, preservation checks

In addition to making the logs less chatty (by default, at `info` level), this PR adds additional metadata to logs throughout the application. For example, any messages logged during a batch update will have the format
```
context=Meadow.Batches id=4f56c458-04e3-43ec-8eb2-c369480d575a [info] Log message
```
(with the appropriate batch ID and log level)

The same format applies to CSV Metadata Updates, Indexing operations, and Preservation Checks.

Pipeline action metadata has been updated as well. Instead of:
```
action=Meadow.Pipeline.Actions.FileSetComplete [info] Ingest pipeline complete for FileSet 197fd179-755b-4f40-9bd2-c303ed03402f
```
the log will read
```
context=Meadow.Pipeline.Actions.FileSetComplete id=197fd179-755b-4f40-9bd2-c303ed03402f [info]  Ingest pipeline complete for FileSet 197fd179-755b-4f40-9bd2-c303ed03402f
```

This might look redundant, but it will help with log filtering in CloudWatch. We can update the log message text (e.g., to remove IDs) if we decide it would look better.