### PR TITLE
Add “Never” as expiration text for public works in bulk shared link export

### DIFF
--- a/lib/meadow/data/shared_links.ex
+++ b/lib/meadow/data/shared_links.ex
@@ -8,6 +8,7 @@ defmodule Meadow.Data.SharedLinks do
   alias NimbleCSV.RFC4180, as: CSV
 
   @index "shared_links"
+  @public_expiration "Never"
   @type_name "_doc"
 
   @enforce_keys [:work_id, :expires]
@@ -57,7 +58,7 @@ defmodule Meadow.Data.SharedLinks do
       |> Stream.map(fn %{"_source" => work_doc} ->
         case work_doc do
           %{"visibility" => %{"id" => "OPEN"}, "published" => true} ->
-            {shared_link_row(work_doc, work_doc["id"], nil, "items"), nil}
+            {shared_link_row(work_doc, work_doc["id"], @public_expiration, "items"), nil}
 
           _ ->
             with doc <- shared_link(work_doc["id"], ttl) |> shared_link_document(),

--- a/test/meadow/data/shared_links_test.exs
+++ b/test/meadow/data/shared_links_test.exs
@@ -94,7 +94,7 @@ defmodule Meadow.Data.SharedLinksTest do
           case work do
             %{visibility: %{id: "OPEN"}, published: true} ->
               assert map["shared_link"] =~ ~r"/items/"
-              assert map["expires"] == ""
+              assert map["expires"] == "Never"
 
             _ ->
               assert map["shared_link"] =~ ~r"/shared/"


### PR DESCRIPTION
Expiration text set to `Never` per discussion with @davidschober 