### PR TITLE
Include EXIF/IPTC metadata in pyramid tiffs

### DIFF
--- a/priv/nodejs/pyramid-tiff/pyramid.js
+++ b/priv/nodejs/pyramid-tiff/pyramid.js
@@ -29,6 +29,7 @@ const createPyramidTiff = (source, dest) => {
           tileWidth: 256,
           pyramid: true
         })
+        .withMetadata()
         .on("info", (info) => metadata = info);
 
       const uploadStream = concat((data) => {


### PR DESCRIPTION
To test:

1. Run a file with both EXIF and IPTC metadata through the ingest pipeline
2. Download the resulting pyramid TIFF from minio
3. Load it in Preview (or run exiftool on it) and verify it has the same metadata as the original
