### PR TITLE
Add request/2 and request!/2 to Meadow.Utils.AWS

### DIFF
--- a/lib/meadow/error.ex
+++ b/lib/meadow/error.ex
@@ -1,6 +1,5 @@
 defmodule Meadow.TimeoutError, do: defexception([:message])
 defmodule Meadow.LambdaError, do: defexception([:message])
-defmodule Meadow.AwsError, do: defexception([:message])
 
 defmodule Meadow.Error do
   @moduledoc """
@@ -30,25 +29,6 @@ defmodule Meadow.Error do
       meadow_version: Config.meadow_version(),
       notifier: module
     })
-  end
-
-  @doc """
-  Pass `response` through, notifying Honeybadger if the response indicates anything
-  but success
-  """
-  def handle_ex_aws_response(response, module) do
-    case response do
-      {:error, {:http_error, status, _}} ->
-        report(%Meadow.AwsError{message: to_string(status)}, module, [])
-
-      {:error, message} ->
-        report(%Meadow.AwsError{message: to_string(message)}, module, [])
-
-      _ ->
-        :noop
-    end
-
-    response
   end
 end
 

--- a/lib/meadow/structural_metadata_listener.ex
+++ b/lib/meadow/structural_metadata_listener.ex
@@ -5,9 +5,9 @@ defmodule Meadow.StructuralMetadataListener do
   """
   use Meadow.DatabaseNotification, tables: [:file_sets]
   use Meadow.Utils.Logging
-  alias Meadow.{Config, Error}
+  alias Meadow.Config
   alias Meadow.Data.FileSets
-  alias Meadow.Utils.Pairtree
+  alias Meadow.Utils.{AWS, Pairtree}
   require Logger
 
   @impl true
@@ -34,16 +34,14 @@ defmodule Meadow.StructuralMetadataListener do
     Logger.info("Writing structural metadata for #{id}")
 
     ExAws.S3.put_object(Config.streaming_bucket(), vtt_location(id), vtt, content_type: "text/vtt")
-    |> ExAws.request()
-    |> Error.handle_ex_aws_response(__MODULE__)
+    |> AWS.request()
   end
 
   defp write_structural_metadata(%{id: id}) do
     Logger.info("Deleting structural metadata for #{id}")
 
     ExAws.S3.delete_object(Config.streaming_bucket(), vtt_location(id))
-    |> ExAws.request()
-    |> Error.handle_ex_aws_response(__MODULE__)
+    |> AWS.request()
   end
 
   defp vtt_location(id), do: Path.join(Pairtree.generate!(id), id <> ".vtt")

--- a/lib/meadow/utils/aws.ex
+++ b/lib/meadow/utils/aws.ex
@@ -1,7 +1,35 @@
+defmodule Meadow.AwsError, do: defexception([:message])
+
 defmodule Meadow.Utils.AWS do
   @moduledoc """
   Utility functions for AWS requests and object management
   """
+  alias Meadow.Error
+  import SweetXml, only: [sigil_x: 2]
+
+  @doc """
+  Drop-in replacement for ExAws.request/2 that reports errors to Honeybadger
+  """
+  def request(op, config_overrides \\ []) do
+    ExAws.request(op, config_overrides) |> handle_response()
+  end
+
+  @doc """
+  Drop-in replacement for ExAws.request!/2 that reports errors to Honeybadger
+  """
+  def request!(op, config_overrides \\ []) do
+    case ExAws.request(op, config_overrides) |> handle_response() do
+      {:ok, result} ->
+        result
+
+      error ->
+        raise ExAws.Error, """
+        ExAws Request Error!
+
+        #{inspect(error)}
+        """
+    end
+  end
 
   def presigned_url(bucket, %{upload_type: "preservation_check", filename: filename}) do
     generate_presigned_url(bucket, "#{filename}", :get)
@@ -23,7 +51,7 @@ defmodule Meadow.Utils.AWS do
     bucket
     |> check_bucket()
     |> ExAws.S3.put_object("#{name}/", "")
-    |> ExAws.request()
+    |> request()
   end
 
   def add_aws_signature(request, region, access_key, secret) do
