### PR TITLE
Rewrite row-level dependency/notification triggers as statement-level triggers

### DIFF
--- a/lib/meadow/utils/dependency_triggers.ex
+++ b/lib/meadow/utils/dependency_triggers.ex
@@ -1,98 +1,99 @@
 defmodule Meadow.Utils.DependencyTriggers do
   @moduledoc """
-  Code to create and drop dependency triggers in migrations
-  See the following files for usage:
-    * priv/repo/migrations/20200507123625_create_dependency_triggers.exs
-    * priv/repo/migrations/20210525165057_add_extracted_metadata_to_file_sets.exs
+  Base behavior for dependency triggers
   """
+
+  @doc """
+  Given the names of a parent table, child table, list of fields, and the stem of the joining column,
+  return the text of the dependency trigger for the child table.
+  """
+  @callback dependency_trigger(
+              parent :: binary(),
+              child :: binary(),
+              fields :: list(),
+              column_name :: binary()
+            ) :: binary()
+
+  @doc """
+  Given the names of a parent table, child table, and list of fields,
+  return the text of the dependency trigger for the parent table.
+  """
+  @callback parent_trigger(parent :: binary(), child :: binary(), fields :: list()) :: binary()
+
+  @doc """
+  Create a trigger on `table_name` that fires `function_name`
+  """
+  @callback create_trigger(
+              trigger_name :: binary(),
+              table_name :: binary(),
+              function_name :: binary()
+            ) :: any()
+
+  @callback switch_trigger(trigger_name :: binary(), table_name :: binary(), action :: binary()) ::
+              any()
+
+  @callback drop_trigger(
+              trigger_name :: binary(),
+              table_name :: binary(),
+              function_name :: binary()
+            ) :: any()
 
   defmacro __using__(_) do
     quote do
-      defp create_dependency_trigger(parent, child, fields) do
+      @behaviour Meadow.Utils.DependencyTriggers
+      use Ecto.Migration
+
+      def create_dependency_trigger(parent, child, fields) do
         create_dependency_trigger(parent, child, fields, parent)
       end
 
-      defp create_dependency_trigger(parent, child, fields, column_name) do
+      def create_dependency_trigger(parent, child, fields, column_name) do
         with {function_name, trigger_name} <- object_names(parent, child) do
-          condition =
-            fields
-            |> Enum.flat_map(
-              &[
-                "(NEW.#{&1} <> OLD.#{&1})",
-                "(NEW.#{&1} IS NULL AND OLD.#{&1} IS NOT NULL)",
-                "(NEW.#{&1} IS NOT NULL AND OLD.#{&1} IS NULL)"
-              ]
-            )
-            |> Enum.join(" OR ")
-
-          execute("""
-          CREATE OR REPLACE FUNCTION #{function_name}()
-            RETURNS trigger AS $$
-          BEGIN
-            IF #{condition} THEN
-              UPDATE #{child} SET updated_at = NOW() WHERE #{Inflex.singularize(column_name)}_id = NEW.id;
-            END IF;
-            RETURN NEW;
-          END;
-          $$ LANGUAGE plpgsql
-          """)
-
-          execute("""
-          CREATE TRIGGER #{trigger_name}
-            AFTER UPDATE
-            ON #{parent}
-            FOR EACH ROW
-            EXECUTE PROCEDURE #{function_name}()
-          """)
+          dependency_trigger(parent, child, fields, column_name) |> execute()
+          create_trigger(trigger_name, parent, function_name)
         end
       end
 
-      defp create_parent_trigger(parent, child, fields) do
+      def create_parent_trigger(parent, child, fields) do
         with {function_name, trigger_name} <- object_names_for_parent_trigger(parent, child) do
