### PR TITLE
Pipeline dispatcher refactor

### DIFF
--- a/lib/meadow/ingest/progress.ex
+++ b/lib/meadow/ingest/progress.ex
@@ -7,9 +7,8 @@ defmodule Meadow.Ingest.Progress do
   alias Meadow.Ingest.Schemas.{Progress, Row, Sheet}
   alias Meadow.Ingest.{Rows, Sheets}
   alias Meadow.IntervalTask
-  alias Meadow.Pipeline
+  alias Meadow.Pipeline.Actions.Dispatcher
   alias Meadow.Repo
-  alias Meadow.Utils.MapList
 
   import Ecto.Query
   import Meadow.Utils.Atoms
@@ -98,11 +97,11 @@ defmodule Meadow.Ingest.Progress do
   an additional entry if the row creates a new work
   """
   def initialize_entry(%Row{} = row, include_work) do
-    initialize_entry(row.id, MapList.get(row.fields, :header, :value, :role), include_work)
+    initialize_entry(row.id, include_work)
   end
 
-  def initialize_entry(row_id, row_role, include_work) do
-    row_actions(row_role, include_work)
+  def initialize_entry(row_id, include_work) do
+    row_actions(include_work)
     |> Enum.each(fn action -> update_entry(row_id, action, "pending") end)
   end
 
@@ -121,8 +120,8 @@ defmodule Meadow.Ingest.Progress do
 
   defp initialize_chunk(chunk, timestamp) do
     new_entries =
-      Enum.flat_map(chunk, fn {row_id, row_role, include_work} ->
-        row_actions(row_role, include_work)
+      Enum.flat_map(chunk, fn {row_id, include_work} ->
+        row_actions(include_work)
         |> Enum.map(fn action ->
           %{
             row_id: row_id,
@@ -140,13 +139,31 @@ defmodule Meadow.Ingest.Progress do
   @doc """
   Update the status of several progress entries at once
   """
-  def update_entries(entries, action, status) do
+  def update_entries(entries, action, status) when is_list(entries) do
     now = DateTime.utc_now()
     row_ids = Enum.map(entries, fn %{row_id: id} -> id end)
 
     {_count, result} =
       from(p in Progress,
         where: p.row_id in ^row_ids and p.action == ^action,
+        select: p
+      )
+      |> Repo.update_all(set: [status: status, updated_at: now])
+
+    result
+  end
+
+  def update_entries(%Row{} = entry, actions, status) when is_list(actions) do
+    update_entries(entry.id, actions, status)
+  end
+
+  def update_entries(entry_id, actions, status) when is_list(actions) do
+    now = DateTime.utc_now()
+    actions = Enum.map(actions, fn a -> atom_to_string(a) end)
+
+    {_count, result} =
+      from(p in Progress,
+        where: p.row_id == ^entry_id and p.action in ^actions,
         select: p
       )
       |> Repo.update_all(set: [status: status, updated_at: now])
@@ -211,23 +228,11 @@ defmodule Meadow.Ingest.Progress do
     |> Repo.aggregate(:count)
   end
 
-  defp row_actions("P", include_work) do
-    actions =
-      Pipeline.actions() --
-        [Meadow.Pipeline.Actions.CreatePyramidTiff, Meadow.Pipeline.Actions.CreateTranscodeJob]
-
+  defp row_actions(include_work) do
     if include_work do
-      ["CreateWork" | actions]
+      ["CreateWork" | Dispatcher.all_progress_actions()]
     else
-      actions
-    end
-  end
-
-  defp row_actions(_, include_work) do
-    if include_work do
-      ["CreateWork" | Pipeline.actions()]
-    else
-      Pipeline.actions()
+      Dispatcher.all_progress_actions()
     end
   end
 

--- a/lib/meadow/ingest/rows.ex
+++ b/lib/meadow/ingest/rows.ex
@@ -23,6 +23,16 @@ defmodule Meadow.Ingest.Rows do
   end
 
   @doc """
