### PR TITLE
Search both labels and hints in NUL.Authority.search/2

### DIFF
--- a/lib/nul/authority.ex
+++ b/lib/nul/authority.ex
@@ -51,6 +51,7 @@ defmodule NUL.Authority do
   defp get_records(query, max_results) do
     from(a in AuthorityRecord,
       where: ilike(a.label, ^"%#{query}%"),
+      or_where: ilike(a.hint, ^"%#{query}%"),
       limit: ^max_results,
       select: %{id: a.id, label: a.label, hint: a.hint}
     )

--- a/test/nul/authority_test.exs
+++ b/test/nul/authority_test.exs
@@ -15,7 +15,13 @@ defmodule NUL.AuthorityTest do
       AuthorityRecords.create_authority_record!(%{
         label: "steering committee"
       }),
-      AuthorityRecords.create_authority_record!(%{label: "Netsch, Walter A."})
+      AuthorityRecords.create_authority_record!(%{
+        label: "Netsch, Walter A.",
+        hint: "Also a Legend"
+      }),
+      AuthorityRecords.create_authority_record!(%{
+        label: "Legendary label"
+      })
     ]
 
     {:ok, authority_record: List.first(authority_records)}
@@ -70,6 +76,12 @@ defmodule NUL.AuthorityTest do
 
       with {:ok, results} <- Authority.search("stee") do
         assert Enum.all?(results, fn result -> String.match?(result.label, ~r/stee/i) end)
+      end
+    end
+
+    test "includes results for both labels and hints" do
+      with {:ok, results} <- Authority.search("Legend") do
+        assert length(results) == 3
       end
     end
 


### PR DESCRIPTION
- Adds hints to NUL.Authority search results, applies to all interfaces including metadata forms and the authorities dashboard.

- Example query performance after importing all production NUL Authority Records:
```elixir
module=Ecto.Adapters.SQL [debug] QUERY OK source="authority_records" db=27.4ms idle=1973.9ms
SELECT a0."id", a0."label", a0."hint" FROM "authority_records" AS a0 WHERE ((a0."label" ILIKE $1)) OR (a0."hint" ILIKE $2) LIMIT $3 ["%ffffffffffff%", "%ffffffffffff%", 30]
```

Screenshots:

![authorities_dashboard](https://user-images.githubusercontent.com/1395707/132765214-ead4d6ac-ea0e-4785-ab29-951177a81c9a.png)
![authorities_form](https://user-images.githubusercontent.com/1395707/132765218-5dc230ca-f878-4a9c-8696-56a110898fc4.png)
