### PR TITLE
Create TranscodeComplete pipeline action

### DIFF
--- a/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
+++ b/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
@@ -1,5 +1,6 @@
 import React, { useContext } from "react";
 import PropTypes from "prop-types";
+import { Button } from "@nulib/admin-react-components";
 import { IIIFContext } from "@js/components/IIIF/IIIFProvider";
 import { IIIF_SIZES } from "@js/services/global-vars";
 import { IconDownload } from "@js/components/Icon";

--- a/assets/js/components/Work/Tabs/Preservation/FileSetDropzone.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/FileSetDropzone.jsx
@@ -27,7 +27,7 @@ function WorkTabsPreservationFileSetDropzone({
     isDragReject,
   } = useDropzone({
     onDrop,
-    accept: "image/tiff, image/jpeg, image/jpg",
+    accept: "image/*, audio/*, video/*",
     multiple: false,
   });
 

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -169,6 +169,16 @@ config :sequins, Actions.ExtractExifMetadata,
     visibility_timeout: 360
   ]
 
+config :sequins, Actions.ExtractMediaMetadata,
+  queue_config: [
+    producer_concurrency: 10,
+    receive_interval: 1000,
+    wait_time_seconds: 1,
+    max_number_of_messages: 10,
+    processor_concurrency: 100,
+    visibility_timeout: 360
+  ]
+
 config :sequins, Actions.ExtractMimeType,
   queue_config: [
     producer_concurrency: 10,
@@ -180,6 +190,26 @@ config :sequins, Actions.ExtractMimeType,
   ]
 
 config :sequins, Actions.CreatePyramidTiff,
+  queue_config: [
+    producer_concurrency: 10,
+    receive_interval: 1000,
+    wait_time_seconds: 1,
+    max_number_of_messages: 10,
+    processor_concurrency: 100,
+    visibility_timeout: 360
+  ]
+
+config :sequins, Actions.CreateTranscodeJob,
+  queue_config: [
+    producer_concurrency: 10,
+    receive_interval: 1000,
+    wait_time_seconds: 1,
+    max_number_of_messages: 10,
+    processor_concurrency: 100,
+    visibility_timeout: 360
+  ]
+
+config :sequins, Actions.TranscodeComplete,
   queue_config: [
     producer_concurrency: 10,
     receive_interval: 1000,

--- a/config/sequins.exs
+++ b/config/sequins.exs
@@ -5,12 +5,14 @@ alias Meadow.Pipeline.Actions.{
   CreatePyramidTiff,
   CreateTranscodeJob,
   Dispatcher,
+  ExtractMediaMetadata,
   ExtractMimeType,
   FileSetComplete,
   GenerateFileSetDigests,
   ExtractExifMetadata,
   IngestFileSet,
-  InitializeDispatch
+  InitializeDispatch,
+  TranscodeComplete
 }
 
 config :sequins,
@@ -27,7 +29,9 @@ config :sequins, Meadow.Pipeline,
     ExtractExifMetadata,
     CopyFileToPreservation,
     CreatePyramidTiff,
+    ExtractMediaMetadata,
     CreateTranscodeJob,
+    TranscodeComplete,
     FileSetComplete
   ]
 
@@ -72,6 +76,15 @@ config :sequins, ExtractExifMetadata,
   ],
   notify_on: [ExtractExifMetadata: [status: :retry]]
 
+config :sequins, ExtractMediaMetadata,
+  queue_config: [
+    receive_interval: 1000,
+    wait_time_seconds: 1,
+    processor_concurrency: 1,
+    visibility_timeout: 300
+  ],
+  notify_on: [ExtractMediaMetadata: [status: :retry]]
+
 config :sequins, CreatePyramidTiff,
   queue_config: [
     receive_interval: 1000,
@@ -94,11 +107,20 @@ config :sequins, CreateTranscodeJob,
     CreateTranscodeJob: [status: :retry]
   ]
 
