### PR TITLE
Supplemental files skip pyramid check on preservation report

### DIFF
--- a/lib/meadow/data/preservation_check_writer.ex
+++ b/lib/meadow/data/preservation_check_writer.ex
@@ -154,6 +154,7 @@ defmodule Meadow.Data.PreservationCheckWriter do
   end
 
   defp validate_pyramid_present(%{role: %{id: "P"}}), do: "N/A"
+  defp validate_pyramid_present(%{role: %{id: "S"}}), do: "N/A"
 
   defp validate_pyramid_present(file_set) do
     Meadow.Utils.Stream.exists?(FileSets.pyramid_uri_for(file_set))

--- a/test/meadow/data/preservation_check_writer_test.exs
+++ b/test/meadow/data/preservation_check_writer_test.exs
@@ -60,7 +60,23 @@ defmodule Meadow.Data.PreservationCheckWriterTest do
         }
       })
 
-    {:ok, file_set_1: file_set_1, file_set_2: file_set_2}
+    file_set_3 =
+      file_set_fixture(%{
+        work_id: work.id,
+        accession_number: "789",
+        role: %{id: "S", scheme: "FILE_SET_ROLE"},
+        core_metadata: %{
+          digests: %{
+            "sha256" => @sha256,
+            "sha1" => @sha1
+          },
+          location: "s3://#{@preservation_bucket}/#{Pairtree.preservation_path(@sha256)}",
+          mime_type: "image/tiff",
+          original_filename: "test.tif"
+        }
+      })
+
+    {:ok, file_set_1: file_set_1, file_set_2: file_set_2, file_set_3: file_set_3}
   end
 
   describe "generate_report/1" do


### PR DESCRIPTION
- Supplemental files do not have pyramid derivatives generated so they should not report an error on the preservation check - instead they should report "N/A"