@@ -67,7 +95,7 @@ defmodule Meadow.Utils.AWS do
           {:error, {:http_error, 404, _}} ->
             bucket
             |> ExAws.S3.put_bucket("us-east-1")
-            |> ExAws.request!()
+            |> request!()
 
             {:ok, :created}
 
@@ -85,5 +113,68 @@ defmodule Meadow.Utils.AWS do
     |> check_bucket()
 
     ExAws.S3.presigned_url(ExAws.Config.new(:s3), method, bucket, path)
+  end
+
+  def handle_response(response) do
+    {:current_stacktrace, [_ | [_ | stacktrace]]} = Process.info(self(), :current_stacktrace)
+    [{module, _, _, _} | _] = stacktrace
+
+    case response do
+      {:error, {:http_error, _status, response}} ->
+        {message, context} = extract_aws_error(response)
+        Error.report(%Meadow.AwsError{message: message}, module, stacktrace, context)
+
+      {:error, message} ->
+        Error.report(%Meadow.AwsError{message: to_string(message)}, module, stacktrace)
+
+      _ ->
+        :noop
+    end
+
+    response
+  end
+
+  def handle_response!(response) do
+    case handle_response(response) do
+      {:ok, result} ->
+        result
+
+      error ->
+        raise ExAws.Error, """
+        ExAws Request Error!
+
+        #{inspect(error)}
+        """
+    end
+  end
+
+  defp extract_aws_error(%{body: body, status_code: status_code}) do
+    case SweetXml.parse(body) |> SweetXml.xpath(~x"/Error") do
+      nil ->
+        status_code
+
+      {:xmlElement, :Error, _, _, _, _, _, _, children, _, _, _} ->
+        context = map_children(children) |> Enum.reject(&is_nil/1) |> Enum.into(%{})
+        {code, context} = Map.pop(context, :Code)
+        {message, context} = Map.pop(context, :Message)
+        message = "#{status_code} (#{code}): #{message}"
+
+        {message, context}
+    end
+  end
+
+  defp extract_aws_error(%{status_code: status_code}), do: {to_string(status_code), %{}}
+
+  defp map_children([]), do: []
+  defp map_children([child | children]), do: [map_child(child) | map_children(children)]
+
+  defp map_child(child) do
+    case child do
+      {:xmlElement, tag, _, _, _, _, _, _, _, _, _, _} ->
+        {tag, SweetXml.xpath(child, ~x"./text()") |> to_string()}
+
+      _ ->
+        nil
+    end
   end
 end

--- a/test/meadow/data/file_sets_test.exs
+++ b/test/meadow/data/file_sets_test.exs
@@ -4,7 +4,7 @@ defmodule Meadow.Data.FileSetsTest do
   alias Meadow.Config
   alias Meadow.Data.FileSets
   alias Meadow.Data.Schemas.FileSet
