### PR TITLE
Support setting poster image , first draft, for Access videos

### DIFF
--- a/assets/js/components/UI/MediaPlayer/MediaPlayer.jsx
+++ b/assets/js/components/UI/MediaPlayer/MediaPlayer.jsx
@@ -46,6 +46,7 @@ function MediaPlayer({ navCues = [], src, videoElAttrs = {}, ...restProps }) {
       <div className="columns">
         <video
           data-testid="video-player"
+          id="media-player"
           ref={playerRef}
           controls
           className="column is-three-quarters"

--- a/assets/js/components/UI/MediaPlayer/PosterSelector.jsx
+++ b/assets/js/components/UI/MediaPlayer/PosterSelector.jsx
@@ -1,0 +1,65 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Button } from "@nulib/admin-react-components";
+import { useMutation } from "@apollo/client";
+import { useParams } from "react-router-dom";
+import { useWorkState } from "@js/context/work-context";
+import { GET_WORK, UPDATE_FILE_SET } from "@js/components/Work/work.gql";
+import { toastWrapper } from "@js/services/helpers";
+
+function MediaPlayerPosterSelector() {
+  const params = useParams();
+  const workId = params.id;
+  const workState = useWorkState();
+
+  const [updateFileSet] = useMutation(UPDATE_FILE_SET, {
+    onCompleted({ updateFileSet }) {
+      toastWrapper(
+        "is-success",
+        "Poster image successfully updated.  The update should be reflected in a few seconds.  Please refresh your browser to see changes."
+      );
+    },
+    onError({ graphQLErrors, networkError }) {
+      console.error("graphQLErrors", graphQLErrors);
+      console.error("networkError", networkError);
+      let errorStrings = [];
+      if (graphQLErrors?.length > 0) {
+        errorStrings = graphQLErrors.map(
+          ({ message, details }) =>
+            `${message}: ${details && details.title ? details.title : ""}`
+        );
+      }
+      toastWrapper("is-danger", errorStrings?.join(" \n ") || "General error");
+    },
+    refetchQueries: [
+      {
+        query: GET_WORK,
+        variables: {
+          id: workId,
+        },
+      },
+    ],
+  });
+
+  const handleSave = () => {
+    const el = document.getElementById("media-player");
+    const posterOffset = parseInt(el.currentTime * 1000);
+
+    updateFileSet({
+      variables: {
+        id: workState.activeMediaFileSet.id,
+        posterOffset,
+      },
+    });
+  };
+
+  return (
+    <div className="block is-flex">
+      <Button isPrimary onClick={handleSave}>
+        Set poster image
+      </Button>
+    </div>
+  );
+}
+
+export default MediaPlayerPosterSelector;

