### PR TITLE
Add COMPLETED_ERROR status to ingest sheets

### DIFF
--- a/assets/js/components/IngestSheet/Alert.jsx
+++ b/assets/js/components/IngestSheet/Alert.jsx
@@ -35,6 +35,14 @@ const IngestSheetAlert = ({ ingestSheet }) => {
         icon: "exclamation-triangle",
       };
       break;
+    case "COMPLETED_ERROR":
+      alertObj = {
+        type: "is-danger",
+        title: "Ingestion Complete (with errors)",
+        body: "Ingestion complete, but some works and/or file sets have errors.",
+        icon: "check-circle",
+      };
+      break;
     case "FILE_FAIL":
       alertObj = {
         type: "is-danger",

--- a/assets/js/components/IngestSheet/IngestSheet.jsx
+++ b/assets/js/components/IngestSheet/IngestSheet.jsx
@@ -23,7 +23,7 @@ const IngestSheet = ({ ingestSheetData, subscribeToIngestSheetUpdates }) => {
     });
   }, []);
 
-  const isCompleted = status === "COMPLETED";
+  const isCompleted = ["COMPLETED", "COMPLETED_ERROR"].indexOf(status) > -1;
 
   return (
     <>

--- a/assets/js/components/IngestSheet/List.jsx
+++ b/assets/js/components/IngestSheet/List.jsx
@@ -85,7 +85,7 @@ const IngestSheetList = ({ project, subscribeToIngestSheetStatusChanges }) => {
                       </IngestSheetStatusTag>
                     </td>
                     <td className="has-text-right">
-                      {["APPROVED", "COMPLETED"].indexOf(status) > -1 && (
+                      {["APPROVED", "COMPLETED", "COMPLETED_ERROR"].indexOf(status) > -1 && (
                         <Link
                           to={`/project/${project.id}/ingest-sheet/${id}`}
                           className="button is-light"

--- a/assets/js/components/IngestSheet/StatusTag.jsx
+++ b/assets/js/components/IngestSheet/StatusTag.jsx
@@ -5,7 +5,7 @@ import { Tag } from "@nulib/admin-react-components";
 function IngestSheetStatusTag({ status, children }) {
   return (
     <Tag
-      isDanger={["ROW_FAIL", "FILE_FAIL"].indexOf(status) > -1}
+      isDanger={["ROW_FAIL", "FILE_FAIL", "COMPLETED_ERROR"].indexOf(status) > -1}
       isSuccess={["APPROVED", "COMPLETED", "VALID"].indexOf(status) > -1}
       isWarning={status === "UPLOADED"}
     >

--- a/assets/js/services/helpers.js
+++ b/assets/js/services/helpers.js
@@ -65,6 +65,7 @@ export const TEMP_USER_FRIENDLY_STATUS = {
   VALID: "Valid, waiting for approval",
   APPROVED: "Ingest in progress...",
   COMPLETED: "Ingest Complete",
+  COMPLETED_ERROR: "Ingest Complete (with errors)",
 };
 
 export function prepWorkItemForDisplay(res) {

--- a/lib/meadow/ingest/sheets.ex
+++ b/lib/meadow/ingest/sheets.ex
@@ -384,6 +384,22 @@ defmodule Meadow.Ingest.Sheets do
     end)
   end
 
+  def sheet_has_errors_query(sheet_id) do
+    row_errors =
+      from([entry: entry, row: row] in row_action_states(sheet_id),
+        where: entry.outcome in ["error", "skipped"],
+        select: entry.object_id
+      )
+
+    file_set_errors =
+      from([entry: entry, row: row] in file_set_action_states(sheet_id),
+        where: entry.outcome in ["error", "skipped"],
+        select: entry.object_id
+      )
+
+    from(row_errors, distinct: true, union_all: ^file_set_errors)
+  end
+
   def row_action_states(sheet_id) do
     from(a in ActionState,
       as: :entry,

--- a/lib/meadow_web/resolvers/ingest.ex
+++ b/lib/meadow_web/resolvers/ingest.ex
@@ -126,7 +126,7 @@ defmodule MeadowWeb.Resolvers.Ingest do
     end
   end
 
-  @invalid_delete_status ["approved", "completed"]
+  @invalid_delete_status ["approved", "completed", "error"]
 
   def delete_ingest_sheet(%{status: status}) when status in @invalid_delete_status do
     {

--- a/lib/meadow_web/schema/types/ingest_types.ex
+++ b/lib/meadow_web/schema/types/ingest_types.ex
@@ -213,7 +213,8 @@ defmodule MeadowWeb.Schema.IngestTypes do
     value(:row_fail, as: "row_fail", description: "Errors in content rows")
     value(:valid, as: "valid", description: "Passes validation")
     value(:approved, as: "approved", description: "Approved, ingest in progress")
-    value(:completed, as: "completed", description: "Ingest Completed")
+    value(:completed, as: "completed", description: "Ingest completed")
+    value(:completed_error, as: "completed_error", description: "Ingest completed (with errors)")
     value(:deleted, as: "deleted", description: "Ingest Sheet deleted")
   end
 

--- a/priv/repo/migrations/20210407204000_add_completed_with_errors_status.exs
+++ b/priv/repo/migrations/20210407204000_add_completed_with_errors_status.exs
@@ -1,0 +1,93 @@
+defmodule Meadow.Repo.Migrations.AddCompletedWithErrorsStatus do
+  use Ecto.Migration
+
+  require Logger
+
+  def up do
+    execute """
+    CREATE OR REPLACE FUNCTION update_sheet_status_when_progress_changes()
+      RETURNS trigger AS $$
+    DECLARE
+      current_sheet_id ingest_sheets.id%TYPE;
+      lock_id bigint;
+      pending integer;
+      errors integer;
+      complete_status varchar;
+    BEGIN
+      SELECT ingest_sheet_rows.sheet_id INTO current_sheet_id
+      FROM ingest_sheet_rows WHERE ingest_sheet_rows.id = NEW.row_id;
+
+      SELECT ('x'||TRANSLATE(current_sheet_id::VARCHAR,'-',''))::BIT(64)::BIGINT INTO lock_id;
+
+      SET LOCAL lock_timeout = '10s';
+      PERFORM pg_advisory_lock(lock_id);
+
+      SELECT COUNT(*) INTO pending
+        FROM ingest_progress
+        JOIN ingest_sheet_rows ON ingest_progress.row_id = ingest_sheet_rows.id
+        WHERE ingest_sheet_rows.sheet_id = current_sheet_id
+        AND ingest_progress.status NOT IN ('ok', 'error');
+
+      IF pending = 0 THEN
+        SELECT COUNT(*) INTO errors
+          FROM ingest_progress
+          JOIN ingest_sheet_rows ON ingest_progress.row_id = ingest_sheet_rows.id
+          WHERE ingest_sheet_rows.sheet_id = current_sheet_id
+          AND ingest_progress.status IN ('ok', 'error');
+
+        IF errors > 0 THEN
+          SELECT 'completed_error' INTO complete_status;
+        ELSE
+          SELECT 'completed' INTO complete_status;
+        END IF;
+
+        UPDATE ingest_sheets
+        SET status = complete_status, updated_at = NOW() AT TIME ZONE 'utc'
+        WHERE ingest_sheets.id = current_sheet_id;
+      END IF;
+
+      PERFORM pg_advisory_unlock(lock_id);
+
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+    """
+  end
+
+  def down do
+    execute """
+    CREATE OR REPLACE FUNCTION update_sheet_status_when_progress_changes()
+      RETURNS trigger AS $$
+    DECLARE
+      current_sheet_id ingest_sheets.id%TYPE;
+      lock_id bigint;
+      pending integer;
+    BEGIN
+      SELECT ingest_sheet_rows.sheet_id INTO current_sheet_id
+      FROM ingest_sheet_rows WHERE ingest_sheet_rows.id = NEW.row_id;
+
+      SELECT ('x'||TRANSLATE(current_sheet_id::VARCHAR,'-',''))::BIT(64)::BIGINT INTO lock_id;
+
+      SET LOCAL lock_timeout = '10s';
+      PERFORM pg_advisory_lock(lock_id);
+
+      SELECT COUNT(*) INTO pending
+        FROM ingest_progress
+        JOIN ingest_sheet_rows ON ingest_progress.row_id = ingest_sheet_rows.id
+        WHERE ingest_sheet_rows.sheet_id = current_sheet_id
+        AND ingest_progress.status NOT IN ('ok', 'error');
+
+      IF pending = 0 THEN
+        UPDATE ingest_sheets
+        SET status = 'completed', updated_at = NOW() AT TIME ZONE 'utc'
+        WHERE ingest_sheets.id = current_sheet_id;
+      END IF;
+
+      PERFORM pg_advisory_unlock(lock_id);
+
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+    """
+  end
+end


### PR DESCRIPTION
* Update the existing progress trigger to set the completed ingest sheet status to `completed_error` if the sheet encountered any errors during processing
* Add the new `COMPLETED_ERROR` status to the GraphQL API
* Update the front end to display the new status

Current styling for the `COMPLETED_ERROR` status is red (`is-danger`) but can be changed easily if a different presentation would be better.

To test: Submit an ingest sheet pointing to a file that exists but that isn’t a valid image.