### PR TITLE
Fix mime-type extraction through UI upload

### DIFF
--- a/assets/js/components/Work/Tabs/Preservation/FileSetDropzone.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/FileSetDropzone.jsx
@@ -20,16 +20,11 @@ function WorkTabsPreservationFileSetDropzone({
     handleSetFile(acceptedFiles[0]);
   }, []);
 
-  const {
-    getRootProps,
-    getInputProps,
-    isDragActive,
-    isDragReject,
-  } = useDropzone({
-    onDrop,
-    accept: "image/*, audio/*, video/*",
-    multiple: false,
-  });
+  const { getRootProps, getInputProps, isDragActive, isDragReject } =
+    useDropzone({
+      onDrop,
+      multiple: false,
+    });
 
   const handleDelete = () => {
     handleSetFile(null);

--- a/lib/meadow/utils/aws.ex
+++ b/lib/meadow/utils/aws.ex
@@ -35,12 +35,12 @@ defmodule Meadow.Utils.AWS do
     generate_presigned_url(bucket, "#{filename}", :get)
   end
 
-  def presigned_url(bucket, %{upload_type: "ingest_sheet"}) do
-    generate_presigned_url(bucket, "ingest_sheets/#{Ecto.UUID.generate()}.csv")
+  def presigned_url(bucket, %{upload_type: "file_set", filename: filename}) do
+    generate_presigned_url(bucket, "file_sets/#{Ecto.UUID.generate()}.#{Path.extname(filename)}")
   end
 
-  def presigned_url(bucket, %{upload_type: "file_set"}) do
-    generate_presigned_url(bucket, "file_sets/#{Ecto.UUID.generate()}")
+  def presigned_url(bucket, %{upload_type: "ingest_sheet"}) do
+    generate_presigned_url(bucket, "ingest_sheets/#{Ecto.UUID.generate()}.csv")
   end
 
   def presigned_url(bucket, %{upload_type: "csv_metadata"}) do

--- a/test/meadow/utils/aws_test.exs
+++ b/test/meadow/utils/aws_test.exs
@@ -41,6 +41,19 @@ defmodule Meadow.Utils.AWSTest do
     end
   end
 
+  test "presigned_url/2 for a file set uses the original filename's extension" do
+    config = ExAws.Config.new(:s3)
+    scheme = config[:scheme]
+    host = config[:host]
+    port = config[:port]
+    regex = ~r{#{scheme}#{host}:#{port}/#{@bucket}/file_sets(.)*.jpg}
+
+    with {:ok, presigned_url} <-
+           AWS.presigned_url(@bucket, %{upload_type: "file_set", filename: "original.jpg"}) do
+      assert presigned_url =~ regex
+    end
+  end
+
   describe "error handling" do
     setup do
       {:ok, _} = Honeybadger.API.start(self())


### PR DESCRIPTION
- We need an extension on file sets uploaded through the UI so that mime-type identification can work.

This PR:
- changes presignedUrl API for file sets so that it uses the original file extension for the presigned url
- changes DropZone for file set upload to accept all file types (for now)
- changes `getPresignedUrl` on front end from `useQuery` to `useLazyQuery` (since if it fires when the component loads it won't know the file extension)

To test: upload a .json, .csv etc file set in the UI. (Supplemental)