### PR TITLE
Add support for audio and video work types, but rendering a hardcoded…

### DIFF
--- a/assets/js/components/UI/MediaPlayer/MediaPlayer.jsx
+++ b/assets/js/components/UI/MediaPlayer/MediaPlayer.jsx
@@ -8,8 +8,7 @@ const vttSampleUrl =
 
 export const mockVideoSources = [
   {
-    id:
-      "http://dlib.indiana.edu/iiif_av/volleyball/high/volleyball-for-boys.mp4",
+    id: "http://dlib.indiana.edu/iiif_av/volleyball/high/volleyball-for-boys.mp4",
     type: "Video",
     format: "video/mp4",
     height: 1080,
@@ -20,8 +19,7 @@ export const mockVideoSources = [
     },
   },
   {
-    id:
-      "http://dlib.indiana.edu/iiif_av/volleyball/medium/volleyball-for-boys.mp4",
+    id: "http://dlib.indiana.edu/iiif_av/volleyball/medium/volleyball-for-boys.mp4",
     type: "Video",
     format: "video/mp4",
     height: 1080,
@@ -32,8 +30,7 @@ export const mockVideoSources = [
     },
   },
   {
-    id:
-      "http://dlib.indiana.edu/iiif_av/volleyball/low/volleyball-for-boys.mp4",
+    id: "http://dlib.indiana.edu/iiif_av/volleyball/low/volleyball-for-boys.mp4",
     type: "Video",
     format: "video/mp4",
     height: 1080,
@@ -55,7 +52,7 @@ export const mockVideoTracks = [
   },
 ];
 
-function VideoPlayer({ sources = [], tracks = [], ...restProps }) {
+function MediaPlayer({ sources = [], tracks = [], ...restProps }) {
   const playerRef = React.useRef();
   const [cues, setCues] = React.useState([]);
 
@@ -97,43 +94,48 @@ function VideoPlayer({ sources = [], tracks = [], ...restProps }) {
   };
 
   return (
-    <div className="columns">
-      <video
-        data-testid="video-player"
-        crossOrigin="anonymous"
-        ref={playerRef}
-        className="column is-three-quarters"
-        {...restProps}
-      >
-        {sources.map((source) => (
-          <source
-            key={source.id}
-            data-testid="source-item"
-            src={source.id}
-            type={source.format}
-          />
-        ))}
-        {tracks.map((track) => (
-          <track
-            key={track.id}
-            id={track.identifier}
-            data-testid="track"
-            src={track.src}
-            kind={track.kind}
-            srcLang={track.srcLang}
-          />
-        ))}
-      </video>
-      <div className="block" className="column is-one-quarter">
-        <h3>Video nav</h3>
-        <MediaPlayerNav cues={cues} handleNavClick={handleNavClick} />
+    <>
+      <p className="notification is-warning is-light has-text-centered">
+        This is a hardcoded test video
+      </p>
+      <div className="columns">
+        <video
+          data-testid="video-player"
+          crossOrigin="anonymous"
+          ref={playerRef}
+          className="column is-three-quarters"
+          {...restProps}
+        >
+          {sources.map((source) => (
+            <source
+              key={source.id}
+              data-testid="source-item"
+              src={source.id}
+              type={source.format}
+            />
+          ))}
+          {tracks.map((track) => (
+            <track
+              key={track.id}
+              id={track.identifier}
+              data-testid="track"
+              src={track.src}
+              kind={track.kind}
+              srcLang={track.srcLang}
+            />
+          ))}
+        </video>
+        <div className="block" className="column is-one-quarter">
+          <h3>Video nav</h3>
+          <MediaPlayerNav cues={cues} handleNavClick={handleNavClick} />
+        </div>
       </div>
-    </div>
+    </>
   );
 }
 
-VideoPlayer.propTypes = {
+MediaPlayer.propTypes = {
   sources: PropTypes.array,
 };
 
-export default VideoPlayer;
+export default MediaPlayer;

--- a/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
+++ b/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
@@ -4,6 +4,7 @@ import { IIIFContext } from "@js/components/IIIF/IIIFProvider";
 import { IIIF_SIZES } from "@js/services/global-vars";
 import { IconDownload } from "@js/components/Icon";
 import { ImageDownloader } from "@samvera/image-downloader";
+import { Button } from "@nulib/admin-react-components";
 
 function MediaButtons() {
   return (

--- a/assets/js/components/Work/Fileset/ActionButtons/Auxillary.jsx
+++ b/assets/js/components/Work/Fileset/ActionButtons/Auxillary.jsx
@@ -3,16 +3,18 @@ import PropTypes from "prop-types";
 import { IIIFContext } from "@js/components/IIIF/IIIFProvider";
 import { IIIF_SIZES } from "@js/services/global-vars";
 import { ImageDownloader } from "@samvera/image-downloader";
-import { Button } from "@nulib/admin-react-components";
 
-const WorkFilesetActionButtonsAccess = ({ fileSet }) => {
+const WorkFilesetActionButtonsAuxiliary = ({ fileSet }) => {
   const iiifServerUrl = useContext(IIIFContext);
+  const url = `${iiifServerUrl}${fileSet.id}${IIIF_SIZES.IIIF_FULL}`;
 
   return (
     <div className="buttons is-flex is-justify-content-flex-end">
-      <Button>View Aux File</Button>
+      <a className="button" href={url} target="_blank">
+        View Aux File
+      </a>
       <ImageDownloader
-        imageUrl={`${iiifServerUrl}${fileSet.id}${IIIF_SIZES.IIIF_FULL}`}
+        imageUrl={url}
         imageTitle={fileSet.accessionNumber}
         className="button"
       >
@@ -22,8 +24,8 @@ const WorkFilesetActionButtonsAccess = ({ fileSet }) => {
   );
 };
 
-WorkFilesetActionButtonsAccess.propTypes = {
+WorkFilesetActionButtonsAuxiliary.propTypes = {
   fileSet: PropTypes.object,
 };
 
-export default WorkFilesetActionButtonsAccess;
+export default WorkFilesetActionButtonsAuxiliary;

--- a/assets/js/components/Work/Fileset/List.jsx
+++ b/assets/js/components/Work/Fileset/List.jsx
@@ -3,6 +3,9 @@ import PropTypes from "prop-types";
 import WorkFilesetListItem from "@js/components/Work/Fileset/ListItem";
 import WorkFilesetDraggable from "@js/components/Work/Fileset/Draggable";
 
+function SubHead({ children }) {
+  return <h3 className="my-4 ml-5 is-size-5">{children}</h3>;
+}
 function WorkFilesetList({
   fileSets,
   handleWorkImageChange,
@@ -28,6 +31,7 @@ function WorkFilesetList({
     <>
       {/* Access Files  */}
       <div data-testid="fileset-list" className="mb-5">
+        <SubHead>Access files</SubHead>
         {fileSets.access.map((fileSet) => (
           <WorkFilesetListItem
             key={fileSet.id}
@@ -43,7 +47,7 @@ function WorkFilesetList({
       {/* Auxillary Files  */}
       {fileSets.auxillary.length > 0 && (
         <>
-          <h3 className="my-4 ml-5">Auxillary Files</h3>
+          <SubHead>Auxillary files</SubHead>
           {fileSets.auxillary.map((fileSet) => (
             <WorkFilesetListItem
               key={fileSet.id}

--- a/assets/js/components/Work/Fileset/List.test.js
+++ b/assets/js/components/Work/Fileset/List.test.js
@@ -43,7 +43,7 @@ describe("WorkFilesetList component", () => {
       })
     );
     await waitFor(() => {
-      expect(screen.getByTestId("fileset-list").children).toHaveLength(3);
+      expect(screen.getAllByTestId("fileset-item")).toHaveLength(3);
     });
   });
 });

--- a/assets/js/components/Work/Tabs/Preservation/FileSetDropzone.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/FileSetDropzone.jsx
@@ -20,16 +20,13 @@ function WorkTabsPreservationFileSetDropzone({
     handleSetFile(acceptedFiles[0]);
   }, []);
 
-  const {
-    getRootProps,
-    getInputProps,
-    isDragActive,
-    isDragReject,
-  } = useDropzone({
-    onDrop,
-    accept: "image/tiff, image/jpeg, image/jpg",
-    multiple: false,
-  });
+  const { getRootProps, getInputProps, isDragActive, isDragReject } =
+    useDropzone({
+      onDrop,
+      accept:
+        "image/tiff, image/jpeg, image/jpg, video/mp4, audio/mp3, audio/wav",
+      multiple: false,
+    });
 
   const handleDelete = () => {
     handleSetFile(null);

--- a/assets/js/components/Work/Work.jsx
+++ b/assets/js/components/Work/Work.jsx
@@ -17,14 +17,16 @@ const osdOptions = {
   height: 800,
 };
 
-const Work = ({ work, isAudio, isVideo }) => {
+const Work = ({ work }) => {
   const [manifestObj, setManifestObj] = React.useState();
   const [randomUrlKey, setRandomUrlKey] = React.useState(Date.now());
   const [manifestChangeItems, setManifestChangeItems] = React.useState({
     label: "",
     canvasCount: "",
   });
-  const isImageWorkType = !isAudio && !isVideo;
+  const isImageWorkType =
+    work.workType?.id === "IMAGE" &&
+    ["AUDIO", "VIDEO"].indexOf(work.workType?.id) === -1;
 
   React.useEffect(() => {
     async function getData() {
@@ -85,8 +87,6 @@ const Work = ({ work, isAudio, isVideo }) => {
 };
 
 Work.propTypes = {
-  isAudio: PropTypes.bool,
-  isVideo: PropTypes.bool,
   work: PropTypes.object,
 };
 


### PR DESCRIPTION
… media file (for now). This work supports rendering (hardcoded video still) of a non-image Work Type needed for the demo.  And for now, just opens an Aux image file in a new browser tab.

![image](https://user-images.githubusercontent.com/3020266/120657880-8866e200-c44a-11eb-974f-4a85e3c98626.png)
