### PR TITLE
Move Elasticsearch.Document definitions to a separate directory

### DIFF
--- a/.circleci/scripts/update_ecs_service.sh
+++ b/.circleci/scripts/update_ecs_service.sh
@@ -1,7 +1,20 @@
 #!/bin/bash
 
+changed_files=$(git diff --name-only HEAD HEAD^)
+case $changed_files in
+  lib/meadow/indexing/*)
+    reindex=true
+    ;;
+  priv/elasticsearch/*)
+    reindex=true
+    ;;
+  *)
+    reindex=false
+    ;;
+esac
+
 networkconfig=$(aws ecs describe-services --cluster ${ECS_CLUSTER} --service ${ECS_SERVICE} | jq -cM '.services[0].networkConfiguration')
-overrides='{"containerOverrides":[{"name":"'${ECS_CONTAINER}'","environment": [{"name": "MEADOW_PROCESSES", "value": "none"}, {"name": "DB_POOL_SIZE", "value": "10"}],"command":["eval","Meadow.ReleaseTasks.migrate()"]}]}'
+overrides='{"containerOverrides":[{"name":"'${ECS_CONTAINER}'","environment": [{"name": "MEADOW_PROCESSES", "value": "none"}, {"name": "DB_POOL_SIZE", "value": "10"}],"command":["eval","Meadow.ReleaseTasks.migrate('${reindex}')"]}]}'
 aws ecs run-task --platform-version 1.4.0 --cluster ${ECS_CLUSTER} --task-definition ${ECS_TASK} --overrides "${overrides}" --launch-type FARGATE --network-configuration ${networkconfig}
 for service in $(aws ecs list-services --cluster meadow | jq -r '.serviceArns[] | split("/") | last'); do
   aws ecs update-service --cluster ${ECS_CLUSTER} --service ${service} --force-new-deployment

--- a/lib/meadow/data/indexer.ex
+++ b/lib/meadow/data/indexer.ex
@@ -69,66 +69,6 @@ defmodule Meadow.Data.Indexer do
     end
   end
 
-  def update_mapping? do
-    Meadow.Config.priv_path("elasticsearch/meadow.json")
-    |> update_mapping?()
-  end
-
-  def update_mapping?(path) do
-    file =
-      path
-      |> File.read!()
-      |> Jason.decode!()
-
-    stored =
-      with {:ok, %{body: body}} <-
-             Config.elasticsearch_url()
-             |> Elastix.Mapping.get(to_string(index()), "_doc") do
-        body |> Map.values() |> List.first()
-      end
-
-    mappings_unequal?(file, stored) or
-      properties_unequal?(file, stored) or
-      settings_unequal?(file)
-  end
-
-  defp all_from_a_in_b?(a, b, path) do
-    case {get_in(a, path), get_in(b, path)} do
-      {a_value, b_value} when is_map(a_value) ->
-        a_value == Map.take(b_value, Map.keys(a_value))
-
-      {a_value, b_value} ->
-        a_value == b_value
-    end
-  end
-
-  defp mappings_unequal?(file, stored) do
-    not all_from_a_in_b?(file, stored, ["mappings", "_doc", "dynamic_templates"])
-  end
-
-  defp properties_unequal?(file, stored) do
-    not all_from_a_in_b?(file, stored, ["mappings", "_doc", "properties"])
-  end
-
-  defp settings_unequal?(file) do
-    file_settings =
-      with analysis_settings <- file |> get_in(["settings", "analysis"]) do
-        file
-        |> get_in(["settings"])
-        |> Map.delete("analysis")
-        |> put_in(["index", "analysis"], analysis_settings)
-      end
-
-    stored_settings =
-      with {:ok, %{body: body}} <-
-             Config.elasticsearch_url()
-             |> Elastix.Index.get(to_string(index())) do
-        body |> Map.values() |> List.first() |> get_in(["settings"])
-      end
-
-    not all_from_a_in_b?(file_settings, stored_settings, ["index"])
-  end
-
   defp index, do: Config.elasticsearch_index()
 
   defp upload_batch(wait_interval) when is_integer(wait_interval), do: :timer.sleep(wait_interval)

--- a/lib/meadow/data/schemas/collection.ex
+++ b/lib/meadow/data/schemas/collection.ex
@@ -50,42 +50,4 @@ defmodule Meadow.Data.Schemas.Collection do
     |> validate_required([:title])
     |> unique_constraint(:title)
   end
-
-  defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Collection do
-    def id(collection), do: collection.id
-    def routing(_), do: false
-
-    def encode(collection) do
-      %{
-        adminEmail: collection.admin_email,
-        createDate: collection.inserted_at,
-        description: collection.description,
-        featured: collection.featured,
-        findingAidUrl: collection.finding_aid_url,
-        id: collection.id,
-        keywords: collection.keywords,
-        model: %{application: "Meadow", name: "Collection"},
-        modifiedDate: collection.updated_at,
-        published: collection.published,
-        representativeImage:
-          case collection.representative_work do
-            nil ->
-              %{}
-
-            work ->
-              %{
-                workId: work.id,
-                url: work.representative_image
-              }
-          end,
-        title: collection.title,
-        visibility: format(collection.visibility)
-      }
-    end
-
-    defp format(%{id: id, name: name}), do: %{id: id, name: name}
-    defp format(%{id: id, title: title}), do: %{id: id, title: title}
-    defp format(%{id: _id, label: _label, scheme: _scheme} = field), do: field
-    defp format(_), do: %{}
-  end
 end

--- a/lib/meadow/data/schemas/file_set.ex
+++ b/lib/meadow/data/schemas/file_set.ex
@@ -7,7 +7,6 @@ defmodule Meadow.Data.Schemas.FileSet do
   alias Meadow.Data.Schemas.FileSetMetadata
   alias Meadow.Data.Schemas.Work
   alias Meadow.Data.Types
-  alias Meadow.Utils.Exif, as: ExifUtil
 
   import Ecto.Changeset
   import EctoRanked
@@ -80,30 +79,5 @@ defmodule Meadow.Data.Schemas.FileSet do
     |> prepare_embed(:metadata)
     |> cast_embed(:metadata)
     |> set_rank(scope: [:work_id, :role])
-  end
-
-  defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.FileSet do
-    def id(file_set), do: file_set.id
-    def routing(_), do: false
-
-    def encode(file_set) do
-      %{
-        createDate: file_set.inserted_at,
-        description: file_set.metadata.description,
-        label: file_set.metadata.label,
-        mime_type: file_set.metadata.mime_type,
-        model: %{application: "Meadow", name: "FileSet"},
-        modifiedDate: file_set.updated_at,
-        role: format(file_set.role),
-        visibility: format(file_set.work.visibility),
-        workId: file_set.work.id,
-        exif: ExifUtil.index(file_set.metadata.exif)
-      }
-    end
-
-    defp format(%{id: id, name: name}), do: %{id: id, name: name}
-    defp format(%{id: id, title: title}), do: %{id: id, title: title}
-    defp format(%{id: _id, label: _label, scheme: _scheme} = field), do: field
-    defp format(_), do: %{}
   end
 end

--- a/lib/meadow/data/schemas/work.ex
+++ b/lib/meadow/data/schemas/work.ex
@@ -12,9 +12,7 @@ defmodule Meadow.Data.Schemas.Work do
   alias Meadow.Data.Schemas.WorkAdministrativeMetadata
   alias Meadow.Data.Schemas.WorkDescriptiveMetadata
   alias Meadow.Data.Types
-  alias Meadow.IIIF
   alias Meadow.Ingest.Schemas.Sheet
-  alias Meadow.Utils.Exif, as: ExifUtil
 
   import Ecto.Changeset
   import Ecto.Query, warn: false
@@ -134,62 +132,5 @@ defmodule Meadow.Data.Schemas.Work do
 
   def required_index_preloads do
     [:collection, :file_sets, :ingest_sheet, :project, :batches, :metadata_update_jobs]
-  end
-
-  defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Work do
-    alias Elasticsearch.Document.Meadow.Data.Schemas.WorkAdministrativeMetadata,
-      as: AdministrativeMetadataDocument
-
-    alias Elasticsearch.Document.Meadow.Data.Schemas.WorkDescriptiveMetadata,
-      as: DescriptiveMetadataDocument
-
-    def id(work), do: work.id
-    def routing(_), do: false
-
-    def encode(work) do
-      %{
-        accessionNumber: work.accession_number,
-        collection: format(work.collection),
-        createDate: work.inserted_at,
-        batches: work.batches |> Enum.map(& &1.id),
-        metadataUpdateJobs: work.metadata_update_jobs |> Enum.map(& &1.id),
-        fileSets:
-          work.file_sets
-          |> Enum.map(fn file_set ->
-            %{
-              id: file_set.id,
-              accessionNumber: file_set.accession_number,
-              label: file_set.metadata.label,
-              exif: ExifUtil.index(file_set.metadata.exif)
-            }
-          end),
-        id: work.id,
-        iiifManifest: IIIF.manifest_id(work.id),
-        model: %{application: "Meadow", name: "Image"},
-        modifiedDate: work.updated_at,
-        project: format(work.project),
-        published: work.published,
-        representativeFileSet:
-          case work.representative_file_set_id do
-            nil ->
-              %{}
-
-            representative_file_set_id ->
-              %{
-                fileSetId: representative_file_set_id,
-                url: work.representative_image
-              }
-          end,
-        sheet: format(work.ingest_sheet),
-        visibility: format(work.visibility),
-        workType: format(work.work_type)
-      }
-      |> Map.merge(AdministrativeMetadataDocument.encode(work.administrative_metadata))
-      |> Map.merge(DescriptiveMetadataDocument.encode(work.descriptive_metadata))
-    end
-
-    defp format(%{id: id, title: title}), do: %{id: id, title: title}
-    defp format(%{id: _id, label: _label, scheme: _scheme} = field), do: field
-    defp format(_), do: %{}
   end
 end

--- a/lib/meadow/data/schemas/work_administrative_metadata.ex
+++ b/lib/meadow/data/schemas/work_administrative_metadata.ex
@@ -38,22 +38,4 @@ defmodule Meadow.Data.Schemas.WorkAdministrativeMetadata do
   end
 
   def field_names, do: __schema__(:fields) -- [:id, :inserted_at, :updated_at]
-
-  defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.WorkAdministrativeMetadata do
-    alias Meadow.Data.Schemas.WorkAdministrativeMetadata, as: Source
-
-    def id(md), do: md.id
-    def routing(_), do: false
-
-    def encode(md) do
-      %{
-        administrativeMetadata:
-          Source.field_names()
-          |> Enum.map(fn field_name ->
-            {Inflex.camelize(field_name, :lower), md |> Map.get(field_name)}
-          end)
-          |> Enum.into(%{})
-      }
-    end
-  end
 end

--- a/lib/meadow/data/schemas/work_descriptive_metadata.ex
+++ b/lib/meadow/data/schemas/work_descriptive_metadata.ex
@@ -111,45 +111,4 @@ defmodule Meadow.Data.Schemas.WorkDescriptiveMetadata do
 
   defp scalar_fields, do: @fields |> Enum.map(fn {name, _} -> name end)
   def field_names, do: __schema__(:fields) -- [:id, :inserted_at, :updated_at]
-
-  defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.WorkDescriptiveMetadata do
-    alias Meadow.Data.Schemas.ControlledMetadataEntry
-    alias Meadow.Data.Schemas.WorkDescriptiveMetadata, as: Source
-
-    def id(md), do: md.id
-    def routing(_), do: false
-
-    def encode(md) do
-      %{
-        descriptiveMetadata:
-          Source.field_names()
-          |> Enum.map(fn field_name ->
-            {Inflex.camelize(field_name, :lower), encode_field(Map.get(md, field_name))}
-          end)
-          |> Enum.into(%{})
-      }
-    end
-
-    def encode_field([field | []]), do: [encode_field(field)]
-    def encode_field([field | fields]), do: [encode_field(field) | encode_field(fields)]
-
-    def encode_field(%ControlledMetadataEntry{role: nil} = field) do
-      Map.from_struct(field)
-      |> Map.put(:displayFacet, field.term.label)
-      |> Map.put(:facet, "#{field.term.id}||#{field.term.label}|")
-    end
-
-    def encode_field(%ControlledMetadataEntry{} = field) do
-      Map.from_struct(field)
-      |> Map.put(:displayFacet, "#{field.term.label} (#{field.role.label})")
-      |> Map.put(
-        :facet,
-        "#{field.term.id}|#{field.role.id}|#{field.term.label} (#{field.role.label})"
-      )
-    end
-
-    def encode_field(%RelatedURLEntry{} = field), do: Map.from_struct(field)
-
-    def encode_field(field), do: field
-  end
 end

--- a/lib/meadow/indexing/collection.ex
+++ b/lib/meadow/indexing/collection.ex
@@ -1,0 +1,37 @@
+defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Collection do
+  def id(collection), do: collection.id
+  def routing(_), do: false
+
+  def encode(collection) do
+    %{
+      adminEmail: collection.admin_email,
+      createDate: collection.inserted_at,
+      description: collection.description,
+      featured: collection.featured,
+      findingAidUrl: collection.finding_aid_url,
+      id: collection.id,
+      keywords: collection.keywords,
+      model: %{application: "Meadow", name: "Collection"},
+      modifiedDate: collection.updated_at,
+      published: collection.published,
+      representativeImage:
+        case collection.representative_work do
+          nil ->
+            %{}
+
+          work ->
+            %{
+              workId: work.id,
+              url: work.representative_image
+            }
+        end,
+      title: collection.title,
+      visibility: format(collection.visibility)
+    }
+  end
+
+  defp format(%{id: id, name: name}), do: %{id: id, name: name}
+  defp format(%{id: id, title: title}), do: %{id: id, title: title}
+  defp format(%{id: _id, label: _label, scheme: _scheme} = field), do: field
+  defp format(_), do: %{}
+end

--- a/lib/meadow/indexing/file_set.ex
+++ b/lib/meadow/indexing/file_set.ex
@@ -1,0 +1,26 @@
+defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.FileSet do
+  alias Meadow.Utils.Exif, as: ExifUtil
+
+  def id(file_set), do: file_set.id
+  def routing(_), do: false
+
+  def encode(file_set) do
+    %{
+      createDate: file_set.inserted_at,
+      description: file_set.metadata.description,
+      label: file_set.metadata.label,
+      mime_type: file_set.metadata.mime_type,
+      model: %{application: "Meadow", name: "FileSet"},
+      modifiedDate: file_set.updated_at,
+      role: format(file_set.role),
+      visibility: format(file_set.work.visibility),
+      workId: file_set.work.id,
+      exif: ExifUtil.index(file_set.metadata.exif)
+    }
+  end
+
+  defp format(%{id: id, name: name}), do: %{id: id, name: name}
+  defp format(%{id: id, title: title}), do: %{id: id, title: title}
+  defp format(%{id: _id, label: _label, scheme: _scheme} = field), do: field
+  defp format(_), do: %{}
+end

--- a/lib/meadow/indexing/work.ex
+++ b/lib/meadow/indexing/work.ex
@@ -1,0 +1,59 @@
+defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Work do
+  alias Elasticsearch.Document.Meadow.Data.Schemas.WorkAdministrativeMetadata,
+    as: AdministrativeMetadataDocument
+
+  alias Elasticsearch.Document.Meadow.Data.Schemas.WorkDescriptiveMetadata,
+    as: DescriptiveMetadataDocument
+
+  alias Meadow.IIIF
+  alias Meadow.Utils.Exif, as: ExifUtil
+
+  def id(work), do: work.id
+  def routing(_), do: false
+
+  def encode(work) do
+    %{
+      accessionNumber: work.accession_number,
+      collection: format(work.collection),
+      createDate: work.inserted_at,
+      batches: work.batches |> Enum.map(& &1.id),
+      metadataUpdateJobs: work.metadata_update_jobs |> Enum.map(& &1.id),
+      fileSets:
+        work.file_sets
+        |> Enum.map(fn file_set ->
+          %{
+            id: file_set.id,
+            accessionNumber: file_set.accession_number,
+            label: file_set.metadata.label,
+            exif: ExifUtil.index(file_set.metadata.exif)
+          }
+        end),
+      id: work.id,
+      iiifManifest: IIIF.manifest_id(work.id),
+      model: %{application: "Meadow", name: "Image"},
+      modifiedDate: work.updated_at,
+      project: format(work.project),
+      published: work.published,
+      representativeFileSet:
+        case work.representative_file_set_id do
+          nil ->
+            %{}
+
+          representative_file_set_id ->
+            %{
+              fileSetId: representative_file_set_id,
+              url: work.representative_image
+            }
+        end,
+      sheet: format(work.ingest_sheet),
+      visibility: format(work.visibility),
+      workType: format(work.work_type)
+    }
+    |> Map.merge(AdministrativeMetadataDocument.encode(work.administrative_metadata))
+    |> Map.merge(DescriptiveMetadataDocument.encode(work.descriptive_metadata))
+  end
+
+  defp format(%{id: id, title: title}), do: %{id: id, title: title}
+  defp format(%{id: _id, label: _label, scheme: _scheme} = field), do: field
+  defp format(_), do: %{}
+end

--- a/lib/meadow/indexing/work_administrative_metadata.ex
+++ b/lib/meadow/indexing/work_administrative_metadata.ex
@@ -1,0 +1,17 @@
+defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.WorkAdministrativeMetadata do
+  alias Meadow.Data.Schemas.WorkAdministrativeMetadata, as: Source
+
+  def id(md), do: md.id
+  def routing(_), do: false
+
+  def encode(md) do
+    %{
+      administrativeMetadata:
+        Source.field_names()
+        |> Enum.map(fn field_name ->
+          {Inflex.camelize(field_name, :lower), md |> Map.get(field_name)}
+        end)
+        |> Enum.into(%{})
+    }
+  end
+end

--- a/lib/meadow/indexing/work_descriptive_metadata.ex
+++ b/lib/meadow/indexing/work_descriptive_metadata.ex
@@ -1,0 +1,41 @@
+defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.WorkDescriptiveMetadata do
+  alias Meadow.Data.Schemas.ControlledMetadataEntry
+  alias Meadow.Data.Schemas.RelatedURLEntry
+  alias Meadow.Data.Schemas.WorkDescriptiveMetadata, as: Source
+
+  def id(md), do: md.id
+  def routing(_), do: false
+
+  def encode(md) do
+    %{
+      descriptiveMetadata:
+        Source.field_names()
+        |> Enum.map(fn field_name ->
+          {Inflex.camelize(field_name, :lower), encode_field(Map.get(md, field_name))}
+        end)
+        |> Enum.into(%{})
+    }
+  end
+
+  def encode_field([field | []]), do: [encode_field(field)]
+  def encode_field([field | fields]), do: [encode_field(field) | encode_field(fields)]
+
+  def encode_field(%ControlledMetadataEntry{role: nil} = field) do
+    Map.from_struct(field)
+    |> Map.put(:displayFacet, field.term.label)
+    |> Map.put(:facet, "#{field.term.id}||#{field.term.label}|")
+  end
+
+  def encode_field(%ControlledMetadataEntry{} = field) do
+    Map.from_struct(field)
+    |> Map.put(:displayFacet, "#{field.term.label} (#{field.role.label})")
+    |> Map.put(
+      :facet,
+      "#{field.term.id}|#{field.role.id}|#{field.term.label} (#{field.role.label})"
+    )
+  end
+
+  def encode_field(%RelatedURLEntry{} = field), do: Map.from_struct(field)
+
+  def encode_field(field), do: field
+end

--- a/lib/meadow/release_tasks.ex
+++ b/lib/meadow/release_tasks.ex
@@ -4,7 +4,6 @@ defmodule Meadow.ReleaseTasks do
   """
 
   alias Meadow.Config
-  alias Meadow.Data.Indexer
 
   @app :meadow
   @modules [
@@ -17,7 +16,7 @@ defmodule Meadow.ReleaseTasks do
 
   require Logger
 
-  def migrate do
+  def migrate(reindex? \\ false) do
     Logger.info("Starting Meadow")
     System.put_env("MEADOW_PROCESSES", "none")
     Application.ensure_all_started(@app)
@@ -29,7 +28,7 @@ defmodule Meadow.ReleaseTasks do
       {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
     end
 
-    if Indexer.update_mapping?() do
+    if reindex? do
       Logger.info("Hot swapping Elasticsearch index #{Config.elasticsearch_index()}")
       Elasticsearch.Index.hot_swap(Meadow.ElasticsearchCluster, Config.elasticsearch_index())
     end

--- a/test/meadow/data/indexer_test.exs
+++ b/test/meadow/data/indexer_test.exs
@@ -258,21 +258,6 @@ defmodule Meadow.Data.IndexerTest do
     end
   end
 
-  describe "update_mappings?/0" do
-    test "returns false if mapping file on disk is equiavalent to stored mapping" do
-      refute Indexer.update_mapping?()
-    end
-
-    test "returns true if mapping file on disk is different from stored mapping" do
-      ~w(templates properties settings)
-      |> Enum.each(fn type_of_change ->
-        assert Indexer.update_mapping?(
-                 "test/fixtures/elasticsearch/different_#{type_of_change}.json"
-               )
-      end)
-    end
-  end
-
   describe "mix task" do
     setup do
       {:ok, indexable_data()}


### PR DESCRIPTION
This PR gets rid of the confusing and over-engineered `Indexer.update_mappings?/0` logic in favor of just having the deploy script detect changes to files that affect indexing via `git diff`.