### PR TITLE
Intercept browser back button event on Search screen, and take user t…

### DIFF
--- a/assets/js/screens/Search/Search.jsx
+++ b/assets/js/screens/Search/Search.jsx
@@ -4,7 +4,7 @@ import { SelectedFilters } from "@appbaseio/reactivesearch";
 import SearchBar from "@js/components/UI/SearchBar";
 import SearchResults from "@js/components/Search/Results";
 import SearchFacetSidebar from "@js/components/Search/FacetSidebar";
-import { useHistory } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import SearchActionRow from "@js/components/Search/ActionRow";
 import {
   parseESAggregationResults,
@@ -39,6 +39,7 @@ async function getParsedAggregations(query) {
 
 const ScreensSearch = () => {
   let history = useHistory();
+  const location = useLocation();
   const [isListView, setIsListView] = useState(false);
   const [selectedItems, setSelectedItems] = useState([]);
   const [filteredQuery, setFilteredQuery] = useState();
@@ -48,6 +49,18 @@ const ScreensSearch = () => {
 
   React.useEffect(() => {
     loadDataLayer({ pageTitle: "Search" });
+
+    function handlePopState(e) {
+      // If ReactiveSearch pushed a state onto the history stack
+      // take user directly to the previous screen.
+      if (e.state.state) {
+        window.history.go(-1);
+      }
+    }
+    // Handle browser's "back" button click
+    window.addEventListener("popstate", handlePopState);
+
+    return () => window.removeEventListener("popstate", handlePopState);
   }, []);
 
   const handleEditAllItems = async () => {


### PR DESCRIPTION
…o previous screen to avoid a double back click.

This solution is only implemented on the Search screen.  Figure tread lightly manipulating the `history` stack and see if this is a more pleasant UX?

To test this:
1. Go to any Collection or Project that has a "View Works" button. 
2. Click the button
3. After Search screen has loaded, click browser "Back" button.

One click should get you back to the previous screen.