+config :sequins, TranscodeComplete,
+  queue_config: [
+    receive_interval: 1000,
+    wait_time_seconds: 1,
+    processor_concurrency: 1,
+    visibility_timeout: 300
+  ],
+  notify_on: [
+    TranscodeComplete: [status: :retry]
+  ]
+
 config :sequins, FileSetComplete,
   queue_config: [receive_interval: 1000, wait_time_seconds: 1, processor_concurrency: 10],
   notify_on: [
-    CreateTranscodeJob: [status: :ok],
-    CreateTranscodeJob: [status: :skip],
     FileSetComplete: [status: :retry]
   ]
 
@@ -109,5 +131,7 @@ config :sequins, Dispatcher,
     GenerateFileSetDigests: [status: :ok],
     CopyFileToPreservation: [status: :ok],
     ExtractExifMetadata: [status: :ok],
-    CreatePyramidTiff: [status: :ok]
+    ExtractMediaMetadata: [status: :ok],
+    CreatePyramidTiff: [status: :ok],
+    TranscodeComplete: [status: :ok]
   ]

--- a/lib/meadow/data/file_sets.ex
+++ b/lib/meadow/data/file_sets.ex
@@ -138,6 +138,14 @@ defmodule Meadow.Data.FileSets do
     end
   end
 
+  def add_derivative(%FileSet{derivatives: nil}, type, value),
+    do: add_derivative_to_map(%{}, type, value)
+
+  def add_derivative(%FileSet{derivatives: map}, type, value),
+    do: add_derivative_to_map(map, type, value)
+
+  defp add_derivative_to_map(map, type, value), do: Map.put(map, to_string(type), value)
+
   defp multi_update(file_set_updates) do
     file_set_updates
     |> Enum.with_index(1)

--- a/lib/meadow/data/schemas/file_set.ex
+++ b/lib/meadow/data/schemas/file_set.ex
@@ -23,6 +23,7 @@ defmodule Meadow.Data.Schemas.FileSet do
     field :role, Types.CodedTerm
     field :rank, :integer
     field :position, :any, virtual: true
+    field :derivatives, :map
 
     embeds_one :core_metadata, FileSetCoreMetadata, on_replace: :update
     embeds_one :structural_metadata, FileSetStructuralMetadata, on_replace: :delete
@@ -37,7 +38,7 @@ defmodule Meadow.Data.Schemas.FileSet do
   end
 
   defp changeset_params do
-    {[:accession_number, :role], [:work_id, :position, :extracted_metadata]}
+    {[:accession_number, :role], [:work_id, :position, :extracted_metadata, :derivatives]}
   end
 
   def changeset(file_set \\ %__MODULE__{}, params) do

