### PR TITLE
Index webvtt in Elasticsearch file_set documents

### DIFF
--- a/lib/meadow/indexing/file_set.ex
+++ b/lib/meadow/indexing/file_set.ex
@@ -18,7 +18,8 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.FileSet do
       role: format(file_set.role),
       visibility: format(file_set.work.visibility),
       workId: file_set.work.id,
-      extractedMetadata: ExtractedMetadata.transform(file_set.extracted_metadata)
+      extractedMetadata: ExtractedMetadata.transform(file_set.extracted_metadata),
+      webvtt: file_set.structural_metadata.value
     }
   end
 

--- a/test/meadow/data/indexer_test.exs
+++ b/test/meadow/data/indexer_test.exs
@@ -330,7 +330,17 @@ defmodule Meadow.Data.IndexerTest do
 
     test "file set encoding", %{file_set: subject} do
       derivatives = FileSets.add_derivative(subject, :poster, FileSets.poster_uri_for(subject))
-      FileSets.update_file_set(subject, %{derivatives: derivatives})
+
+      {:ok, subject} =
+        subject
+        |> FileSets.update_file_set(%{
+          derivatives: derivatives,
+          structural_metadata: %{
+            type: "webvtt",
+            value:
+              "WEBVTT\n\n00:00:00.500 --> 00:00:02.000\nThe Web is always changing\n\n00:00:02.500 --> 00:00:04.300\nand the way we access it is changing"
+          }
+        })
 
       subject = FileSets.get_file_set_with_work_and_sheet!(subject.id)
 
@@ -340,6 +350,7 @@ defmodule Meadow.Data.IndexerTest do
       assert doc |> get_in(["model", "name"]) == "FileSet"
       assert doc |> get_in(["description"]) == subject.core_metadata.description
       assert doc |> get_in(["label"]) == subject.core_metadata.label
+      assert doc |> get_in(["webvtt"]) == subject.structural_metadata.value
 
       assert doc |> get_in(["streamingUrl"]) == Path.join(Config.streaming_url(), "bar.m3u8")
 


### PR DESCRIPTION
- Index the `webvtt` value from the structural_metadata map into Elasticsearch file_set documents
- Updates `indexer_test` to include the change

Screenshot:
![webvtt](https://user-images.githubusercontent.com/1395707/128544197-de58cfa0-72f4-46b1-945d-06a623275ff9.png)
