### PR TITLE
Create database listener to clean up file set assets on deletion

### DIFF
--- a/lib/meadow/application/children.ex
+++ b/lib/meadow/application/children.ex
@@ -13,6 +13,7 @@ defmodule Meadow.Application.Children do
       "csv_update_driver" => Meadow.CSVMetadataUpdateDriver,
       "index_worker" => {Meadow.Data.IndexWorker, interval: Config.index_interval()},
       "database_listeners" => [
+        Meadow.FilesetDeleteListener,
         Meadow.IIIF.ManifestListener,
         Meadow.StructuralMetadataListener
       ],

--- a/lib/meadow/file_set_delete_listener.ex
+++ b/lib/meadow/file_set_delete_listener.ex
@@ -1,0 +1,141 @@
+defmodule Meadow.FilesetDeleteListener do
+  @moduledoc """
+  Database notification listener to clean up file set assets after records are deleted
+  """
+
+  use GenServer
+
+  alias Meadow.Data.Schemas.FileSet
+  alias Meadow.Utils.AWS
+
+  use Meadow.Utils.Logging
+
+  import Ecto.Query
+
+  require Logger
+
+  @message "file_sets_deleted"
+
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]}
+    }
+  end
+
+  def start_link(args \\ []) do
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  @impl GenServer
+  def init(initial_state) do
+    Logger.info("#{__MODULE__}: Listening for delete notifications on 'file_sets'")
+    Meadow.Repo.listen(@message)
+
+    {:ok, initial_state}
+  end
+
+  def handle_info({:notification, _pid, _ref, @message, payload}, state) do
+    with %{data: data} <- Jason.decode!(payload, keys: :atoms) do
+      Enum.each(data, fn file_set_data ->
+        clean_up!(file_set_data, state)
+      end)
+    end
+
+    {:noreply, state}
+  rescue
+    exception ->
+      Meadow.Error.report(exception, __MODULE__, __STACKTRACE__)
+      reraise(exception, __STACKTRACE__)
+  end
+
+  @impl GenServer
+  def handle_info({:ssl_closed, _msg}, state), do: {:noreply, state}
+
+  defp clean_up!(file_set_data, state) do
+    with_log_metadata(module: __MODULE__, id: file_set_data.id) do
+      Logger.warn("Cleaning up assets for file set #{file_set_data.id}")
+
+      file_set_data
+      |> clean_derivatives!(state)
+      |> clean_preservation_file!(state)
+
+      with target <- Keyword.get(state, :notify) do
+        if target |> is_pid(), do: send(target, {"cleaned", file_set_data.id})
+      end
+    end
+  end
+
+  defp clean_derivatives!(file_set_data, _state) do
+    file_set_data.derivatives
+    |> Enum.each(fn {type, location} ->
+      clean_derivative!(type, location)
+    end)
+
+    file_set_data
+  end
+
+  defp clean_derivative!(:playlist, "s3://" <> _ = playlist) do
+    with stream_base <- Path.dirname(playlist) <> "/" do
+      Logger.warn("Removing streaming files from #{stream_base}")
+      delete_s3_uri(stream_base, true)
+    end
+  end
+
+  defp clean_derivative!(type, "s3://" <> _ = uri) do
+    Logger.warn("Removing #{type} derivative at #{uri}")
+    delete_s3_uri(uri)
+  end
+
+  defp clean_derivative!(_, _), do: :ok
+
+  defp clean_preservation_file!(file_set_data, state) do
+    with location <- file_set_data.location,
+         repo <- Keyword.get(state, :repo, Meadow.Repo) do
+      refs =
+        from(f in FileSet,
+          where:
+            fragment("core_metadata ->> 'location' = ?", ^location) and
+              f.id != ^file_set_data.id
+        )
+        |> repo.aggregate(:count)
+
+      if refs == 0 do
+        Logger.warn("Removing preservation file at #{location}")
+        delete_s3_uri(location)
+      else
+        references = Inflex.Pluralize.inflect("reference", refs)
+        Logger.warn("Leaving #{location} intact: #{refs} additional #{references}")
+      end
+    end
+
+    file_set_data
+  end
+
+  defp delete_s3_uri(uri, recursive \\ false)
+
+  defp delete_s3_uri(uri, true) do
+    with %{host: bucket, path: "/" <> key} <- URI.parse(uri) do
+      case ExAws.S3.head_bucket(bucket) |> AWS.request() do
+        {:error, {:http_error, 404, _}} ->
+          :noop
+
+        _ ->
+          keys =
+            ExAws.S3.list_objects(bucket, prefix: key)
+            |> ExAws.stream!()
+            |> Stream.map(& &1.key)
+
+          ExAws.S3.delete_all_objects(bucket, keys)
+          |> AWS.request()
+      end
+    end
+  end
+
+  defp delete_s3_uri(uri, false) do
+    with %{host: bucket, path: "/" <> key} <- URI.parse(uri) do
+      ExAws.S3.delete_object(bucket, key)
+      |> AWS.request()
+    end
+  end
+end

