### PR TITLE
Change "context" to "module" in logger metadata

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -75,7 +75,7 @@ end
 # Configures Elixir's Logger
 config :logger, :console,
   format: "$time $metadata[$level] $levelpad$message\n",
-  metadata: [:request_id, :context, :id]
+  metadata: [:request_id, :module, :id]
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -151,7 +151,7 @@ config :exldap, :settings,
 # Do not include metadata nor timestamps in development logs
 config :logger, :console,
   format: "$metadata[$level] $levelpad$message\n",
-  metadata: [:context, :id]
+  metadata: [:module, :id]
 
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.

--- a/lib/meadow/batch_driver.ex
+++ b/lib/meadow/batch_driver.ex
@@ -30,7 +30,7 @@ defmodule Meadow.BatchDriver do
         :noop
 
       batch ->
-        with_log_metadata(context: Batches, id: batch.id) do
+        with_log_metadata module: Batches, id: batch.id do
           Logger.info("Starting batch #{batch.id}")
           Batches.process_batch(batch)
         end

--- a/lib/meadow/csv_metadata_update_driver.ex
+++ b/lib/meadow/csv_metadata_update_driver.ex
@@ -29,7 +29,7 @@ defmodule Meadow.CSVMetadataUpdateDriver do
       job ->
         Logger.info("Starting CSV update job #{job.id}")
 
-        with_log_metadata(context: MetadataUpdateJobs, id: job.id) do
+        with_log_metadata module: MetadataUpdateJobs, id: job.id do
           MetadataUpdateJobs.apply_job(job)
         end
     end

--- a/lib/meadow/data/indexer.ex
+++ b/lib/meadow/data/indexer.ex
@@ -13,7 +13,7 @@ defmodule Meadow.Data.Indexer do
   require Logger
 
   def synchronize_index do
-    with_log_metadata(context: __MODULE__) do
+    with_log_metadata module: __MODULE__ do
       [:deleted, FileSet, Work, Collection]
       |> Enum.each(&synchronize_schema/1)
 

--- a/lib/meadow/data/preservation_checks.ex
+++ b/lib/meadow/data/preservation_checks.ex
@@ -73,7 +73,7 @@ defmodule Meadow.Data.PreservationChecks do
 
     case create_job(attrs) do
       {:ok, job} ->
-        with_log_metadata(context: __MODULE__, id: job.id) do
+        with_log_metadata module: __MODULE__, id: job.id do
           Logger.info("Starting preservation check: #{job.id}")
 
           try do

--- a/lib/meadow/iiif/manifest_listener.ex
+++ b/lib/meadow/iiif/manifest_listener.ex
@@ -12,7 +12,7 @@ defmodule Meadow.IIIF.ManifestListener do
   def handle_notification(:works, :delete, _key, state), do: {:noreply, state}
 
   def handle_notification(:works, _op, %{id: id}, state) do
-    with_log_metadata(context: __MODULE__, id: id) do
+    with_log_metadata module: __MODULE__, id: id do
       Logger.info("Writing manifest for #{id}")
       id |> IIIF.write_manifest()
     end

--- a/lib/meadow/ingest/notifications.ex
+++ b/lib/meadow/ingest/notifications.ex
@@ -11,7 +11,7 @@ defmodule Meadow.Ingest.Notifications do
     do: {:ok, ingest_sheet(sheet)}
 
   def ingest_sheet(%Sheet{} = sheet) do
-    with_log_metadata context: __MODULE__, id: sheet.id do
+    with_log_metadata module: __MODULE__, id: sheet.id do
       ("Sending notifications for ingest sheet: #{sheet.id} " <>
          "in project: #{sheet.project_id} with status: #{sheet.status}")
       |> Logger.info()

--- a/lib/meadow/ingest/validator.ex
+++ b/lib/meadow/ingest/validator.ex
@@ -29,7 +29,7 @@ defmodule Meadow.Ingest.Validator do
   end
 
   def validate(%Sheet{} = sheet) do
-    with_log_metadata context: __MODULE__, id: sheet.id do
+    with_log_metadata module: __MODULE__, id: sheet.id do
       Logger.info("Beginning validation for Ingest Sheet: #{sheet.id}")
 
       unless Ecto.assoc_loaded?(sheet.project) do

--- a/lib/meadow/ingest/work_creator.ex
+++ b/lib/meadow/ingest/work_creator.ex
@@ -28,7 +28,7 @@ defmodule Meadow.Ingest.WorkCreator do
   Turn a batch of pending work rows into works
   """
   def create_works(state) do
-    with_log_metadata context: __MODULE__ do
+    with_log_metadata module: __MODULE__ do
       with_log_level :info do
         state
         |> get_and_update_pending_work_rows()

--- a/lib/meadow/pipeline/actions/common.ex
+++ b/lib/meadow/pipeline/actions/common.ex
@@ -10,7 +10,7 @@ defmodule Meadow.Pipeline.Actions.Common do
       alias Meadow.Ingest.{Progress, Rows}
 
       def process(data, attrs) do
-        with_log_metadata context: __MODULE__, id: data.file_set_id do
+        with_log_metadata module: __MODULE__, id: data.file_set_id do
           try do
             Logger.info("Beginning #{__MODULE__} for file set: #{data.file_set_id}")
 

--- a/lib/meadow/utils/logging.ex
+++ b/lib/meadow/utils/logging.ex
@@ -40,7 +40,7 @@ defmodule Meadow.Utils.Logging do
   Transparently change the logging metadata around a block
 
   Examples:
-    iex> Meadow.Utils.Logging.with_log_metadata context: "math" do
+    iex> Meadow.Utils.Logging.with_log_metadata module: "math" do
     ...>   8 * 8
     ...> end
     64

--- a/test/meadow/error_test.exs
+++ b/test/meadow/error_test.exs
@@ -1,6 +1,7 @@
 defmodule Meadow.ErrorTest do
   use Honeybadger.Case
   use MeadowWeb.ConnCase, async: true
+  use Meadow.Utils.Logging
 
   alias Meadow.Config
   alias Plug.Conn.Cookies
@@ -22,11 +23,13 @@ defmodule Meadow.ErrorTest do
       restart_with_config(exclude_envs: [])
 
       bad_function = fn denominator ->
-        try do
-          107 / denominator
-        rescue
-          exception ->
-            Meadow.Error.report(exception, __MODULE__, __STACKTRACE__, %{extra_data: "foo"})
+        with_log_metadata module: __MODULE__, id: 107 do
+          try do
+            107 / denominator
+          rescue
+            exception ->
+              Meadow.Error.report(exception, __MODULE__, __STACKTRACE__, %{extra_data: "foo"})
+          end
         end
       end
 


### PR DESCRIPTION
Honeybadger automatically uses the current `Logger.metadata/0` as part of its context map for all notifications. If the metadata has a `context` key, it automatically overrides the built-in Honeybadger context, which will always cause an undesirable result, and in some cases an error that makes it impossible for Honeybadger to submit its report.

This issue was introduced by #2112, which added a `context` attribute to most of our logging.
This PR solves that by replacing `context` with `module` throughout our logger metadata, since the context is always the module where the logged code runs.