### PR TITLE
Update MediaConvert settings to transcode audio and video to HLS

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -63,6 +63,19 @@ config :meadow, :lambda,
   mime_type: {:local, {"nodejs/mime-type/index.js", "handler"}},
   tiff: {:local, {"nodejs/pyramid-tiff/index.js", "handler"}}
 
+config :meadow,
+  transcoding_presets: %{
+    audio: [
+      %{NameModifier: "-high", Preset: "meadow-audio-high"},
+      %{NameModifier: "-medium", Preset: "meadow-audio-medium"}
+    ],
+    video: [
+      %{NameModifier: "-1080", Preset: "System-Avc_16x9_1080p_29_97fps_8500kbps"},
+      %{NameModifier: "-720", Preset: "System-Avc_16x9_720p_29_97fps_5000kbps"},
+      %{NameModifier: "-540", Preset: "System-Avc_16x9_540p_29_97fps_3500kbps"}
+    ]
+  }
+
 # Configures the pyramid TIFF processor
 with val <- System.get_env("PYRAMID_PROCESSOR") do
   unless is_nil(val), do: config(:meadow, pyramid_processor: val)

--- a/lib/meadow/config.ex
+++ b/lib/meadow/config.ex
@@ -202,6 +202,11 @@ defmodule Meadow.Config do
     )
   end
 
+  def transcoding_presets(type) do
+    Application.get_env(:meadow, :transcoding_presets, %{})
+    |> Map.get(type, [])
+  end
+
   def workers do
     System.get_env("MEADOW_PROCESSES", "ALL")
     |> String.split(~r/\s*,\s*/)

--- a/lib/media_convert/audio_template.ex
+++ b/lib/media_convert/audio_template.ex
@@ -13,7 +13,7 @@ defmodule MediaConvert.AudioTemplate do
       :OutputGroups,
       Access.at(0),
       :OutputGroupSettings,
-      :FileGroupSettings,
+      :HlsGroupSettings,
       :Destination
     ]
 
@@ -41,33 +41,16 @@ defmodule MediaConvert.AudioTemplate do
         ],
         OutputGroups: [
           %{
-            Name: "File Group",
+            Name: "HLS",
             OutputGroupSettings: %{
-              FileGroupSettings: %{},
-              Type: "FILE_GROUP_SETTINGS"
+              HlsGroupSettings: %{
+                MinSegmentLength: 0,
+                SegmentControl: "SEGMENTED_FILES",
+                SegmentLength: 2
+              },
+              Type: "HLS_GROUP_SETTINGS"
             },
-            Outputs: [
-              %{
-                ContainerSettings: %{
-                  Container: "MP4",
-                  Mp4Settings: %{}
-                },
-                AudioDescriptions: [
-                  %{
-                    AudioSourceName: "Audio Selector 1",
-                    CodecSettings: %{
-                      Codec: "AAC",
-                      AacSettings: %{
-                        VbrQuality: "MEDIUM_HIGH",
-                        RateControlMode: "VBR",
-                        CodingMode: "CODING_MODE_2_0",
-                        SampleRate: 44_100
-                      }
-                    }
-                  }
-                ]
-              }
-            ]
+            Outputs: Config.transcoding_presets(:audio)
           }
         ],
         TimecodeConfig: %{Source: "ZEROBASED"}

--- a/lib/media_convert/mock.ex
+++ b/lib/media_convert/mock.ex
@@ -75,16 +75,7 @@ defmodule MediaConvert.Mock do
   defp destination(%{
          Settings: %{
            OutputGroups: [
-             %{OutputGroupSettings: %{CmafGroupSettings: %{Destination: destination}}}
-           ]
-         }
-       }),
-       do: destination
-
-  defp destination(%{
-         Settings: %{
-           OutputGroups: [
-             %{OutputGroupSettings: %{FileGroupSettings: %{Destination: destination}}}
+             %{OutputGroupSettings: %{HlsGroupSettings: %{Destination: destination}}}
            ]
          }
        }),
@@ -92,8 +83,8 @@ defmodule MediaConvert.Mock do
 
   defp destination(_template), do: ""
 
