### PR TITLE
Reshape FileSet metadata

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -35,7 +35,7 @@ alias Meadow.Data.Schemas.{
   ControlledTermCache,
   Field,
   FileSet,
-  FileSetMetadata,
+  FileSetCoreMetadata,
   IndexTime,
   Value,
   Work,

--- a/assets/js/client.js
+++ b/assets/js/client.js
@@ -46,7 +46,7 @@ const client = new ApolloClient({
       },
       FileSet: {
         fields: {
-          metadata: { merge: false },
+          coreMetadata: { merge: false },
         },
       },
     },

--- a/assets/js/components/IngestSheet/ingestSheet.gql.js
+++ b/assets/js/components/IngestSheet/ingestSheet.gql.js
@@ -190,7 +190,7 @@ export const INGEST_SHEET_WORKS = gql`
           label
         }
         accessionNumber
-        metadata {
+        coreMetadata {
           description
           originalFilename
           label

--- a/assets/js/components/Work/ListItemDeleteMe.jsx
+++ b/assets/js/components/Work/ListItemDeleteMe.jsx
@@ -35,9 +35,9 @@ const WorkListItem = ({ work }) => {
             i < fileSetsToDisplay - 1 ? (
               <span key={fileSet.id} className="list-item">
                 {fileSet.accessionNumber} -{" "}
-                {fileSet.metadata &&
-                  fileSet.metadata.description &&
-                  fileSet.metadata.description}
+                {fileSet.coreMetadata &&
+                  fileSet.coreMetadata.description &&
+                  fileSet.coreMetadata.description}
               </span>
             ) : null
           )}

--- a/assets/js/components/Work/Row.jsx
+++ b/assets/js/components/Work/Row.jsx
@@ -38,9 +38,9 @@ const WorkRow = ({ work }) => {
                     i < fileSetsToDisplay - 1 ? (
                       <li key={fileSet.id}>
                         {fileSet.accessionNumber} -{" "}
-                        {fileSet.metadata &&
-                          fileSet.metadata.description &&
-                          fileSet.metadata.description}
+                        {fileSet.coreMetadata &&
+                          fileSet.coreMetadata.description &&
+                          fileSet.coreMetadata.description}
                       </li>
                     ) : null
                   )}

--- a/assets/js/components/Work/Row.test.js
+++ b/assets/js/components/Work/Row.test.js
@@ -8,7 +8,7 @@ const work = {
     {
       accessionNumber: "Example-34-3",
       id: "01DV4BAEAGKNT5P3GH10X263K1",
-      metadata: {
+      coreMetadata: {
         description: "Lorem Ipsum",
       },
       work: {
@@ -18,7 +18,7 @@ const work = {
     {
       accessionNumber: "Example-34-4",
       id: "01DV4BAEANHGYQKQ2EPBWJVJSR",
-      metadata: {
+      coreMetadata: {
         description: "Lorem Ipsum",
       },
       work: {
@@ -28,7 +28,7 @@ const work = {
   ],
   id: "01DV4BAE9NDQHSMRHKM8KC4FNC",
   insertedAt: "2019-12-02T22:22:30",
-  metadata: {
+  coreMetadata: {
     title: null,
   },
   updatedAt: "2019-12-02T22:22:30",

--- a/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
@@ -49,7 +49,7 @@ function WorkTabsPreservationFileSetModal({ closeModal, isVisible, workId }) {
       onCompleted({ ingestFileSet }) {
         toastWrapper(
           "is-success",
-          `FileSet record id: ${ingestFileSet.id} created successfully and ${ingestFileSet.metadata.original_filename} was submitted to the ingest pipeline.`
+          `FileSet record id: ${ingestFileSet.id} created successfully and ${ingestFileSet.coreMetadata.original_filename} was submitted to the ingest pipeline.`
         );
         resetForm();
         closeModal();
@@ -74,7 +74,7 @@ function WorkTabsPreservationFileSetModal({ closeModal, isVisible, workId }) {
         accession_number: data.accessionNumber,
         workId,
         role: { id: data.role, scheme: "FILE_SET_ROLE" },
-        metadata: {
+        coreMetadata: {
           description: data.description,
           label: data.label,
           original_filename: currentFile.name,

--- a/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
@@ -256,7 +256,7 @@ const WorkTabsPreservation = ({ work }) => {
             <tbody>
               {orderedFileSets.fileSets.length > 0 &&
                 orderedFileSets.fileSets.map((fileset) => {
-                  const metadata = fileset.metadata;
+                  const metadata = fileset.coreMetadata;
                   return (
                     <tr key={fileset.id} data-testid="preservation-row">
                       <td className="is-hidden">{fileset.id}</td>
@@ -273,7 +273,7 @@ const WorkTabsPreservation = ({ work }) => {
                             <UIDropdownItem
                               data-testid="button-copy-checksum"
                               onClick={() =>
-                                clipboard.copy(fileset.metadata.sha256)
+                                clipboard.copy(fileset.coreMetadata.sha256)
                               }
                             >
                               <UIIconText icon={<IconBinaryFile />}>
@@ -283,7 +283,7 @@ const WorkTabsPreservation = ({ work }) => {
                             <UIDropdownItem
                               data-testid="button-copy-preservation-location"
                               onClick={() =>
-                                clipboard.copy(fileset.metadata.location)
+                                clipboard.copy(fileset.coreMetadata.location)
                               }
                             >
                               <UIIconText icon={<IconBucket />}>
@@ -357,8 +357,8 @@ const WorkTabsPreservation = ({ work }) => {
             }
             handleConfirm={handleConfirmDeleteFileset}
             thingToDeleteLabel={`Fileset: ${
-              deleteFilesetModal.fileset.metadata
-                ? deleteFilesetModal.fileset.metadata.label
+              deleteFilesetModal.fileset.coreMetadata
+                ? deleteFilesetModal.fileset.coreMetadata.label
                 : ""
             }`}
           />

--- a/assets/js/components/Work/Tabs/Preservation/Technical.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/Technical.jsx
@@ -28,9 +28,8 @@ function WorkTabsPreservationTechnical({
   handleClose,
   isVisible,
 }) {
-  const { metadata } = fileSet;
-  const extracted = metadata?.extractedMetadata ? JSON.parse(metadata.extractedMetadata) : null;
-  const exifData = extracted?.exif?.value;
+  const extractedMetadata = fileSet.extractedMetadata ? JSON.parse(fileSet.extractedMetadata) : null;
+  const exifData = extractedMetadata?.exif?.value;
 
   return (
     <div

--- a/assets/js/components/Work/Tabs/Structure/Fileset.jsx
+++ b/assets/js/components/Work/Tabs/Structure/Fileset.jsx
@@ -38,10 +38,10 @@ function WorkTabsStructureFileset({
                 name={`${fileSet.id}.label`}
                 data-testid="input-label"
                 placeholder="Label"
-                defaultValue={fileSet.metadata.label}
+                defaultValue={fileSet.coreMetadata.label}
               />
             ) : (
-              <p>{fileSet.metadata.label}</p>
+              <p>{fileSet.coreMetadata.label}</p>
             )}
           </UIFormField>
 
@@ -51,12 +51,12 @@ function WorkTabsStructureFileset({
                 isReactHookForm
                 name={`${fileSet.id}.description`}
                 data-testid="textarea-metadata-description"
-                defaultValue={fileSet.metadata.description}
+                defaultValue={fileSet.coreMetadata.description}
                 label="Description"
                 rows="2"
               />
             ) : (
-              <p>{fileSet.metadata.description}</p>
+              <p>{fileSet.coreMetadata.description}</p>
             )}
           </UIFormField>
         </div>

--- a/assets/js/components/Work/Tabs/Structure/Fileset.test.js
+++ b/assets/js/components/Work/Tabs/Structure/Fileset.test.js
@@ -30,8 +30,8 @@ describe("Fileset component", () => {
       await waitFor(() => {
         expect(screen.getByTestId("fileset-item"));
         expect(screen.getByTestId("fileset-image"));
-        expect(screen.getByText(mockFileSets[0].metadata.label));
-        expect(screen.getByText(mockFileSets[0].metadata.description));
+        expect(screen.getByText(mockFileSets[0].coreMetadata.label));
+        expect(screen.getByText(mockFileSets[0].coreMetadata.description));
       });
     });
 

--- a/assets/js/components/Work/Tabs/Structure/FilesetDraggable.jsx
+++ b/assets/js/components/Work/Tabs/Structure/FilesetDraggable.jsx
@@ -36,13 +36,13 @@ function WorkTabsStructureFilesetDraggable({ fileSet, index }) {
             </figure>
             <UIFormField label="Label">
               <p className="mr-6" data-testid="fileset-label">
-                {fileSet.metadata.label}
+                {fileSet.coreMetadata.label}
               </p>
             </UIFormField>
 
             <UIFormField label="Description">
               <p data-testid="fileset-description">
-                {fileSet.metadata.description}
+                {fileSet.coreMetadata.description}
               </p>
             </UIFormField>
           </div>

--- a/assets/js/components/Work/Tabs/Structure/FilesetDraggable.test.js
+++ b/assets/js/components/Work/Tabs/Structure/FilesetDraggable.test.js
@@ -21,10 +21,10 @@ describe("WorkTabsStructureFilesetDraggable components", () => {
   it("renders image, label and description", () => {
     expect(screen.getByTestId("fileset-image"));
     expect(screen.getByTestId("fileset-label")).toHaveTextContent(
-      mockFileSets[0].metadata.label
+      mockFileSets[0].coreMetadata.label
     );
     expect(screen.getByTestId("fileset-description")).toHaveTextContent(
-      mockFileSets[0].metadata.description
+      mockFileSets[0].coreMetadata.description
     );
   });
 });

--- a/assets/js/components/Work/Tabs/Structure/Structure.jsx
+++ b/assets/js/components/Work/Tabs/Structure/Structure.jsx
@@ -113,7 +113,7 @@ const WorkTabsStructure = ({ work }) => {
     for (let id of filteredIds) {
       formPostData.push({
         id,
-        metadata: {
+        coreMetadata: {
           label: data[id].label,
           description: data[id].description,
         },

--- a/assets/js/components/Work/work.gql.js
+++ b/assets/js/components/Work/work.gql.js
@@ -204,14 +204,14 @@ export const GET_WORK = gql`
           label
         }
         accessionNumber