-          condition =
-            fields
-            |> Enum.flat_map(
-              &[
-                "(NEW.#{&1} <> OLD.#{&1})",
-                "(NEW.#{&1} IS NULL AND OLD.#{&1} IS NOT NULL)",
-                "(NEW.#{&1} IS NOT NULL AND OLD.#{&1} IS NULL)"
-              ]
-            )
-            |> Enum.join(" OR ")
-
-          execute("""
-          CREATE OR REPLACE FUNCTION #{function_name}()
-            RETURNS trigger AS $$
-          BEGIN
-            IF #{condition} THEN
-              UPDATE #{parent} SET updated_at = NOW() WHERE id = NEW.#{Inflex.singularize(parent)}_id;
-            END IF;
-            RETURN NEW;
-          END;
-          $$ LANGUAGE plpgsql
-          """)
-
-          execute("""
-          CREATE TRIGGER #{trigger_name}
-            AFTER UPDATE
-            ON #{child}
-            FOR EACH ROW
-            EXECUTE PROCEDURE #{function_name}()
-          """)
+          parent_trigger(parent, child, fields) |> execute()
+          create_trigger(trigger_name, child, function_name)
         end
       end
 
-      defp drop_dependency_trigger(parent, child) do
+      def disable_dependency_trigger(parent, child) do
+        with {_function_name, trigger_name} <- object_names(parent, child) do
+          switch_trigger(trigger_name, parent, "DISABLE")
+        end
+      end
+
+      def enable_dependency_trigger(parent, child) do
+        with {_function_name, trigger_name} <- object_names(parent, child) do
+          switch_trigger(trigger_name, parent, "ENABLE")
+        end
+      end
+
+      def disable_parent_trigger(parent, child) do
+        with {_function_name, trigger_name} <- object_names_for_parent_trigger(parent, child) do
+          switch_trigger(trigger_name, child, "DISABLE")
+        end
+      end
+
+      def enable_parent_trigger(parent, child) do
+        with {_function_name, trigger_name} <- object_names_for_parent_trigger(parent, child) do
+          switch_trigger(trigger_name, child, "ENABLE")
+        end
+      end
+
+      def drop_dependency_trigger(parent, child) do
         with {function_name, trigger_name} <- object_names(parent, child) do
-          execute("DROP TRIGGER IF EXISTS #{trigger_name} ON #{parent};")
-          execute("DROP FUNCTION IF EXISTS #{function_name};")
+          drop_trigger(trigger_name, parent, function_name)
         end
       end
 
-      defp drop_parent_trigger(parent, child) do
+      def drop_parent_trigger(parent, child) do
         with {function_name, trigger_name} <- object_names_for_parent_trigger(parent, child) do
-          execute("DROP TRIGGER IF EXISTS #{trigger_name} ON #{child};")
-          execute("DROP FUNCTION IF EXISTS #{function_name};")
+          drop_trigger(trigger_name, child, function_name)
         end
       end
 
@@ -110,5 +111,218 @@ defmodule Meadow.Utils.DependencyTriggers do
         }
       end
     end
