### PR TITLE
Ensure ingest sheet structure files are present with basic validation of WebVTT format

### DIFF
--- a/test/fixtures/ingest_sheet_invalid_webvtt.csv
+++ b/test/fixtures/ingest_sheet_invalid_webvtt.csv
@@ -1,0 +1,9 @@
+work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image,structure
+IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",,
+,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P,"The label",,
+,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",TRUE,
+,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",X,"The label",,
+VIDEO,Donohue_002,Donohue_002_01,small.m4v,"Photo, man with two children",A,"The label",,invalid.vtt
+,Donohue_002,Donohue_002_02,small.m4v,Small Video,A,"The label",,
+,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",X,"The label",,
+,Donohue_002,Donohue_002_04,details.json,"Supplemental information",S,"Supplement",,

--- a/test/fixtures/ingest_sheet_missing_webvtt.csv
+++ b/test/fixtures/ingest_sheet_missing_webvtt.csv
@@ -1,0 +1,9 @@
+work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image,structure
+IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",,
+,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P,"The label",,
+,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",TRUE,
+,Donohue_001,Donohue_001_04,coffee.tif,"Letter, page 2, If these papers, verso, blank",X,"The label",,
+VIDEO,Donohue_002,Donohue_002_01,small.m4v,"Photo, man with two children",A,"The label",,MISSING_FILE.vtt
+,Donohue_002,Donohue_002_02,small.m4v,Small Video,A,"The label",,
+,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",X,"The label",,
+,Donohue_002,Donohue_002_04,details.json,"Supplemental information",S,"Supplement",,

--- a/test/fixtures/invalid.vtt
+++ b/test/fixtures/invalid.vtt
@@ -1,0 +1,21 @@
+This file is invalid because it does not start with the string WEBVTT
+
+NOTE
+This translation was done by Kyle so that
+some friends can watch it with their parents.
+
+1
+00:02:15.000 --> 00:02:20.000
+- Ta en kopp varmt te.
+- Det är inte varmt.
+
+2
+00:02:20.000 --> 00:02:25.000
+- Har en kopp te.
+- Det smakar som te.
+
+NOTE This last line may not translate well.
+
+3
+00:02:25.000 --> 00:02:30.000
+- Ta en kopp


### PR DESCRIPTION
- Validates presence of WebVTT file in structure column
- Validates WebVTT file in ingest bucket begins with the string `WEBVTT` (extremely basic validation to start)
- Updates test and fixtures

![webvtt_ingest_validation](https://user-images.githubusercontent.com/1395707/128780745-21fd71b5-4593-4cf4-bfd9-d26e499654fd.png)