-        metadata {
+        coreMetadata {
           description
-          extractedMetadata
           label
           location
           originalFilename
           sha256
         }
+        extractedMetadata
         insertedAt
         updatedAt
       }
@@ -256,7 +256,7 @@ export const GET_WORKS = gql`
           label
         }
         accessionNumber
-        metadata {
+        coreMetadata {
           description
           originalFilename
           location
@@ -417,13 +417,13 @@ export const INGEST_FILE_SET = gql`
   mutation IngestFileSet(
     $accession_number: String!
     $role: FileSetRole!
-    $metadata: FileSetMetadataInput!
+    $coreMetadata: FileSetCoreMetadataInput!
     $workId: ID!
   ) {
     ingestFileSet(
       accessionNumber: $accession_number
       role: $role
-      metadata: $metadata
+      coreMetadata: $coreMetadata
       workId: $workId
     ) {
       id
@@ -435,7 +435,7 @@ export const INGEST_FILE_SET = gql`
       work {
         id
       }
-      metadata {
+      coreMetadata {
         location
         label
         description
@@ -458,7 +458,7 @@ export const UPDATE_FILE_SETS = gql`
   mutation UpdateFileSets($fileSets: [FileSetUpdate]!) {
     updateFileSets(fileSets: $fileSets) {
       id
-      metadata {
+      coreMetadata {
         description
         label
       }

--- a/assets/js/components/Work/work.gql.mock.js
+++ b/assets/js/components/Work/work.gql.mock.js
@@ -147,16 +147,14 @@ export const mockWork = {
       accessionNumber: "Donohue_001_04",
       id: "01E08T3EXBJX3PWDG22NSRE0BS",
       role: { id: "A", label: "Access" },
-      metadata: {
+      coreMetadata: {
         description: "Letter, page 2, If these papers, verso, blank",
-        extractedMetadata:
-          '{"exif": {"tool": "exifr", "tool_version": "6.1.1", "value": {"Artist":"Artist Name","BitsPerSample":{"0":8,"1":8,"2":8},"Compression":1,"Copyright":"In Copyright","FillOrder":1,"ImageDescription":"inu-wint-58.6, 8/20/07, 11:16 AM,  8C, 9990x9750 (0+3570), 125%, bent 6 b/w adj,  1/30 s, R43.0, G4.4, B12.6","ImageHeight":1024,"ImageWidth":1024,"Make":"Better Light","Model":"Model Super8K","Orientation":"Horizontal (normal)","PhotometricInterpretation":2,"PlanarConfiguration":1,"ResolutionUnit":"inches","SamplesPerPixel":3,"Software":"Adobe Photoshop CC 2015.5 (Windows)","XResolution":72,"YResolution":72}}}',
-        exif: '{"Artist":"Artist Name","BitsPerSample":{"0":8,"1":8,"2":8},"Compression":1,"Copyright":"In Copyright","FillOrder":1,"ImageDescription":"inu-wint-58.6, 8/20/07, 11:16 AM,  8C, 9990x9750 (0+3570), 125%, bent 6 b/w adj,  1/30 s, R43.0, G4.4, B12.6","ImageHeight":1024,"ImageWidth":1024,"Make":"Better Light","Model":"Model Super8K","Orientation":"Horizontal (normal)","PhotometricInterpretation":2,"PlanarConfiguration":1,"ResolutionUnit":"inches","SamplesPerPixel":3,"Software":"Adobe Photoshop CC 2015.5 (Windows)","XResolution":72,"YResolution":72}',
         location: "s3://bucket/foo/bar",
         label: "foo.tiff",
         originalFilename: "coffee.jpg",
         sha256: "foobar",
       },
+      extractedMetadata: '{"exif": {"tool": "exifr", "tool_version": "6.1.1", "value": {"Artist":"Artist Name","BitsPerSample":{"0":8,"1":8,"2":8},"Compression":1,"Copyright":"In Copyright","FillOrder":1,"ImageDescription":"inu-wint-58.6, 8/20/07, 11:16 AM,  8C, 9990x9750 (0+3570), 125%, bent 6 b/w adj,  1/30 s, R43.0, G4.4, B12.6","ImageHeight":1024,"ImageWidth":1024,"Make":"Better Light","Model":"Model Super8K","Orientation":"Horizontal (normal)","PhotometricInterpretation":2,"PlanarConfiguration":1,"ResolutionUnit":"inches","SamplesPerPixel":3,"Software":"Adobe Photoshop CC 2015.5 (Windows)","XResolution":72,"YResolution":72}}}',
       insertedAt: "2020-09-12T10:01:01",
       updatedAt: "2020-09-18T09:01:01",
     },
@@ -164,17 +162,15 @@ export const mockWork = {
       accessionNumber: "Donohue_001_01",
       id: "01E08T3EW3TQ9T0AXCR6X9QDJW",
       role: { id: "A", label: "Access" },
-      metadata: {
+      coreMetadata: {
         description: "Letter, page 1, Dear Sir, recto",
-        extractedMetadata:
-          '{"exif": {"tool": "exifr", "tool_version": "6.1.1", "value": {"Artist":"Artist Name","BitsPerSample":{"0":8,"1":8,"2":8},"Compression":1,"Copyright":"In Copyright","FillOrder":1,"ImageDescription":"inu-wint-58.6, 8/20/07, 11:16 AM,  8C, 9990x9750 (0+3570), 125%, bent 6 b/w adj,  1/30 s, R43.0, G4.4, B12.6","ImageHeight":1024,"ImageWidth":1024,"Make":"Better Light","Model":"Model Super8K","Orientation":"Horizontal (normal)","PhotometricInterpretation":2,"PlanarConfiguration":1,"ResolutionUnit":"inches","SamplesPerPixel":3,"Software":"Adobe Photoshop CC 2015.5 (Windows)","XResolution":72,"YResolution":72}}}',
-        exif: '{"Artist":"Artist Name","BitsPerSample":{"0":8,"1":8,"2":8},"Compression":1,"Copyright":"In Copyright","FillOrder":1,"ImageDescription":"inu-wint-58.6, 8/20/07, 11:16 AM,  8C, 9990x9750 (0+3570), 125%, bent 6 b/w adj,  1/30 s, R43.0, G4.4, B12.6","ImageHeight":1024,"ImageWidth":1024,"Make":"Better Light","Model":"Model Super8K","Orientation":"Horizontal (normal)","PhotometricInterpretation":2,"PlanarConfiguration":1,"ResolutionUnit":"inches","SamplesPerPixel":3,"Software":"Adobe Photoshop CC 2015.5 (Windows)","XResolution":72,"YResolution":72}',
         location: "s3://bucket/foo/bar",
         originalFilename: "coffee.jpg",
         location: "s3://bucket/foo/bar",
         label: "foo.tiff",
         sha256: "foobar",
       },
+      extractedMetadata: '{"exif": {"tool": "exifr", "tool_version": "6.1.1", "value": {"Artist":"Artist Name","BitsPerSample":{"0":8,"1":8,"2":8},"Compression":1,"Copyright":"In Copyright","FillOrder":1,"ImageDescription":"inu-wint-58.6, 8/20/07, 11:16 AM,  8C, 9990x9750 (0+3570), 125%, bent 6 b/w adj,  1/30 s, R43.0, G4.4, B12.6","ImageHeight":1024,"ImageWidth":1024,"Make":"Better Light","Model":"Model Super8K","Orientation":"Horizontal (normal)","PhotometricInterpretation":2,"PlanarConfiguration":1,"ResolutionUnit":"inches","SamplesPerPixel":3,"Software":"Adobe Photoshop CC 2015.5 (Windows)","XResolution":72,"YResolution":72}}}',
       insertedAt: "2020-11-12T10:01:01",
       updatedAt: "2020-11-18T09:01:01",
     },
@@ -182,7 +178,7 @@ export const mockWork = {
       accessionNumber: "Donohue_001_03",
       id: "01E08T3EWRPXMWW0B1NHZ56AW6",
       role: { id: "A", label: "Access" },
-      metadata: {
+      coreMetadata: {
         description: "Letter, page 2, If these papers, recto",
         originalFilename: "coffee.jpg",
         location: "s3://bucket/foo/bar",
@@ -196,7 +192,7 @@ export const mockWork = {
       accessionNumber: "Donohue_001_02",
       id: "01E08T3EWFJB35RY3RVR65AXMK",
       role: { id: "A", label: "Access" },
-      metadata: {
+      coreMetadata: {
         description: "Letter, page 1, Dear Sir, verso, blank",
         originalFilename: "coffee.jpg",
         location: "s3://bucket/foo/bar",
@@ -313,7 +309,7 @@ const mockWork2 = {
     {
       accessionNumber: "Donohue_002_03b",
       id: "0afa26f5-78e0-4ccb-b96f-052034dbbe27",
-      metadata: {
+      coreMetadata: {
         description: "Photo, two children praying",
         label: "painting7.JPG",
         location:
@@ -329,7 +325,7 @@ const mockWork2 = {
     {
       accessionNumber: "Donohue_002_01b",
       id: "38620e42-7c71-4364-8123-8106db5fd31c",
-      metadata: {
+      coreMetadata: {
         description: "Photo, man with two children",
         label: "painting5.JPG",
         location:
@@ -343,7 +339,7 @@ const mockWork2 = {
     {
       accessionNumber: "Donohue_002_02b",
       id: "251a0c80-4dbe-48c5-a77b-bcf8c403591d",
-      metadata: {
+      coreMetadata: {
         description: "Verso",
         label: "painting6.JPG",
         location:

--- a/assets/js/mock-data/filesets.js
+++ b/assets/js/mock-data/filesets.js
@@ -3,7 +3,7 @@ export const mockFileSets = [
     id: "45226a50-87ca-443e-bc05-f47884e14505",
     role: { id: "A", scheme: "FILE_SET_ROLE" },
     accessionNumber: "Voyager:2569254_FILE_0",
-    metadata: {
+    coreMetadata: {
       description: "inu-dil-9d35d0ba-a84b-4e0a-99e6-9c6b548a46db.tif",
       originalFilename: "inu-dil-9d35d0ba-a84b-4e0a-99e6-9c6b548a46db.jpg",
       label: "inu-dil-9d35d0ba-a84b-4e0a-99e6-9c6b548a46db.jpg",
@@ -18,8 +18,8 @@ export const mockFileSets = [
     id: "109b9a5c-3c6f-4a98-b98b-12402b871dc7",
     role: { id: "A", scheme: "FILE_SET_ROLE" },
     accessionNumber: "Voyager:2572813_FILE_0",
-    metadata: {
-      __typename: "FileSetMetadata",
+    coreMetadata: {
+      __typename: "FileSetCoreMetadata",
       description: "inu-dil-41913a91-037f-494b-9113-06004a8a98fb.tif",
       originalFilename: "inu-dil-41913a91-037f-494b-9113-06004a8a98fb.jpg",
       label: "inu-dil-41913a91-037f-494b-9113-06004a8a98fb.jpg",
@@ -34,8 +34,8 @@ export const mockFileSets = [
     id: "d414d3d4-b72c-49cc-b7cc-faa9bc0f256e",
     role: { id: "A", scheme: "FILE_SET_ROLE" },
     accessionNumber: "Voyager:2553177_FILE_0",
-    metadata: {
-      __typename: "FileSetMetadata",
+    coreMetadata: {
+      __typename: "FileSetCoreMetadata",
       description: "inu-dil-96e6d167-5022-42e7-9de7-7f851a866f44.tif",
       originalFilename: "inu-dil-96e6d167-5022-42e7-9de7-7f851a866f44.jpg",
       label: "inu-dil-96e6d167-5022-42e7-9de7-7f851a866f44.jpg",

--- a/assets/js/services/helpers.js
+++ b/assets/js/services/helpers.js
@@ -108,8 +108,8 @@ export function setVisibilityClass(visibility = "") {
  */
 export function sortFileSets({ order = "asc", fileSets = [] }) {
   const orderedFileSets = [...fileSets].sort((a, b) => {
-    const aName = a.metadata.originalFilename;
-    const bName = b.metadata.originalFilename;
+    const aName = a.coreMetadata.originalFilename;
+    const bName = b.coreMetadata.originalFilename;
 
     if (aName === bName) return 0;
 

--- a/assets/js/services/helpers.test.js
+++ b/assets/js/services/helpers.test.js
@@ -79,8 +79,8 @@ describe("Sort file sets", () => {
       id: "2357ea03-9dd5-49f2-a88c-dfc9aa88be3c",
       role: { id: "A", scheme: "FILE_SET_ROLE" },
       accessionNumber: "inu-fava-5145080_FILE_0",
-      metadata: {
-        __typename: "FileSetMetadata",
+      coreMetadata: {
+        __typename: "FileSetCoreMetadata",
         description: "inu-fava-5145080-6.tif",
         originalFilename: "BBBBBBB.jpg",
         label: "inu-fava-5145080-6.jpg",
@@ -94,8 +94,8 @@ describe("Sort file sets", () => {
       id: "26357d25-b5e0-4e27-b683-c6844a13dc6b",
       role: { id: "A", scheme: "FILE_SET_ROLE" },
       accessionNumber: "inu-fava-5145080_FILE_1",
-      metadata: {
-        __typename: "FileSetMetadata",
+      coreMetadata: {
+        __typename: "FileSetCoreMetadata",
         description: "inu-fava-5145080-5.tif",
         originalFilename: "CCCCCC.jpg",
         label: "inu-fava-5145080-5.jpg",
@@ -109,8 +109,8 @@ describe("Sort file sets", () => {
       id: "0607a735-9f99-4d38-b75a-6c10027f0937",
       role: { id: "A", scheme: "FILE_SET_ROLE" },
       accessionNumber: "inu-fava-5145080_FILE_2",
-      metadata: {
-        __typename: "FileSetMetadata",
+      coreMetadata: {
+        __typename: "FileSetCoreMetadata",
         description: "inu-fava-5145080-1.tif",
         originalFilename: "AAAAA.jpg",
         label: "inu-fava-5145080-1.jpg",
@@ -124,13 +124,13 @@ describe("Sort file sets", () => {
 
   it("should order file sets in ascending order", () => {
     const sorted = sortFileSets({ fileSets: originalFileSets });
-    expect(sorted[0].metadata.originalFilename).toEqual("AAAAA.jpg");
-    expect(sorted[2].metadata.originalFilename).toEqual("CCCCCC.jpg");
+    expect(sorted[0].coreMetadata.originalFilename).toEqual("AAAAA.jpg");
+    expect(sorted[2].coreMetadata.originalFilename).toEqual("CCCCCC.jpg");
   });
 
   it("should order file sets in descending order", () => {
     const sorted = sortFileSets({ order: "desc", fileSets: originalFileSets });
-    expect(sorted[2].metadata.originalFilename).toEqual("AAAAA.jpg");
-    expect(sorted[0].metadata.originalFilename).toEqual("CCCCCC.jpg");
+    expect(sorted[2].coreMetadata.originalFilename).toEqual("AAAAA.jpg");
+    expect(sorted[0].coreMetadata.originalFilename).toEqual("CCCCCC.jpg");
   });
 });

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -3512,10 +3512,10 @@ css-declaration-sorter@^6.0.3:
   dependencies:
     timsort "^0.3.0"
 
-css-loader@^5.2.5:
-  version "5.2.5"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-5.2.5.tgz#cdd18d6fe42748990793b4a7ec32eb16f36ba9d7"
-  integrity sha512-bH6QQacvSRtLX0lycAOs43S173n+lfXxB5cx4FjVkTLw5tAEwk5bxNLbkt5K1iETd5KxazRx70GpqOxsuwKiFA==
+css-loader@^5.2.4:
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-5.2.6.tgz#c3c82ab77fea1f360e587d871a6811f4450cc8d1"
+  integrity sha512-0wyN5vXMQZu6BvjbrPdUJvkCzGEO24HC7IS7nW4llc6BBFC+zwR9CKtYGv63Puzsg10L/o12inMY5/2ByzfD6w==
   dependencies:
     icss-utils "^5.1.0"
     loader-utils "^2.0.0"
@@ -6676,6 +6676,28 @@ node-releases@^1.1.71:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.72.tgz#14802ab6b1039a79a0c7d662b610a5bbd76eacbe"
   integrity sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==
 
+node-sass@~5.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-5.0.0.tgz#4e8f39fbef3bac8d2dc72ebe3b539711883a78d2"
+  integrity sha512-opNgmlu83ZCF792U281Ry7tak9IbVC+AKnXGovcQ8LG8wFaJv6cLnRlc6DIHlmNxWEexB5bZxi9SZ9JyUuOYjw==
+  dependencies:
+    async-foreach "^0.1.3"
+    chalk "^1.1.1"
+    cross-spawn "^7.0.3"
+    gaze "^1.0.0"
+    get-stdin "^4.0.1"
+    glob "^7.0.3"
+    lodash "^4.17.15"
+    meow "^3.7.0"
+    mkdirp "^0.5.1"
+    nan "^2.13.2"
+    node-gyp "^7.1.0"
+    npmlog "^4.0.0"
+    request "^2.88.0"
+    sass-graph "2.2.5"
+    stdout-stream "^1.4.0"
+    "true-case-path" "^1.0.2"
+
 node-webvtt@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/node-webvtt/-/node-webvtt-1.9.3.tgz#756b144a4eb8f2f277510a5787cd8a21fc4d46b1"
@@ -6683,7 +6705,14 @@ node-webvtt@^1.9.3:
   dependencies:
     commander "^6.1.0"
 
-normalize-package-data@^2.5.0:
+nopt@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-5.0.0.tgz#530942bb58a512fccafe53fe210f13a25355dc88"
+  integrity sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
+  dependencies:
+    abbrev "1"
+
+normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==

--- a/lib/meadow/data/file_sets.ex
+++ b/lib/meadow/data/file_sets.ex
@@ -122,10 +122,10 @@ defmodule Meadow.Data.FileSets do
 
   ## Examples
 
-      iex> update_file_sets(%{id: "2b281f5f-bbca-4bfb-a323-df1ab595e99f", metadata: %{label: "new label", description: "new description"}})
+      iex> update_file_sets(%{id: "2b281f5f-bbca-4bfb-a323-df1ab595e99f", core_metadata: %{label: "new label", description: "new description"}})
       {:ok, [%Meadow.Data.Schemas.FileSet{}]}
 
-      iex> update_file_sets(%{id: "2b281f5f-bbca-4bfb-a323-df1ab595e99f", metadata: %{label: 009, description: "new description"}})
+      iex> update_file_sets(%{id: "2b281f5f-bbca-4bfb-a323-df1ab595e99f", core_metadata: %{label: 009, description: "new description"}})
       {:error, :file_set_1, %Ecto.Changeset{}}
   """
   def update_file_sets(file_set_updates) do
@@ -146,7 +146,7 @@ defmodule Meadow.Data.FileSets do
         multi,
         :"index_#{index}",
         FileSet.update_changeset(get_file_set!(changes.id), %{
-          metadata: changes.metadata,
+          core_metadata: changes.core_metadata,
           updated_at: NaiveDateTime.utc_now()
         })
       )

--- a/lib/meadow/data/preservation_check_writer.ex
+++ b/lib/meadow/data/preservation_check_writer.ex
@@ -108,11 +108,11 @@ defmodule Meadow.Data.PreservationCheckWriter do
 
       [
         file_set.id,
-        file_set.metadata.label,
+        file_set.core_metadata.label,
         file_set.role.id,
         get_if_map(result.digests, "sha256"),
         get_if_map(result.digests, "sha1"),
-        file_set.metadata.location,
+        file_set.core_metadata.location,
         Map.fetch!(result, :preservation),
         FileSets.pyramid_uri_for(file_set),
         Map.fetch!(result, :pyramid)
@@ -128,8 +128,8 @@ defmodule Meadow.Data.PreservationCheckWriter do
 
   defp check_files(file_set) do
     %{
-      :digests => file_set.metadata |> Map.get(:digests),
-      :preservation => validate_preservation_file(file_set.metadata.location),
+      :digests => file_set.core_metadata |> Map.get(:digests),
+      :preservation => validate_preservation_file(file_set.core_metadata.location),
       :pyramid => validate_pyramid_present(file_set)
     }
   end

--- a/lib/meadow/data/schemas/file_set_core_metadata.ex
+++ b/lib/meadow/data/schemas/file_set_core_metadata.ex
@@ -1,4 +1,4 @@
-defmodule Meadow.Data.Schemas.FileSetMetadata do
+defmodule Meadow.Data.Schemas.FileSetCoreMetadata do
   @moduledoc """
   Descriptive metadata embedded in FileSet records.
   """
@@ -13,7 +13,6 @@ defmodule Meadow.Data.Schemas.FileSetMetadata do
     field :description
     field :label
     field :digests, :map
-    field :extracted_metadata, :map
     field :mime_type
 
     timestamps()
@@ -27,8 +26,7 @@ defmodule Meadow.Data.Schemas.FileSetMetadata do
       :label,
       :location,
       :mime_type,
-      :original_filename,
-      :extracted_metadata
+      :original_filename
     ])
     |> validate_required([:location, :original_filename])
   end

--- a/lib/meadow/data/schemas/iiif/collection.ex
+++ b/lib/meadow/data/schemas/iiif/collection.ex
@@ -19,7 +19,7 @@ defimpl Meadow.IIIF.Resource, for: Meadow.Data.Schemas.Collection do
                     %Canvas{
                       images: %ImageResource{
                         id: IIIF.image_id(file_set.id),
-                        label: file_set.metadata.description
+                        label: file_set.core_metadata.description
                       }
                     }
                   ]

--- a/lib/meadow/data/schemas/iiif/work.ex
+++ b/lib/meadow/data/schemas/iiif/work.ex
@@ -13,13 +13,13 @@ defimpl Meadow.IIIF.Resource, for: Meadow.Data.Schemas.Work do
             Enum.map(work.file_sets, fn file_set ->
               %Canvas{
                 id: "#{IIIF.manifest_id(work.id)}/canvas/#{file_set.id}",
-                label: file_set.metadata.label,
+                label: file_set.core_metadata.label,
                 images: [
                   %Image{
                     resource: %ImageResource{
                       id: IIIF.image_id(file_set.id),
-                      label: file_set.metadata.label,
-                      description: file_set.metadata.description,
+                      label: file_set.core_metadata.label,
+                      description: file_set.core_metadata.description,
                       service: %Service{
                         id: IIIF.image_service_id(file_set.id)
                       }

--- a/lib/meadow/data/works.ex
+++ b/lib/meadow/data/works.ex
@@ -631,7 +631,7 @@ defmodule Meadow.Data.Works do
   defp verify_file_set(file_set) do
     case ExAws.S3.head_object(
            Config.preservation_bucket(),
-           URI.parse(file_set.metadata.location).path
+           URI.parse(file_set.core_metadata.location).path
          )
          |> ExAws.request() do
       {:ok, _} -> true

--- a/lib/meadow/indexing/file_set.ex
+++ b/lib/meadow/indexing/file_set.ex
@@ -7,15 +7,15 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.FileSet do
   def encode(file_set) do
     %{
       createDate: file_set.inserted_at,
-      description: file_set.metadata.description,
-      label: file_set.metadata.label,
-      mime_type: file_set.metadata.mime_type,
+      description: file_set.core_metadata.description,
+      label: file_set.core_metadata.label,
+      mime_type: file_set.core_metadata.mime_type,
       model: %{application: "Meadow", name: "FileSet"},
       modifiedDate: file_set.updated_at,
       role: format(file_set.role),
       visibility: format(file_set.work.visibility),
       workId: file_set.work.id,
-      extractedMetadata: ExtractedMetadata.transform(file_set.metadata.extracted_metadata)
+      extractedMetadata: ExtractedMetadata.transform(file_set.extracted_metadata)
     }
   end
 

--- a/lib/meadow/indexing/work.ex
+++ b/lib/meadow/indexing/work.ex
@@ -24,8 +24,8 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Work do
           %{
             id: file_set.id,
             accessionNumber: file_set.accession_number,
-            label: file_set.metadata.label,
-            extractedMetadata: ExtractedMetadata.transform(file_set.metadata.extracted_metadata)
+            label: file_set.core_metadata.label,
+            extractedMetadata: ExtractedMetadata.transform(file_set.extracted_metadata)
           }
         end),
       id: work.id,

--- a/lib/meadow/ingest/work_creator.ex
+++ b/lib/meadow/ingest/work_creator.ex
@@ -109,7 +109,7 @@ defmodule Meadow.Ingest.WorkCreator do
           %{
             accession_number: row |> Row.field_value(:file_accession_number),
             role: %{scheme: "file_set_role", id: row |> Row.field_value(:role)},
-            metadata: %{
+            core_metadata: %{
               description: row |> Row.field_value(:description),
               location: location,
               original_filename: Path.basename(file_path),

--- a/lib/meadow/pipeline/actions/create_pyramid_tiff.ex
+++ b/lib/meadow/pipeline/actions/create_pyramid_tiff.ex
@@ -17,7 +17,7 @@ defmodule Meadow.Pipeline.Actions.CreatePyramidTiff do
   end
 
   defp process(file_set, _, _) do
-    source = file_set.metadata.location
+    source = file_set.core_metadata.location
     target = FileSets.pyramid_uri_for(file_set.id)
 
     case create_pyramid_tiff(source, target) do

--- a/lib/meadow/pipeline/actions/extract_media_metadata.ex
+++ b/lib/meadow/pipeline/actions/extract_media_metadata.ex
@@ -20,7 +20,7 @@ defmodule Meadow.Pipeline.Actions.ExtractMediaMetadata do
     with existing_metadata <-
            file_set
            |> StructMap.deep_struct_to_map()
-           |> get_in([:metadata, :extracted_metadata, "mediainfo"]) do
+           |> get_in([:extracted_metadata, "mediainfo"]) do
       not (is_nil(existing_metadata) or Enum.empty?(existing_metadata))
     end
   end
@@ -28,7 +28,7 @@ defmodule Meadow.Pipeline.Actions.ExtractMediaMetadata do
   defp process(file_set, _attributes, _) do
     ActionStates.set_state!(file_set, __MODULE__, "started")
 
-    file_set.metadata.location
+    file_set.core_metadata.location
     |> extract_media_metadata()
     |> handle_result(file_set)
   rescue
@@ -51,13 +51,12 @@ defmodule Meadow.Pipeline.Actions.ExtractMediaMetadata do
 
   def handle_result({:ok, metadata}, file_set) do
     extracted_metadata =
-      case file_set.metadata.extracted_metadata do
+      case file_set.extracted_metadata do
         nil -> %{mediainfo: metadata}
         map -> Map.put(map, :mediainfo, metadata)
       end
 
-    changes = %{metadata: %{extracted_metadata: extracted_metadata}}
-    FileSets.update_file_set(file_set, changes)
+    FileSets.update_file_set(file_set, %{extracted_metadata: extracted_metadata})
     ActionStates.set_state!(file_set, __MODULE__, "ok")
     :ok
   end

--- a/lib/meadow/pipeline/actions/extract_mime_type.ex
+++ b/lib/meadow/pipeline/actions/extract_mime_type.ex
@@ -22,14 +22,14 @@ defmodule Meadow.Pipeline.Actions.ExtractMimeType do
   defp already_complete?(file_set, _) do
     file_set
     |> StructMap.deep_struct_to_map()
-    |> get_in([:metadata, :mime_type])
+    |> get_in([:core_metadata, :mime_type])
     |> is_binary()
   end
 
   defp process(file_set, _attributes, _) do
     ActionStates.set_state!(file_set, __MODULE__, "started")
 
-    file_set.metadata.location
+    file_set.core_metadata.location
     |> extract_mime_type()
     |> handle_result(file_set)
   end
@@ -64,7 +64,7 @@ defmodule Meadow.Pipeline.Actions.ExtractMimeType do
   end
 
   def handle_result({:ok, mime_type}, file_set) do
-    FileSets.update_file_set(file_set, %{metadata: %{mime_type: mime_type}})
+    FileSets.update_file_set(file_set, %{core_metadata: %{mime_type: mime_type}})
     ActionStates.set_state!(file_set, __MODULE__, "ok")
     :ok
   end

--- a/lib/meadow/pipeline/actions/generate_file_set_digests.ex
+++ b/lib/meadow/pipeline/actions/generate_file_set_digests.ex
@@ -22,7 +22,7 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigests do
   defp already_complete?(file_set, _) do
     case file_set
          |> StructMap.deep_struct_to_map()
-         |> get_in([:metadata, :digests]) do
+         |> get_in([:core_metadata, :digests]) do
       %{"sha1" => _, "sha256" => _} -> true
       %{sha1: _, sha256: _} -> true
       _ -> false
@@ -33,7 +33,7 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigests do
     ActionStates.set_state!(file_set, __MODULE__, "started")
 
     try do
-      file_set.metadata.location
+      file_set.core_metadata.location
       |> generate_hashes()
       |> handle_result(file_set)
     rescue
@@ -59,7 +59,7 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigests do
         file_set
       ) do
     Logger.info("Hash for #{file_set.id}: #{sha256}")
-    FileSets.update_file_set(file_set, %{metadata: %{digests: hashes}})
+    FileSets.update_file_set(file_set, %{core_metadata: %{digests: hashes}})
     ActionStates.set_state!(file_set, __MODULE__, "ok")
     :ok
   end

--- a/lib/meadow/seed/export.ex
+++ b/lib/meadow/seed/export.ex
@@ -76,7 +76,7 @@ defmodule Meadow.Seed.Export do
       where: w.ingest_sheet_id in ^ingest_sheet_ids,
       select: %{
         id: fs.id,
-        preservation_file: fragment("?.metadata::jsonb -> 'location'", fs)
+        preservation_file: fragment("?.core_metadata::jsonb -> 'location'", fs)
       }
     )
     |> Repo.all()
@@ -90,7 +90,7 @@ defmodule Meadow.Seed.Export do
       where: fs.work_id in ^work_ids,
       select: %{
         id: fs.id,
-        preservation_file: fragment("?.metadata::jsonb -> 'location'", fs)
+        preservation_file: fragment("?.core_metadata::jsonb -> 'location'", fs)
       }
     )
     |> Repo.all()

--- a/lib/meadow/seed/import.ex
+++ b/lib/meadow/seed/import.ex
@@ -168,17 +168,30 @@ defmodule Meadow.Seed.Import do
     )
   end
 
-  defp update_file_set_preservation_location(%FileSet{metadata: %{location: location}} = file_set)
-       when is_binary(location) do
-    new_location =
-      URI.parse(location)
-      |> Map.put(:host, Config.preservation_bucket())
-      |> URI.to_string()
+  defp update_file_set_preservation_location(%FileSet{} = file_set) do
+    case Map.from_struct(file_set) |> update_file_set_preservation_location() do
+      :noop -> :noop
+      attrs -> file_set |> FileSets.update_file_set(attrs)
+    end
+  end
 
-    file_set |> FileSets.update_file_set(%{metadata: %{location: new_location}})
+  defp update_file_set_preservation_location(%{core_metadata: %{location: location}} = file_set)
+       when is_map(file_set) and is_binary(location) do
+    %{core_metadata: %{location: update_location(location)}}
+  end
+
+  defp update_file_set_preservation_location(%{metadata: %{location: location}} = file_set)
+       when is_map(file_set) and is_binary(location) do
+    %{metadata: %{location: update_location(location)}}
   end
 
   defp update_file_set_preservation_location(_), do: :noop
+
+  defp update_location(location) do
+    URI.parse(location)
+    |> Map.put(:host, Config.preservation_bucket())
+    |> URI.to_string()
+  end
 
   defp prepare_stream(data, headers, schema) do
     with rows <- data |> CSV.parse_stream(headers: true) do

--- a/lib/meadow/utils/dependency_triggers.ex
+++ b/lib/meadow/utils/dependency_triggers.ex
@@ -1,0 +1,114 @@
+defmodule Meadow.Utils.DependencyTriggers do
+  @moduledoc """
+  Code to create and drop dependency triggers in migrations
+  See the following files for usage:
+    * priv/repo/migrations/20200507123625_create_dependency_triggers.exs
+    * priv/repo/migrations/20210525165057_add_extracted_metadata_to_file_sets.exs
+  """
+
+  defmacro __using__(_) do
+    quote do
+      defp create_dependency_trigger(parent, child, fields) do
+        create_dependency_trigger(parent, child, fields, parent)
+      end
+
+      defp create_dependency_trigger(parent, child, fields, column_name) do
+        with {function_name, trigger_name} <- object_names(parent, child) do
+          condition =
+            fields
+            |> Enum.flat_map(
+              &[
+                "(NEW.#{&1} <> OLD.#{&1})",
+                "(NEW.#{&1} IS NULL AND OLD.#{&1} IS NOT NULL)",
+                "(NEW.#{&1} IS NOT NULL AND OLD.#{&1} IS NULL)"
+              ]
+            )
+            |> Enum.join(" OR ")
+
+          execute("""
+          CREATE OR REPLACE FUNCTION #{function_name}()
+            RETURNS trigger AS $$
+          BEGIN
+            IF #{condition} THEN
+              UPDATE #{child} SET updated_at = NOW() WHERE #{Inflex.singularize(column_name)}_id = NEW.id;
+            END IF;
+            RETURN NEW;
+          END;
+          $$ LANGUAGE plpgsql
+          """)
+
+          execute("""
+          CREATE TRIGGER #{trigger_name}
+            AFTER UPDATE
+            ON #{parent}
+            FOR EACH ROW
+            EXECUTE PROCEDURE #{function_name}()
+          """)
+        end
+      end
+
+      defp create_parent_trigger(parent, child, fields) do
+        with {function_name, trigger_name} <- object_names_for_parent_trigger(parent, child) do
+          condition =
+            fields
+            |> Enum.flat_map(
+              &[
+                "(NEW.#{&1} <> OLD.#{&1})",
+                "(NEW.#{&1} IS NULL AND OLD.#{&1} IS NOT NULL)",
+                "(NEW.#{&1} IS NOT NULL AND OLD.#{&1} IS NULL)"
+              ]
+            )
+            |> Enum.join(" OR ")
+
+          execute("""
+          CREATE OR REPLACE FUNCTION #{function_name}()
+            RETURNS trigger AS $$
+          BEGIN
+            IF #{condition} THEN
+              UPDATE #{parent} SET updated_at = NOW() WHERE id = NEW.#{Inflex.singularize(parent)}_id;
+            END IF;
+            RETURN NEW;
+          END;
+          $$ LANGUAGE plpgsql
+          """)
+
+          execute("""
+          CREATE TRIGGER #{trigger_name}
+            AFTER UPDATE
+            ON #{child}
+            FOR EACH ROW
+            EXECUTE PROCEDURE #{function_name}()
+          """)
+        end
+      end
+
+      defp drop_dependency_trigger(parent, child) do
+        with {function_name, trigger_name} <- object_names(parent, child) do
+          execute("DROP TRIGGER IF EXISTS #{trigger_name} ON #{parent};")
+          execute("DROP FUNCTION IF EXISTS #{function_name};")
+        end
+      end
+
+      defp drop_parent_trigger(parent, child) do
+        with {function_name, trigger_name} <- object_names_for_parent_trigger(parent, child) do
+          execute("DROP TRIGGER IF EXISTS #{trigger_name} ON #{child};")
+          execute("DROP FUNCTION IF EXISTS #{function_name};")
+        end
+      end
+
+      defp object_names(parent, child) do
+        {
+          "reindex_#{child}_when_#{parent}_changes",
+          "#{parent}_#{child}_reindex"
+        }
+      end
+
+      defp object_names_for_parent_trigger(parent, child) do
+        {
+          "reindex_#{parent}_when_#{child}_changes",
+          "#{child}_#{parent}_reindex"
+        }
+      end
+    end
+  end
+end

--- a/lib/meadow_web/resolvers/data.ex
+++ b/lib/meadow_web/resolvers/data.ex
@@ -140,10 +140,10 @@ defmodule MeadowWeb.Resolvers.Data do
     end
   end
 
-  def update_file_set(_, %{id: id, metadata: metadata_params}, _) do
+  def update_file_set(_, %{id: id, core_metadata: metadata_params}, _) do
     file_set = FileSets.get_file_set!(id)
 
-    case FileSets.update_file_set(file_set, %{metadata: metadata_params}) do
+    case FileSets.update_file_set(file_set, %{core_metadata: metadata_params}) do
       {:error, changeset} ->
         {:error,
          message: "Could not update FileSet", details: ChangesetErrors.humanize_errors(changeset)}

--- a/lib/mix/tasks/seed/import.ex
+++ b/lib/mix/tasks/seed/import.ex
@@ -43,7 +43,7 @@ defmodule Mix.Tasks.Meadow.Seed.Import do
         |> Map.get(:prefix)
         |> normalize_prefix()
 
-      Import.import_assets(prefix, parsed_opts.threads)
+      #      Import.import_assets(prefix, parsed_opts.threads)
       Import.import(prefix)
     else
       Logger.error("Import can only be run on an empty database.")

--- a/priv/repo/migrations/20200507123625_create_dependency_triggers.exs
+++ b/priv/repo/migrations/20200507123625_create_dependency_triggers.exs
@@ -1,5 +1,6 @@
 defmodule Meadow.Repo.Migrations.CreateDependencyTriggers do
   use Ecto.Migration
+  use Meadow.Utils.DependencyTriggers
 
   def up do
     create_dependency_trigger(:ingest_sheets, :works, [:title])
@@ -23,107 +24,5 @@ defmodule Meadow.Repo.Migrations.CreateDependencyTriggers do
     drop_dependency_trigger(:works, :collections)
 
     drop_parent_trigger(:works, :file_sets)
-  end
-
-  defp create_dependency_trigger(parent, child, fields) do
-    create_dependency_trigger(parent, child, fields, parent)
-  end
-
-  defp create_dependency_trigger(parent, child, fields, column_name) do
-    with {function_name, trigger_name} <- object_names(parent, child) do
-      condition =
-        fields
-        |> Enum.flat_map(
-          &[
-            "(NEW.#{&1} <> OLD.#{&1})",
-            "(NEW.#{&1} IS NULL AND OLD.#{&1} IS NOT NULL)",
-            "(NEW.#{&1} IS NOT NULL AND OLD.#{&1} IS NULL)"
-          ]
-        )
-        |> Enum.join(" OR ")
-
-      execute """
-      CREATE OR REPLACE FUNCTION #{function_name}()
-        RETURNS trigger AS $$
-      BEGIN
-        IF #{condition} THEN
-          UPDATE #{child} SET updated_at = NOW() WHERE #{Inflex.singularize(column_name)}_id = NEW.id;
-        END IF;
-        RETURN NEW;
-      END;
-      $$ LANGUAGE plpgsql
-      """
-
-      execute """
-      CREATE TRIGGER #{trigger_name}
-        AFTER UPDATE
-        ON #{parent}
-        FOR EACH ROW
-        EXECUTE PROCEDURE #{function_name}()
-      """
-    end
-  end
-
-  defp create_parent_trigger(parent, child, fields) do
-    with {function_name, trigger_name} <- object_names_for_parent_trigger(parent, child) do
-      condition =
-        fields
-        |> Enum.flat_map(
-          &[
-            "(NEW.#{&1} <> OLD.#{&1})",
-            "(NEW.#{&1} IS NULL AND OLD.#{&1} IS NOT NULL)",
-            "(NEW.#{&1} IS NOT NULL AND OLD.#{&1} IS NULL)"
-          ]
-        )
-        |> Enum.join(" OR ")
-
-      execute """
-      CREATE OR REPLACE FUNCTION #{function_name}()
-        RETURNS trigger AS $$
-      BEGIN
-        IF #{condition} THEN
-          UPDATE #{parent} SET updated_at = NOW() WHERE id = NEW.#{Inflex.singularize(parent)}_id;
-        END IF;
-        RETURN NEW;
-      END;
-      $$ LANGUAGE plpgsql
-      """
-
-      execute """
-      CREATE TRIGGER #{trigger_name}
-        AFTER UPDATE
-        ON #{child}
-        FOR EACH ROW
-        EXECUTE PROCEDURE #{function_name}()
-      """
-    end
-  end
-
-  defp drop_dependency_trigger(parent, child) do
-    with {function_name, trigger_name} <- object_names(parent, child) do
-      execute("DROP TRIGGER IF EXISTS #{trigger_name} ON #{parent};")
-      execute("DROP FUNCTION IF EXISTS #{function_name};")
-    end
-  end
-
-  defp drop_parent_trigger(parent, child) do
-    with {function_name, trigger_name} <- object_names_for_parent_trigger(parent, child) do
-      execute("DROP TRIGGER IF EXISTS #{trigger_name} ON #{child};")
-      execute("DROP FUNCTION IF EXISTS #{function_name};")
-    end
-  end
-
-  defp object_names(parent, child) do
-    {
-      "reindex_#{child}_when_#{parent}_changes",
-      "#{parent}_#{child}_reindex"
-    }
-  end
-
-  defp object_names_for_parent_trigger(parent, child) do
-    {
-      "reindex_#{parent}_when_#{child}_changes",
-      "#{child}_#{parent}_reindex"
-    }
   end
 end

--- a/priv/repo/migrations/20210525165057_add_extracted_metadata_to_file_sets.exs
+++ b/priv/repo/migrations/20210525165057_add_extracted_metadata_to_file_sets.exs
@@ -1,0 +1,27 @@
+defmodule Meadow.Repo.Migrations.AddExtractedMetadataToFileSets do
+  use Ecto.Migration
+  use Meadow.Utils.DependencyTriggers
+
+  def up do
+    drop_parent_trigger(:works, :file_sets)
+    rename table("file_sets"), :metadata, to: :core_metadata
+    alter table("file_sets"), do: add :extracted_metadata, :map, default: %{}
+    execute """
+    UPDATE file_sets
+    SET extracted_metadata = core_metadata -> 'extracted_metadata',
+        core_metadata = core_metadata - 'extracted_metadata';
+    """
+    create_parent_trigger(:works, :file_sets, [:core_metadata, :rank])
+  end
+
+  def down do
+    drop_parent_trigger(:works, :file_sets)
+    execute """
+    UPDATE file_sets
+    SET core_metadata = jsonb_set(core_metadata, '{extracted_metadata}', extracted_metadata);
+    """
+    alter table("file_sets"), do: remove :extracted_metadata
+    rename table("file_sets"), :core_metadata, to: :metadata
+    create_parent_trigger(:works, :file_sets, [:metadata, :rank])
+  end
+end

--- a/test/gql/FileSetFields.frag.gql
+++ b/test/gql/FileSetFields.frag.gql
@@ -8,11 +8,12 @@ fragment FileSetFields on FileSet {
   }
   rank
   position
-  metadata {
+  coreMetadata {
     description
     sha256
     label
     location
-    original_filename
+    originalFilename
   }
+  extractedMetadata
 }

--- a/test/gql/IngestFileSet.gql
+++ b/test/gql/IngestFileSet.gql
@@ -1,13 +1,13 @@
 mutation(
   $accession_number: String!
   $role: FileSetRole!
-  $metadata: FileSetMetadataInput!
+  $coreMetadata: FileSetCoreMetadataInput!
   $work_id: ID!
 ) {
   ingestFileSet(
     accessionNumber: $accession_number
     role: $role
-    metadata: $metadata
+    coreMetadata: $coreMetadata
     workId: $work_id
   ) {
     id

--- a/test/gql/UpdateFileSet.gql
+++ b/test/gql/UpdateFileSet.gql
@@ -1,7 +1,7 @@
 #import "./FileSetFields.frag.gql"
 
-mutation($id: ID!, $metadata: FileSetMetadataUpdate!) {
-  updateFileSet(id: $id, metadata: $metadata) {
+mutation($id: ID!, $coreMetadata: FileSetCoreMetadataUpdate!) {
+  updateFileSet(id: $id, coreMetadata: $coreMetadata) {
     ...FileSetFields
   }
 }

--- a/test/meadow/data/file_sets_test.exs
+++ b/test/meadow/data/file_sets_test.exs
@@ -9,7 +9,7 @@ defmodule Meadow.Data.FileSetsTest do
     @valid_attrs %{
       accession_number: "12345",
       role: %{id: "A", scheme: "FILE_SET_ROLE"},
-      metadata: %{
+      core_metadata: %{
         description: "yes",
         location: "https://example.com",
         original_filename: "test.tiff"
@@ -41,9 +41,11 @@ defmodule Meadow.Data.FileSetsTest do
       file_set = file_set_fixture()
 
       assert {:ok, %FileSet{} = file_set} =
-               FileSets.update_file_set(file_set, %{metadata: %{description: "New description"}})
+               FileSets.update_file_set(file_set, %{
+                 core_metadata: %{description: "New description"}
+               })
 
-      assert file_set.metadata.description == "New description"
+      assert file_set.core_metadata.description == "New description"
     end
 
     test "update_file_set/2 with invalid attributes returns an error" do
@@ -58,12 +60,12 @@ defmodule Meadow.Data.FileSetsTest do
       assert {:ok, %FileSet{} = updated_file_set} =
                FileSets.update_file_set(file_set, %{
                  rank: 123,
-                 metadata: %{label: "New label"},
+                 core_metadata: %{label: "New label"},
                  accession_number: "Unsupported",
                  role: %{id: "P", scheme: "FILE_SET_ROLE"}
                })
 
-      assert updated_file_set.metadata.label == "New label"
+      assert updated_file_set.core_metadata.label == "New label"
       assert updated_file_set.role.id == "A"
       assert updated_file_set.accession_number == file_set.accession_number
       assert updated_file_set.rank == file_set.rank
@@ -73,21 +75,21 @@ defmodule Meadow.Data.FileSetsTest do
       file_set1 = file_set_fixture()
       file_set2 = file_set_fixture()
 
-      updates1 = %{id: file_set1.id, metadata: %{description: "New description"}}
-      updates2 = %{id: file_set2.id, metadata: %{label: "New label"}}
+      updates1 = %{id: file_set1.id, core_metadata: %{description: "New description"}}
+      updates2 = %{id: file_set2.id, core_metadata: %{label: "New label"}}
 
       assert {:ok, [file_set1, file_set2]} = FileSets.update_file_sets([updates1, updates2])
 
-      assert file_set1.metadata.description == "New description"
-      assert file_set2.metadata.label == "New label"
+      assert file_set1.core_metadata.description == "New description"
+      assert file_set2.core_metadata.label == "New label"
     end
 
     test "update_file_sets/1 with bad data returns an error" do
       file_set1 = file_set_fixture()
       file_set2 = file_set_fixture()
 
-      updates1 = %{id: file_set1.id, metadata: %{description: 900}}
-      updates2 = %{id: file_set2.id, metadata: %{label: "New label"}}
+      updates1 = %{id: file_set1.id, core_metadata: %{description: 900}}
+      updates2 = %{id: file_set2.id, core_metadata: %{label: "New label"}}
 
       assert {:error, :index_1, %Ecto.Changeset{} = changeset} =
                FileSets.update_file_sets([updates1, updates2])
@@ -95,7 +97,7 @@ defmodule Meadow.Data.FileSetsTest do
       refute changeset.valid?
 
       assert ChangesetErrors.error_details(changeset) == %{
-               metadata: %{description: [%{error: "is invalid", value: "900"}]}
+               core_metadata: %{description: [%{error: "is invalid", value: "900"}]}
              }
     end
 

--- a/test/meadow/data/indexer_test.exs
+++ b/test/meadow/data/indexer_test.exs
@@ -182,7 +182,7 @@ defmodule Meadow.Data.IndexerTest do
 
   describe "parent update triggers" do
     @tag unboxed: true
-    test "file_set metadata changes cascade to work" do
+    test "file_set.core_metadata changes cascade to work" do
       Sandbox.unboxed_run(Repo, fn ->
         %{file_sets: [file_set | _]} = indexable_data()
 
@@ -194,7 +194,7 @@ defmodule Meadow.Data.IndexerTest do
         {:ok, file_set} =
           file_set
           |> FileSets.update_file_set(%{
-            metadata: %{label: "New Label", description: "New Description"}
+            core_metadata: %{label: "New Label", description: "New Description"}
           })
 
         work_updated_timestamp = Works.get_work!(file_set.work_id).updated_at
@@ -301,8 +301,8 @@ defmodule Meadow.Data.IndexerTest do
       assert header |> get_in(["index", "_id"]) == subject.id
       assert doc |> get_in(["model", "application"]) == "Meadow"
       assert doc |> get_in(["model", "name"]) == "FileSet"
-      assert doc |> get_in(["description"]) == subject.metadata.description
-      assert doc |> get_in(["label"]) == subject.metadata.label
+      assert doc |> get_in(["description"]) == subject.core_metadata.description
+      assert doc |> get_in(["label"]) == subject.core_metadata.label
     end
   end
 

--- a/test/meadow/data/preservation_check_writer_test.exs
+++ b/test/meadow/data/preservation_check_writer_test.exs
@@ -33,7 +33,7 @@ defmodule Meadow.Data.PreservationCheckWriterTest do
         work_id: work.id,
         accession_number: "123",
         role: %{id: "A", scheme: "FILE_SET_ROLE"},
-        metadata: %{
+        core_metadata: %{
           digests: %{
             "sha256" => @sha256,
             "sha1" => @sha1
@@ -49,7 +49,7 @@ defmodule Meadow.Data.PreservationCheckWriterTest do
         work_id: work.id,
         accession_number: "456",
         role: %{id: "A", scheme: "FILE_SET_ROLE"},
-        metadata: %{
+        core_metadata: %{
           digests: %{
             "sha256" => @sha256,
             "sha1" => @sha1
@@ -97,7 +97,7 @@ defmodule Meadow.Data.PreservationCheckWriterTest do
       CreatePyramidTiff.process(%{file_set_id: file_set_2.id}, %{})
 
       FileSets.update_file_set(file_set_2, %{
-        metadata: %{
+        core_metadata: %{
           location:
             "s3://#{@preservation_bucket}/d6d3ac3443c6141638faad1ac06c73a4fa355682da9364c5fa863ead4cf2361a"
         }
@@ -118,7 +118,7 @@ defmodule Meadow.Data.PreservationCheckWriterTest do
       CreatePyramidTiff.process(%{file_set_id: file_set_2.id}, %{})
 
       FileSets.update_file_set(file_set_2, %{
-        metadata: %{
+        core_metadata: %{
           location: "s3://#{@ingest_bucket}/#{@key}"
         }
       })
@@ -146,8 +146,8 @@ defmodule Meadow.Data.PreservationCheckWriterTest do
       file_set_1: file_set_1,
       file_set_2: file_set_2
     } do
-      FileSets.update_file_set(file_set_1, %{metadata: %{digests: nil}})
-      FileSets.update_file_set(file_set_2, %{metadata: %{digests: %{"sha256" => "badsha"}}})
+      FileSets.update_file_set(file_set_1, %{core_metadata: %{digests: nil}})
+      FileSets.update_file_set(file_set_2, %{core_metadata: %{digests: %{"sha256" => "badsha"}}})
 
       CreatePyramidTiff.process(%{file_set_id: file_set_1.id}, %{})
       CreatePyramidTiff.process(%{file_set_id: file_set_2.id}, %{})

--- a/test/meadow/data/preservation_checks_test.exs
+++ b/test/meadow/data/preservation_checks_test.exs
@@ -21,7 +21,7 @@ defmodule Meadow.Data.PreservationChecksTest do
       work_id: work.id,
       accession_number: "123",
       role: %{id: "A", scheme: "FILE_SET_ROLE"},
-      metadata: %{
+      core_metadata: %{
         digests: %{
           "sha256" => @sha256,
           "sha1" => @sha1

--- a/test/meadow/data/schemas/file_set_test.exs
+++ b/test/meadow/data/schemas/file_set_test.exs
@@ -3,24 +3,62 @@ defmodule Meadow.Data.Schemas.FileSetTest do
 
   alias Meadow.Data.Schemas.FileSet
 
+  import ExUnit.CaptureLog
+
   describe "file_sets" do
     @valid_attrs %{
       accession_number: "12345",
       role: %{id: "A", scheme: "FILE_SET_ROLE"},
-      metadata: %{
+      core_metadata: %{
         description: "yes",
         location: "https://example.com",
         original_filename: "test.tiff"
       }
     }
 
-    test "created file_set has a UUID identifier" do
+    setup do
       {:ok, file_set} =
         %FileSet{}
         |> FileSet.changeset(@valid_attrs)
         |> Repo.insert()
 
+      {:ok, %{file_set: file_set}}
+    end
+
+    test "created file_set has a UUID identifier", %{file_set: file_set} do
       assert {:ok, <<_data::binary-size(16)>>} = Ecto.UUID.dump(file_set.id)
+    end
+
+    test "Rename metadata to core_metadata", %{file_set: file_set} do
+      log =
+        capture_log(fn ->
+          changeset =
+            file_set |> FileSet.changeset(%{metadata: %{description: "New Description"}})
+
+          assert changeset.valid?
+          assert changeset.changes.core_metadata.changes.description == "New Description"
+        end)
+
+      assert log =~ ~r/Renaming to :core_metadata/
+    end
+
+    test "Ignore metadata if core_metadata is present", %{file_set: file_set} do
+      log =
+        capture_log(fn ->
+          changeset =
+            file_set
+            |> FileSet.changeset(%{
+              metadata: %{description: "Metadata Description"},
+              core_metadata: %{description: "Core Metadata Description"}
+            })
+
+          assert changeset.valid?
+
+          assert changeset.changes.core_metadata.changes.description ==
+                   "Core Metadata Description"
+        end)
+
+      assert log =~ ~r/Ignoring :metadata/
     end
   end
 end

--- a/test/meadow/data/works_test.exs
+++ b/test/meadow/data/works_test.exs
@@ -441,7 +441,7 @@ defmodule Meadow.Data.WorksTest do
 
       Enum.each(work.file_sets, fn file_set ->
         FileSets.update_file_set(file_set, %{
-          metadata: %{location: location}
+          core_metadata: %{location: location}
         })
       end)
 

--- a/test/meadow/data_test.exs
+++ b/test/meadow/data_test.exs
@@ -11,7 +11,7 @@ defmodule Meadow.DataTest do
         %{
           accession_number: "1234",
           role: %{id: "A", scheme: "FILE_SET_ROLE"},
-          metadata: %{
+          core_metadata: %{
             description: "This is the description",
             location: "https://www.library.northwestern.edu",
             original_filename: "test.tiff"
@@ -34,7 +34,7 @@ defmodule Meadow.DataTest do
         work_id: work.id,
         accession_number: "2222",
         role: %{id: "A", scheme: "FILE_SET_ROLE"},
-        metadata: %{location: "test", original_filename: "test"}
+        core_metadata: %{location: "test", original_filename: "test"}
       })
       |> Repo.insert!()
 
@@ -44,7 +44,7 @@ defmodule Meadow.DataTest do
         work_id: work.id,
         accession_number: "1111",
         role: %{id: "A", scheme: "FILE_SET_ROLE"},
-        metadata: %{location: "test", original_filename: "test"}
+        core_metadata: %{location: "test", original_filename: "test"}
       })
       |> Repo.insert!()
 
@@ -54,7 +54,7 @@ defmodule Meadow.DataTest do
         work_id: work.id,
         accession_number: "no",
         role: %{id: "P", scheme: "FILE_SET_ROLE"},
-        metadata: %{location: "test", original_filename: "test"}
+        core_metadata: %{location: "test", original_filename: "test"}
       })
       |> Repo.insert!()
 
@@ -63,7 +63,7 @@ defmodule Meadow.DataTest do
         position: 0,
         accession_number: "nono",
         role: %{id: "A", scheme: "FILE_SET_ROLE"},
-        metadata: %{location: "test", original_filename: "test"}
+        core_metadata: %{location: "test", original_filename: "test"}
       })
       |> Repo.insert!()
 

--- a/test/meadow/iiif/generator_test.exs
+++ b/test/meadow/iiif/generator_test.exs
@@ -12,7 +12,7 @@ defmodule Meadow.IIIF.GeneratorTest do
         file_set_fixture(%{
           work_id: work.id,
           role: %{id: "A", scheme: "FILE_SET_ROLE"},
-          metadata: %{
+          core_metadata: %{
             location: "foo",
             description: "bar",
             original_filename: "something",
@@ -24,7 +24,7 @@ defmodule Meadow.IIIF.GeneratorTest do
         file_set_fixture(%{
           work_id: work.id,
           role: %{id: "P", scheme: "FILE_SET_ROLE"},
-          metadata: %{
+          core_metadata: %{
             location: "foo",
             description: "preservation master",
             original_filename: "something",

--- a/test/meadow/pipeline_test.exs
+++ b/test/meadow/pipeline_test.exs
@@ -13,7 +13,7 @@ defmodule Meadow.Data.PipelineTest do
     @valid_attrs %{
       accession_number: "12345",
       role: %{id: "A", scheme: "FILE_SET_ROLE"},
-      metadata: %{
+      core_metadata: %{
         description: "yes",
         location: "https://example.com",
         original_filename: "test.tiff"
@@ -43,7 +43,7 @@ defmodule Meadow.Data.PipelineTest do
       preservation_attrs = %{
         accession_number: "12345",
         role: %{id: "P", scheme: "FILE_SET_ROLE"},
-        metadata: %{
+        core_metadata: %{
           description: "yes",
           location: "https://example.com",
           original_filename: "test.tiff"

--- a/test/meadow_web/schema/mutation/ingest_file_set_test.exs
+++ b/test/meadow_web/schema/mutation/ingest_file_set_test.exs
@@ -20,7 +20,7 @@ defmodule MeadowWeb.Schema.Mutation.IngestFileSetTest do
           "accession_number" => "99999",
           "role" => %{"id" => "A", "scheme" => "FILE_SET_ROLE"},
           "work_id" => work.id,
-          "metadata" => %{
+          "coreMetadata" => %{
             "description" => "Something",
             "original_filename" => "file.tif",
             "location" => "s3://#{@bucket}/#{@key}"
@@ -43,7 +43,7 @@ defmodule MeadowWeb.Schema.Mutation.IngestFileSetTest do
             "accession_number" => "99999",
             "role" => %{"id" => "A", "scheme" => "FILE_SET_ROLE"},
             "work_id" => work.id,
-            "metadata" => %{
+            "coreMetadata" => %{
               "description" => "Something",
               "original_filename" => "file.tif",
               "location" => "s3://#{@bucket}/#{@key}"

--- a/test/meadow_web/schema/mutation/update_file_set_test.exs
+++ b/test/meadow_web/schema/mutation/update_file_set_test.exs
@@ -11,14 +11,14 @@ defmodule MeadowWeb.Schema.Mutation.UpdateFileSetTest do
       query_gql(
         variables: %{
           "id" => file_set.id,
-          "metadata" => %{"label" => "Something"}
+          "coreMetadata" => %{"label" => "Something"}
         },
         context: gql_context()
       )
 
     assert {:ok, query_data} = result
 
-    label = get_in(query_data, [:data, "updateFileSet", "metadata", "label"])
+    label = get_in(query_data, [:data, "updateFileSet", "coreMetadata", "label"])
     assert label == "Something"
   end
 end

--- a/test/meadow_web/schema/mutation/update_file_sets_test.exs
+++ b/test/meadow_web/schema/mutation/update_file_sets_test.exs
@@ -12,8 +12,8 @@ defmodule MeadowWeb.Schema.Mutation.UpdateFileSetsTest do
       query_gql(
         variables: %{
           "fileSets" => [
-            %{"id" => file_set1.id, "metadata" => %{"label" => "Something"}},
-            %{"id" => file_set2.id, "metadata" => %{"label" => "Something Else"}}
+            %{"id" => file_set1.id, "coreMetadata" => %{"label" => "Something"}},
+            %{"id" => file_set2.id, "coreMetadata" => %{"label" => "Something Else"}}
           ]
         },
         context: gql_context()
@@ -24,7 +24,7 @@ defmodule MeadowWeb.Schema.Mutation.UpdateFileSetsTest do
     updated_file_sets = get_in(query_data, [:data, "updateFileSets"])
 
     Enum.each(updated_file_sets, fn fs ->
-      case get_in(fs, ["metadata", "label"]) do
+      case get_in(fs, ["coreMetadata", "label"]) do
         "Something" ->
           assert get_in(fs, ["id"]) == file_set1.id
 

--- a/test/pipeline/actions/create_pyramid_tiff_test.exs
+++ b/test/pipeline/actions/create_pyramid_tiff_test.exs
@@ -19,7 +19,7 @@ defmodule Meadow.Pipeline.Actions.CreatePyramidTiffTest do
         id: "6caf2759-c476-46ae-9c40-ec58cf44c704",
         accession_number: "123",
         role: %{id: "A", scheme: "FILE_SET_ROLE"},
-        metadata: %{
+        core_metadata: %{
           location: "s3://#{@ingest_bucket}/#{@key}",
           original_filename: "coffee.tif"
         }
@@ -30,7 +30,7 @@ defmodule Meadow.Pipeline.Actions.CreatePyramidTiffTest do
         id: "5915fe2b-6b66-4373-b69a-e13f765dc2a4",
         accession_number: "1234",
         role: %{id: "A", scheme: "FILE_SET_ROLE"},
-        metadata: %{
+        core_metadata: %{
           location: "invalid",
           original_filename: "coffee.tif"
         }

--- a/test/pipeline/actions/extract_exif_metadata_test.exs
+++ b/test/pipeline/actions/extract_exif_metadata_test.exs
@@ -60,7 +60,7 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadataTest do
         id: "cecb1180-054e-4764-8d2b-8a46c6b777b2",
         accession_number: "1234",
         role: %{id: "A", scheme: "FILE_SET_ROLE"},
-        metadata: %{
+        core_metadata: %{
           location: "s3://#{@bucket}/#{@exif_key}",
           original_filename: "test.tif"
         }
@@ -71,7 +71,7 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadataTest do
         id: "bbcb54da-fb1d-48ed-8438-99a030431086",
         accession_number: "2314",
         role: %{id: "A", scheme: "FILE_SET_ROLE"},
-        metadata: %{
+        core_metadata: %{
           location: "s3://#{@bucket}/#{@no_exif_key}",
           original_filename: "test.tif"
         }
@@ -82,7 +82,7 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadataTest do
         id: "979d3570-9dc9-4d3b-ac1b-ee5524ee0bd3",
         accession_number: "4321",
         role: %{id: "A", scheme: "FILE_SET_ROLE"},
-        metadata: %{
+        core_metadata: %{
           location: "invalid",
           original_filename: "test.tif"
         }
@@ -101,9 +101,9 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadataTest do
       assert(ActionStates.ok?(file_set_id, ExtractExifMetadata))
 
       file_set = FileSets.get_file_set!(file_set_id)
-      assert file_set.metadata.extracted_metadata |> is_map()
+      assert file_set.extracted_metadata |> is_map()
 
-      with subject <- file_set.metadata.extracted_metadata |> Map.get("exif") do
+      with subject <- file_set.extracted_metadata |> Map.get("exif") do
         assert Map.get(subject, "tool") == @tool_name
         assert Map.get(subject, "tool_version")
         assert_maps_equal(Map.get(subject, "value"), @exif, @keys)
@@ -123,7 +123,7 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadataTest do
 
       file_set = FileSets.get_file_set!(file_set_id)
 
-      with extracted <- file_set.metadata.extracted_metadata do
+      with extracted <- file_set.extracted_metadata do
         assert is_nil(extracted) || is_nil(Map.get(extracted, "exif"))
       end
 

--- a/test/pipeline/actions/extract_media_metadata_test.exs
+++ b/test/pipeline/actions/extract_media_metadata_test.exs
@@ -19,7 +19,7 @@ defmodule Meadow.Pipeline.Actions.ExtractMediaMetadataTest do
         id: "cecb1180-054e-4764-8d2b-8a46c6b777b2",
         accession_number: "1234",
         role: %{id: "A", scheme: "FILE_SET_ROLE"},
-        metadata: %{
+        core_metadata: %{
           location: "s3://#{@bucket}/#{@media_key}",
           original_filename: "small.m4v"
         }
@@ -30,7 +30,7 @@ defmodule Meadow.Pipeline.Actions.ExtractMediaMetadataTest do
         id: "bbcb54da-fb1d-48ed-8438-99a030431086",
         accession_number: "2314",
         role: %{id: "A", scheme: "FILE_SET_ROLE"},
-        metadata: %{
+        core_metadata: %{
           location: "s3://#{@bucket}/#{@missing_media_key}",
           original_filename: "missing.m4v"
         }
@@ -41,7 +41,7 @@ defmodule Meadow.Pipeline.Actions.ExtractMediaMetadataTest do
         id: "979d3570-9dc9-4d3b-ac1b-ee5524ee0bd3",
         accession_number: "4321",
         role: %{id: "A", scheme: "FILE_SET_ROLE"},
-        metadata: %{
+        core_metadata: %{
           location: "invalid",
           original_filename: "small.m4v"
         }
@@ -60,9 +60,9 @@ defmodule Meadow.Pipeline.Actions.ExtractMediaMetadataTest do
       assert(ActionStates.ok?(file_set_id, ExtractMediaMetadata))
 
       file_set = FileSets.get_file_set!(file_set_id)
-      assert file_set.metadata.extracted_metadata |> is_map()
+      assert file_set.extracted_metadata |> is_map()
 
-      with subject <- file_set.metadata.extracted_metadata |> Map.get("mediainfo") do
+      with subject <- file_set.extracted_metadata |> Map.get("mediainfo") do
         assert Map.get(subject, "tool") == @tool_name
         assert Map.get(subject, "tool_version")
 
@@ -93,7 +93,7 @@ defmodule Meadow.Pipeline.Actions.ExtractMediaMetadataTest do
 
       file_set = FileSets.get_file_set!(file_set_id)
 
-      with extracted <- file_set.metadata.extracted_metadata do
+      with extracted <- file_set.extracted_metadata do
         assert is_nil(extracted) || is_nil(Map.get(extracted, "mediainfo"))
       end
 

--- a/test/pipeline/actions/extract_mime_type_test.exs
+++ b/test/pipeline/actions/extract_mime_type_test.exs
@@ -15,7 +15,7 @@ defmodule Meadow.Pipeline.Actions.ExtractMimeTypeTest do
       file_set_fixture(%{
         accession_number: "123",
         role: %{id: "P", scheme: "FILE_SET_ROLE"},
-        metadata: %{
+        core_metadata: %{
           location: "s3://#{@bucket}/#{@key}",
           original_filename: "test.tif"
         }
@@ -31,7 +31,7 @@ defmodule Meadow.Pipeline.Actions.ExtractMimeTypeTest do
       assert(ActionStates.ok?(file_set_id, ExtractMimeType))
 
       file_set = FileSets.get_file_set!(file_set_id)
-      assert(file_set.metadata.mime_type == "image/tiff")
+      assert(file_set.core_metadata.mime_type == "image/tiff")
 
       assert capture_log(fn ->
                ExtractMimeType.process(%{file_set_id: file_set_id}, %{})

--- a/test/pipeline/actions/generate_file_set_digests_test.exs
+++ b/test/pipeline/actions/generate_file_set_digests_test.exs
@@ -17,7 +17,7 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigestsTest do
       file_set_fixture(%{
         accession_number: "123",
         role: %{id: "A", scheme: "FILE_SET_ROLE"},
-        metadata: %{
+        core_metadata: %{
           location: "s3://#{@bucket}/#{@key}",
           original_filename: "test.tif"
         }
@@ -32,7 +32,7 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigestsTest do
     assert(ActionStates.ok?(file_set_id, GenerateFileSetDigests))
 
     file_set = FileSets.get_file_set!(file_set_id)
-    assert(file_set.metadata.digests == %{"sha256" => @sha256, "sha1" => @sha1})
+    assert(file_set.core_metadata.digests == %{"sha256" => @sha256, "sha1" => @sha1})
 
     assert capture_log(fn ->
              GenerateFileSetDigests.process(%{file_set_id: file_set_id}, %{})
@@ -44,7 +44,7 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigestsTest do
 
     setup %{file_set_id: file_set_id} do
       FileSets.get_file_set!(file_set_id)
-      |> FileSets.update_file_set(%{metadata: %{digests: %{sha1: @sha1, sha256: @sha256}}})
+      |> FileSets.update_file_set(%{core_metadata: %{digests: %{sha1: @sha1, sha256: @sha256}}})
 
       :ok
     end
@@ -55,7 +55,7 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigestsTest do
           assert(GenerateFileSetDigests.process(%{file_set_id: file_set_id}, %{}) == :ok)
           assert(ActionStates.ok?(file_set_id, GenerateFileSetDigests))
           file_set = FileSets.get_file_set!(file_set_id)
-          assert(file_set.metadata.digests == %{"sha256" => @sha256, "sha1" => @sha1})
+          assert(file_set.core_metadata.digests == %{"sha256" => @sha256, "sha1" => @sha1})
         end)
 
       refute log =~ ~r/already complete without overwriting/
@@ -71,7 +71,7 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigestsTest do
 
           assert(ActionStates.ok?(file_set_id, GenerateFileSetDigests))
           file_set = FileSets.get_file_set!(file_set_id)
-          assert(file_set.metadata.digests == %{"sha256" => @sha256, "sha1" => @sha1})
+          assert(file_set.core_metadata.digests == %{"sha256" => @sha256, "sha1" => @sha1})
         end)
 
       assert log =~ ~r/already complete without overwriting/

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -192,13 +192,14 @@ defmodule Meadow.TestHelpers do
     Enum.into(attrs, %{
       accession_number: attrs[:accession_number] || Faker.String.base64(),
       role: attrs[:role] || %{id: Faker.Util.pick(["A", "P"]), scheme: "FILE_SET_ROLE"},
-      metadata:
-        attrs[:metadata] ||
+      core_metadata:
+        attrs[:core_metadata] ||
           %{
             description: attrs[:description] || Faker.String.base64(),
             location: "https://fake-s3-bucket/" <> Faker.String.base64(),
             original_filename: Faker.File.file_name()
-          }
+          },
+      extracted_metadata: attrs[:extracted_metadata] || %{}
     })
   end
 


### PR DESCRIPTION
* Rename FileSet `metadata` field to `core_metadata` / `coreMetadata`
* Add `extracted_metadata` / `extractedMetadata`
* Move existing extracted metadata from `metadata` to `extracted_metadata`
* Update GraphQL queries and mutations
* Update front-end components
* Update all back- and front-end tests

This PR includes both forward and backward data migrations, as well as code to ensure that seed data and migration manifests created before the change will still import and migrate properly.