### PR TITLE
Add @actiondoc to pyramid TIFF action

### DIFF
--- a/lib/meadow/pipeline/actions/create_pyramid_tiff.ex
+++ b/lib/meadow/pipeline/actions/create_pyramid_tiff.ex
@@ -8,6 +8,7 @@ defmodule Meadow.Pipeline.Actions.CreatePyramidTiff do
   use Action
   use Meadow.Pipeline.Actions.Common
 
+  @actiondoc "Create pyramid TIFF from source image"
   @timeout 240_000
 
   defp already_complete?(file_set, _) do


### PR DESCRIPTION
The pyramid TIFF action is missing its `@actiondoc` attribute, which affects the `actionStates` GraphQL query

![image](https://user-images.githubusercontent.com/196872/114101058-cef4f180-988a-11eb-8887-4d3226489e5f.png)
