### PR TITLE
Update Terraform config for v1.x

### DIFF
--- a/terraform/ecs_services.tf
+++ b/terraform/ecs_services.tf
@@ -1,5 +1,5 @@
 locals {
-  container_ports = list(4000, 4369, 24601)
+  container_ports = tolist([4000, 4369, 24601])
 
   meadow_urls = [for hostname in concat([aws_route53_record.app_hostname.fqdn], var.additional_hostnames) : "//${hostname}"]
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,7 @@
 terraform {
-  backend "s3" {}
+  backend "s3" {
+    key = "meadow.tfstate"
+  }
 }
 
 provider "aws" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -7,6 +7,7 @@ output "endpoint" {
 }
 
 output "upload_user_key_id" {
+  sensitive = true
   value = {
     aws_access_key_id = aws_iam_access_key.upload_user_access_key.id,
     aws_secret_access_key = aws_iam_access_key.upload_user_access_key.secret


### PR DESCRIPTION
This is a terraform-only update, and should be reviewed (and the update steps followed) by all terraform-using developers before merging.

1. Update your local terraform:
    ```
    $ asdf plugin add terraform
    $ asdf install terraform 1.0.3
    $ asdf global terraform 1.0.3
    ```
2. In your `meadow/terraform` directory:
    ```
    $ git switch 2039-meadow-terraform-1.0
    $ export AWS_PROFILE=staging-admin
    $ aws-adfs login --profile $AWS_PROFILE
    $ terraform init -reconfigure
       # when prompted, enter nulterra-state-sandbox as the S3 bucket
    $ terraform workspace select staging
    $ terraform refresh -var-file staging.tfvars
    ```

If anything looks weird or doesn't work the way you think it should, check with MBK.

Future terraform updates should require fewer steps thanks to their semantic versioning roadmap and promises.