+  end
+end
+
+defmodule Meadow.Utils.DependencyTriggers.ForEachStatement do
+  @moduledoc """
+  Statement-level implementation for Meadow.Utils.DependencyTriggers
+  """
+
+  use Meadow.Utils.DependencyTriggers
+
+  @impl true
+  def dependency_trigger(parent, child, fields, column_name) do
+    with {function_name, _trigger_name} <- object_names(parent, child),
+         condition <- match_condition(fields) do
+      """
+      CREATE OR REPLACE FUNCTION #{function_name}()
+        RETURNS trigger AS $$
+      BEGIN
+        CASE TG_OP
+          WHEN 'INSERT' THEN
+            IF EXISTS (SELECT FROM new_table) THEN
+              UPDATE #{child} SET updated_at = NOW()
+              WHERE #{Inflex.singularize(column_name)}_id = ANY (SELECT DISTINCT new_table.id FROM new_table);
+            END IF;
+          WHEN 'UPDATE' THEN
+            IF EXISTS (SELECT FROM new_table) THEN
+              UPDATE #{child} SET updated_at = NOW()
+              WHERE #{Inflex.singularize(column_name)}_id = ANY (
+                SELECT DISTINCT new_table.id
+                FROM new_table JOIN old_table ON new_table.id = old_table.id AND (#{condition})
+              );
+            END IF;
+          WHEN 'DELETE' THEN
+            IF EXISTS (SELECT FROM old_table) THEN
+              UPDATE #{child} SET updated_at = NOW()
+              WHERE #{Inflex.singularize(column_name)}_id = ANY (SELECT DISTINCT old_table.id FROM old_table);
+            END IF;
+        END CASE;
+        RETURN NULL;
+      END;
+      $$ LANGUAGE plpgsql
+      """
+    end
+  end
+
+  @impl true
+  def parent_trigger(parent, child, fields) do
+    with {function_name, _trigger_name} <- object_names_for_parent_trigger(parent, child),
+         condition <- match_condition(fields) do
+      """
+      CREATE OR REPLACE FUNCTION #{function_name}()
+        RETURNS trigger AS $$
+      BEGIN
+        CASE TG_OP
+          WHEN 'INSERT' THEN
+            IF EXISTS (SELECT FROM new_table) THEN
+              UPDATE #{parent} SET updated_at = NOW()
+              WHERE id = ANY (SELECT DISTINCT new_table.id FROM new_table);
+            END IF;
+          WHEN 'UPDATE' THEN
+            IF EXISTS (SELECT FROM new_table) THEN
+              UPDATE #{parent} SET updated_at = NOW()
+              WHERE id = ANY (
+                SELECT DISTINCT new_table.#{Inflex.singularize(parent)}_id
+                FROM new_table JOIN old_table ON new_table.id = old_table.id AND (#{condition})
+              );
+            END IF;
+          WHEN 'DELETE' THEN
+            IF EXISTS (SELECT FROM old_table) THEN
+              UPDATE #{parent} SET updated_at = NOW()
+              WHERE id = ANY (SELECT DISTINCT old_table.id FROM old_table);
+            END IF;
+        END CASE;
+        RETURN NULL;
+      END;
+      $$ LANGUAGE plpgsql
+      """
+    end
+  end
+
+  defp match_condition(fields) do
+    fields
+    |> Enum.flat_map(
+      &[
+        "(new_table.#{&1} <> old_table.#{&1})",
+        "(new_table.#{&1} IS NULL AND old_table.#{&1} IS NOT NULL)",
+        "(new_table.#{&1} IS NOT NULL AND old_table.#{&1} IS NULL)"
+      ]
+    )
+    |> Enum.join(" OR ")
+  end
+
+  @impl true
+  def create_trigger(trigger_name, table_name, function_name) do
+    execute("""
+    CREATE TRIGGER #{trigger_name}_insert
+      AFTER INSERT ON #{table_name}
+      REFERENCING NEW TABLE AS new_table
+      FOR EACH STATEMENT
+      EXECUTE PROCEDURE #{function_name}();
+    """)
+
+    execute("""
+    CREATE TRIGGER #{trigger_name}_update
+      AFTER UPDATE ON #{table_name}
+      REFERENCING OLD TABLE AS old_table NEW TABLE AS new_table
+      FOR EACH STATEMENT
+      EXECUTE PROCEDURE #{function_name}();
+    """)
+
+    execute("""
+    CREATE TRIGGER #{trigger_name}_delete
+      AFTER DELETE ON #{table_name}
+      REFERENCING OLD TABLE AS old_table
+      FOR EACH STATEMENT
+      EXECUTE PROCEDURE #{function_name}();
+    """)
+  end
+
+  @impl true
+  def switch_trigger(trigger_name, table_name, action) do
+    ["insert", "update", "delete"]
+    |> Enum.each(fn operation ->
+      execute("ALTER TABLE #{table_name} #{action} TRIGGER #{trigger_name}_#{operation}")
+    end)
+  end
+
+  @impl true
+  def drop_trigger(trigger_name, table_name, function_name) do
+    ["insert", "update", "delete"]
+    |> Enum.each(fn operation ->
+      execute("DROP TRIGGER IF EXISTS #{trigger_name}_#{operation} ON #{table_name};")
+    end)
+
+    execute("DROP FUNCTION IF EXISTS #{function_name};")
+  end
+end
+
+defmodule Meadow.Utils.DependencyTriggers.ForEachRow do
+  @moduledoc """
+  Row-level implementation for Meadow.Utils.DependencyTriggers
+  """
+
+  use Meadow.Utils.DependencyTriggers
+
+  @impl true
+  def dependency_trigger(parent, child, fields, column_name) do
+    with {function_name, _trigger_name} <- object_names(parent, child),
+         condition <- match_condition(fields) do
+      """
+      CREATE OR REPLACE FUNCTION #{function_name}()
+        RETURNS trigger AS $$
+      BEGIN
+        IF #{condition} THEN
+          UPDATE #{child} SET updated_at = NOW() WHERE #{Inflex.singularize(column_name)}_id = NEW.id;
+        END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql
+      """
+    end
+  end
+
+  @impl true
+  def parent_trigger(parent, child, fields) do
+    with {function_name, _trigger_name} <- object_names_for_parent_trigger(parent, child),
+         condition <- match_condition(fields) do
+      """
+      CREATE OR REPLACE FUNCTION #{function_name}()
+        RETURNS trigger AS $$
+      BEGIN
+        IF #{condition} THEN
+          UPDATE #{parent} SET updated_at = NOW() WHERE id = NEW.#{Inflex.singularize(parent)}_id;
+        END IF;
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql
+      """
+    end
+  end
+
+  defp match_condition(fields) do
+    fields
+    |> Enum.flat_map(
+      &[
+        "(NEW.#{&1} <> OLD.#{&1})",
+        "(NEW.#{&1} IS NULL AND OLD.#{&1} IS NOT NULL)",
+        "(NEW.#{&1} IS NOT NULL AND OLD.#{&1} IS NULL)"
+      ]
+    )
+    |> Enum.join(" OR ")
+  end
+
+  @impl true
+  def create_trigger(trigger_name, table_name, function_name) do
+    execute("""
+    CREATE TRIGGER #{trigger_name}
+      AFTER UPDATE
+      ON #{table_name}
+      FOR EACH ROW
+      EXECUTE PROCEDURE #{function_name}()
+    """)
+  end
+
+  @impl true
+  def switch_trigger(trigger_name, table_name, action) do
+    execute("ALTER TABLE #{table_name} #{action} TRIGGER #{trigger_name}")
+  end
+
+  @impl true
+  def drop_trigger(trigger_name, table_name, function_name) do
+    execute("DROP TRIGGER IF EXISTS #{trigger_name} ON #{table_name};")
+    execute("DROP FUNCTION IF EXISTS #{function_name};")
   end
 end

