### PR TITLE
Adds structural metadata to file sets on ingest

### DIFF
--- a/lib/meadow/constants.ex
+++ b/lib/meadow/constants.ex
@@ -4,7 +4,7 @@ defmodule Meadow.Constants do
   defmacro __using__(_) do
     quote do
       @ingest_sheet_headers ~w(description file_accession_number filename label
-        role work_accession_number work_image work_type)
+        role structure work_accession_number work_image work_type)
       @role_priority ~w[Administrators Managers Editors Users]
     end
   end

--- a/lib/meadow/ingest/validator.ex
+++ b/lib/meadow/ingest/validator.ex
@@ -269,6 +269,8 @@ defmodule Meadow.Ingest.Validator do
     end
   end
 
+  defp validate_value(_row, {"structure", _value}, _context), do: :ok
+
   defp validate_value(_row, {field_name, value}, _context)
        when byte_size(value) == 0,
        do: {:error, field_name, "cannot be blank"}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Meadow.MixProject do
   use Mix.Project
 
-  @app_version "2.0.2"
+  @app_version "3.0.0"
 
   def project do
     [

--- a/test/fixtures/Donohue_002_01.vtt
+++ b/test/fixtures/Donohue_002_01.vtt
@@ -1,0 +1,21 @@
+WEBVTT - Translation of that film I like
+
+NOTE
+This translation was done by Kyle so that
+some friends can watch it with their parents.
+
+1
+00:02:15.000 --> 00:02:20.000
+- Ta en kopp varmt te.
+- Det är inte varmt.
+
+2
+00:02:20.000 --> 00:02:25.000
+- Har en kopp te.
+- Det smakar som te.
+
+NOTE This last line may not translate well.
+
+3
+00:02:25.000 --> 00:02:30.000
+- Ta en kopp

--- a/test/fixtures/ingest_sheet.csv
+++ b/test/fixtures/ingest_sheet.csv
@@ -1,9 +1,9 @@
-work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image
-IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",
-,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P,"The label",
-,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",TRUE
-,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",X,"The label",
-VIDEO,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",
-,Donohue_002,Donohue_002_02,small.m4v,Small Video,A,"The label",
-,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",X,"The label",
-,Donohue_002,Donohue_002_04,details.json,"Supplemental information",S,"Supplement",
+work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image,structure
+IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",,
+,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P,"The label",,
+,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",TRUE,
+,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",X,"The label",,
+VIDEO,Donohue_002,Donohue_002_01,small.m4v,"Photo, man with two children",A,"The label",,Donohue_002_01.vtt
+,Donohue_002,Donohue_002_02,small.m4v,Small Video,A,"The label",,
+,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",X,"The label",,
+,Donohue_002,Donohue_002_04,details.json,"Supplemental information",S,"Supplement",,

--- a/test/fixtures/ingest_sheet_accession_exists.csv
+++ b/test/fixtures/ingest_sheet_accession_exists.csv
@@ -1,8 +1,8 @@
-work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image
-IMAGE,Donohue_001,6777,Donohue_001_01.tif,"Letter, page 1, Dear Sir, recto",A,"The label",
-,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P,"The label",
-,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",
-,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A,"The label",
-IMAGE,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",
-,Donohue_002,Donohue_002_02,coffee.tif,Verso,A,"The label",
-,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A,"The label",
+work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image,structure
+IMAGE,Donohue_001,6777,Donohue_001_01.tif,"Letter, page 1, Dear Sir, recto",A,"The label",,
+,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P,"The label",,
+,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",,
+,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A,"The label",,
+IMAGE,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",,
+,Donohue_002,Donohue_002_02,coffee.tif,Verso,A,"The label",,
+,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A,"The label",,

--- a/test/fixtures/ingest_sheet_duplicate_accession.csv
+++ b/test/fixtures/ingest_sheet_duplicate_accession.csv
@@ -1,8 +1,8 @@
-work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image
-IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",
-,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P,"The label",
-,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",
-,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A,"The label",
-IMAGE,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",
-,Donohue_002,Donohue_002_01,coffee.tif,Verso,A,"The label",
-,Donohue_002,Donohue_002_01,coffee.tif,"Photo, two children praying",A,"The label",
+work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image,structure
+IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",,
+,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P,"The label",,
+,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",,
+,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A,"The label",,
+IMAGE,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",,
+,Donohue_002,Donohue_002_01,coffee.tif,Verso,A,"The label",,
+,Donohue_002,Donohue_002_01,coffee.tif,"Photo, two children praying",A,"The label",,

--- a/test/fixtures/ingest_sheet_incorrect_role.csv
+++ b/test/fixtures/ingest_sheet_incorrect_role.csv
@@ -1,8 +1,8 @@
-work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image
-IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",H,"The label",
-,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P,"The label",
-,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",
-,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A,"The label",
-IMAGE,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",
-,Donohue_002,Donohue_002_02,coffee.tif,Verso,A,"The label",
-,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A,"The label",
+work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image,structure
+IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",H,"The label",,
+,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P,"The label",,
+,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",,
+,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A,"The label",,
+IMAGE,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",,
+,Donohue_002,Donohue_002_02,coffee.tif,Verso,A,"The label",,
+,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A,"The label",,

--- a/test/fixtures/ingest_sheet_invalid_work_image.csv
+++ b/test/fixtures/ingest_sheet_invalid_work_image.csv
@@ -1,8 +1,8 @@
-work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image
-IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",
-,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P,"The label",TRUE
-,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",
-,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A,"The label",
-VIDEO,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",
-,Donohue_002,Donohue_002_02,coffee.tif,Verso,A,"The label",
-,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A,"The label",
+work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image,structure
+IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",,
+,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P,"The label",TRUE,
+,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",,
+,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A,"The label",,
+VIDEO,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",,
+,Donohue_002,Donohue_002_02,coffee.tif,Verso,A,"The label",,
+,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A,"The label",,

--- a/test/fixtures/ingest_sheet_missing_field.csv
+++ b/test/fixtures/ingest_sheet_missing_field.csv
@@ -1,8 +1,8 @@
-work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image
-IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",
-,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",A,"The label",
-,Donohue_001,,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",
-,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A,"The label",
-IMAGE,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",
-,Donohue_002,Donohue_002_02,coffee.tif,Verso,A,"The label",
-,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A,"The label",
+work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image,structure
+IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",,
+,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",A,"The label",,
+,Donohue_001,,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",,
+,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A,"The label",,
+IMAGE,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",,
+,Donohue_002,Donohue_002_02,coffee.tif,Verso,A,"The label",,
+,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A,"The label",,

--- a/test/fixtures/ingest_sheet_missing_file.csv
+++ b/test/fixtures/ingest_sheet_missing_file.csv
@@ -1,8 +1,8 @@
-work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image
-IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",
-,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",A,"The label",
-,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",
-,Donohue_001,Donohue_001_04,Missing_001_04.tif,"Letter, page 2, If these papers, verso, blank",A,"The label",
-IMAGE,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",
-,Donohue_002,Donohue_002_02,coffee.tif,Verso,A,"The label",
-,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A,"The label",
+work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image,structure
+IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",,
+,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",A,"The label",,
+,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",,
+,Donohue_001,Donohue_001_04,Missing_001_04.tif,"Letter, page 2, If these papers, verso, blank",A,"The label",,
+IMAGE,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",,
+,Donohue_002,Donohue_002_02,coffee.tif,Verso,A,"The label",,
+,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A,"The label",,

--- a/test/fixtures/ingest_sheet_missing_work_type.csv
+++ b/test/fixtures/ingest_sheet_missing_work_type.csv
@@ -1,8 +1,8 @@
-work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image
-IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",
-,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P,"The label",
-,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",TRUE
-,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A,"The label",
-,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",
-,Donohue_002,Donohue_002_02,coffee.tif,Verso,A,"The label",
-,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A,"The label",
+work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image,structure
+IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",,
+,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P,"The label",,
+,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",TRUE,
+,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A,"The label",,
+,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",,
+,Donohue_002,Donohue_002_02,coffee.tif,Verso,A,"The label",,
+,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A,"The label",,

--- a/test/fixtures/ingest_sheet_work_accession_exists.csv
+++ b/test/fixtures/ingest_sheet_work_accession_exists.csv
@@ -1,8 +1,8 @@
-work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image
-IMAGE,6779,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",
-,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P,"The label",
-,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",
-,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A,"The label",
-IMAGE,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",
-,Donohue_002,Donohue_002_02,coffee.tif,Verso,A,"The label",
-,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A,"The label",
+work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image,structure
+IMAGE,6779,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",,
+,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P,"The label",,
+,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",,
+,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A,"The label",,
+IMAGE,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",,
+,Donohue_002,Donohue_002_02,coffee.tif,Verso,A,"The label",,
+,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A,"The label",,

--- a/test/fixtures/ingest_sheet_wrong_headers.csv
+++ b/test/fixtures/ingest_sheet_wrong_headers.csv
@@ -1,8 +1,8 @@
-work_type,work_accession_number,not_the_accession_number,filename,description,role,label,work_image
-IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",
-,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",A,"The label",
-,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",
-,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A,"The label",
-IMAGE,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",
-,Donohue_002,Donohue_002_02,coffee.tif,Verso,A,"The label",
-,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A,"The label",
+work_type,work_accession_number,not_the_accession_number,filename,description,role,label,work_image,structure
+IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",,
+,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",A,"The label",,
+,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",,
+,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",A,"The label",,
+IMAGE,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",,
+,Donohue_002,Donohue_002_02,coffee.tif,Verso,A,"The label",,
+,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A,"The label",,

--- a/test/meadow/ingest/validator_test.exs
+++ b/test/meadow/ingest/validator_test.exs
@@ -62,7 +62,6 @@ defmodule Meadow.Ingest.ValidatorTest do
   test "validates an ingest sheet", context do
     assert(Validator.result(context.sheet.id) == "pass")
     ingest_sheet = Validator.validate(context.sheet.id)
-
     assert(ingest_sheet.file_errors == [])
 
     assert(ingest_sheet.status == "valid")

--- a/test/meadow/structural_metadata_listener_test.exs
+++ b/test/meadow/structural_metadata_listener_test.exs
@@ -35,6 +35,15 @@ defmodule Meadow.StructuralMetadataListenerTest do
       assert object_exists?(@streaming_bucket, location)
       assert object_size(@streaming_bucket, location) == byte_size(@vtt)
     end
+
+    test "when file set is created" do
+      file_set = file_set_fixture(%{structural_metadata: %{type: "webvtt", value: @vtt}})
+      StructuralMetadataListener.handle_notification(:file_sets, :create, %{id: file_set.id}, nil)
+      location = Path.join(Pairtree.generate!(file_set.id), file_set.id <> ".vtt")
+
+      assert object_exists?(@streaming_bucket, location)
+      assert object_size(@streaming_bucket, location) == byte_size(@vtt)
+    end
   end
 
   describe "delete structural metadata file" do


### PR DESCRIPTION
- Adds `structure` header to ingest sheet
- .vtt files uploaded to the ingest sheet's project folder in S3 and referenced in the ingest sheet (by file basename - ex: `filename.vtt`) in the structure column will be saved as structural metadata on the file set. 
- (validation not included)

* Bumped version to `3.0.0` because of backwards incompatible API change (ingest sheet)