### PR TITLE
Extract ark functions to Meadow.Ark.Serializer

### DIFF
--- a/lib/meadow/ark/serializer.ex
+++ b/lib/meadow/ark/serializer.ex
@@ -1,0 +1,49 @@
+defmodule Meadow.Ark.Serializer do
+  @moduledoc """
+  Helper functions to serialize and deserialize ark values
+  """
+
+  @datacite_map %{
+    ark: "success",
+    creator: "datacite.creator",
+    title: "datacite.title",
+    publisher: "datacite.publisher",
+    publication_year: "datacite.publicationyear",
+    resource_type: "datacite.resourcetype",
+    status: "_status",
+    target: "_target"
+  }
+
+  def deserialize(response) do
+    field_map =
+      Map.values(@datacite_map)
+      |> Enum.zip(Map.keys(@datacite_map))
+      |> Enum.into(%{})
+
+    struct!(
+      Meadow.Ark,
+      response
+      |> String.trim()
+      |> String.split("\n")
+      |> Enum.map(fn attribute ->
+        [key, value] = String.split(attribute, ": ", parts: 2)
+        {Map.get(field_map, key), URI.decode(value)}
+      end)
+      |> Enum.reject(fn {key, _} -> is_nil(key) end)
+    )
+  end
+
+  def serialize(%Meadow.Ark{} = ark), do: serialize(Map.from_struct(ark))
+
+  def serialize(ark) when is_map(ark) do
+    Enum.reduce(ark, ["_profile: datacite"], fn
+      {_, nil}, acc -> acc
+      {:ark, _}, acc -> acc
+      entry, acc -> [serialize(entry) | acc]
+    end)
+    |> Enum.reverse()
+    |> Enum.join("\n")
+  end
+
+  def serialize({key, value}) when is_atom(key), do: Map.get(@datacite_map, key) <> ": " <> String.replace(value, "%", "%25")
+end

--- a/test/meadow/ark/serializer_test.exs
+++ b/test/meadow/ark/serializer_test.exs
@@ -1,0 +1,39 @@
+defmodule Meadow.Ark.SerializerTest do
+  use ExUnit.Case, async: false
+
+  alias Meadow.Ark.Serializer
+
+  @response_body "success: ark:/99999/fk4z90ps4x\n_updated: 1630613597\ndatacite.publisher: Test publisher\n_profile: datacite\ndatacite.title: Test title\n_export: yes\ndatacite.creator: Test creator\n_owner: apitest\n_ownergroup: apitest\n_target: https://test/items/123\n_created: 1630613597\ndatacite.publicationyear: 2021\ndatacite.resourcetype: Image\n_status: public\n"
+
+  describe "serialize/1" do
+    test "desconstructs a Meadow.Ark and properly handles ANVL escaping of % characters" do
+      ark = %Meadow.Ark{
+        ark: "ark:/99999/fk4z90ps4x",
+        creator: "Test % creator",
+        publication_year: "2021",
+        publisher: "%Test publisher%",
+        resource_type: "Image",
+        status: "public",
+        target: "https://test/items/123",
+        title: "100%"
+      }
+
+      assert Serializer.serialize(ark) == "_profile: datacite\ndatacite.creator: Test %25 creator\ndatacite.publicationyear: 2021\ndatacite.publisher: %25Test publisher%25\ndatacite.resourcetype: Image\n_status: public\n_target: https://test/items/123\ndatacite.title: 100%25"
+    end
+  end
+
+  describe "deserialize/1" do
+    test "builds a Meadow.Ark struct" do
+      assert %Meadow.Ark{
+               ark: "ark:/99999/fk4z90ps4x",
+               creator: "Test creator",
+               publication_year: "2021",
+               publisher: "Test publisher",
+               resource_type: "Image",
+               status: "public",
+               target: "https://test/items/123",
+               title: "Test title"
+             } = Serializer.deserialize(@response_body)
+    end
+  end
+end


### PR DESCRIPTION
- Moved private functions from `Meadow.Ark` to public and tested functions in `Meadow.Ark.Serializer`
- Replaces `URI.encode/1` calls in `Meadow.Ark.Serializer.serialize/1` with a simple string replacement of `%` to `%25` because the EZID client returns:
  -  `error: bad request - ANVL parse error (percent-decode error)` if you send unencoded `%` characters
  - `error: bad request - character decoding error` if you send any other encoded characters (such as `%C3%A1` for `á`)