--- a/priv/repo/migrations/20200507123625_create_dependency_triggers.exs
+++ b/priv/repo/migrations/20200507123625_create_dependency_triggers.exs
@@ -1,6 +1,7 @@
 defmodule Meadow.Repo.Migrations.CreateDependencyTriggers do
   use Ecto.Migration
-  use Meadow.Utils.DependencyTriggers
+
+  import Meadow.Utils.DependencyTriggers.ForEachRow
 
   def up do
     create_dependency_trigger(:ingest_sheets, :works, [:title])

--- a/priv/repo/migrations/20201102222710_works_changed_notification.exs
+++ b/priv/repo/migrations/20201102222710_works_changed_notification.exs
@@ -3,7 +3,7 @@ defmodule Meadow.Repo.Migrations.WorksChangedNotification do
   import Meadow.DatabaseNotification
 
   def up do
-    create_notification_trigger(:works)
+    create_notification_trigger(:row, :works, :all)
   end
 
   def down do

--- a/priv/repo/migrations/20201103221340_ingest_sheet_notification.exs
+++ b/priv/repo/migrations/20201103221340_ingest_sheet_notification.exs
@@ -4,7 +4,7 @@ defmodule Meadow.Repo.Migrations.IngestSheetNotification do
 
 
   def up do
-    create_notification_trigger(:ingest_sheets)
+    create_notification_trigger(:row, :ingest_sheets, :all)
   end
 
   def down do