--- a/lib/meadow/pipeline/actions/copy_file_to_preservation.ex
+++ b/lib/meadow/pipeline/actions/copy_file_to_preservation.ex
@@ -103,7 +103,7 @@ defmodule Meadow.Pipeline.Actions.CopyFileToPreservation do
   defp extract_error(body) do
     with error <-
            SweetXml.xmap(body, code: ~x"/Error/Code/text()", message: ~x"/Error/Message/text()") do
-      "#{error.code}: #{error.message}"
+      "#{error[:code]}: #{error[:message]}"
     end
   end
 end

--- a/priv/repo/migrations/20210803142131_create_file_set_cleanup_trigger.exs
+++ b/priv/repo/migrations/20210803142131_create_file_set_cleanup_trigger.exs
@@ -1,0 +1,42 @@
+defmodule Meadow.Repo.Migrations.CreateFileSetCleanupTrigger do
+  use Ecto.Migration
+
+  def up do
+    Ecto.Migration.execute("""
+      CREATE OR REPLACE FUNCTION notify_file_sets_deleted()
+      RETURNS trigger AS $$
+      DECLARE
+        ids UUID[];
+        payload TEXT;
+      BEGIN
+        CREATE TEMPORARY TABLE notifications AS
+          (SELECT DISTINCT id, jsonb_build_object('id', id, 'location', core_metadata -> 'location', 'derivatives', derivatives) AS data
+          FROM old_table);
+
+        SELECT array_agg(id) INTO ids FROM (SELECT id AS id FROM notifications LIMIT 20) AS notification_ids;
+        WHILE array_length(ids, 1) > 0 LOOP
+          SELECT jsonb_build_object('data', array_agg(data)) INTO payload FROM (SELECT data FROM notifications WHERE id = ANY(ids)) AS _data;
+          PERFORM pg_notify('file_sets_deleted', payload);
+          DELETE FROM notifications WHERE id = ANY(ids);
+          SELECT array_agg(id) INTO ids FROM (SELECT id AS id FROM notifications LIMIT 20) AS notification_ids;
+        END LOOP;
+        DROP TABLE notifications;
+        RETURN NULL;
+      END;
+      $$ LANGUAGE plpgsql;
+    """)
+
+    Ecto.Migration.execute("""
+      CREATE TRIGGER file_sets_deleted
+        AFTER DELETE ON file_sets
+        REFERENCING OLD TABLE AS old_table
+        FOR EACH STATEMENT
+        EXECUTE PROCEDURE notify_file_sets_deleted()
+    """)
+  end
+
+  def down do
+    Ecto.Migration.execute("DROP TRIGGER IF EXISTS file_sets_deleted ON file_sets")
+    Ecto.Migration.execute("DROP FUNCTION IF EXISTS notify_file_sets_deleted")
+  end
+end

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -78,6 +78,18 @@ resource "aws_s3_bucket" "meadow_preservation" {
     enabled = true
   }
 
