### PR TITLE
Add a search button to the NUL Authorities Dashboard

### DIFF
--- a/assets/js/components/Dashboards/LocalAuthorities/List.jsx
+++ b/assets/js/components/Dashboards/LocalAuthorities/List.jsx
@@ -12,11 +12,12 @@ import {
 } from "@js/components/Dashboards/dashboards.gql";
 import { AUTHORITIES_SEARCH } from "@js/components/Work/controlledVocabulary.gql";
 import { Button } from "@nulib/admin-react-components";
+import { Link } from "react-router-dom";
 import { toastWrapper } from "@js/services/helpers";
 import DashboardsLocalAuthoritiesModalEdit from "@js/components/Dashboards/LocalAuthorities/ModalEdit";
 import UIFormInput from "@js/components/UI/Form/Input";
 import { ModalDelete, SearchBarRow } from "@js/components/UI/UI";
-import { IconEdit, IconTrashCan } from "@js/components/Icon";
+import { IconEdit, IconImages, IconTrashCan } from "@js/components/Icon";
 
 const colHeaders = ["Label", "Hint"];
 
@@ -227,6 +228,17 @@ export default function DashboardsLocalAuthoritiesList() {
                       >
                         <IconTrashCan />
                       </Button>
+                      <Link
+                        data-testid="button-to-search"
+                        className="button is-small is-light"
+                        title="View works containing this record"
+                        to={{
+                          pathname: "/search",
+                          state: { passedInSearchTerm: `all_controlled_terms:\"${id}\"` },
+                        }}
+                      >
+                        <IconImages />
+                      </Link>
                     </div>
                   </td>
                 </tr>

--- a/assets/js/components/Dashboards/LocalAuthorities/List.test.jsx
+++ b/assets/js/components/Dashboards/LocalAuthorities/List.test.jsx
@@ -40,13 +40,14 @@ describe("DashboardsLocalAuthoritiesList component", () => {
     expect(utils.getByText(/Ima Hint 1/i));
   });
 
-  it("renders an edit and delete buttons", async () => {
+  it("renders an edit, search, and delete buttons", async () => {
     const td = await screen.findByText(
       "info:nul/675ed59a-ab54-481a-9bd1-d9b7fd2604dc"
     );
     const row = td.closest("tr");
     const utils = within(row);
     expect(utils.getByTestId("edit-button"));
+    expect(utils.getByTestId("button-to-search"));
     expect(utils.getByTestId("delete-button"));
   });
 });


### PR DESCRIPTION
The new search button finds all works containing the authority record id. The search uses the new `all_controlled_terms` dynamically mapped field so will match against any field in the work record. In the example, you can see the term is in several different fields such as `genre`, `location` and `subject`

https://user-images.githubusercontent.com/1395707/114777319-2f77a900-9d39-11eb-8abd-ca7eccb04496.mov