--- a/priv/repo/migrations/20210525165057_add_extracted_metadata_to_file_sets.exs
+++ b/priv/repo/migrations/20210525165057_add_extracted_metadata_to_file_sets.exs
@@ -1,9 +1,10 @@
 defmodule Meadow.Repo.Migrations.AddExtractedMetadataToFileSets do
   use Ecto.Migration
-  use Meadow.Utils.DependencyTriggers
+
+  import Meadow.Utils.DependencyTriggers.ForEachRow
 
   def up do
-    drop_parent_trigger(:works, :file_sets)
+    disable_parent_trigger(:works, :file_sets)
     rename table("file_sets"), :metadata, to: :core_metadata
     alter table("file_sets"), do: add :extracted_metadata, :map, default: %{}
     execute """
@@ -11,17 +12,17 @@ defmodule Meadow.Repo.Migrations.AddExtractedMetadataToFileSets do
     SET extracted_metadata = core_metadata -> 'extracted_metadata',
         core_metadata = core_metadata - 'extracted_metadata';
     """
-    create_parent_trigger(:works, :file_sets, [:core_metadata, :rank])
+    enable_parent_trigger(:works, :file_sets)
   end
 
   def down do
-    drop_parent_trigger(:works, :file_sets)
+    disable_parent_trigger(:works, :file_sets)
     execute """
     UPDATE file_sets
     SET core_metadata = jsonb_set(core_metadata, '{extracted_metadata}', extracted_metadata);
     """
     alter table("file_sets"), do: remove :extracted_metadata
     rename table("file_sets"), :core_metadata, to: :metadata
-    create_parent_trigger(:works, :file_sets, [:metadata, :rank])
+    enable_parent_trigger(:works, :file_sets)
   end
 end

--- a/priv/repo/migrations/20210525224100_create_file_set_structural_metadata.exs
+++ b/priv/repo/migrations/20210525224100_create_file_set_structural_metadata.exs
@@ -4,7 +4,7 @@ defmodule Meadow.Repo.Migrations.CreateFileSetStructuralMetadata do
 
   def up do
     alter table("file_sets"), do: add :structural_metadata, :map, default: %{}
-    create_notification_trigger(:file_sets, ["structural_metadata"])
+    create_notification_trigger(:row, :file_sets, ["structural_metadata"])
   end
 
   def down do

--- a/priv/repo/migrations/20210624123252_replace_row_triggers_with_statement_triggers.exs
+++ b/priv/repo/migrations/20210624123252_replace_row_triggers_with_statement_triggers.exs
@@ -1,0 +1,48 @@
+defmodule Meadow.Repo.Migrations.ReplaceRowTriggersWithStatementTriggers do
+  use Ecto.Migration
+
+  alias Meadow.Utils.DependencyTriggers.ForEachRow, as: RowTriggers
+  alias Meadow.Utils.DependencyTriggers.ForEachStatement, as: StatementTriggers
+
+  def up do
+    RowTriggers.drop_parent_trigger(:works, :file_sets)
+    RowTriggers.drop_dependency_trigger(:works, :collections)
+    RowTriggers.drop_dependency_trigger(:works, :file_sets)
+    RowTriggers.drop_dependency_trigger(:collections, :works)
+    RowTriggers.drop_dependency_trigger(:ingest_sheets, :works)
+
+    StatementTriggers.create_dependency_trigger(:ingest_sheets, :works, [:title])
+    StatementTriggers.create_dependency_trigger(:collections, :works, [:title])
+    StatementTriggers.create_dependency_trigger(:works, :file_sets, [:published, :visibility])
+
+    StatementTriggers.create_dependency_trigger(
+      :works,
+      :collections,
+      [:representative_file_set_id],
+      :representative_work
+    )
+
+    StatementTriggers.create_parent_trigger(:works, :file_sets, [:core_metadata, :rank])
+  end
+
+  def down do
+    StatementTriggers.drop_parent_trigger(:works, :file_sets)
+    StatementTriggers.drop_dependency_trigger(:works, :collections)
+    StatementTriggers.drop_dependency_trigger(:works, :file_sets)
+    StatementTriggers.drop_dependency_trigger(:collections, :works)
+    StatementTriggers.drop_dependency_trigger(:ingest_sheets, :works)
+
+    RowTriggers.create_dependency_trigger(:ingest_sheets, :works, [:title])
+    RowTriggers.create_dependency_trigger(:collections, :works, [:title])
+    RowTriggers.create_dependency_trigger(:works, :file_sets, [:published, :visibility])
+
+    RowTriggers.create_dependency_trigger(
+      :works,
+      :collections,
+      [:representative_file_set_id],
+      :representative_work
+    )
+
+    RowTriggers.create_parent_trigger(:works, :file_sets, [:core_metadata, :rank])
+  end
+end

