### PR TITLE
Add posterOffset to file set elasticsearch document

### DIFF
--- a/lib/meadow/indexing/file_set.ex
+++ b/lib/meadow/indexing/file_set.ex
@@ -15,6 +15,7 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.FileSet do
       mime_type: file_set.core_metadata.mime_type,
       model: %{application: "Meadow", name: "FileSet"},
       modifiedDate: file_set.updated_at,
+      posterOffset: file_set.poster_offset,
       representativeImageUrl: FileSets.representative_image_url_for(file_set),
       streamingUrl: FileSets.distribution_streaming_uri_for(file_set),
       role: format(file_set.role),

--- a/test/meadow/data/indexer_test.exs
+++ b/test/meadow/data/indexer_test.exs
@@ -337,6 +337,7 @@ defmodule Meadow.Data.IndexerTest do
         subject
         |> FileSets.update_file_set(%{
           derivatives: derivatives,
+          poster_offset: 100,
           structural_metadata: %{
             type: "webvtt",
             value:
@@ -352,6 +353,7 @@ defmodule Meadow.Data.IndexerTest do
       assert doc |> get_in(["model", "name"]) == "FileSet"
       assert doc |> get_in(["description"]) == subject.core_metadata.description
       assert doc |> get_in(["label"]) == subject.core_metadata.label
+      assert doc |> get_in(["posterOffset"]) == 100
       assert doc |> get_in(["webvtt"]) == subject.structural_metadata.value
 
       assert doc |> get_in(["streamingUrl"]) == Path.join(Config.streaming_url(), "bar.m3u8")


### PR DESCRIPTION
- Adds `posterOffset` field to indexed file set documents

Screenshot:
![file_set_poster_offset](https://user-images.githubusercontent.com/1395707/133124748-e746bb6a-e33b-4a8d-be4a-5eb44cfa8c0f.png)