--- a/lib/meadow/pipeline/actions/transcode_complete.ex
+++ b/lib/meadow/pipeline/actions/transcode_complete.ex
@@ -1,0 +1,79 @@
+defmodule Meadow.Pipeline.Actions.TranscodeComplete do
+  @moduledoc """
+  Action to handle job state change messages from MediaConvert
+  """
+
+  alias Meadow.Data.{ActionStates, FileSets}
+  alias Meadow.Ingest.{Progress, Rows}
+
+  use Sequins.Pipeline.Action
+  use Meadow.Utils.Logging
+
+  require Logger
+
+  @impl true
+  def process(%{detail_type: "MediaConvert Job State Change"} = message, _attributes) do
+    with {data, attributes} <- parse(message) do
+      process(data, attributes)
+    end
+  end
+
+  def process(%{file_set_id: file_set_id} = data, attributes) do
+    with_log_metadata module: __MODULE__, id: data.file_set_id do
+      with {status, response} <-
+             file_set_id |> FileSets.get_file_set() |> process_mediaconvert_response(data) do
+        update_progress(attributes, status)
+        {status, response, attributes}
+      end
+    end
+  end
+
+  defp parse(message) do
+    {%{
+       file_set_id: message |> get_in([:detail, :user_metadata, :file_set_id]),
+       status: message |> get_in([:detail, :status]),
+       error: message |> get_in([:detail, :error_message]),
+       playlist: message |> extract_playlist()
+     },
+     message
+     |> get_in([:detail, :user_metadata])
+     |> Map.delete(:file_set_id)}
+  end
+
+  defp extract_playlist(message) do
+    case message |> get_in([:detail, :output_group_details]) do
+      [detail | _] ->
+        detail |> get_in([:playlist_file_paths, Access.at(-1)])
+
+      _ ->
+        nil
+    end
+  end
+
+  defp process_mediaconvert_response(nil, %{file_set_id: file_set_id}) do
+    Logger.warn(
+      "Marking #{__MODULE__} for #{file_set_id} as error because the file set was not found"
+    )
+
+    {:error, "FileSet #{file_set_id} not found"}
+  end
+
+  defp process_mediaconvert_response(file_set, %{status: "COMPLETE", playlist: playlist}) do
+    derivatives = FileSets.add_derivative(file_set, :playlist, playlist)
+    FileSets.update_file_set(file_set, %{derivatives: derivatives})
+    ActionStates.set_state!(file_set, __MODULE__, "ok")
+    {:ok, %{file_set_id: file_set.id}}
+  end
+
+  defp process_mediaconvert_response(file_set, %{status: "ERROR", error: error}) do
+    ActionStates.set_state!(file_set, __MODULE__, "error", error)
+    {:error, error}
+  end
+
+  defp update_progress(%{ingest_sheet: sheet_id, ingest_sheet_row: row_num}, status) do
+    Rows.get_row(sheet_id, row_num)
+    |> Progress.update_entry(__MODULE__, to_string(status))
+  end
+
+  defp update_progress(_, _), do: :noop
+end

--- a/lib/meadow/utils/extracted_metadata.ex
+++ b/lib/meadow/utils/extracted_metadata.ex
@@ -10,7 +10,7 @@ defmodule Meadow.Utils.ExtractedMetadata do
     |> Enum.map(fn {key, data} ->
       case key do
         "exif" -> {key, transform_data(data, &Exif.transform/1)}
-        other -> {key, other}
+        _ -> {key, data}
       end
     end)
     |> Enum.into(%{})

--- a/lib/media_convert/mock.ex
+++ b/lib/media_convert/mock.ex
@@ -2,6 +2,8 @@ defmodule MediaConvert.Mock do
   @moduledoc """
   Mock AWS Elemental MediaConvert client
   """
+  alias Meadow.Pipeline.Actions.TranscodeComplete
+
   def configure! do
     :ok
   end
