### PR TITLE
Add culturalContext metadata field to display, edit and batch screens.

### DIFF
--- a/assets/js/components/BatchEdit/About/About.jsx
+++ b/assets/js/components/BatchEdit/About/About.jsx
@@ -1,12 +1,11 @@
-import React, { useState } from "react";
-import PropTypes from "prop-types";
+import React from "react";
 import BatchEditAboutCoreMetadata from "./CoreMetadata";
 import BatchEditAboutControlledMetadata from "./ControlledMetadata";
 import BatchEditAboutUncontrolledMetadata from "./UncontrolledMetadata";
 import BatchEditAboutPhysicalMetadata from "./PhysicalMetadata";
 import BatchEditAboutRightsMetadata from "./RightsMetadata";
 import BatchEditAboutIdentifiersMetadata from "./IdentifiersMetadata";
-import UIAccordion from "../../UI/Accordion";
+import UIAccordion from "@js/components/UI/Accordion";
 
 const BatchEditAbout = () => {
   return (

--- a/assets/js/components/BatchEdit/About/UncontrolledMetadata.jsx
+++ b/assets/js/components/BatchEdit/About/UncontrolledMetadata.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import UIFormBatchFieldArray from "../../UI/Form/BatchFieldArray";
-import { UNCONTROLLED_METADATA } from "../../../services/metadata";
+import UIFormBatchFieldArray from "@js/components/UI/Form/BatchFieldArray";
+import { UNCONTROLLED_METADATA } from "@js/services/metadata";
 
 const BatchEditAboutUncontrolledMetadata = ({ ...restProps }) => {
   return (

--- a/assets/js/components/BatchEdit/Tabs.jsx
+++ b/assets/js/components/BatchEdit/Tabs.jsx
@@ -103,13 +103,6 @@ export default function BatchEditTabs() {
       replaceItems.administrative.projectCycle = currentFormValues.projectCycle;
     }
 
-    // // Process Core metadata items
-    // ["status"].forEach((item) => {
-    //   if (currentFormValues[item]) {
-    //     replaceItems.administrative[item] = currentFormValues[item];
-    //   }
-    // });
-
     // Update controlled term values to match shape the GraphQL mutation expects
     for (let term of CONTROLLED_METADATA) {
       // Include only active form additions

--- a/assets/js/components/Work/CardItem.jsx
+++ b/assets/js/components/Work/CardItem.jsx
@@ -1,10 +1,16 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
-import { setVisibilityClass, getImageUrl } from "@js/services/helpers";
+import { getImageUrl } from "@js/services/helpers";
 import UIWorkImage from "@js/components/UI/WorkImage";
 import { Tag } from "@nulib/admin-react-components";
 import UIVisibilityTag from "@js/components/UI/VisibilityTag";
+
+/** @jsx jsx */
+import { css, jsx } from "@emotion/react";
+const breakWord = css`
+  word-break: break-all
+`;
 
 const WorkCardItem = ({
   id,
@@ -45,7 +51,7 @@ const WorkCardItem = ({
           )}
         </div>
         <p data-testid={`work-title-${id}`}>{title}</p>
-        <p data-testid="accession-number">{accessionNumber}</p>
+        <p data-testid="accession-number" css={breakWord}>{accessionNumber}</p>
 
         {collectionName && <p className="heading">{collectionName}</p>}
       </div>

--- a/assets/js/components/Work/Tabs/About.test.js
+++ b/assets/js/components/Work/Tabs/About.test.js
@@ -1,6 +1,6 @@
 import React from "react";
-import { renderWithRouterApollo } from "../../../services/testing-helpers";
-import { mockWork } from "../work.gql.mock";
+import { renderWithRouterApollo } from "@js/services/testing-helpers";
+import { mockWork } from "@js/components/Work/work.gql.mock";
 import WorkTabsAbout from "./About";
 import { fireEvent, waitFor, screen } from "@testing-library/react";
 import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";

--- a/assets/js/components/Work/Tabs/About/UncontrolledMetadata.jsx
+++ b/assets/js/components/Work/Tabs/About/UncontrolledMetadata.jsx
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
-import UIFormFieldArray from "../../../UI/Form/FieldArray";
-import UIFormFieldArrayDisplay from "../../../UI/Form/FieldArrayDisplay";
-import { UNCONTROLLED_METADATA } from "../../../../services/metadata";
+import UIFormFieldArray from "@js/components/UI/Form/FieldArray";
+import UIFormFieldArrayDisplay from "@js/components/UI/Form/FieldArrayDisplay";
+import { UNCONTROLLED_METADATA } from "@js/services/metadata";
 
 const WorkTabsAboutUncontrolledMetadata = ({
   descriptiveMetadata,

--- a/assets/js/components/Work/Tabs/About/UncontrolledMetadata.test.js
+++ b/assets/js/components/Work/Tabs/About/UncontrolledMetadata.test.js
@@ -1,9 +1,9 @@
 import React from "react";
-import { renderWithRouterApollo } from "../../../../services/testing-helpers";
-import { mockWork } from "../../work.gql.mock";
+import { renderWithRouterApollo } from "@js/services/testing-helpers";
+import { mockWork } from "@js/components/Work/work.gql.mock";
 import WorkTabsAboutUncontrolledMetadata from "./UncontrolledMetadata";
 import { waitFor } from "@testing-library/react";
-import { UNCONTROLLED_METADATA } from "../../../../services/metadata";
+import { UNCONTROLLED_METADATA } from "@js/services/metadata";
 
 describe("Work About tab Uncontrolled Metadata component", () => {
   function setupTests() {

--- a/assets/js/components/Work/work.gql.js
+++ b/assets/js/components/Work/work.gql.js
@@ -115,6 +115,7 @@ export const GET_WORK = gql`
             label
           }
         }
+        culturalContext
         dateCreated {
           edtf
           humanized
@@ -323,12 +324,6 @@ export const UPDATE_WORK = gql`
       }
 
       descriptiveMetadata {
-        title
-        description
-        dateCreated {
-          edtf
-          humanized
-        }
         contributor {
           term {
             id
@@ -340,12 +335,17 @@ export const UPDATE_WORK = gql`
             scheme
           }
         }
-        termsOfUse
         creator {
           term {
             id
             label
           }
+        }
+        culturalContext
+        description
+        dateCreated {
+          edtf
+          humanized
         }
         genre {
           term {
@@ -396,6 +396,8 @@ export const UPDATE_WORK = gql`
             label
           }
         }
+        title
+        termsOfUse
       }
       insertedAt
       published

--- a/assets/js/components/Work/work.gql.mock.js
+++ b/assets/js/components/Work/work.gql.mock.js
@@ -3,8 +3,8 @@ import {
   DELETE_FILESET,
   GET_WORK,
   VERIFY_FILE_SETS,
-} from "../../components/Work/work.gql.js";
-import { mockVisibility, mockWorkType } from "../../client-local";
+} from "@js/components/Work/work.gql.js";
+import { mockVisibility, mockWorkType } from "@js/client-local";
 
 export const mockWork = {
   id: "ABC123",
@@ -57,6 +57,7 @@ export const mockWork = {
         },
       },
     ],
+    culturalContext: ["Ima context"],
     dateCreated: [{ edtf: "2010" }, { edtf: "2020" }],
     description: ["Work description here"],
     folderName: [],

--- a/assets/js/services/metadata.js
+++ b/assets/js/services/metadata.js
@@ -40,6 +40,11 @@ export const METADATA_FIELDS = {
     scheme: "MARC_RELATOR",
   },
   CREATOR: { name: "creator", label: "Creator", metadataClass: "descriptive" },
+  CULTURAL_CONTEXT: {
+    name: "culturalContext",
+    label: "Cultural Context",
+    metadataClass: "descriptive",
+  },
   DATE_CREATED: {
     name: "dateCreated",
     label: "Date Created",
@@ -223,6 +228,7 @@ const {
   CATALOG_KEY,
   CONTRIBUTOR,
   CREATOR,
+  CULTURAL_CONTEXT,
   DATE_CREATED,
   DESCRIPTION,
   FOLDER_NAME,
@@ -282,6 +288,7 @@ export const UNCONTROLLED_MULTI_VALUE_METADATA = [
   BOX_NUMBER,
   CAPTION,
   CATALOG_KEY,
+  CULTURAL_CONTEXT,
   DATE_CREATED,
   DESCRIPTION,
   FOLDER_NAME,
@@ -332,6 +339,7 @@ export const OTHER_METADATA = [
 export const UNCONTROLLED_METADATA = [
   ABSTRACT,
   CAPTION,
+  CULTURAL_CONTEXT,
   KEYWORDS,
   NOTES,
   TABLE_OF_CONTENTS,


### PR DESCRIPTION
This is now added to Work screen and Batch Edit.  

Looks like everything works end to end for REPLACE and DELETE, however APPEND seems to error out.  See screen shot in the issue https://github.com/nulib/repodev_planning_and_docs/issues/1835

![image](https://user-images.githubusercontent.com/3020266/116115470-0a136500-a680-11eb-80db-55637a738b50.png)
