### PR TITLE
Don't put pyramid url in pres report for audio and video files

### DIFF
--- a/lib/meadow/data/file_sets.ex
+++ b/lib/meadow/data/file_sets.ex
@@ -246,6 +246,13 @@ defmodule Meadow.Data.FileSets do
   """
   def pyramid_uri_for(%FileSet{role: %{id: "P"}}), do: nil
   def pyramid_uri_for(%FileSet{role: %{id: "S"}}), do: nil
+
+  def pyramid_uri_for(%FileSet{core_metadata: %{mime_type: "video/" <> _thing}}),
+    do: nil
+
+  def pyramid_uri_for(%FileSet{core_metadata: %{mime_type: "audio/" <> _thing}}),
+    do: nil
+
   def pyramid_uri_for(%FileSet{} = file_set), do: pyramid_uri_for(file_set.id)
 
   def pyramid_uri_for(file_set_id) do

--- a/test/meadow/data/file_sets_test.exs
+++ b/test/meadow/data/file_sets_test.exs
@@ -200,12 +200,34 @@ defmodule Meadow.Data.FileSetsTest do
       file_set_p = file_set_fixture(role: %{id: "P", scheme: "FILE_SET_ROLE"})
       file_set_x = file_set_fixture(role: %{id: "X", scheme: "FILE_SET_ROLE"})
 
+      file_set_video =
+        file_set_fixture(
+          role: %{id: "A", scheme: "FILE_SET_ROLE"},
+          core_metadata: %{
+            mime_type: "video/mp4",
+            location: "s3://foo",
+            original_filename: "s3://bar"
+          }
+        )
+
+      file_set_audio =
+        file_set_fixture(
+          role: %{id: "A", scheme: "FILE_SET_ROLE"},
+          core_metadata: %{
+            mime_type: "audio/mpeg",
+            location: "s3://foo",
+            original_filename: "s3://bar"
+          }
+        )
+
       with uri <- file_set_a |> FileSets.pyramid_uri_for() |> URI.parse() do
         assert uri.host == Config.pyramid_bucket()
       end
 
       assert is_nil(FileSets.pyramid_uri_for(file_set_s))
       assert is_nil(FileSets.pyramid_uri_for(file_set_p))
+      assert is_nil(FileSets.pyramid_uri_for(file_set_video))
+      assert is_nil(FileSets.pyramid_uri_for(file_set_audio))
 
       with uri <- file_set_x |> FileSets.pyramid_uri_for() |> URI.parse() do
         assert uri.host == Config.pyramid_bucket()


### PR DESCRIPTION
- Fixes bug where preservation report listed a pyramid uri for audio and video files 