-  alias Meadow.Utils.{ChangesetErrors, Pairtree}
+  alias Meadow.Utils.ChangesetErrors
 
   describe "queries" do
     @valid_attrs %{

--- a/test/meadow/error_test.exs
+++ b/test/meadow/error_test.exs
@@ -78,41 +78,4 @@ defmodule Meadow.ErrorTest do
       end
     end
   end
-
-  describe "handle_ex_aws_response/2" do
-    test "does not report anything when AWS request is successful" do
-      restart_with_config(exclude_envs: [])
-
-      ExAws.S3.head_bucket(Config.upload_bucket())
-      |> ExAws.request()
-      |> Meadow.Error.handle_ex_aws_response(__MODULE__)
-
-      refute_receive {:api_request, _report}, 1000
-    end
-
-    test "reports error when AWS returns an HTTP error" do
-      restart_with_config(exclude_envs: [])
-
-      ExAws.S3.head_bucket("nonexistent-bucket")
-      |> ExAws.request()
-      |> Meadow.Error.handle_ex_aws_response(__MODULE__)
-
-      assert_receive {:api_request, report}, 1000
-
-      assert report |> get_in(["error", "class"]) == "Meadow.AwsError"
-      assert report |> get_in(["error", "message"]) == "404"
-    end
-
-    test "reports error when ExAws fails any other way" do
-      restart_with_config(exclude_envs: [])
-
-      {:error, "Catastrophic Failure"}
-      |> Meadow.Error.handle_ex_aws_response(__MODULE__)
-
-      assert_receive {:api_request, report}, 1000
-
-      assert report |> get_in(["error", "class"]) == "Meadow.AwsError"
-      assert report |> get_in(["error", "message"]) == "Catastrophic Failure"
-    end
-  end
 end

--- a/test/meadow/utils/aws_test.exs
+++ b/test/meadow/utils/aws_test.exs
@@ -1,5 +1,7 @@
 defmodule Meadow.Utils.AWSTest do
+  use Honeybadger.Case
   use Meadow.S3Case
+  alias Meadow.Config
   alias Meadow.Utils.AWS
 
   @project_folder_name "name-of-folder"
@@ -36,6 +38,77 @@ defmodule Meadow.Utils.AWSTest do
 
     with {:ok, presigned_url} <- AWS.presigned_url(@bucket, %{upload_type: "ingest_sheet"}) do
       assert presigned_url =~ regex
+    end
+  end
+
+  describe "error handling" do
+    setup do
+      {:ok, _} = Honeybadger.API.start(self())
+      restart_with_config(exclude_envs: [])
+
+      on_exit(&Honeybadger.API.stop/0)
+    end
+
+    test "request/2 does not report to Honeybadger when request is successful" do
+      ExAws.S3.head_bucket(Config.upload_bucket())
+      |> AWS.request()
+
+      refute_receive {:api_request, _report}, 1000
+    end
+
+    test "request/2 reports error when AWS returns an HTTP error with a body" do
+      ExAws.S3.put_object("nonexistent-bucket", "/path/to/key", "contents")
+      |> AWS.request()
+
+      assert_receive {:api_request, report}, 1000
+
+      assert report |> get_in(["error", "class"]) == "Meadow.AwsError"
+
+      assert report |> get_in(["error", "message"]) ==
+               "404 (NoSuchBucket): The specified bucket does not exist"
+
+      assert report |> get_in(["request", "context", "BucketName"]) == "nonexistent-bucket"
+    end
+
+    test "request/2 reports error when AWS returns an HTTP error without a body" do
+      ExAws.S3.head_bucket("nonexistent-bucket")
+      |> AWS.request()
+
+      assert_receive {:api_request, report}, 1000
+
+      assert report |> get_in(["error", "class"]) == "Meadow.AwsError"
+      assert report |> get_in(["error", "message"]) == "404"
+    end
+
+    test "request/2 reports error when ExAws fails any other way" do
+      {:error, "Catastrophic Failure"}
+      |> AWS.handle_response()
+
+      assert_receive {:api_request, report}, 1000
+
+      assert report |> get_in(["error", "class"]) == "Meadow.AwsError"
+      assert report |> get_in(["error", "message"]) == "Catastrophic Failure"
+    end
+
+    test "request!/2 does not raise or report when AWS request is successful" do
+      ExAws.S3.head_bucket(Config.upload_bucket())
+      |> AWS.request!()
+
+      refute_receive {:api_request, _report}, 1000
+    end
+
+    test "request!/2 reports and raises when it encounters an error" do
+      assert_raise(ExAws.Error, fn ->
+        ExAws.S3.put_object("nonexistent-bucket", "/path/to/key", "contents")
+        |> AWS.request!()
+      end)
+
+      assert_receive {:api_request, report}, 1000
+
+      assert report |> get_in(["error", "message"]) ==
+               "404 (NoSuchBucket): The specified bucket does not exist"
+
+      assert report |> get_in(["request", "context", "BucketName"]) == "nonexistent-bucket"
     end
   end
 end


### PR DESCRIPTION
This PR creates two new utility functions, `Meadow.Utils.AWS.request/2` and `Meadow.Utils.AWS.request!/2`, to act as drop-in replacements for their `ExAws` equivalents. They behave in the exact same way, but they report error responses to Honeybadger (with full stacktrace and context info) whether the calling code reports them or not.