+  Gets a row by ingest sheet and file set accession_number
+  """
+  def get_row_by_accession_number(sheet_id, file_set_accession_number) do
+    from(r in Row,
+      where: r.sheet_id == ^sheet_id and r.file_set_accession_number == ^file_set_accession_number
+    )
+    |> Repo.one()
+  end
+
+  @doc """
   Changes the validation state of a Row
   """
   def change_ingest_sheet_row_validation_state(

--- a/lib/meadow/ingest/rows.ex
+++ b/lib/meadow/ingest/rows.ex
@@ -25,7 +25,7 @@ defmodule Meadow.Ingest.Rows do
   @doc """
   Gets a row by ingest sheet and file set accession_number
   """
-  def get_row_by_accession_number(sheet_id, file_set_accession_number) do
+  def get_row_by_file_set_accession_number(sheet_id, file_set_accession_number) do
     from(r in Row,
       where: r.sheet_id == ^sheet_id and r.file_set_accession_number == ^file_set_accession_number
     )

--- a/lib/meadow/ingest/sheets_to_works.ex
+++ b/lib/meadow/ingest/sheets_to_works.ex
@@ -7,7 +7,6 @@ defmodule Meadow.Ingest.SheetsToWorks do
   alias Meadow.Ingest.{Progress, Rows, Sheets, WorkCreator}
   alias Meadow.Ingest.Schemas.{Row, Sheet}
   alias Meadow.Repo
-  alias Meadow.Utils.MapList
 
   def create_works_from_ingest_sheet(%Sheet{} = ingest_sheet, :sync) do
     create_works_from_ingest_sheet(ingest_sheet)
@@ -39,7 +38,7 @@ defmodule Meadow.Ingest.SheetsToWorks do
         rows
         |> Enum.with_index()
         |> Enum.map(fn {row, index} ->
-          {row.id, MapList.get(row.fields, :header, :value, :role), index == 0}
+          {row.id, index == 0}
         end)
       end)
       |> Progress.initialize_entries()

--- a/lib/meadow/pipeline.ex
+++ b/lib/meadow/pipeline.ex
@@ -6,6 +6,7 @@ defmodule Meadow.Pipeline do
 
   alias Meadow.Data.{ActionStates, FileSets}
   alias Meadow.Data.Schemas.FileSet
+  alias Meadow.Pipeline.Actions.Dispatcher
 
   def ingest_file_set(attrs \\ %{}) do
     case FileSets.create_file_set(attrs) do
@@ -22,16 +23,8 @@ defmodule Meadow.Pipeline do
 
   def kickoff(%FileSet{} = file_set, context), do: kickoff(file_set.id, context)
 
-  def kickoff(file_set_id, %{role: "P"} = context) do
-    actions = actions() -- [Meadow.Pipeline.Actions.CreatePyramidTiff, Meadow.Pipeline.Actions.CreateTranscodeJob]
-    kickoff(file_set_id, context, actions)
-  end
-
   def kickoff(file_set_id, context) do
-    kickoff(file_set_id, context, actions())
-  end
-
-  def kickoff(file_set_id, context, actions) do
+    actions = Dispatcher.initial_actions()
     ActionStates.initialize_states({FileSet, file_set_id}, actions)
 
     with initial_action <- List.first(actions) do

--- a/lib/meadow/pipeline/actions/common.ex
+++ b/lib/meadow/pipeline/actions/common.ex
@@ -27,7 +27,10 @@ defmodule Meadow.Pipeline.Actions.Common do
                 result
               end
             else
-              Logger.warn("Marking #{__MODULE__} for #{data.file_set_id} as error because the file set was not found")
+              Logger.warn(
+                "Marking #{__MODULE__} for #{data.file_set_id} as error because the file set was not found"
+              )
+
               update_progress(data, attrs, {:error, "FileSet #{data.file_set_id} not found"})
               {:error, "FileSet #{data.file_set_id} not found"}
             end

--- a/lib/meadow/pipeline/actions/initialize_dispatch.ex
+++ b/lib/meadow/pipeline/actions/initialize_dispatch.ex
@@ -1,0 +1,69 @@
+defmodule Meadow.Pipeline.Actions.InitializeDispatch do
+  @moduledoc """
+  Action that sets up the rest of the actions in the pipeline
+  that the file set will be dispatched to
+
+  Subscribes to:
+  * ExtractMimeType
+  """
+  alias Meadow.Data.{ActionStates, FileSets}
+  alias Meadow.Ingest.{Progress, Rows}
+  alias Meadow.Pipeline
+  alias Meadow.Pipeline.Actions.Dispatcher
+
+  alias Sequins.Pipeline.Action
+
+  use Action
+  use Meadow.Pipeline.Actions.Common
+
+  require Logger
+
+  @actiondoc "Initialize dispatch for rest of pipeline"
+
+  defp already_complete?(file_set, _) do
+    count = length(ActionStates.get_states(file_set.id))
+
+    case Dispatcher.initial_actions() |> length() do
+      ^count ->
+        false
+
+      _ ->
+        true
+    end
+  end
+
+  defp process(file_set, attributes, _) do
+    Logger.info("Initializing dispatch for FileSet #{file_set.id}")
+
+    case Dispatcher.dispatcher_actions(file_set) do
+      nil ->
+        err = "Invalid mime-type and file set role combination"
+        ActionStates.set_state!(file_set, __MODULE__, "error", err)
+        {:error, err}
+
+      actions ->
+        ActionStates.initialize_states({FileSet, file_set.id}, actions, "waiting")
+
+        with %{context: "Sheet"} <- attributes do
+          fixup_progress(FileSets.get_file_set_with_work_and_sheet!(file_set.id))
+        end
+
+        {result, _} =
+          file_set
+          |> ActionStates.set_state(__MODULE__, "ok")
+
+        result
+    end
+  end
+
+  defp fixup_progress(%{work: %{ingest_sheet: sheet}}) when is_nil(sheet), do: :noop
+  defp fixup_progress(%{work: work}) when is_nil(work), do: :noop
+
+  defp fixup_progress(%{work_id: _work_id, work: %{ingest_sheet_id: ingest_sheet_id}} = file_set) do
+    Rows.get_row_by_accession_number(ingest_sheet_id, file_set.accession_number)
+    |> Progress.update_entries(
+      Dispatcher.not_my_actions(file_set),
+      "ok"
+    )
+  end
+end

--- a/lib/meadow/pipeline/actions/initialize_dispatch.ex
+++ b/lib/meadow/pipeline/actions/initialize_dispatch.ex
@@ -60,7 +60,7 @@ defmodule Meadow.Pipeline.Actions.InitializeDispatch do
   defp fixup_progress(%{work: work}) when is_nil(work), do: :noop
 
   defp fixup_progress(%{work_id: _work_id, work: %{ingest_sheet_id: ingest_sheet_id}} = file_set) do
-    Rows.get_row_by_accession_number(ingest_sheet_id, file_set.accession_number)
+    Rows.get_row_by_file_set_accession_number(ingest_sheet_id, file_set.accession_number)
     |> Progress.update_entries(
       Dispatcher.not_my_actions(file_set),
       "ok"

--- a/lib/meadow/pipeline/dispatcher.ex
+++ b/lib/meadow/pipeline/dispatcher.ex
@@ -1,0 +1,123 @@
+defmodule Meadow.Pipeline.Actions.Dispatcher do
+  @moduledoc """
+  Action responsible for dispatching processing to
+  the next action in the pipeline
+
+  Subscribes to: all other actions with status: :ok
+  *
+
+  """
+  alias Meadow.Data.{ActionStates, FileSets}
+  alias Meadow.Utils.Atoms
+  alias Sequins.Pipeline.Action
+
+  alias Meadow.Pipeline.Actions.{
+    CopyFileToPreservation,
+    CreatePyramidTiff,
+    ExtractMimeType,
+    FileSetComplete,
+    GenerateFileSetDigests,
+    ExtractExifMetadata,
+    IngestFileSet,
+    InitializeDispatch
+  }
+
+  use Action
+  require Logger
+
+  @actiondoc "Disatch pipeline actions specific to role + mime_type"
+
+  @initial_actions [
+    IngestFileSet,
+    ExtractMimeType,
+    InitializeDispatch
+  ]
+
+  @access_image_actions [
+    GenerateFileSetDigests,
+    ExtractExifMetadata,
+    CopyFileToPreservation,
+    CreatePyramidTiff,
+    FileSetComplete
+  ]
+
+  @preservation_actions [
+    GenerateFileSetDigests,
+    CopyFileToPreservation,
+    FileSetComplete
+  ]
+
+  @preservation_image_actions [
+    GenerateFileSetDigests,
+    ExtractExifMetadata,
+    CopyFileToPreservation,
+    FileSetComplete
+  ]
+
+  def process(data, attributes) do
+    Logger.info("dispatcher called")
+    file_set = FileSets.get_file_set(data.file_set_id)
+
+    dispatch_next_action(file_set, attributes)
+    :ok
+  end
+
+  def process(data, attributes, _), do: process(data, attributes)
+
+  def initial_actions, do: @initial_actions
+
+  def all_progress_actions do
+    Enum.uniq(
+      @initial_actions ++
+        @preservation_actions ++ @preservation_image_actions ++ @access_image_actions
+    )
+  end
+
+  def dispatcher_actions(%{role: %{id: "A"}, core_metadata: %{mime_type: "image/" <> _}}),
+    do: @access_image_actions
+
+  def dispatcher_actions(%{role: %{id: "X"}, core_metadata: %{mime_type: "image/" <> _}}),
+    do: @access_image_actions
+
+  def dispatcher_actions(%{role: %{id: "P"}, core_metadata: %{mime_type: "image/" <> _}}),
+    do: @preservation_image_actions
+
+  def dispatcher_actions(%{role: %{id: "S"}}),
+    do: @preservation_actions
+
+  def dispatcher_actions(_), do: nil
+
+  def not_my_actions(file_set) do
+    (all_progress_actions() -- @initial_actions) -- dispatcher_actions(file_set)
+  end
+
+  defp dispatch_next_action(file_set, attributes) do
+    last = ActionStates.get_latest_state(file_set.id)
+
+    next_action =
+      next_action(
+        last.action,
+        dispatcher_actions(file_set)
+      )
+
+    Logger.info(
+      "Last action was: #{last.action}, next action is: #{next_action} for file set id: #{
+        file_set.id
+      }"
+    )
+
+    next_action.send_message(%{file_set_id: file_set.id}, attributes)
+  end
+
+  defp next_action(last_action, action_queue) do
+    index = action_queue |> Enum.find_index(&(Atoms.atom_to_string(&1) == last_action))
+
+    case index do
+      nil ->
+        Enum.at(action_queue, 0)
+
+      number ->
+        Enum.at(action_queue, number + 1)
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Meadow.MixProject do
   use Mix.Project
 
-  @app_version "2.0.0"
+  @app_version "2.0.1"
 
   def project do
     [

--- a/test/fixtures/ingest_sheet.csv
+++ b/test/fixtures/ingest_sheet.csv
@@ -2,7 +2,7 @@ work_type,work_accession_number,file_accession_number,filename,description,role,
 IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",
 ,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P,"The label",
 ,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",TRUE
-,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A,"The label",
+,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",X,"The label",
 VIDEO,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",
 ,Donohue_002,Donohue_002_02,coffee.tif,Verso,A,"The label",
 ,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A,"The label",

--- a/test/meadow/data/file_sets_test.exs
+++ b/test/meadow/data/file_sets_test.exs
@@ -4,7 +4,7 @@ defmodule Meadow.Data.FileSetsTest do
   alias Meadow.Config
   alias Meadow.Data.FileSets
   alias Meadow.Data.Schemas.FileSet
-  alias Meadow.Utils.{ChangesetErrors, Pairtree}
+  alias Meadow.Utils.ChangesetErrors
 
   describe "queries" do
     @valid_attrs %{

--- a/test/meadow/ingest/rows_test.exs
+++ b/test/meadow/ingest/rows_test.exs
@@ -66,5 +66,12 @@ defmodule Meadow.Ingest.RowsTest do
         end)
       end
     end
+
+    test "get_row_by_file_set_accession_number/2", %{prefix: prefix, sheet: sheet} do
+      with row <-
+             Rows.get_row_by_file_set_accession_number(sheet.id, "#{prefix}_Donohue_001_01") do
+        assert row.file_set_accession_number == "#{prefix}_Donohue_001_01"
+      end
+    end
   end
 end

--- a/test/meadow/ingest/sheets_test.exs
+++ b/test/meadow/ingest/sheets_test.exs
@@ -161,7 +161,7 @@ defmodule Meadow.Ingest.SheetsTest do
         rows
         |> Enum.with_index()
         |> Enum.map(fn {row, index} ->
-          {row.id, MapList.get(row.fields, :header, :value, :role), rem(index, 4) == 0}
+          {row.id, rem(index, 4) == 0}
         end)
         |> Progress.initialize_entries()
 

--- a/test/meadow/ingest/work_creator_test.exs
+++ b/test/meadow/ingest/work_creator_test.exs
@@ -3,7 +3,8 @@ defmodule Meadow.Ingest.WorkCreatorTest do
   alias Ecto.Adapters.SQL.Sandbox
   alias Meadow.Data.{FileSets, Works}
   alias Meadow.Ingest.{Progress, SheetsToWorks, WorkCreator}
-  alias Meadow.{Pipeline, Repo}
+  alias Meadow.Repo
+  alias Meadow.Pipeline.Actions.Dispatcher
 
   import Assertions
   import ExUnit.CaptureLog
@@ -44,7 +45,7 @@ defmodule Meadow.Ingest.WorkCreatorTest do
         assert_async(timeout: 1500, sleep_time: 150) do
           assert Works.list_works() |> length() == 1
 
-          assert ["CreateWork" | Pipeline.actions()]
+          assert ["CreateWork" | Dispatcher.all_progress_actions()]
                  |> Enum.all?(fn action ->
                    Progress.get_entry(row, action) |> Map.get(:status) == "error"
                  end)

--- a/test/meadow/ingest/work_redriver_test.exs
+++ b/test/meadow/ingest/work_redriver_test.exs
@@ -3,7 +3,6 @@ defmodule Meadow.Ingest.WorkRedriverTest do
   alias Meadow.Ingest.{Progress, Rows, WorkRedriver}
   alias Meadow.Ingest.Schemas.Progress, as: ProgressSchema
   alias Meadow.Repo
-  alias Meadow.Utils.MapList
 
   import ExUnit.CaptureLog
 
@@ -16,7 +15,7 @@ defmodule Meadow.Ingest.WorkRedriverTest do
       rows
       |> Enum.with_index()
       |> Enum.map(fn {row, index} ->
-        {row.id, MapList.get(row.fields, :header, :value, :role), rem(index, 4) == 0}
+        {row.id, rem(index, 4) == 0}
       end)
       |> Progress.initialize_entries()
 

--- a/test/meadow_web/schema/subscription/ingest_progress_test.exs
+++ b/test/meadow_web/schema/subscription/ingest_progress_test.exs
@@ -3,11 +3,11 @@ defmodule MeadowWeb.Schema.Subscription.IngestProgressTest do
   use MeadowWeb.SubscriptionCase, async: true
   alias Meadow.Ingest.{Progress, Sheets, SheetsToWorks}
   alias Meadow.Pipeline
-  alias Meadow.Pipeline.Actions.GenerateFileSetDigests
+  alias Meadow.Pipeline.Actions.{Dispatcher, GenerateFileSetDigests}
 
   @work_count 2
   @file_set_count 7
-  @action_count length(Pipeline.actions())
+  @action_count length(Dispatcher.all_progress_actions())
   @pct_factor 100 / (@file_set_count * @action_count - 1 + @work_count)
 
   load_gql(MeadowWeb.Schema, "test/gql/IngestProgress.gql")

--- a/test/pipeline/actions/initialize_dispatch_test.exs
+++ b/test/pipeline/actions/initialize_dispatch_test.exs
@@ -1,0 +1,146 @@
+defmodule Meadow.Pipeline.Actions.InitializeDispatchTest do
+  use Meadow.S3Case
+  use Meadow.DataCase
+  use Meadow.IngestCase
+
+  alias Meadow.Data.{ActionStates, FileSets}
+  alias Meadow.Ingest.{Progress, Rows}
+  alias Meadow.Pipeline.Actions.{Dispatcher, ExtractMimeType, IngestFileSet, InitializeDispatch}
+  alias Meadow.Utils.MapList
+
+  @bucket "test-ingest"
+  @key "generate_file_set_digests_test/test.tif"
+  @content "test/fixtures/coffee.tif"
+
+  @fixture "test/fixtures/ingest_sheet.csv"
+
+  describe "process/2" do
+    setup do
+      file_set =
+        file_set_fixture(%{
+          accession_number: "123",
+          role: %{id: "A", scheme: "FILE_SET_ROLE"},
+          core_metadata: %{
+            location: "s3://#{@bucket}/#{@key}",
+            original_filename: "test.tif"
+          }
+        })
+
+      {:ok, file_set: file_set}
+    end
+
+    @tag s3: [%{bucket: @bucket, key: @key, content: File.read!(@content)}]
+    test "initializes correct action_states entries for access image file set", %{
+      file_set: file_set
+    } do
+      assert(IngestFileSet.process(%{file_set_id: file_set.id}, %{}) == :ok)
+      assert(ExtractMimeType.process(%{file_set_id: file_set.id}, %{}) == :ok)
+
+      assert(InitializeDispatch.process(%{file_set_id: file_set.id}, %{}) == :ok)
+      assert(ActionStates.ok?(file_set.id, InitializeDispatch))
+
+      file_set = FileSets.get_file_set(file_set.id)
+
+      Enum.each(Dispatcher.dispatcher_actions(file_set), fn action ->
+        assert %{outcome: "waiting"} = ActionStates.get_latest_state(file_set.id, action)
+      end)
+    end
+  end
+
+  describe "process/2 with ingest sheet" do
+    setup do
+      sheet = ingest_sheet_rows_fixture(@fixture) |> Repo.preload(:ingest_sheet_rows)
+      [_ | [row | _]] = Rows.list_ingest_sheet_rows(sheet: sheet)
+
+      work =
+        work_fixture(%{
+          accession_number: MapList.get(row.fields, :header, :value, :work_accession_number),
+          work_type: %{id: "IMAGE", scheme: "work_type"},
+          ingest_sheet_id: sheet.id
+        })
+
+      file_set =
+        file_set_fixture(%{
+          accession_number: row.file_set_accession_number,
+          role: %{id: "P", scheme: "FILE_SET_ROLE"},
+          core_metadata: %{
+            location: "s3://#{@bucket}/#{@key}",
+            original_filename: "test.tif"
+          },
+          work_id: work.id
+        })
+
+      {:ok, %{row: row, file_set: file_set}}
+    end
+
+    @tag s3: [%{bucket: @bucket, key: @key, content: File.read!(@content)}]
+    test "sets unused progress entries for a file set to :ok", %{
+      row: row,
+      file_set: file_set
+    } do
+      Progress.initialize_entry(row, true)
+      assert Progress.get_entry(row, "CreateWork") |> Map.get(:status) == "pending"
+
+      assert Progress.get_entry(row, Meadow.Pipeline.Actions.CreatePyramidTiff)
+             |> Map.get(:status) == "pending"
+
+      assert(IngestFileSet.process(%{file_set_id: file_set.id}, %{context: "Sheet"}) == :ok)
+      assert(ExtractMimeType.process(%{file_set_id: file_set.id}, %{context: "Sheet"}) == :ok)
+
+      assert(InitializeDispatch.process(%{file_set_id: file_set.id}, %{context: "Sheet"}) == :ok)
+
+      assert Progress.get_entry(row, Meadow.Pipeline.Actions.CreatePyramidTiff)
+             |> Map.get(:status) == "ok"
+    end
+  end
+
+  describe "process/2 with invalid file set role + mime type" do
+    setup do
+      sheet = ingest_sheet_rows_fixture(@fixture) |> Repo.preload(:ingest_sheet_rows)
+      [_ | [row | _]] = Rows.list_ingest_sheet_rows(sheet: sheet)
+
+      work =
+        work_fixture(%{
+          accession_number: MapList.get(row.fields, :header, :value, :work_accession_number),
+          work_type: %{id: "IMAGE", scheme: "work_type"},
+          ingest_sheet_id: sheet.id
+        })
+
+      file_set =
+        file_set_fixture(%{
+          accession_number: row.file_set_accession_number,
+          role: %{id: "P", scheme: "FILE_SET_ROLE"},
+          core_metadata: %{
+            location: "s3://#{@bucket}/#{@key}",
+            original_filename: "test.tif"
+          },
+          work_id: work.id
+        })
+
+      {:ok, %{row: row, file_set: file_set}}
+    end
+
+    @tag s3: [%{bucket: @bucket, key: @key, content: File.read!(@content)}]
+    test "errors remaining actions and progress entries", %{
+      row: row,
+      file_set: file_set
+    } do
+      Progress.initialize_entry(row, true)
+      assert Progress.get_entry(row, "CreateWork") |> Map.get(:status) == "pending"
+
+      assert Progress.get_entry(row, Meadow.Pipeline.Actions.CreatePyramidTiff)
+             |> Map.get(:status) == "pending"
+
+      assert(IngestFileSet.process(%{file_set_id: file_set.id}, %{context: "Sheet"}) == :ok)
+      assert(ExtractMimeType.process(%{file_set_id: file_set.id}, %{context: "Sheet"}) == :ok)
+
+      {:ok, file_set} =
+        FileSets.update_file_set(file_set, %{core_metadata: %{mime_type: "appliation/json"}})
+
+      assert(
+        InitializeDispatch.process(%{file_set_id: file_set.id}, %{context: "Sheet"}) ==
+          {:error, "Invalid mime-type and file set role combination"}
+      )
+    end
+  end
+end

--- a/test/pipeline/dispatcher_test.exs
+++ b/test/pipeline/dispatcher_test.exs
@@ -1,0 +1,153 @@
+defmodule Meadow.Pipeline.Actions.DispatcherTest do
+  use Meadow.S3Case
+  use Meadow.DataCase
+
+  alias Meadow.Pipeline.Actions.{
+    CopyFileToPreservation,
+    CreatePyramidTiff,
+    Dispatcher,
+    ExtractMimeType,
+    FileSetComplete,
+    GenerateFileSetDigests,
+    ExtractExifMetadata,
+    IngestFileSet,
+    InitializeDispatch
+  }
+
+  import ExUnit.CaptureLog
+
+  @bucket "test-ingest"
+  @key "generate_file_set_digests_test/test.tif"
+  @content "test/fixtures/coffee.tif"
+
+  setup do
+    file_set =
+      file_set_fixture(%{
+        accession_number: "123",
+        role: %{id: "P", scheme: "FILE_SET_ROLE"},
+        core_metadata: %{
+          location: "s3://#{@bucket}/#{@key}",
+          original_filename: "test.tif"
+        }
+      })
+
+    {:ok, file_set_id: file_set.id}
+  end
+
+  describe "process/2" do
+    @tag s3: [%{bucket: @bucket, key: @key, content: File.read!(@content)}]
+    test "Dispatches the next action for a file set", %{file_set_id: file_set_id} do
+      assert(IngestFileSet.process(%{file_set_id: file_set_id}, %{}) == :ok)
+      assert(ExtractMimeType.process(%{file_set_id: file_set_id}, %{}) == :ok)
+      assert(InitializeDispatch.process(%{file_set_id: file_set_id}, %{}) == :ok)
+
+      assert capture_log(fn ->
+               Dispatcher.process(%{file_set_id: file_set_id}, %{})
+             end) =~
+               "Last action was: Meadow.Pipeline.Actions.InitializeDispatch, next action is: Elixir.Meadow.Pipeline.Actions.GenerateFileSetDigests for file set id: #{
+                 file_set_id
+               }"
+    end
+  end
+
+  describe "action retrieval" do
+    test "initial_actions" do
+      assert Dispatcher.initial_actions() == [
+               IngestFileSet,
+               ExtractMimeType,
+               InitializeDispatch
+             ]
+    end
+
+    test "dispatcher_actions for file set role: P, mime_type: image/*" do
+      file_set =
+        file_set_fixture(%{
+          role: %{id: "P", scheme: "FILE_SET_ROLE"},
+          core_metadata: %{
+            mime_type: "image/tiff",
+            location: "s3://blahblah",
+            original_filename: "test.tif"
+          }
+        })
+
+      assert Dispatcher.dispatcher_actions(file_set) == [
+               GenerateFileSetDigests,
+               ExtractExifMetadata,
+               CopyFileToPreservation,
+               FileSetComplete
+             ]
+    end
+
+    test "dispatcher_actions for file set role: A, mime_type: image/*" do
+      file_set =
+        file_set_fixture(%{
+          role: %{id: "A", scheme: "FILE_SET_ROLE"},
+          core_metadata: %{
+            mime_type: "image/tiff",
+            location: "s3://blahblah",
+            original_filename: "test.tif"
+          }
+        })
+
+      assert Dispatcher.dispatcher_actions(file_set) == [
+               GenerateFileSetDigests,
+               ExtractExifMetadata,
+               CopyFileToPreservation,
+               CreatePyramidTiff,
+               FileSetComplete
+             ]
+    end
+
+    test "dispatcher_actions for file set role: X, mime_type: image/*" do
+      file_set =
+        file_set_fixture(%{
+          role: %{id: "X", scheme: "FILE_SET_ROLE"},
+          core_metadata: %{
+            mime_type: "image/tiff",
+            location: "s3://blahblah",
+            original_filename: "test.tif"
+          }
+        })
+
+      assert Dispatcher.dispatcher_actions(file_set) == [
+               GenerateFileSetDigests,
+               ExtractExifMetadata,
+               CopyFileToPreservation,
+               CreatePyramidTiff,
+               FileSetComplete
+             ]
+    end
+
+    test "dispatcher_actions for file set role: S, mime_type: *" do
+      file_set =
+        file_set_fixture(%{
+          role: %{id: "S", scheme: "FILE_SET_ROLE"},
+          core_metadata: %{
+            mime_type: "application/json",
+            location: "s3://blahblah",
+            original_filename: "test.tif"
+          }
+        })
+
+      assert Dispatcher.dispatcher_actions(file_set) == [
+               GenerateFileSetDigests,
+               CopyFileToPreservation,
+               FileSetComplete
+             ]
+    end
+
+    test "dispatcher_actions for unknown mime type" do
+      file_set =
+        file_set_fixture(%{
+          role: %{id: "A", scheme: "FILE_SET_ROLE"},
+          core_metadata: %{
+            mime_type: "video/mp4",
+            location: "s3://blahblah",
+            original_filename: "test.tif"
+          }
+        })
+
+      assert Dispatcher.dispatcher_actions(file_set) == nil
+    end
+  end
+end

--- a/test/pipeline/dispatcher_test.exs
+++ b/test/pipeline/dispatcher_test.exs
@@ -42,9 +42,12 @@ defmodule Meadow.Pipeline.Actions.DispatcherTest do
       assert(InitializeDispatch.process(%{file_set_id: file_set_id}, %{}) == :ok)
 
       assert capture_log(fn ->
-               Dispatcher.process(%{file_set_id: file_set_id}, %{})
+               Dispatcher.process(%{file_set_id: file_set_id}, %{
+                 process: "InitializeDispatch",
+                 status: "ok"
+               })
              end) =~
-               "Last action was: Meadow.Pipeline.Actions.InitializeDispatch, next action is: Elixir.Meadow.Pipeline.Actions.GenerateFileSetDigests for file set id: #{
+               "Last action was: Elixir.Meadow.Pipeline.Actions.InitializeDispatch, next action is: Elixir.Meadow.Pipeline.Actions.GenerateFileSetDigests for file set id: #{
                  file_set_id
                }"
     end


### PR DESCRIPTION
- Change the pipeline so that the actions up to `ExtractMimeType` are common, after that a Dispatcher is initialized which handles routing through the correct processing pipeline based on file set role + mime type. 

Docs PR: https://github.com/nulib/repodev_planning_and_docs/pull/1922