--- a/assets/js/components/UI/MediaPlayer/Switcher.jsx
+++ b/assets/js/components/UI/MediaPlayer/Switcher.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { useWorkDispatch, useWorkState } from "@js/context/work-context";
+
+function MediaPlayerSwitcher({ fileSets }) {
+  const workState = useWorkState();
+  const dispatch = useWorkDispatch();
+
+  const handleSelectChange = (e) => {
+    dispatch({
+      type: "updateActiveMediaFileSet",
+      fileSet: fileSets.find((fs) => fs.id === e.target.value),
+    });
+  };
+
+  return (
+    <div className="block">
+      <div className="field">
+        <div className="control">
+          <div className="select">
+            <select
+              value={workState?.activeMediaFileSet?.id}
+              onChange={handleSelectChange}
+              data-testid="media-player-switcher"
+            >
+              {fileSets.map((option) => (
+                <option
+                  key={option.id}
+                  value={option.id}
+                  data-testid="switcher-option"
+                >
+                  {option.coreMetadata?.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+MediaPlayerSwitcher.propTypes = {
+  fileSets: PropTypes.array,
+};
+
+export default MediaPlayerSwitcher;

--- a/assets/js/components/UI/MediaPlayer/Switcher.test.js
+++ b/assets/js/components/UI/MediaPlayer/Switcher.test.js
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import UIMediaPlayerSwitcher from "@js/components/UI/MediaPlayer/Switcher";
+import { WorkProvider } from "@js/context/work-context";
+
+const fileSets = [
+  {
+    id: "1149a688-dba9-4555-9bc0-bd30bd9c5269",
+    coreMetadata: {
+      label: "Ima label 1",
+    },
+    representativeImageUrl: "",
+  },
+  {
+    id: "2149a688-dba9-4555-9bc0-bd30bd9c5269",
+    coreMetadata: {
+      label: "Ima label 2",
+    },
+    representativeImageUrl: "",
+  },
+  {
+    id: "3149a688-dba9-4555-9bc0-bd30bd9c5269",
+    coreMetadata: {
+      label: "Ima label 3",
+    },
+    representativeImageUrl: "",
+  },
+];
+
+describe("UIMediaPlayerSwitcher component", () => {
+  beforeEach(() => {
+    render(
+      <WorkProvider>
+        <UIMediaPlayerSwitcher fileSets={fileSets} />
+      </WorkProvider>
+    );
+  });
+
+  it("renders", () => {
+    expect(screen.getByTestId("media-player-switcher"));
+  });
+
+  it("renders the correct select options for filesets", () => {
+    const options = screen.getAllByTestId("switcher-option");
+    expect(options).toHaveLength(3);
+    expect(options[1]).toHaveTextContent("Ima label 2");
+    expect(options[1]).toHaveValue("2149a688-dba9-4555-9bc0-bd30bd9c5269");
+  });
+});

--- a/assets/js/components/UI/MediaPlayer/Wrapper.jsx
+++ b/assets/js/components/UI/MediaPlayer/Wrapper.jsx
@@ -7,7 +7,8 @@ import { Notification } from "@nulib/admin-react-components";
 import UIIconText from "@js/components/UI/IconText";
 import { IconAlert } from "@js/components/Icon";
 const webvtt = require("node-webvtt");
-import { useWorkDispatch, useWorkState } from "@js/context/work-context";
+import MediaPlayerPosterSelector from "@js/components/UI/MediaPlayer/PosterSelector";
+import MediaPlayerSwitcher from "@js/components/UI/MediaPlayer/Switcher";
 
 function MediaPlayerWrapper({ fileSet, fileSets }) {
   const { getWebVttString, isEmpty } = useFileSet();
@@ -17,8 +18,6 @@ function MediaPlayerWrapper({ fileSet, fileSets }) {
   const mediaInfoTracks = getTechnicalMetadata(fileSet);
   const webVttString = getWebVttString(fileSet);
   let navCues;
-  const workState = useWorkState();
-  const dispatch = useWorkDispatch();
 
   // FileSet hasn't yet been fully ran through the pipeline
   if (!fileSet?.coreMetadata?.mimeType) {
@@ -52,45 +51,32 @@ function MediaPlayerWrapper({ fileSet, fileSets }) {
     );
   }
 
-  const handleSelectChange = (e) => {
-    dispatch({
-      type: "updateActiveMediaFileSet",
-      fileSet: fileSets.find((fs) => fs.id === e.target.value),
-    });
-  };
-
   return (
     <>
-      <div>
-        <MediaPlayer
-          key={fileSet.id}
-          navCues={navCues}
-          src={fileSet?.streamingUrl}
-          poster={
-            fileSet?.representativeImageUrl
-              ? `${fileSet?.representativeImageUrl}/full/600,/0/default.jpg`
-              : `/images/video-placeholder.png`
-          }
-          videoElAttrs={videoElAttrs}
-        />
-      </div>
-      <div className="block content mt-4">
-        <p>
-          <strong>Attached Filesets:</strong>
-        </p>
-        <div className="select">
-          <select
-            value={workState?.activeMediaFileSet?.id}
-            onChange={handleSelectChange}
-          >
-            {fileSets.map((option) => (
-              <option key={option.id} value={option.id}>
-                {option.coreMetadata?.label}
-              </option>
-            ))}
-          </select>
+      <div className="has-background-grey-lighter py-3">
+        <div className="container block">
+          <MediaPlayerSwitcher fileSets={fileSets} />
         </div>
       </div>
+
+      <section className="section hero is-black">
+        <div className="container">
+          <div>
+            <MediaPlayer
+              key={fileSet.id}
+              navCues={navCues}
+              src={fileSet?.streamingUrl}
+              poster={
+                fileSet?.representativeImageUrl
+                  ? `${fileSet?.representativeImageUrl}/full/1200,/0/default.jpg`
+                  : `/images/video-placeholder2.png`
+              }
+              videoElAttrs={videoElAttrs}
+            />
+          </div>
+          <MediaPlayerPosterSelector />
+        </div>
+      </section>
     </>
   );
 }

--- a/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
+++ b/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
@@ -13,7 +13,6 @@ function MediaButtons({ fileSet }) {
   const dispatch = useWorkDispatch();
   return (
     <div className="buttons is-flex is-justify-content-flex-end">
-      <Button>Download media file</Button>
       <Button
         onClick={() =>
           dispatch({

--- a/assets/js/components/Work/Fileset/ListItem.jsx
+++ b/assets/js/components/Work/Fileset/ListItem.jsx
@@ -31,7 +31,9 @@ function WorkFilesetListItem({
   // https://stackoverflow.com/questions/34097560/react-js-replace-img-src-onerror
   const [imgState, setImgState] = React.useState({
     errored: false, // This prevents a potential infinite loop
-    src: `${fileSet.representativeImageUrl}/square/500,500/0/default.jpg`,
+    src: `${fileSet.representativeImageUrl}/${
+      isMedia(fileSet) ? "full" : "square"
+    }/500,/0/default.jpg`,
   });
 
   const handleError = (e) => {
@@ -39,7 +41,7 @@ function WorkFilesetListItem({
       setImgState({
         errored: true,
         src: isMedia(fileSet)
-          ? "/images/video-placeholder.png"
+          ? "/images/video-placeholder2.png"
           : "/images/placeholder.png",
       });
     }
@@ -49,7 +51,7 @@ function WorkFilesetListItem({
     <article className="box" data-testid="fileset-item">
       <div className="columns">
         <div className="column is-2">
-          <figure className="image is-square">
+          <figure className="image">
             <img
               src={imgState.src}
               placeholder="Fileset Image"

--- a/assets/js/components/Work/Work.jsx
+++ b/assets/js/components/Work/Work.jsx
@@ -86,14 +86,10 @@ const Work = ({ work }) => {
       )}
 
       {!isImageWorkType && (
-        <section className="section hero is-black">
-          <div className="container">
-            <MediaPlayerWrapper
-              fileSet={workContextState?.activeMediaFileSet}
-              fileSets={[...filterFileSets(work.fileSets).access]}
-            />
-          </div>
-        </section>
+        <MediaPlayerWrapper
+          fileSet={workContextState?.activeMediaFileSet}
+          fileSets={[...filterFileSets(work.fileSets).access]}
+        />
       )}
 
       <section className="section">

--- a/assets/js/components/Work/work.gql.js
+++ b/assets/js/components/Work/work.gql.js
@@ -485,11 +485,13 @@ export const UPDATE_FILE_SET = gql`
   mutation UpdateFileSet(
     $id: ID!
     $coreMetadata: FileSetCoreMetadataUpdate
+    $posterOffset: Int
     $structuralMetadata: FileSetStructuralMetadataInput
   ) {
     updateFileSet(
       id: $id
       coreMetadata: $coreMetadata
+      posterOffset: $posterOffset
       structuralMetadata: $structuralMetadata
     ) {
       id


### PR DESCRIPTION
This PR wires up setting a poster image to the UI for a Fileset Access video.   The user can scrub anywhere in the video, then click the button to set a poster image, which will send an async update.  Since this is not an immediate operation on the backend, for now the user will have to refresh their browser tab to see changes.  There is a note in the confirmation message which pops up letting the user know.   If we want to automate this, we could create an additional ticket.

Also updated the default video placeholder image and poster thumbnails to be 4:3 aspect ratio, which seems to be common with older legacy videos  as opposed to 16:9 HD.

![image](https://user-images.githubusercontent.com/3020266/132702980-5865063a-56eb-4dc1-88d4-cf6cae8954d5.png)
