### PR TITLE
Terraform changes to support streaming media

### DIFF
--- a/terraform/ec2_files/dev.local.exs
+++ b/terraform/ec2_files/dev.local.exs
@@ -56,6 +56,10 @@ config :meadow, preservation_check_bucket: get_required_var.("PRESERVATION_CHECK
 config :meadow, iiif_server_url: get_required_var.("IIIF_SERVER_URL")
 config :meadow, iiif_manifest_url: get_required_var.("IIIF_MANIFEST_URL")
 config :meadow, digital_collections_url: get_required_var.("DIGITAL_COLLECTIONS_URL")
+config :meadow, mediaconvert_client: MediaConvert,
+config :meadow, mediaconvert_queue: get_required_var.("MEDIACONVERT_QUEUE")
+config :meadow, mediaconvert_role: get_required_var.("MEDIACONVERT_ROLE")
+config :meadow, streaming_bucket: get_required_var.("STREAMING_BUCKET")
 config :meadow, sitemaps: [
   gzip: true,
   store: Sitemapper.S3Store,

--- a/terraform/ec2_files/meadowrc
+++ b/terraform/ec2_files/meadowrc
@@ -32,10 +32,13 @@ export RELEASE_DISTRIBUTION="name"
 export RELEASE_NODE="meadow@${host_name}"
 export SECRET_KEY_BASE="${secret_key_base}"
 export SITEMAP_BUCKET="${digital_collections_bucket}"
+export STREAMING_BUCKET="${streaming_bucket}
 export UPLOAD_BUCKET="${upload_bucket}"
 export MIGRATION_BINARY_BUCKET="${migration_binary_bucket}"
 export MIGRATION_MANIFEST_BUCKET="${migration_manifest_bucket}"
 export PRESERVATION_CHECK_BUCKET="${preservation_check_bucket}"
+export MEDIACONVERT_QUEUE="${mediaconvert_queue}"
+export MEDIACONVERT_ROLE="${mediaconvert_role}"
 
 cd ~/meadow
 git fetch -pa origin

--- a/terraform/ecs_services.tf
+++ b/terraform/ecs_services.tf
@@ -35,6 +35,9 @@ locals {
     ldap_bind_dn               = var.ldap_bind_dn
     ldap_bind_password         = var.ldap_bind_password
     preservation_check_bucket  = aws_s3_bucket.meadow_preservation_checks.bucket
+    streaming_bucket           = aws_s3_bucket.meadow_streaming.bucket
+    mediaconvert_queue         = aws_media_convert_queue.transcode_queue.arn
+    mediaconvert_role          = aws_iam_role.transcode_role.arn
   }
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -357,3 +357,8 @@ resource "aws_iam_role" "transcode_role" {
     })
   }
 }
+
+resource "aws_media_convert_queue" "transcode_queue" {
+  name   = var.stack_name
+  status = "ACTIVE"
+}

--- a/terraform/sequins.tf
+++ b/terraform/sequins.tf
@@ -1,0 +1,50 @@
+locals {
+  actions = ["ingest-file-set", "extract-mime-type", "generate-file-set-digests", 
+             "extract-exif-metadata", "copy-file-to-preservation", "create-pyramid-tiff", 
+             "create-transcode-job", "transcode-complete", "file-set-complete"]
+}
+
+resource "aws_sqs_queue" "sequins_queue" {
+  for_each = toset(local.actions)
+  name = "${var.stack_name}-${each.key}"
+  policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Sid = "sns-notifications-1"
+          Effect = "Allow"
+          Principal = { "AWS" : "*" }
+          Action = "SQS:SendMessage"
+          Resource = "arn:aws:sqs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:${var.stack_name}-${each.key}"
+          Condition = {
+            ArnLike = {
+              "aws:SourceArn" = "arn:aws:sns:${var.aws_region}:${data.aws_caller_identity.current.id}:*"
+            }
+          }
+        }
+      ]
+  })
+}
+
+resource "aws_sns_topic" "sequins_topic" {
+  for_each = toset(local.actions)
+  name = "${var.stack_name}-${each.key}"
+}
+
+resource "aws_cloudwatch_event_rule" "mediaconvert_state_change" {
+  name = "${var.stack_name}-mediaconvert-state-change"
+  description = "Send MediaConvert state changes to Meadow"
+  event_pattern = jsonencode({
+    source = ["aws.mediaconvert"]
+    "detail-type" = ["MediaConvert Job State Change"]
+    detail = {
+      queue = [aws_media_convert_queue.transcode_queue.arn]
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "mediaconvert_state_change_sqs" {
+  rule      = aws_cloudwatch_event_rule.mediaconvert_state_change.name
+  target_id = "SendToTranscodeCompleteQueue"
+  arn       = aws_sqs_queue.sequins_queue["transcode-complete"].arn
+}

--- a/terraform/task-definitions/meadow_app.json
+++ b/terraform/task-definitions/meadow_app.json
@@ -113,6 +113,14 @@
         "value": "${db_queue_interval}"
       },
       {
+        "name": "MEDIACONVERT_QUEUE",
+        "value": "${mediaconvert_queue}"
+      },
+      {
+        "name": "MEDIACONVERT_ROLE",
+        "value": "${mediaconvert_role}"
+      },
+      {
         "name": "PRESERVATION_BUCKET",
         "value": "${preservation_bucket}"
       },
@@ -135,6 +143,10 @@
       {
         "name": "RELEASE_DISTRIBUTION",
         "value": "name"
+      },
+      {
+        "name": "STREAMING_BUCKET",
+        "value": "${streaming_bucket}"
       },
       {
         "name": "UPLOAD_BUCKET",


### PR DESCRIPTION
- Add MediaConvert related environment variables to Meadow task definition and console configs
- Create MediaConvert queue
- Create EventBridge rule to notify Meadow of completed transcode jobs
- Import existing Sequins queues and topics so Terraform can use them

Changes already applied on staging
Queues and topics imported into Terraform state on production but other changes not applied