### PR TITLE
Remove 'DOCUMENT' work_type from coded_terms table

### DIFF
--- a/priv/repo/migrations/20210602202440_remove_document_work_type.exs
+++ b/priv/repo/migrations/20210602202440_remove_document_work_type.exs
@@ -1,0 +1,17 @@
+defmodule Meadow.Repo.Migrations.RemoveDocumentWorkType do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    DELETE FROM coded_terms
+    WHERE scheme = 'work_type' AND id = 'DOCUMENT';
+    """
+  end
+
+  def down do
+    execute """
+    INSERT INTO coded_terms (id, scheme, label, inserted_at, updated_at)
+    VALUES ('DOCUMENT', 'work_type', 'Document', now(), now())
+    """
+  end
+end

--- a/priv/repo/seeds/coded_terms/work_type.json
+++ b/priv/repo/seeds/coded_terms/work_type.json
@@ -4,10 +4,6 @@
     "label": "Audio"
   },
   {
-    "id": "DOCUMENT",
-    "label": "Document"
-  },
-  {
     "id": "IMAGE",
     "label": "Image"
   },

--- a/test/meadow/data/coded_terms_test.exs
+++ b/test/meadow/data/coded_terms_test.exs
@@ -25,11 +25,10 @@ defmodule Meadow.Data.CodedTermsTest do
 
     test "lists terms within a scheme" do
       with results <- CodedTerms.list_coded_terms("work_type") do
-        assert_lists_equal(results |> Enum.map(& &1.id), ["AUDIO", "DOCUMENT", "IMAGE", "VIDEO"])
+        assert_lists_equal(results |> Enum.map(& &1.id), ["AUDIO", "IMAGE", "VIDEO"])
 
         assert_lists_equal(results |> Enum.map(& &1.label), [
           "Audio",
-          "Document",
           "Image",
           "Video"
         ])


### PR DESCRIPTION
- Removes the `DOCUMENT` work_type from the `work_type.json` seed.
- Adds a migration (be sure to run `mix meadow.setup` when testing locally. You may need to run `MIX_ENV=test mix ecto.reset` as well)