+  lifecycle_rule {
+    id = "retain-on-delete"
+    enabled = true
+    
+    noncurrent_version_expiration {
+      days = var.deleted_object_expiration
+    }
+    expiration {
+      expired_object_delete_marker = true
+    }
+  }
+
   tags = var.tags
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -35,6 +35,11 @@ variable "digital_collections_url" {
   type = string
 }
 
+variable "deleted_object_expiration" {
+  type    = number
+  default = 180
+}
+
 variable "geonames_username" {
   type = string
 }

--- a/test/meadow/file_set_delete_listener_test.exs
+++ b/test/meadow/file_set_delete_listener_test.exs
@@ -1,0 +1,162 @@
+defmodule Meadow.FileSetDeleteListenerTest do
+  use Meadow.S3Case
+  use Meadow.UnsandboxedDataCase, async: false
+
+  alias Ecto.Adapters.SQL
+  alias Meadow.Data.Schemas.FileSet
+  alias Meadow.UnsandboxedDataCase.Repo
+
+  import Ecto.Changeset
+  import ExUnit.CaptureLog
+
+  @pairtree "44/87/89/28/-c/4d/e-/40/76/-b/61/3-/15/35/66/5f/fa/e2"
+  @poster_key "posters/#{@pairtree}-poster.tif"
+  @preservation_key "#{@pairtree}/preservation-file"
+  @pyramid_key "#{@pairtree}-pyramid.tif"
+  @poster_location "s3://test-pyramids/#{@poster_key}"
+  @preservation_location "s3://test-preservation/#{@preservation_key}"
+  @pyramid_location "s3://test-pyramids/#{@pyramid_key}"
+  @streaming_location "s3://test-streaming/#{@pairtree}"
+  @timeout 5000
+
+  def file_set_notification_fixture(index) do
+    params = %{
+      accession_number: "NOTIFICATION_TEST_FIXTURE_#{index}",
+      core_metadata: %{
+        location: @preservation_location,
+        original_filename: "coffee.tif"
+      },
+      derivatives: %{
+        "pyramid_tiff" => @pyramid_location,
+        "poster" => @poster_location,
+        "playlist" => "#{@streaming_location}/playlist.m3u8"
+      },
+      role: %{id: "A", schema: "file_set_role"}
+    }
+
+    %FileSet{}
+    |> cast(params, [:accession_number, :derivatives, :role])
+    |> cast_embed(:core_metadata)
+    |> unique_constraint(:accession_number)
+    |> Repo.insert!()
+  end
+
+  describe "clean_up!/1" do
+    @describetag s3: [
+                   %{
+                     bucket: "test-preservation",
+                     key: @preservation_key,
+                     content: File.read!("test/fixtures/coffee.tif")
+                   },
+                   %{
+                     bucket: "test-pyramids",
+                     key: @pyramid_key,
+                     content: File.read!("test/fixtures/coffee.tif")
+                   },
+                   %{
+                     bucket: "test-pyramids",
+                     key: @poster_key,
+                     content: File.read!("test/fixtures/coffee.tif")
+                   },
+                   %{
+                     bucket: "test-streaming",
+                     key: "#{@pairtree}/playlist.m3u8",
+                     content: "#EXTM3U\n"
+                   },
+                   %{
+                     bucket: "test-streaming",
+                     key: "#{@pairtree}/stream_file.m4v",
+                     content: File.read!("test/fixtures/small.m4v")
+                   }
+                 ]
+
+    setup do
+      start_supervised!({Meadow.FilesetDeleteListener, repo: Repo, notify: self()})
+      on_exit(fn -> FileSet |> Repo.delete_all() end)
+      {:ok, %{file_set: file_set_notification_fixture(1)}}
+    end
+
+    test "derivatives deleted", %{file_set: file_set} do
+      with file_set_id <- file_set.id do
+        Repo.delete(file_set)
+        assert_receive {"cleaned", ^file_set_id}, @timeout
+        refute object_exists?("test-pyramids", @pyramid_key)
+        refute object_exists?("test-pyramids", @poster_key)
+        refute object_exists?("test-streaming", "#{@pairtree}/playlist.m3u8")
+        refute object_exists?("test-streaming", "#{@pairtree}/stream_file.m4v")
+      end
+    end
+
+    test "preservation file deleted", %{file_set: file_set} do
+      with file_set_id <- file_set.id do
+        Repo.delete(file_set)
+        assert_receive {"cleaned", ^file_set_id}, @timeout
+        refute object_exists?("test-preservation", @preservation_key)
+      end
+    end
+
+    test "preservation file retained if other file sets refer to it", %{file_set: last_file_set} do
+      file_sets = Enum.map(2..3, &file_set_notification_fixture/1)
+
+      file_sets
+      |> Enum.each(fn file_set ->
+        with file_set_id <- file_set.id do
+          Repo.delete(file_set)
+          assert_receive {"cleaned", ^file_set_id}, @timeout
+          assert object_exists?("test-preservation", @preservation_key)
+        end
+      end)
+
+      with file_set_id <- last_file_set.id do
+        Repo.delete(last_file_set)
+        assert_receive {"cleaned", ^file_set_id}, @timeout
+        refute object_exists?("test-preservation", @preservation_key)
+      end
+    end
+
+    test "bulk delete", %{file_set: file_set} do
+      file_sets = [file_set | Enum.map(2..10, &file_set_notification_fixture/1)]
+      SQL.query!(Repo, "DELETE FROM file_sets")
+      Enum.each(file_sets, fn %{id: id} -> assert_receive {"cleaned", ^id}, @timeout end)
+      refute object_exists?("test-preservation", @preservation_key)
+    end
+
+    test "logging", %{file_set: file_set} do
+      extra_file_set = file_set_notification_fixture(2)
+
+      log =
+        capture_log(fn ->
+          with id <- extra_file_set.id do
+            Repo.delete(extra_file_set)
+            assert_receive {"cleaned", ^id}, @timeout
+          end
+        end)
+
+      [
+        "[warn]  Cleaning up assets for file set #{extra_file_set.id}",
+        "[warn]  Removing streaming files from #{@streaming_location}/",
+        "[warn]  Removing poster derivative at #{@poster_location}",
+        "[warn]  Removing pyramid_tiff derivative at #{@pyramid_location}",
+        "[warn]  Leaving #{@preservation_location} intact: 1 additional reference"
+      ]
+      |> Enum.each(fn line -> assert String.contains?(log, line) end)
+
+      log =
+        capture_log(fn ->
+          with id <- file_set.id do
+            Repo.delete(file_set)
+            assert_receive {"cleaned", ^id}, @timeout
+          end
+        end)
+
+      [
+        "[warn]  Cleaning up assets for file set #{file_set.id}",
+        "[warn]  Removing streaming files from #{@streaming_location}/",
+        "[warn]  Removing poster derivative at #{@poster_location}",
+        "[warn]  Removing pyramid_tiff derivative at #{@pyramid_location}",
+        "[warn]  Removing preservation file at #{@preservation_location}"
+      ]
+      |> Enum.each(fn line -> assert String.contains?(log, line) end)
+    end
+  end
+end


### PR DESCRIPTION
## Description

* A migration to create a notification trigger containing all the data needed to clean up after a file set is deleted
* A listener to receive those notifications and clean up deleted file set assets
* A Terraform change to add 6-month (default) deleted version retention to Meadow's preservation bucket

## Assets Deleted

* Any S3 objects referenced by the file set's `derivatives` metadata field (pyramids, streaming derivatives, posters, etc.)
* The file set's preservation object _if_ there are no other references to the object in other file sets

## Example

### Before Deleting Works

<img width="794" alt="Screen Shot 2021-08-03 at 5 15 50 PM" src="https://user-images.githubusercontent.com/196872/128093952-d6ff5332-f050-41a1-b79f-6fcc4d1d448b.png">

### After Deleting Works
<img width="794" alt="Screen Shot 2021-08-03 at 5 17 59 PM" src="https://user-images.githubusercontent.com/196872/128093973-89ebebb2-7468-4ee7-a252-f81246a70fa2.png">

