### PR TITLE
Update CORS policy and CloudFront configuration to allow XmlHttpRequest-based streaming

### DIFF
--- a/terraform/js/cors_streaming_headers.js
+++ b/terraform/js/cors_streaming_headers.js
@@ -1,0 +1,7 @@
+function handler(event) {
+  var request = event.request;
+  var response = event.response;
+  var origin = request.headers.origin ? request.headers.origin.value : "*";
+  response.headers['access-control-allow-origin'] = { value: origin };
+  return response;
+}


### PR DESCRIPTION
This is a Terraform-only PR that has already been applied on staging.

As it turns out, Chrome was being picky about the `Access-Control-Allow-Origin` header being present on the `GET` request as well as the `OPTIONS` request, and the fact that CloudFront was caching `OPTIONS` requests was also a blocker. There's no good way to force the S3 origin to include `Access-Control-Allow-Origin` in every response, so I added a CloudFront Viewer Response function that adds it no matter what. Its value depends on the request:

* If the request includes an `Origin` header, that value is used
* Otherwise, it's set to `*`

This change, along with using those cache and origin request policies, allowed @adamjarling's `hls.js`-based code to stream our test video in Chrome, Firefox, and Safari with no modifications or configuration.

What a huge pain.