### PR TITLE
Remove ingest_progress update trigger

### DIFF
--- a/lib/meadow/ingest/progress.ex
+++ b/lib/meadow/ingest/progress.ex
@@ -13,7 +13,7 @@ defmodule Meadow.Ingest.Progress do
   import Ecto.Query
   import Meadow.Utils.Atoms
 
-  use IntervalTask, default_interval: 500, function: :send_progress_notifications
+  use IntervalTask, default_interval: 500, function: :send_notifications_and_update_sheet_status
   require Logger
 
   defstruct sheet_id: nil,
@@ -288,10 +288,12 @@ defmodule Meadow.Ingest.Progress do
     )
   end
 
-  def send_progress_notifications(state) do
+  def send_notifications_and_update_sheet_status(state) do
     with_log_level :info do
       send_notifications()
     end
+
+    Sheets.update_completed_sheets()
 
     {:noreply, state}
   end

--- a/lib/meadow/ingest/schemas/sheet.ex
+++ b/lib/meadow/ingest/schemas/sheet.ex
@@ -12,7 +12,7 @@ defmodule Meadow.Ingest.Schemas.Sheet do
     %{name: "overall", state: "pending"}
   ]
 
-  @statuses ~w(uploaded file_fail row_fail valid approved completed deleted)
+  @statuses ~w(uploaded file_fail row_fail valid approved completed completed_error deleted)
 
   @primary_key {:id, Ecto.UUID, autogenerate: false, read_after_writes: true}
   @foreign_key_type Ecto.UUID

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Meadow.MixProject do
   use Mix.Project
 
-  @app_version "3.0.1"
+  @app_version "3.0.2"
 
   def project do
     [

--- a/priv/repo/migrations/20210412152853_fix_completed_with_errors_status.exs
+++ b/priv/repo/migrations/20210412152853_fix_completed_with_errors_status.exs
@@ -1,4 +1,4 @@
-defmodule Meadow.Repo.Migrations.AddCompletedWithErrorsStatus do
+defmodule Meadow.Repo.Migrations.FixCompletedWithErrorsStatus do
   use Ecto.Migration
 
   require Logger

--- a/priv/repo/migrations/20210820172452_remove_progress_update_trigger.exs
+++ b/priv/repo/migrations/20210820172452_remove_progress_update_trigger.exs
@@ -1,0 +1,67 @@
+defmodule Meadow.Repo.Migrations.RemoveProgressUpdateTrigger do
+  use Ecto.Migration
+
+  def up do
+    execute "DROP TRIGGER IF EXISTS progress_update_sheet_status ON ingest_progress;"
+    execute "DROP FUNCTION IF EXISTS update_sheet_status_when_progress_changes;"
+  end
+
+  def down do
+    execute """
+    CREATE OR REPLACE FUNCTION update_sheet_status_when_progress_changes()
+      RETURNS trigger AS $$
+    DECLARE
+      current_sheet_id ingest_sheets.id%TYPE;
+      lock_id bigint;
+      pending integer;
+      errors integer;
+      complete_status varchar;
+    BEGIN
+      SELECT ingest_sheet_rows.sheet_id INTO current_sheet_id
+      FROM ingest_sheet_rows WHERE ingest_sheet_rows.id = NEW.row_id;
+
+      SELECT ('x'||TRANSLATE(current_sheet_id::VARCHAR,'-',''))::BIT(64)::BIGINT INTO lock_id;
+
+      SET LOCAL lock_timeout = '10s';
+      PERFORM pg_advisory_lock(lock_id);
+
+      SELECT COUNT(*) INTO pending
+        FROM ingest_progress
+        JOIN ingest_sheet_rows ON ingest_progress.row_id = ingest_sheet_rows.id
+        WHERE ingest_sheet_rows.sheet_id = current_sheet_id
+        AND ingest_progress.status NOT IN ('ok', 'error');
+
+      IF pending = 0 THEN
+        SELECT COUNT(*) INTO errors
+          FROM ingest_progress
+          JOIN ingest_sheet_rows ON ingest_progress.row_id = ingest_sheet_rows.id
+          WHERE ingest_sheet_rows.sheet_id = current_sheet_id
+          AND ingest_progress.status = 'error';
+
+        IF errors > 0 THEN
+          SELECT 'completed_error' INTO complete_status;
+        ELSE
+          SELECT 'completed' INTO complete_status;
+        END IF;
+
+        UPDATE ingest_sheets
+        SET status = complete_status, updated_at = NOW() AT TIME ZONE 'utc'
+        WHERE ingest_sheets.id = current_sheet_id;
+      END IF;
+
+      PERFORM pg_advisory_unlock(lock_id);
+
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql
+    """
+
+    execute """
+    CREATE TRIGGER progress_update_sheet_status
+      AFTER UPDATE OR DELETE
+      ON ingest_progress
+      FOR EACH ROW
+      EXECUTE PROCEDURE update_sheet_status_when_progress_changes()
+    """
+  end
+end


### PR DESCRIPTION
* Delete `progress_update_sheet_status` trigger
* Remove `Sheets.kick!/1`
* Implement `Sheets.update_completed_sheets/0`
* Call `Sheets.update_completed_sheets()` during the existing progress notification interval task
* Rename conflicting migration module that was throwing a warning