-  defp media_type(%{Settings: %{OutputGroups: [%{Name: "File Group"}]}}), do: :audio
-  defp media_type(%{Settings: %{OutputGroups: [%{Name: "CMAF"}]}}), do: :video
+  defp media_type(%{Settings: %{Inputs: [%{AudioSelectorGroups: %{}}]}}), do: :audio
+  defp media_type(%{Settings: %{Inputs: [%{VideoSelector: %{}}]}}), do: :video
   defp media_type(_), do: :unknown
 
   defp send_transcode_complete(template) do

--- a/lib/media_convert/video_template.ex
+++ b/lib/media_convert/video_template.ex
@@ -13,7 +13,7 @@ defmodule MediaConvert.VideoTemplate do
       :OutputGroups,
       Access.at(0),
       :OutputGroupSettings,
-      :CmafGroupSettings,
+      :HlsGroupSettings,
       :Destination
     ]
 
@@ -39,41 +39,16 @@ defmodule MediaConvert.VideoTemplate do
         ],
         OutputGroups: [
           %{
-            Name: "CMAF",
+            Name: "HLS",
             OutputGroupSettings: %{
-              CmafGroupSettings: %{FragmentLength: 2, SegmentLength: 10},
-              Type: "CMAF_GROUP_SETTINGS"
+              HlsGroupSettings: %{
+                MinSegmentLength: 0,
+                SegmentControl: "SEGMENTED_FILES",
+                SegmentLength: 2
+              },
+              Type: "HLS_GROUP_SETTINGS"
             },
-            Outputs: [
-              %{
-                NameModifier: "-1080",
-                Preset: "System-Ott_Cmaf_Cmfc_Avc_16x9_Sdr_1920x1080p_30Hz_8Mbps_Qvbr_Vq8"
-              },
-              %{
-                NameModifier: "-720",
-                Preset: "System-Ott_Cmaf_Cmfc_Avc_16x9_Sdr_1280x720p_30Hz_4Mbps_Qvbr_Vq7"
-              },
-              %{
-                NameModifier: "-540",
-                Preset: "System-Ott_Cmaf_Cmfc_Avc_16x9_Sdr_960x540p_30Hz_2.5Mbps_Qvbr_Vq7"
-              },
-              %{
-                AudioDescriptions: [
-                  %{
-                    AudioSourceName: "Audio Selector 1",
-                    CodecSettings: %{
-                      AacSettings: %{
-                        Bitrate: 192_000,
-                        CodingMode: "CODING_MODE_2_0",
-                        SampleRate: 44_100
-                      },
-                      Codec: "AAC"
-                    }
-                  }
-                ],
-                ContainerSettings: %{Container: "CMFC"}
-              }
-            ]
+            Outputs: Config.transcoding_presets(:video)
           }
         ],
         TimecodeConfig: %{Source: "ZEROBASED"}

--- a/test/media_convert/audio_template_test.exs
+++ b/test/media_convert/audio_template_test.exs
@@ -1,6 +1,7 @@
 defmodule MediaConvert.AudioTemplateTest do
   use Meadow.DataCase
 
+  alias Meadow.Config
   alias MediaConvert.AudioTemplate
 
   @template %{
@@ -19,30 +20,17 @@ defmodule MediaConvert.AudioTemplateTest do
       ],
       OutputGroups: [
         %{
-          Name: "File Group",
+          Name: "HLS",
           OutputGroupSettings: %{
-            FileGroupSettings: %{Destination: "s3://destination/"},
-            Type: "FILE_GROUP_SETTINGS"
+            HlsGroupSettings: %{
+              MinSegmentLength: 0,
+              SegmentControl: "SEGMENTED_FILES",
+              SegmentLength: 2,
+              Destination: "s3://destination/"
+            },
+            Type: "HLS_GROUP_SETTINGS"
           },
-          Outputs: [
-            %{
-              AudioDescriptions: [
-                %{
-                  AudioSourceName: "Audio Selector 1",
-                  CodecSettings: %{
-                    AacSettings: %{
-                      CodingMode: "CODING_MODE_2_0",
-                      RateControlMode: "VBR",
-                      SampleRate: 44_100,
-                      VbrQuality: "MEDIUM_HIGH"
-                    },
-                    Codec: "AAC"
-                  }
-                }
-              ],
-              ContainerSettings: %{Container: "MP4", Mp4Settings: %{}}
-            }
-          ]
+          Outputs: Config.transcoding_presets(:audio)
         }
       ],
       TimecodeConfig: %{Source: "ZEROBASED"}
