### PR TITLE
Analytics dashboard iFrame height remove scroll

### DIFF
--- a/assets/js/components/Dashboards/Analytics/Analytics.jsx
+++ b/assets/js/components/Dashboards/Analytics/Analytics.jsx
@@ -1,17 +1,16 @@
 import React from "react";
+import { isMobile, isTablet, isBrowser } from "react-device-detect";
 
 export default function DashboardsAnalytics() {
   return (
     <div>
       <iframe
-        // width="100%"
-        // height="1000"
         src="https://datastudio.google.com/embed/reporting/45a94985-73a2-4219-b8d8-e51c605eb61a/page/FW7"
         frameBorder="0"
         style={{
           border: "0",
           height: "auto",
-          minHeight: "1000px",
+          minHeight: isBrowser ? "4600px" : isTablet ? "2400px" : "1000px",
           width: "100%",
         }}
         allowFullScreen

--- a/assets/js/screens/Dashboards/Analytics/Analytics.jsx
+++ b/assets/js/screens/Dashboards/Analytics/Analytics.jsx
@@ -7,6 +7,7 @@ import UIFallbackErrorComponent from "@js/components/UI/FallbackErrorComponent";
 import IconText from "@js/components/UI/IconText";
 import { IconChart } from "@js/components/Icon";
 import useGTM from "@js/hooks/useGTM";
+import { PageTitle } from "@js/components/UI/UI";
 
 export default function ScreensDashboardsAnalytics() {
   const { loadDataLayer } = useGTM();
@@ -34,11 +35,11 @@ export default function ScreensDashboardsAnalytics() {
             ]}
           />
           <div className="box">
-            <h1 className="title" data-testid="page-title">
+            <PageTitle data-testid="page-title">
               <IconText icon={<IconChart />}>
                 Digital Collections Analytics
               </IconText>
-            </h1>
+            </PageTitle>
             <ErrorBoundary FallbackComponent={UIFallbackErrorComponent}>
               <DashboardsAnalytics />
             </ErrorBoundary>


### PR DESCRIPTION
Analytics dashboard no longer has in iFrame scrolling, for desktop/mobile/tablet.

![image](https://user-images.githubusercontent.com/3020266/114043609-0ee8b400-984c-11eb-9d1a-d1bed1dd9c76.png)