--- a/priv/repo/migrations/20210628192601_replace_row_notifications_with_statement_notifications.exs
+++ b/priv/repo/migrations/20210628192601_replace_row_notifications_with_statement_notifications.exs
@@ -1,0 +1,23 @@
+defmodule Meadow.Repo.Migrations.ReplaceRowNotificationsWithStatementNotifications do
+  use Ecto.Migration
+
+  import Meadow.DatabaseNotification
+
+  def up do
+    drop_notification_trigger(:works)
+    drop_notification_trigger(:ingest_sheets)
+    drop_notification_trigger(:file_sets)
+    create_notification_trigger(:statement, :works, :all)
+    create_notification_trigger(:statement, :ingest_sheets, :all)
+    create_notification_trigger(:statement, :file_sets, ["structural_metadata"])
+  end
+
+  def down do
+    drop_notification_trigger(:works)
+    drop_notification_trigger(:ingest_sheets)
+    drop_notification_trigger(:file_sets)
+    create_notification_trigger(:row, :works, :all)
+    create_notification_trigger(:row, :ingest_sheets, :all)
+    create_notification_trigger(:row, :file_sets, ["structural_metadata"])
+  end
+end

--- a/test/meadow/database_notification_test.exs
+++ b/test/meadow/database_notification_test.exs
@@ -16,7 +16,7 @@ defmodule Meadow.DatabaseNotificationTest do
         add(:data, :string)
       end
 
-      create_notification_trigger(@table)
+      create_notification_trigger(@table, :all)
     end
 
     def down do


### PR DESCRIPTION
This PR replaces all existing dependency triggers and notification triggers with statement-level equivalents.

### Details

* For notification triggers, instead of firing for every operation on each row, the trigger fires once at the end of the whole operation and sends notifications for each _distinct_ affected row in batches of 100.
* For dependency triggers, instead of updating the relevant parent/child `updated_at` one at a time for each affected row, the trigger uses a single `UPDATE ... WHERE` statement to do them all at once.
* The `DatabaseNotification` module has been updated to handle notifications in batches.
* Migrations run correctly in both directions
* Only one test required a very minor change to its setup code, demonstrating interface compatibility

### Testing

* Make sure you can migrate
* Make sure IIIF manifests and cascading index changes still work
* Make sure nothing else blows up
* Manually check batch/CSV update functionality

### Benchmarks

* Dev database was seeded with 145,927 works and 221,138 file sets from production
* In a SQL session, I ran a series of file set updates. First I updated the description on 100 file sets:

    ```
    update file_sets 
    set core_metadata = jsonb_set(core_metadata, '{description}', '"Update 100 Descriptions"', updated_at = now())
    WHERE id in (SELECT id FROM file_sets LIMIT 100);
    ```

    ran quickly using both `EACH ROW` and `EACH STATEMENT` triggers. But while

    ```
    update file_sets 
    set core_metadata = jsonb_set(core_metadata, '{description}', '"Update All Descriptions"', updated_at = now());
    ```

    never completed using `EACH ROW` (I waited for a half hour), it only took 30 seconds using the `EACH STATEMENT` trigger.

### Notes

The trigger generation code is _extra_ complicated because of the need to keep both the `EACH ROW` and `EACH STATEMENT` logic around (for migrating both up and down). We should consider whether it's worth refactoring migrations again once everything is updated on staging and production so we don't have to deal with all the legacy/backout code. This would require a manual update of the `schema_migrations` table to make the DB recognize the refactored migrations.