@@ -13,13 +15,100 @@ defmodule MediaConvert.Mock do
   the word "error", e.g. %{FileInput: "s3://error/test.mov"} => {:error, "Fake error response"}
   """
   def create_job(template) do
-    if String.match?(file_input(template), ~r/error/) do
+    if String.match?(file_input(template), ~r/input-error/) do
       {:error, "Fake error response"}
     else
+      send_transcode_complete(template)
       {:ok, "fake-job-id"}
     end
   end
 
   defp file_input(%{Settings: %{Inputs: [%{FileInput: file_input}]}}), do: file_input
   defp file_input(_template), do: ""
+
+  defp destination(%{
+         Settings: %{
+           OutputGroups: [
+             %{OutputGroupSettings: %{CmafGroupSettings: %{Destination: destination}}}
+           ]
+         }
+       }),
+       do: destination
+
+  defp destination(_template), do: ""
+
+  defp send_transcode_complete(template) do
+    if String.match?(file_input(template), ~r/transcode-error/) do
+      event(template, "ERROR")
+    else
+      event(template, "COMPLETE")
+    end
+    |> TranscodeComplete.send_message(%{})
+  end
+
+  defp event(template, "COMPLETE") do
+    playlist_path =
+      Path.join(destination(template), file_input(template) |> Path.basename()) <> ".m3u8"
+
+    timestamp = DateTime.utc_now()
+    metadata = template |> Map.get(:UserMetadata, %{})
+
+    %{
+      account: "012345678901",
+      detail: %{
+        accountId: "012345678901",
+        jobId: "fake-job-id",
+        outputGroupDetails: [
+          %{
+            outputDetails: [
+              %{
+                durationInMs: 5538,
+                videoDetails: %{heightInPx: 720, widthInPx: 1280}
+              },
+              %{durationInMs: 5526}
+            ],
+            playlistFilePaths: [playlist_path],
+            type: "CMAF_GROUP"
+          }
+        ],
+        queue: template |> Map.get(:Queue),
+        status: "COMPLETE",
+        timestamp: DateTime.to_unix(timestamp, :millisecond),
+        userMetadata: metadata
+      },
+      "detail-type": "MediaConvert Job State Change",
+      id: Ecto.UUID.generate(),
+      region: ExAws.Config.new(:mediaconvert) |> Map.get(:region),
+      resources: ["arn:aws:mediaconvert:us-east-1:012345678901:jobs/fake-job-id"],
+      source: "aws.mediaconvert",
+      time: timestamp |> DateTime.truncate(:second) |> DateTime.to_iso8601(),
+      version: "0"
+    }
+  end
+
+  defp event(template, "ERROR") do
+    timestamp = DateTime.utc_now()
+    metadata = template |> Map.get(:UserMetadata, %{})
+
+    %{
+      account: "012345678901",
+      detail: %{
+        accountId: "012345678901",
+        errorCode: 1401,
+        errorMessage: "Unable to open input file [#{file_input(template)}]",
+        jobId: "fake-job-id",
+        queue: template |> Map.get(:Queue),
+        status: "ERROR",
+        timestamp: DateTime.to_unix(timestamp, :millisecond),
+        userMetadata: metadata
+      },
+      "detail-type": "MediaConvert Job State Change",
+      id: Ecto.UUID.generate(),
+      region: ExAws.Config.new(:mediaconvert) |> Map.get(:region),
+      resources: ["arn:aws:mediaconvert:us-east-1:012345678901:jobs/fake-job-id"],
+      source: "aws.mediaconvert",
+      time: timestamp |> DateTime.truncate(:second) |> DateTime.to_iso8601(),
+      version: "0"
+    }
+  end
 end

--- a/priv/nodejs/mediainfo/index.js
+++ b/priv/nodejs/mediainfo/index.js
@@ -19,21 +19,25 @@ const makeCallbacks = (input) => {
 
   const readChunk = (length, offset) => {
     return new Promise((resolve, _reject) => {
-      let params = {...input};
-  
-      if (typeof offset === 'number') {
-        let end = length ? offset + length - 1 : undefined;
-        params.Range = `bytes=${[offset, end].join('-')}`;
-      }
-  
-      s3.getObject(params, (err, data) => {
-        if (err) {
-          console.error(err);
-          resolve(undefined);
-        } else {
-          resolve(data.Body);
+      if (length < 1) {
+        resolve("");
+      } else {
+        let params = {...input};
+    
+        if (typeof offset === 'number') {
+          let end = length ? offset + length - 1 : undefined;
+          params.Range = `bytes=${[offset, end].join('-')}`;
         }
-      });
+    
+        s3.getObject(params, (err, data) => {
+          if (err) {
+            console.error(err);
+            resolve(undefined);
+          } else {
+            resolve(data.Body);
+          }
+        });
+      }
     });
   };
 

--- a/priv/repo/migrations/20210601214522_add_derivatives_to_filesets.exs
+++ b/priv/repo/migrations/20210601214522_add_derivatives_to_filesets.exs
@@ -1,0 +1,15 @@
+defmodule Meadow.Repo.Migrations.AddDerivativesToFilesets do
+  use Ecto.Migration
+
+  def up do
+    alter table("file_sets") do
+      add(:derivatives, :map)
+    end
+  end
+
+  def down do
+    alter table("file_sets") do
+      remove(:derivatives)
+    end
+  end
+end

--- a/test/fixtures/ingest_sheet.csv
+++ b/test/fixtures/ingest_sheet.csv
@@ -4,6 +4,6 @@ IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,
 ,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",TRUE
 ,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",X,"The label",
 VIDEO,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",
-,Donohue_002,Donohue_002_02,coffee.tif,Verso,A,"The label",
+,Donohue_002,Donohue_002_02,small.m4v,Small Video,A,"The label",
 ,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",X,"The label",
 ,Donohue_002,Donohue_002_04,details.json,"Supplemental information",S,"Supplement",

--- a/test/fixtures/transcode/complete.json
+++ b/test/fixtures/transcode/complete.json
@@ -1,0 +1,44 @@
+{
+  "version": "0",
+  "id": "15d08782-e7da-c31e-66e3-544ec526d647",
+  "detail-type": "MediaConvert Job State Change",
+  "source": "aws.mediaconvert",
+  "account": "012345678901",
+  "time": "2021-05-26T19:48:02Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:mediaconvert:us-east-1:012345678901:jobs/1622058474636-k5t3hx"
+  ],
+  "detail": {
+    "timestamp": 1622058482317,
+    "accountId": "012345678901",
+    "queue": "arn:aws:mediaconvert:us-east-1:012345678901:queues/Default",
+    "jobId": "1622058474636-k5t3hx",
+    "status": "COMPLETE",
+    "userMetadata": {
+      "file_set_id": "2d4d7380-68d2-49b5-a6ee-3de577f63770",
+      "context": "Test"
+    },
+    "outputGroupDetails": [
+      {
+        "outputDetails": [
+          {
+            "durationInMs": 5538,
+            "videoDetails": {
+              "widthInPx": 1280,
+              "heightInPx": 720
+            }
+          },
+          {
+            "durationInMs": 5526
+          }
+        ],
+        "playlistFilePaths": [
+          "s3://test-streaming/event-test/small.mpd",
+          "s3://test-streaming/event-test/small.m3u8"
+        ],
+        "type": "CMAF_GROUP"
+      }
+    ]
+  }
+}

--- a/test/fixtures/transcode/error.json
+++ b/test/fixtures/transcode/error.json
@@ -1,0 +1,25 @@
+{
+  "version": "0",
+  "id": "9a8d71df-b96f-e5a2-0654-41d09c07fb58",
+  "detail-type": "MediaConvert Job State Change",
+  "source": "aws.mediaconvert",
+  "account": "012345678901",
+  "time": "2021-05-27T00:14:12Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:mediaconvert:us-east-1:012345678901:jobs/1622074446914-kze5ap"
+  ],
+  "detail": {
+    "timestamp": 1622074452932,
+    "accountId": "012345678901",
+    "queue": "arn:aws:mediaconvert:us-east-1:012345678901:queues/Default",
+    "jobId": "1622074446914-kze5ap",
+    "status": "ERROR",
+    "errorCode": 1401,
+    "errorMessage": "Unable to open input file [s3://test-preservation/test/bad_input.mp4]: [Failed probe/open: [Can't read input stream: [Failed to read data: Access denied to s3://test-preservation/test/bad_input.mp4]]]",
+    "userMetadata": {
+      "file_set_id": "66116b0f-8fd5-4d44-9508-7540abcd6239",
+      "context": "Test"
+    }
+  }
+}

--- a/test/meadow/data/file_sets_test.exs
+++ b/test/meadow/data/file_sets_test.exs
@@ -145,5 +145,14 @@ defmodule Meadow.Data.FileSetsTest do
         assert uri.path |> String.length() == 55
       end
     end
+
+    test "add_derivatives/3" do
+      assert FileSets.add_derivative(%FileSet{derivatives: nil}, "playlist", "test.m3u8") ==
+               %{"playlist" => "test.m3u8"}
+
+      assert %FileSet{derivatives: %{"pyramid" => "test.tif"}}
+             |> FileSets.add_derivative("playlist", "test.m3u8") ==
+               %{"pyramid" => "test.tif", "playlist" => "test.m3u8"}
+    end
   end
 end

--- a/test/meadow/ingest/progress_test.exs
+++ b/test/meadow/ingest/progress_test.exs
@@ -110,7 +110,7 @@ defmodule Meadow.Ingest.ProgressTest do
     end
 
     test "action_count/1", %{ingest_sheet: sheet} do
-      assert Progress.action_count(sheet) == 66
+      assert Progress.action_count(sheet) == 90
       assert Progress.action_count(@bad_sheet_id) == 0
     end
 
@@ -136,7 +136,7 @@ defmodule Meadow.Ingest.ProgressTest do
         assert progress.sheet_id == sheet.id
         assert progress.total_file_sets == 8
         assert progress.completed_file_sets == 0
-        assert progress.total_actions == 66
+        assert progress.total_actions == 90
         assert progress.completed_actions == 0
         assert progress.percent_complete == 0.0
       end
@@ -155,7 +155,7 @@ defmodule Meadow.Ingest.ProgressTest do
 
       with progress <- Progress.pipeline_progress(sheet) do
         assert progress.completed_file_sets == 8
-        assert progress.completed_actions == 66
+        assert progress.completed_actions == 90
         assert progress.percent_complete == 100.0
       end
 

--- a/test/meadow/ingest/validator_test.exs
+++ b/test/meadow/ingest/validator_test.exs
@@ -9,6 +9,7 @@ defmodule Meadow.Ingest.ValidatorTest do
   @ingest_bucket Meadow.Config.ingest_bucket()
   @image_fixture "test/fixtures/coffee.tif"
   @json_fixture "test/fixtures/details.json"
+  @video_fixture "test/fixtures/small.m4v"
 
   setup context do
     project =
@@ -41,10 +42,17 @@ defmodule Meadow.Ingest.ValidatorTest do
       File.read!(@json_fixture)
     )
 
+    upload_object(
+      @ingest_bucket,
+      "#{project.folder}/small.m4v",
+      File.read!(@video_fixture)
+    )
+
     on_exit(fn ->
       delete_object(@uploads_bucket, @sheet_path <> context.sheet)
       delete_object(@ingest_bucket, "#{project.folder}/coffee.tif")
       delete_object(@ingest_bucket, "#{project.folder}/details.json")
+      delete_object(@ingest_bucket, "#{project.folder}/small.m4v")
     end)
 
     {:ok, %{sheet: sheet, project: project}}

--- a/test/pipeline/actions/create_pyramid_tiff_test.exs
+++ b/test/pipeline/actions/create_pyramid_tiff_test.exs
@@ -1,7 +1,7 @@
 defmodule Meadow.Pipeline.Actions.CreatePyramidTiffTest do
   use Meadow.DataCase
   use Meadow.S3Case
-  alias Meadow.Data.ActionStates
+  alias Meadow.Data.{ActionStates, FileSets}
   alias Meadow.Pipeline.Actions.CreatePyramidTiff
   alias Meadow.Repo
   alias Meadow.Utils.Pairtree
@@ -49,6 +49,10 @@ defmodule Meadow.Pipeline.Actions.CreatePyramidTiffTest do
       assert(CreatePyramidTiff.process(%{file_set_id: file_set_id}, %{}) == :ok)
       assert(ActionStates.ok?(file_set_id, CreatePyramidTiff))
       assert(object_exists?(@pyramid_bucket, dest))
+
+      assert FileSets.get_file_set(file_set_id)
+             |> Map.get(:derivatives)
+             |> Map.get("pyramid_tiff") == "s3://#{@pyramid_bucket}/#{dest}"
 
       with metadata <- object_metadata(@pyramid_bucket, dest) do
         assert metadata.height == "1024"

--- a/test/pipeline/actions/create_transcode_job_test.exs
+++ b/test/pipeline/actions/create_transcode_job_test.exs
@@ -41,7 +41,8 @@ defmodule Meadow.Pipeline.Actions.CreateTranscodeJobTest do
 
   describe "handle errors from MediaConvert response" do
     test "process/2" do
-      mock_error_file_input = "s3://error/test.mov"
+      mock_error_file_input = "s3://input-error/test.mov"
+
       object =
         file_set_fixture(
           role: %{id: "A", scheme: "FILE_SET_ROLE"},
@@ -52,13 +53,13 @@ defmodule Meadow.Pipeline.Actions.CreateTranscodeJobTest do
           }
         )
 
-        assert capture_log(fn ->
-          assert(
-            {:error, "Fake error response"} =
-              CreateTranscodeJob.process(%{file_set_id: object.id}, %{})
-          )
-        end) =~
-          "Error creating MediaConvert Job"
+      assert capture_log(fn ->
+               assert(
+                 {:error, "Fake error response"} =
+                   CreateTranscodeJob.process(%{file_set_id: object.id}, %{})
+               )
+             end) =~
+               "Error creating MediaConvert Job"
     end
   end
 end

--- a/test/pipeline/actions/transcode_complete_test.exs
+++ b/test/pipeline/actions/transcode_complete_test.exs
@@ -1,0 +1,41 @@
+defmodule Meadow.Pipeline.Actions.TranscodeCompleteTest do
+  use Meadow.DataCase
+  alias Meadow.Data.{ActionStates, FileSets}
+  alias Meadow.Pipeline.Actions.TranscodeComplete
+
+  describe "process AWS MediaConvert Event" do
+    setup %{message_file: file} do
+      file_set = file_set_fixture()
+
+      message =
+        Path.join("test/fixtures", file)
+        |> File.read!()
+        |> Jason.decode!(keys: :atoms)
+        |> AtomicMap.convert(safe: false)
+        |> put_in([:detail, :user_metadata, :file_set_id], file_set.id)
+
+      {:ok, %{file_set: file_set, message: message}}
+    end
+
+    @tag message_file: "transcode/error.json"
+    test "error", %{file_set: file_set, message: message} do
+      assert {:error, error, %{context: "Test"}} = TranscodeComplete.process(message, %{})
+      assert error |> String.contains?("Failed to read data")
+
+      with state <- ActionStates.get_latest_state(file_set.id, TranscodeComplete) do
+        assert state.outcome == "error"
+        assert state.notes |> String.contains?("Failed to read data")
+      end
+    end
+
+    @tag message_file: "transcode/complete.json"
+    test "complete", %{file_set: file_set, message: message} do
+      assert {:ok, _, %{context: "Test"}} = TranscodeComplete.process(message, %{})
+      assert ActionStates.ok?(file_set.id, TranscodeComplete)
+
+      assert FileSets.get_file_set(file_set.id)
+             |> Map.get(:derivatives)
+             |> Map.get("playlist") == "s3://test-streaming/event-test/small.m3u8"
+    end
+  end
+end


### PR DESCRIPTION
* Allow front end to accept `audio/*` and `video/*` files
* Update `MediaConvert.Mock` to send an appropriate EventBridge message to the `transcode-complete` queue
* Add correct queue configuration for `create-transcode-job` and `transcode-complete`
* Integrate audio and video types into the dispatcher
* Add a `derivatives` field to the `FileSet` schema that will hold a named map
  * Update `CreatePyramidTiff` action to write the pyramid TIFF location to `derivatives -> pyramid_tiff`
  * For audio and video, write the playlist location to `derivatives -> playlist`
  * Create a mix task to add pyramid TIFF locations for existing file sets to `derivatives` at a later date