@@ -52,7 +40,12 @@ defmodule MediaConvert.AudioTemplateTest do
 
   describe "render/2" do
     test "template" do
-      assert @template == AudioTemplate.render(%{file_set_id: "fake-file-set-id"}, "s3://source/test.wav", "s3://destination/")
+      assert @template ==
+               AudioTemplate.render(
+                 %{file_set_id: "fake-file-set-id"},
+                 "s3://source/test.wav",
+                 "s3://destination/"
+               )
     end
   end
 end

--- a/test/media_convert/video_template_test.exs
+++ b/test/media_convert/video_template_test.exs
@@ -1,6 +1,7 @@
 defmodule MediaConvert.VideoTemplateTest do
   use Meadow.DataCase
 
+  alias Meadow.Config
   alias MediaConvert.VideoTemplate
 
   @template %{
@@ -17,45 +18,17 @@ defmodule MediaConvert.VideoTemplateTest do
       ],
       OutputGroups: [
         %{
-          Name: "CMAF",
+          Name: "HLS",
           OutputGroupSettings: %{
-            CmafGroupSettings: %{
-              Destination: "s3://destination/",
-              FragmentLength: 2,
-              SegmentLength: 10
+            HlsGroupSettings: %{
+              MinSegmentLength: 0,
+              SegmentControl: "SEGMENTED_FILES",
+              SegmentLength: 2,
+              Destination: "s3://destination/"
             },
-            Type: "CMAF_GROUP_SETTINGS"
+            Type: "HLS_GROUP_SETTINGS"
           },
-          Outputs: [
-            %{
-              NameModifier: "-1080",
-              Preset: "System-Ott_Cmaf_Cmfc_Avc_16x9_Sdr_1920x1080p_30Hz_8Mbps_Qvbr_Vq8"
-            },
-            %{
-              NameModifier: "-720",
-              Preset: "System-Ott_Cmaf_Cmfc_Avc_16x9_Sdr_1280x720p_30Hz_4Mbps_Qvbr_Vq7"
-            },
-            %{
-              NameModifier: "-540",
-              Preset: "System-Ott_Cmaf_Cmfc_Avc_16x9_Sdr_960x540p_30Hz_2.5Mbps_Qvbr_Vq7"
-            },
-            %{
-              AudioDescriptions: [
-                %{
-                  AudioSourceName: "Audio Selector 1",
-                  CodecSettings: %{
-                    AacSettings: %{
-                      Bitrate: 192_000,
-                      CodingMode: "CODING_MODE_2_0",
-                      SampleRate: 44_100
-                    },
-                    Codec: "AAC"
-                  }
-                }
-              ],
-              ContainerSettings: %{Container: "CMFC"}
-            }
-          ]
+          Outputs: Config.transcoding_presets(:video)
         }
       ],
       TimecodeConfig: %{Source: "ZEROBASED"}
@@ -65,7 +38,12 @@ defmodule MediaConvert.VideoTemplateTest do
 
   describe "render/2" do
     test "template" do
-      assert @template == VideoTemplate.render(%{file_set_id: "fake-file-set-id"}, "s3://source/test.mkv", "s3://destination/")
+      assert @template ==
+               VideoTemplate.render(
+                 %{file_set_id: "fake-file-set-id"},
+                 "s3://source/test.mkv",
+                 "s3://destination/"
+               )
     end
   end
 end


### PR DESCRIPTION
This PR changes Meadow's audio and video transcoding templates to use HLS instead of CMAF for better compatibility with `video.js` and our range of supported browsers. It uses three built-in MediaConvert presets for video (1080p, 720p, and 540p at reasonable bitrates), but since there are no audio-only system presets, I had to copy the settings we use for AVR over from Elastic Transcoder. The only problem with this is that Terraform's AWS module does not currently support MediaConvert presets, so I had to create them manually (which I've done on both staging and production). nulib/repodev_planning_and_docs#2028 covers the terraforming of those resources.