### PR TITLE
Update Docker & CircleCI builds to use Elixir 1.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   dependencies:
     working_directory: ~/meadow
     docker:
-      - image: circleci/elixir:1.11-node
+      - image: circleci/elixir:1.12-node
     steps:
       - checkout
       - run:
@@ -51,7 +51,7 @@ jobs:
   js-test:
     working_directory: ~/meadow
     docker:
-      - image: circleci/elixir:1.11-node
+      - image: circleci/elixir:1.12-node
     steps:
       - checkout
       - restore_cache:
@@ -75,7 +75,7 @@ jobs:
   elixir-test:
     working_directory: ~/meadow
     docker:
-      - image: circleci/elixir:1.11-node
+      - image: circleci/elixir:1.12-node
         environment:
           DATABASE_URL: ecto://root@localhost/circle_test
           DB_PORT: "5432"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Install elixir & npm dependencies
-FROM nulib/elixir-phoenix-base:1.11.1 AS deps
+FROM nulib/elixir-phoenix-base:1.12.1 AS deps
 LABEL edu.northwestern.library.app=meadow \
   edu.northwestern.library.cache=true \
   edu.northwestern.library.stage=deps
@@ -8,7 +8,7 @@ COPY ./mix.exs /app/mix.exs
 COPY ./mix.lock /app/mix.lock
 WORKDIR /app
 RUN mix deps.get --only prod \
-    && mix deps.compile 
+    && mix deps.compile
 COPY ./assets/package.json /app/assets/package.json
 COPY ./assets/yarn.lock /app/assets/yarn.lock
 WORKDIR /app/assets
@@ -20,7 +20,7 @@ RUN for flag in $(find . -name .docker-yarn); do \
     done
 
 # Create elixir release
-FROM nulib/elixir-phoenix-base:1.11.1 AS release
+FROM nulib/elixir-phoenix-base:1.12.1 AS release
 ARG HONEYBADGER_API_KEY=
 ARG HONEYBADGER_API_KEY_FRONTEND=
 ARG HONEYBADGER_ENVIRONMENT=

--- a/test/meadow/data/donut_works_test.exs
+++ b/test/meadow/data/donut_works_test.exs
@@ -75,7 +75,7 @@ defmodule Meadow.Data.DonutWorksTest do
         |> Enum.map(fn _ ->
           Task.async(fn ->
             DonutWorks.with_next_donut_work(fn dw ->
-              (:random.uniform() * 1000) |> trunc() |> :timer.sleep()
+              (:rand.uniform() * 1000) |> trunc() |> :timer.sleep()
               dw
             end)
           end)


### PR DESCRIPTION
No hurry to merge this, but once all of us are up and running on Elixir 1.12 and Erlang/OTP 24, the CI test suite and deploy should follow as closely as possible.

## Upgrading Erlang and Elixir

Everyone should already be using the `asdf` package manager, so the upgrade is pretty simple.

### Update `asdf`
```
$ asdf update
```

You might get a message saying `Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.` In that case:

```
$ brew upgrade asdf
```

### Update `asdf` plugins
```
$ asdf plugin update --all
```

### Install new versions of Erlang and Elixir

Erlang install may take 20-30 minutes
```
$ asdf install erlang 24.0.2
```
Elixir install should be almost instantaneous
```
$ asdf install elixir 1.12.1-otp-24
```

### Make latest versions the default
```
$ asdf global erlang 24.0.2
$ asdf global elixir 1.12.1-otp-24
```

### Install Hex & Rebar
```
$ mix local.hex --force
$ mix local.rebar --force
```

### Verify
```
$ elixir --version
Erlang/OTP 24 [erts-12.0.2] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [jit]

Elixir 1.12.1 (compiled with Erlang/OTP 24)
```