### PR TITLE
Support an active File Set and being able to play multiple File Set A…

### DIFF
--- a/assets/js/components/Icon/Play.jsx
+++ b/assets/js/components/Icon/Play.jsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { FaPlay } from "react-icons/fa";
+
+export default function IconPlay(props) {
+  return <FaPlay {...props} />;
+}

--- a/assets/js/components/Icon/index.js
+++ b/assets/js/components/Icon/index.js
@@ -21,6 +21,7 @@ import IconFile from "@js/components/Icon/File";
 import IconImages from "@js/components/Icon/Images";
 import IconList from "@js/components/Icon/List";
 import IconMinus from "@js/components/Icon/Minus";
+import IconPlay from "@js/components/Icon/Play";
 import IconProjects from "@js/components/Icon/Projects";
 import IconReplace from "@js/components/Icon/Replace";
 import IconSearch from "@js/components/Icon/Search";
@@ -54,6 +55,7 @@ export {
   IconImages,
   IconList,
   IconMinus,
+  IconPlay,
   IconProjects,
   IconReplace,
   IconSearch,

--- a/assets/js/components/UI/MediaPlayer/Wrapper.jsx
+++ b/assets/js/components/UI/MediaPlayer/Wrapper.jsx
@@ -22,15 +22,13 @@ export const mockVideoTracks = [
 ];
 
 function MediaPlayerWrapper({ fileSet }) {
-  const { getTechnicalMetadata } = useTechnicalMetadata();
-  const mediaInfoTracks = getTechnicalMetadata(fileSet);
   const { isEmpty } = useFileSet();
-
   if (isEmpty(fileSet)) return null;
 
-  {
-    /* FileSet hasn't yet been fully ran through the pipeline */
-  }
+  const { getTechnicalMetadata } = useTechnicalMetadata();
+  const mediaInfoTracks = getTechnicalMetadata(fileSet);
+
+  // FileSet hasn't yet been fully ran through the pipeline
   if (!fileSet?.coreMetadata?.mimeType) {
     return (
       <Notification isWarning>
@@ -57,6 +55,7 @@ function MediaPlayerWrapper({ fileSet }) {
   return (
     <div>
       <MediaPlayer
+        key={fileSet.id}
         sources={sources}
         tracks={mockVideoTracks}
         videoElAttrs={videoElAttrs}

--- a/assets/js/components/Work/Fileset/List.test.js
+++ b/assets/js/components/Work/Fileset/List.test.js
@@ -5,6 +5,7 @@ import { mockFileSets } from "@js/mock-data/filesets";
 import { withReactBeautifulDND } from "@js/services/testing-helpers";
 import { mockUser } from "@js/components/Auth/auth.gql.mock";
 import useIsAuthorized from "@js/hooks/useIsAuthorized";
+import { WorkProvider } from "@js/context/work-context";
 
 jest.mock("@js/hooks/useIsAuthorized");
 useIsAuthorized.mockReturnValue({
@@ -15,10 +16,12 @@ useIsAuthorized.mockReturnValue({
 describe("WorkFilesetList component", () => {
   it("renders a draggable list component if re-ordering the list", async () => {
     render(
-      withReactBeautifulDND(WorkFilesetList, {
-        fileSets: { access: mockFileSets, auxillary: [] },
-        isReordering: true,
-      })
+      <WorkProvider>
+        {withReactBeautifulDND(WorkFilesetList, {
+          fileSets: { access: mockFileSets, auxillary: [] },
+          isReordering: true,
+        })}
+      </WorkProvider>
     );
     await waitFor(() => {
       expect(screen.getByTestId("fileset-draggable-list"));
@@ -27,9 +30,11 @@ describe("WorkFilesetList component", () => {
 
   it("renders a non-draggable list if not-reordering", async () => {
     render(
-      withReactBeautifulDND(WorkFilesetList, {
-        fileSets: { access: mockFileSets, auxillary: [] },
-      })
+      <WorkProvider>
+        {withReactBeautifulDND(WorkFilesetList, {
+          fileSets: { access: mockFileSets, auxillary: [] },
+        })}
+      </WorkProvider>
     );
     await waitFor(() => {
       expect(screen.getByTestId("fileset-list"));
@@ -38,9 +43,11 @@ describe("WorkFilesetList component", () => {
 
   it("renders the correct number of list elements", async () => {
     render(
-      withReactBeautifulDND(WorkFilesetList, {
-        fileSets: { access: mockFileSets, auxillary: [] },
-      })
+      <WorkProvider>
+        {withReactBeautifulDND(WorkFilesetList, {
+          fileSets: { access: mockFileSets, auxillary: [] },
+        })}
+      </WorkProvider>
     );
     await waitFor(() => {
       expect(screen.getAllByTestId("fileset-item")).toHaveLength(3);

--- a/assets/js/components/Work/Fileset/ListItem.jsx
+++ b/assets/js/components/Work/Fileset/ListItem.jsx
@@ -7,6 +7,10 @@ import WorkFilesetActionButtonsAccess from "@js/components/Work/Fileset/ActionBu
 import WorkFilesetActionButtonsAuxillary from "@js/components/Work/Fileset/ActionButtons/Auxillary";
 import { IIIFContext } from "@js/components/IIIF/IIIFProvider";
 import AuthDisplayAuthorized from "@js/components/Auth/DisplayAuthorized";
+import useFileSet from "@js/hooks/useFileSet";
+import { useWorkDispatch, useWorkState } from "@js/context/work-context";
+import { Button, Tag } from "@nulib/admin-react-components";
+import { IconPlay } from "@js/components/Icon";
 
 function WorkFilesetListItem({
   fileSet,
@@ -16,6 +20,11 @@ function WorkFilesetListItem({
 }) {
   const iiifServerUrl = useContext(IIIFContext);
   const { id, coreMetadata } = fileSet;
+  const dispatch = useWorkDispatch();
+  const { isMedia } = useFileSet();
+  const workContextState = useWorkState();
+  const isCurrentStateFileSet =
+    workContextState?.activeMediaFileSet?.id === fileSet?.id;
 
   // https://stackoverflow.com/questions/34097560/react-js-replace-img-src-onerror
   const [imgState, setImgState] = React.useState({
@@ -44,8 +53,30 @@ function WorkFilesetListItem({
               onError={handleError}
             />
           </figure>
+          {isMedia(fileSet) && (
+            <Button
+              onClick={() =>
+                dispatch({
+                  type: "updateActiveMediaFileSet",
+                  fileSet,
+                })
+              }
+              className="is-small is-fullwidth mt-2"
+            >
+              <span className="icon">
+                <IconPlay />
+              </span>
+              <span>Play</span>
+            </Button>
+          )}
         </div>
         <div className="column">
+          {isMedia(fileSet) && isCurrentStateFileSet && (
+            <span className="mb-4 is-inline-block">
+              <Tag isInfo>Now Playing</Tag>
+            </span>
+          )}
+
           <UIFormField label="Label">
             {isEditing ? (
               <UIFormInput
@@ -77,7 +108,7 @@ function WorkFilesetListItem({
             )}
           </UIFormField>
         </div>
-        <div className="column is-3 has-text-right is-clearfix">
+        <div className="column is-5 has-text-right is-clearfix">
           {!isEditing && (
             <>
               <AuthDisplayAuthorized>

--- a/assets/js/components/Work/Fileset/ListItem.test.js
+++ b/assets/js/components/Work/Fileset/ListItem.test.js
@@ -8,6 +8,7 @@ import {
 } from "@js/services/testing-helpers";
 import { mockUser } from "@js/components/Auth/auth.gql.mock";
 import useIsAuthorized from "@js/hooks/useIsAuthorized";
+import { WorkProvider } from "@js/context/work-context";
 
 jest.mock("@js/hooks/useIsAuthorized");
 useIsAuthorized.mockReturnValue({
@@ -19,10 +20,12 @@ describe("Fileset component", () => {
   describe("when not editing", () => {
     function setUpTests(workImageFilesetId) {
       return render(
-        <WorkFilesetListItemImage
-          fileSet={mockFileSets[0]}
-          workImageFilesetId={workImageFilesetId}
-        />
+        <WorkProvider>
+          <WorkFilesetListItemImage
+            fileSet={mockFileSets[0]}
+            workImageFilesetId={workImageFilesetId}
+          />
+        </WorkProvider>
       );
     }
     it("renders the image preview, label and description", async () => {
@@ -54,13 +57,13 @@ describe("Fileset component", () => {
 
   describe("when editing", () => {
     beforeEach(() => {
-      return renderWithReactHookForm(
-        withReactBeautifulDND(WorkFilesetListItemImage, {
-          fileSet: mockFileSets[0],
-          index: 0,
-          isEditing: true,
-        })
-      );
+      const Wrapped = withReactBeautifulDND(WorkFilesetListItemImage, {
+        fileSet: mockFileSets[0],
+        index: 0,
+        isEditing: true,
+      });
+
+      return renderWithReactHookForm(<WorkProvider>{Wrapped}</WorkProvider>);
     });
 
     it("renders the component", async () => {

--- a/assets/js/components/Work/Work.jsx
+++ b/assets/js/components/Work/Work.jsx
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import { Notification } from "@nulib/admin-react-components";
 import { getManifest } from "@js/services/get-manifest";
 import MediaPlayerWrapper from "@js/components/UI/MediaPlayer/Wrapper";
+import { useWorkDispatch, useWorkState } from "@js/context/work-context";
 
 const osdOptions = {
   showDropdown: true,
@@ -17,6 +18,8 @@ const osdOptions = {
 const Work = ({ work }) => {
   const [manifestObj, setManifestObj] = React.useState();
   const [randomUrlKey, setRandomUrlKey] = React.useState(Date.now());
+  const workContextState = useWorkState();
+  const workDispatch = useWorkDispatch();
   const [manifestChangeItems, setManifestChangeItems] = React.useState({
     label: "",
     canvasCount: "",
@@ -47,6 +50,16 @@ const Work = ({ work }) => {
     isImageWorkType && getData();
   }, [work.fileSets, work.descriptiveMetadata.title]);
 
+  React.useEffect(() => {
+    // If Work Context State doesn't yet have an active File Set, default to the first File Set
+    if (!workContextState?.activeMediaFileSet) {
+      workDispatch({
+        type: "updateActiveMediaFileSet",
+        fileSet: work.fileSets[0],
+      });
+    }
+  }, []);
+
   return (
     <div data-testid="work-component">
       {isImageWorkType && (
@@ -66,7 +79,9 @@ const Work = ({ work }) => {
       {!isImageWorkType && (
         <section className="section">
           <div className="container">
-            <MediaPlayerWrapper fileSet={work.fileSets[0]} />
+            <MediaPlayerWrapper
+              fileSet={workContextState?.activeMediaFileSet}
+            />
           </div>
         </section>
       )}

--- a/assets/js/components/Work/Work.test.js
+++ b/assets/js/components/Work/Work.test.js
@@ -11,6 +11,7 @@ import {
   getCollectionMock,
   getCollectionsMock,
 } from "@js/components/Collection/collection.gql.mock";
+import { WorkProvider } from "@js/context/work-context";
 
 jest.mock("@js/hooks/useIsAuthorized");
 useIsAuthorized.mockReturnValue({
@@ -29,7 +30,12 @@ jest.mock("@js/services/get-manifest");
 
 describe("Work component", () => {
   beforeEach(() => {
-    renderWithRouterApollo(<Work work={mockWork} />, { mocks });
+    renderWithRouterApollo(
+      <WorkProvider>
+        <Work work={mockWork} />
+      </WorkProvider>,
+      { mocks }
+    );
   });
 
   it("renders without crashing", async () => {

--- a/assets/js/context/work-context.js
+++ b/assets/js/context/work-context.js
@@ -1,0 +1,52 @@
+import React from "react";
+
+const WorkStateContext = React.createContext();
+const WorkDispatchContext = React.createContext();
+
+const defaultState = {
+  activeMediaFileSet: null,
+};
+
+function workReducer(state, action) {
+  switch (action.type) {
+    case "updateActiveMediaFileSet": {
+      console.log(`action.type`, action.type);
+      return {
+        ...state,
+        activeMediaFileSet: { ...action.fileSet },
+      };
+    }
+    default: {
+      throw new Error(`Unhandled action type: ${action.type}`);
+    }
+  }
+}
+
+function WorkProvider({ initialState = defaultState, children }) {
+  const [state, dispatch] = React.useReducer(workReducer, initialState);
+  return (
+    <WorkStateContext.Provider value={state}>
+      <WorkDispatchContext.Provider value={dispatch}>
+        {children}
+      </WorkDispatchContext.Provider>
+    </WorkStateContext.Provider>
+  );
+}
+
+function useWorkState() {
+  const context = React.useContext(WorkStateContext);
+  if (context === undefined) {
+    throw new Error("useWorkState must be used within a WorkProvider");
+  }
+  return context;
+}
+
+function useWorkDispatch() {
+  const context = React.useContext(WorkDispatchContext);
+  if (context === undefined) {
+    throw new Error("useWorkDispatch must be used within a WorkProvider");
+  }
+  return context;
+}
+
+export { WorkProvider, useWorkState, useWorkDispatch };

--- a/assets/js/hooks/useFileSet.js
+++ b/assets/js/hooks/useFileSet.js
@@ -1,6 +1,6 @@
 export default function useFileSet() {
   function isEmpty(fileSet = {}) {
-    return Object.keys(fileSet).length === 0;
+    return !fileSet || Object.keys(fileSet).length === 0;
   }
 
   function isImage(fileSet = {}) {

--- a/assets/js/screens/Work/Work.jsx
+++ b/assets/js/screens/Work/Work.jsx
@@ -29,6 +29,7 @@ import classNames from "classnames";
 import { isMobile } from "react-device-detect";
 import useGTM from "@js/hooks/useGTM";
 import { Helmet } from "react-helmet";
+import { WorkProvider } from "@js/context/work-context";
 
 const ScreensWork = () => {
   const params = useParams();
@@ -257,7 +258,9 @@ const ScreensWork = () => {
         <UISkeleton rows={20} />
       ) : (
         <ErrorBoundary FallbackComponent={FallbackErrorComponent}>
-          <Work work={data.work} />
+          <WorkProvider>
+            <Work work={data.work} />
+          </WorkProvider>
         </ErrorBoundary>
       )}
     </Layout>


### PR DESCRIPTION
…ccess copies on the Work page for an Audio or Video Work type

This PR creates a new "Work" Provider, or an object store of Work-related state information we can pass around the `Work` component hierarchy.    A top level component will need to keep track of which File Set is "active", and also children components need a way to alert top-level components that the user has selected a new File Set to play in the player.

![image](https://user-images.githubusercontent.com/3020266/124654792-9d2d0000-de64-11eb-805c-c3260a7d7906.png)
