### PR TITLE
Download filesets on Work Preservation tab

### DIFF
--- a/assets/js/components/UI/Dropdown.jsx
+++ b/assets/js/components/UI/Dropdown.jsx
@@ -1,0 +1,58 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { IconArrowDown } from "@js/components/Icon";
+import classNames from "classnames";
+
+function UIDropdown({
+  id = "ui-dropdown",
+  isRight,
+  label = "Actions",
+  children,
+  ...restProps
+}) {
+  const [isActive, setIsActive] = React.useState();
+
+  return (
+    <div
+      className={classNames(["dropdown"], {
+        "is-active": isActive,
+        "is-right": isRight,
+      })}
+      {...restProps}
+    >
+      <div className="dropdown-trigger" data-testid="dropdown-trigger">
+        <button
+          onClick={() => setIsActive(!isActive)}
+          className="button"
+          aria-haspopup="true"
+          aria-controls={id}
+          data-testid="dropdown-trigger-button"
+        >
+          <span>{label}</span>
+          <span className="icon is-small">
+            <IconArrowDown aria-hidden="true" />
+          </span>
+        </button>
+      </div>
+      <div
+        className="dropdown-menu"
+        id={id}
+        data-testid="dropdown-menu"
+        role="menu"
+      >
+        <div className="dropdown-content" data-testid="dropdown-content">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+UIDropdown.propTypes = {
+  id: PropTypes.string,
+  isRight: PropTypes.bool,
+  label: PropTypes.string,
+  children: PropTypes.node,
+};
+
+export default UIDropdown;

--- a/assets/js/components/UI/Dropdown.test.js
+++ b/assets/js/components/UI/Dropdown.test.js
@@ -1,0 +1,36 @@
+import { screen, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import UIDropdown from "./Dropdown";
+
+describe("UIDropdown component", () => {
+  beforeEach(() => {
+    render(
+      <UIDropdown data-testid="test-dropdown" id="dropdown1">
+        <a href="#">Option 1</a>
+        <a href="#">Option 2</a>
+      </UIDropdown>
+    );
+  });
+
+  it("renders the component ", async () => {
+    expect(screen.getByTestId("test-dropdown"));
+    expect(screen.getByTestId("dropdown-trigger"));
+  });
+
+  it("renders the id attribute for accessibility", () => {
+    const el = screen.getByTestId("dropdown-menu");
+    expect(el.id).toEqual("dropdown1");
+  });
+
+  it("renders dropdown content", () => {
+    const dropdownEl = screen.getByTestId("test-dropdown");
+    const el = screen.getByTestId("dropdown-content");
+
+    expect(el.childElementCount).toEqual(2);
+    expect(dropdownEl).not.toHaveClass("is-active");
+
+    userEvent.click(screen.getByTestId("dropdown-trigger-button"));
+    expect(dropdownEl).toHaveClass("is-active");
+  });
+});

--- a/assets/js/components/UI/DropdownItem.jsx
+++ b/assets/js/components/UI/DropdownItem.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import PropTypes from "prop-types";
+import classNames from "classnames";
+
+function UIDropdownItem({ as = "a", isActive, children, ...restProps }) {
+  const Tag = as;
+  const aProps = {
+    href: "#",
+  };
+  return (
+    <Tag
+      {...(as === "a" && { ...aProps })}
+      className={classNames(["dropdown-item"], {
+        "is-active": isActive,
+      })}
+      {...restProps}
+    >
+      {children}
+    </Tag>
+  );
+}
+
+UIDropdownItem.propTypes = {
+  isActive: PropTypes.bool,
+  children: PropTypes.node,
+};
+
+export default UIDropdownItem;

--- a/assets/js/components/UI/DropdownItem.test.js
+++ b/assets/js/components/UI/DropdownItem.test.js
@@ -1,0 +1,47 @@
+import { screen, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import UIDropdownItem from "./DropdownItem";
+
+const mockHandleClick = jest.fn();
+
+describe("UIDropdownItem component", () => {
+  describe("default implementation", () => {
+    beforeEach(() => {
+      render(
+        <UIDropdownItem
+          data-testid="test-dropdown-item"
+          onClick={mockHandleClick}
+        >
+          Option 1
+        </UIDropdownItem>
+      );
+    });
+
+    it("renders the component", async () => {
+      expect(screen.getByTestId("test-dropdown-item"));
+      expect(screen.getByText("Option 1"));
+    });
+
+    it("handles click event", () => {
+      userEvent.click(screen.getByTestId("test-dropdown-item"));
+      expect(mockHandleClick).toHaveBeenCalled();
+    });
+  });
+
+  describe("custom implementation", () => {
+    it("renders as dynamic HTML element", async () => {
+      render(
+        <UIDropdownItem
+          as="div"
+          data-testid="test-dropdown-item"
+          onClick={mockHandleClick}
+        >
+          Option 1
+        </UIDropdownItem>
+      );
+      const el = screen.getByTestId("test-dropdown-item");
+      expect(el.tagName).toEqual("DIV");
+    });
+  });
+});

--- a/assets/js/components/Work/Tabs/DownloadLinks.jsx
+++ b/assets/js/components/Work/Tabs/DownloadLinks.jsx
@@ -3,15 +3,16 @@ import PropTypes from "prop-types";
 import { IIIFContext } from "../../IIIF/IIIFProvider";
 import { IIIF_SIZES } from "@js/services/global-vars";
 import { IconDownload } from "@js/components/Icon";
+import { ImageDownloader } from "@samvera/image-downloader";
 
-const WorkTabsDownloadLinks = ({ handleDownloadClick, fileSetId }) => {
+const WorkTabsDownloadLinks = ({ handleDownloadClick, fileset }) => {
   const iiifServerUrl = useContext(IIIFContext);
 
   return (
     <div className="field has-addons is-pulled-right">
       <p className="control">
         <a
-          href={`${iiifServerUrl}${fileSetId}${IIIF_SIZES.IIIF_FULL_TIFF}`}
+          href={`${iiifServerUrl}${fileset.id}${IIIF_SIZES.IIIF_FULL_TIFF}`}
           target="_blank"
           className="button"
         >
@@ -22,7 +23,14 @@ const WorkTabsDownloadLinks = ({ handleDownloadClick, fileSetId }) => {
         </a>
       </p>
       <p className="control">
-        <a
+        <ImageDownloader
+          imageUrl={`${iiifServerUrl}${fileset.id}${IIIF_SIZES.IIIF_FULL}`}
+          imageTitle={fileset.accessionNumber}
+          className="button"
+        >
+          JPG
+        </ImageDownloader>
+        {/* <a
           href={`${iiifServerUrl}${fileSetId}${IIIF_SIZES.IIIF_FULL}`}
           target="_blank"
           className="button"
@@ -31,7 +39,7 @@ const WorkTabsDownloadLinks = ({ handleDownloadClick, fileSetId }) => {
             <IconDownload />
           </span>{" "}
           <span>JPG</span>
-        </a>
+        </a> */}
       </p>
     </div>
   );
@@ -39,7 +47,7 @@ const WorkTabsDownloadLinks = ({ handleDownloadClick, fileSetId }) => {
 
 WorkTabsDownloadLinks.propTypes = {
   handleDownloadClick: PropTypes.func,
-  fileSetId: PropTypes.string,
+  fileSet: PropTypes.object,
 };
 
 export default WorkTabsDownloadLinks;

--- a/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
@@ -6,7 +6,6 @@ import { useMutation, useQuery } from "@apollo/client";
 import {
   DELETE_FILESET,
   DELETE_WORK,
-  GET_WORK,
   VERIFY_FILE_SETS,
 } from "@js/components/Work/work.gql";
 import UIModalDelete from "@js/components/UI/Modal/Delete";
@@ -29,6 +28,9 @@ import {
   IconTrashCan,
   IconView,
 } from "@js/components/Icon";
+import UIDropdown from "@js/components/UI/Dropdown";
+import UIDropdownItem from "@js/components/UI/DropdownItem";
+import UIIconText from "@js/components/UI/IconText";
 
 const WorkTabsPreservation = ({ work }) => {
   if (!work) return null;
@@ -226,7 +228,7 @@ const WorkTabsPreservation = ({ work }) => {
       </UITabsStickyHeader>
       <div className="box mt-4">
         {/* TODO: Put a mobile block display here instead of table below */}
-        <div className="table-container">
+        <div className="">
           <table
             className="table is-fullwidth is-striped is-hoverable is-narrow"
             data-testid="preservation-table"
@@ -235,6 +237,7 @@ const WorkTabsPreservation = ({ work }) => {
               <tr>
                 <th className="is-hidden">ID</th>
                 <th>Role</th>
+                <th>Accession #</th>
                 <th className="is-flex">
                   {orderedFileSets.order === "asc" ? (
                     <IconArrowDown />
@@ -247,9 +250,7 @@ const WorkTabsPreservation = ({ work }) => {
                 </th>
                 <th>Created</th>
                 <th className="has-text-centered">Verified</th>
-                <AuthDisplayAuthorized action="delete">
-                  <th className="has-text-right">Actions</th>
-                </AuthDisplayAuthorized>
+                <th className="has-text-right"></th>
               </tr>
             </thead>
             <tbody>
@@ -259,52 +260,57 @@ const WorkTabsPreservation = ({ work }) => {
                   return (
                     <tr key={fileset.id} data-testid="preservation-row">
                       <td className="is-hidden">{fileset.id}</td>
-                      <td>{fileset.role && fileset.role.label}</td>
+                      <td>{fileset.role?.label.slice(0, 1)}</td>
+                      <td>{fileset.accessionNumber}</td>
                       <td>{metadata ? metadata.originalFilename : " "}</td>
                       <td>{formatDate(fileset.insertedAt)}</td>
                       <td className="has-text-centered">
                         <Verified id={fileset.id} />
                       </td>
                       <td>
-                        <div className="buttons buttons-end">
-                          <Button
-                            isLight
-                            data-testid="button-copy-checksum"
-                            onClick={() =>
-                              clipboard.copy(fileset.metadata.sha256)
-                            }
-                            title="Copy checksum (sha256) to clipboard"
-                          >
-                            <IconBinaryFile />
-                          </Button>
-                          <Button
-                            isLight
-                            data-testid="button-copy-preservation-location"
-                            onClick={() =>
-                              clipboard.copy(fileset.metadata.location)
-                            }
-                            title="Copy preservation location to clipboard"
-                          >
-                            <IconBucket />
-                          </Button>
-                          <Button
-                            isLight
-                            data-testid="button-show-technical-metadata"
-                            onClick={() => handleTechnicalMetaClick(fileset)}
-                            title="View technical metadata"
-                          >
-                            <IconView />
-                          </Button>
-                          <AuthDisplayAuthorized action="delete">
-                            <Button
-                              isLight
-                              data-testid="button-fileset-delete"
-                              onClick={() => handleDeleteFilesetClick(fileset)}
-                              title="Delete file set"
+                        <div>
+                          <UIDropdown isRight>
+                            <UIDropdownItem
+                              data-testid="button-copy-checksum"
+                              onClick={() =>
+                                clipboard.copy(fileset.metadata.sha256)
+                              }
                             >
-                              <IconTrashCan />
-                            </Button>
-                          </AuthDisplayAuthorized>
+                              <UIIconText icon={<IconBinaryFile />}>
+                                Copy checksum (sha256) to clipboard
+                              </UIIconText>
+                            </UIDropdownItem>
+                            <UIDropdownItem
+                              data-testid="button-copy-preservation-location"
+                              onClick={() =>
+                                clipboard.copy(fileset.metadata.location)
+                              }
+                            >
+                              <UIIconText icon={<IconBucket />}>
+                                Copy preservation location to clipboard
+                              </UIIconText>
+                            </UIDropdownItem>
+                            <UIDropdownItem
+                              data-testid="button-show-technical-metadata"
+                              onClick={() => handleTechnicalMetaClick(fileset)}
+                            >
+                              <UIIconText icon={<IconView />}>
+                                View technical metadata
+                              </UIIconText>
+                            </UIDropdownItem>
+                            <AuthDisplayAuthorized>
+                              <UIDropdownItem
+                                data-testid="button-fileset-delete"
+                                onClick={() =>
+                                  handleDeleteFilesetClick(fileset)
+                                }
+                              >
+                                <UIIconText icon={<IconTrashCan />}>
+                                  Delete fileset
+                                </UIIconText>
+                              </UIDropdownItem>
+                            </AuthDisplayAuthorized>
+                          </UIDropdown>
                         </div>
                       </td>
                     </tr>

--- a/assets/js/components/Work/Tabs/Preservation/Preservation.test.js
+++ b/assets/js/components/Work/Tabs/Preservation/Preservation.test.js
@@ -28,7 +28,7 @@ describe("WorkTabsPreservation component", () => {
   });
 
   it("renders preservation column headers", async () => {
-    const cols = ["Role", "Filename", "Created", "Verified", "Actions"];
+    const cols = ["Role", "Filename", "Created", "Verified"];
     const th = await screen.findByText("Filename");
     const row = th.closest("tr");
     const utils = within(row);
@@ -46,7 +46,7 @@ describe("WorkTabsPreservation component", () => {
     const td = await screen.findByText(mockWork.fileSets[0].id);
     const row = td.closest("tr");
     const utils = within(row);
-    expect(utils.getByText("Access"));
+    expect(utils.getByText("A"));
     expect(utils.getByText(/coffee.jpg/i));
     expect(utils.getByText("Sep 12, 2020 10:01 AM"));
   });

--- a/assets/js/components/Work/Tabs/Structure/Fileset.jsx
+++ b/assets/js/components/Work/Tabs/Structure/Fileset.jsx
@@ -81,7 +81,7 @@ function WorkTabsStructureFileset({
               </AuthDisplayAuthorized>
               <WorkTabsDownloadLinks
                 handleDownloadClick={handleDownloadClick}
-                fileSetId={fileSet.id}
+                fileset={fileSet}
               />
             </>
           )}

--- a/assets/js/components/Work/Tabs/Tabs.jsx
+++ b/assets/js/components/Work/Tabs/Tabs.jsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect } from "react";
-import WorkTabAbout from "./About";
-import WorkTabStructure from "./Structure/Structure";
-import WorkTabsAdministrative from "./Administrative/Administrative";
-import WorkTabsPreservation from "./Preservation";
-import { IIIFProvider } from "../../IIIF/IIIFProvider";
+import React, { useState } from "react";
+import WorkTabAbout from "@js/components/Work/Tabs/About";
+import WorkTabStructure from "@js/components/Work/Tabs/Structure/Structure";
+import WorkTabsAdministrative from "@js/components/Work/Tabs/Administrative/Administrative";
+import WorkTabsPreservation from "@js/components/Work/Tabs/Preservation/Preservation";
+import { IIIFProvider } from "@js/components/IIIF/IIIFProvider";
 import { CodeListProvider } from "@js/context/code-list-context";
 import AuthDisplayAuthorized from "@js/components/Auth/DisplayAuthorized";
 

--- a/assets/package.json
+++ b/assets/package.json
@@ -20,6 +20,7 @@
     "@honeybadger-io/js": "^3.2.0",
     "@honeybadger-io/react": "^1.0.1",
     "@nulib/admin-react-components": "^1.8.1",
+    "@samvera/image-downloader": "^1.1.0",
     "bulma": "^0.9.2",
     "bulma-checkradio": "^1.1.1",
     "bulma-pageloader": "^0.3.0",

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -1524,6 +1524,13 @@
   resolved "https://registry.yarnpkg.com/@reglendo/canvas2image/-/canvas2image-1.0.5-2.tgz#57b50017d1a4914ff687fb65eb7aef341762d20d"
   integrity sha512-nt9QaZPwJxZdPZall2GuxpTLyZwSXwHlL35K8uJjpl29uCYVlWJAMa8JZ8vAXIhHSJ8e5a1tbiOqDBWX5JxVvA==
 
+"@samvera/image-downloader@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@samvera/image-downloader/-/image-downloader-1.1.0.tgz#2313e05e741d7c8e4ebde615faf48ff8ad7d1840"
+  integrity sha512-WWLrrwTw7Rv3oIrKrSOX4HetipXyv2ejPl0zda1Vjr+dUFQssj51kvqa2CG9mE2Scv4m6fjPcd6neklTpAhPFw==
+  dependencies:
+    svg-loaders-react "^2.2.1"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.2.tgz#858f5c4b48d80778fde4b9d541f27edc0d56488b"
@@ -8988,6 +8995,11 @@ supports-hyperlinks@^2.0.0:
   dependencies:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
+
+svg-loaders-react@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/svg-loaders-react/-/svg-loaders-react-2.2.1.tgz#d546cea2a895144cfd652e1bd846166d8a07d2ed"
+  integrity sha512-ATfg5pAMOla2GqPcwGRDrNTLlTQzl2fMvfW290j20qH7qpB61C3SQAnu+T9t8Z+V4IKKN2Bm1d/SaCv5IR1DDA==
 
 svg-parser@^2.0.2:
   version "2.0.4"


### PR DESCRIPTION
Cleaned up the Preservation tab table row, including a Bulma `dropdown` component which is now converted to a React `UIDropdown` and `UIDropdownItem` component for our app.

Pulled in `@samvera/image-downloader` package, and added this to the Structure tab, replacing previous "JPG" download button.

Note downloading a TIF is not implemented here, and we should create a separate issue for how to handle that as it'll be a little more involved between packages.

![image](https://user-images.githubusercontent.com/3020266/117674752-912d0680-b171-11eb-9a9f-bc8f56587d5a.png)

![image](https://user-images.githubusercontent.com/3020266/117674808-9db15f00-b171-11eb-857f-3a255a77f508.png)
