### PR TITLE
Create top level fields in indexed work doc for commonly accessed metadata

### DIFF
--- a/lib/meadow/indexing/work.ex
+++ b/lib/meadow/indexing/work.ex
@@ -51,9 +51,30 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Work do
     }
     |> Map.merge(AdministrativeMetadataDocument.encode(work.administrative_metadata))
     |> Map.merge(DescriptiveMetadataDocument.encode(work.descriptive_metadata))
+    |> copy_field([:descriptiveMetadata, "title"], :title)
+    |> copy_field([:descriptiveMetadata, "alternateTitle"], :alternateTitle)
+    |> copy_field([:descriptiveMetadata, "description"], :description)
+    |> copy_field([:descriptiveMetadata, "creator"], :creator)
+    |> copy_field([:descriptiveMetadata, "contributor"], :contributor)
+    |> copy_field([:descriptiveMetadata, "dateCreated"], :dateCreated)
+    |> copy_field([:descriptiveMetadata, "subject"], :subject)
+    |> copy_field([:collection, :title], :collectionTitle)
   end
 
   defp format(%{id: id, title: title}), do: %{id: id, title: title}
   defp format(%{id: _id, label: _label, scheme: _scheme} = field), do: field
   defp format(_), do: %{}
+
+  defp copy_field(doc, source, dest) do
+    Map.put(doc, dest, copy_field(get_in(doc, source)))
+  end
+
+  defp copy_field(list) when is_list(list) do
+    Enum.map(list, fn entry -> copy_field(entry) end)
+  end
+
+  defp copy_field(%{role: %{scheme: "subject_role"}, term: %{label: label}}), do: label
+  defp copy_field(%{displayFacet: display_facet}), do: display_facet
+  defp copy_field(%{humanized: humanized}), do: humanized
+  defp copy_field(value), do: value
 end


### PR DESCRIPTION
- all_titles (exists)
- all_controlled_terms (exists)
- all_controlled_labels (exists)
- title -- descriptiveMetadata.title
- alternateTitle -- descriptiveMetadata.alternateTitle
- creator -- descriptiveMetadata.creator.term.label
- collectionTitle --collection.title
- contributor -- descriptiveMetadata.creator.term.label (can't remember the field with the role, but I think it's label)
- description -- descriptiveMetadata.description
- dateCreated -- descriptiveMetadata.dateCreated.humanized 
- subject -- descriptiveMetadata.subject.term.label
<img width="799" alt="Screen Shot 2021-05-17 at 3 23 23 PM" src="https://user-images.githubusercontent.com/6372022/118559526-4721c300-b725-11eb-84ba-08d820ecda90.png">
