### PR TITLE
Add work archiver endpoint as env variable and expose in GQL

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -101,7 +101,8 @@ config :meadow,
   digital_collections_url:
     System.get_env("DIGITAL_COLLECTIONS_URL", "https://fen.rdc-staging.library.northwestern.edu/"),
   progress_ping_interval: System.get_env("PROGRESS_PING_INTERVAL", "1000"),
-  validation_ping_interval: System.get_env("VALIDATION_PING_INTERVAL", "1000")
+  validation_ping_interval: System.get_env("VALIDATION_PING_INTERVAL", "1000"),
+  work_archiver_endpoint: ""
 
 config :elastix,
   custom_headers: {Meadow.Utils.AWS, :add_aws_signature, ["us-east-1", "fake", "fake"]}

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -111,7 +111,8 @@ config :meadow,
   streaming_bucket: get_required_var.("STREAMING_BUCKET"),
   streaming_url: get_required_var.("STREAMING_URL"),
   upload_bucket: get_required_var.("UPLOAD_BUCKET"),
-  validation_ping_interval: System.get_env("VALIDATION_PING_INTERVAL", "1000")
+  validation_ping_interval: System.get_env("VALIDATION_PING_INTERVAL", "1000"),
+  work_archiver_endpoint: get_required_var.("WORK_ARCHIVER_ENDPOINT")
 
 config :logger, level: :info
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -45,7 +45,8 @@ config :meadow,
   mediaconvert_client: MediaConvert.Mock,
   iiif_server_url: "http://localhost:8184/iiif/2/",
   iiif_manifest_url: "http://localhost:9002/minio/test-pyramids/public/",
-  digital_collections_url: "https://fen.rdc-staging.library.northwestern.edu/"
+  digital_collections_url: "https://fen.rdc-staging.library.northwestern.edu/",
+  work_archiver_endpoint: ""
 
 config :meadow,
   ark: %{

--- a/lib/meadow/config.ex
+++ b/lib/meadow/config.ex
@@ -85,6 +85,11 @@ defmodule Meadow.Config do
     |> ensure_trailing_slash()
   end
 
+  @doc "Retrieve the work archiver endpoint"
+  def work_archiver_endpoint do
+    Application.get_env(:meadow, :work_archiver_endpoint)
+  end
+
   @doc "Retrieve a list of configured buckets"
   def buckets do
     [

--- a/lib/meadow_web/resolvers/helpers.ex
+++ b/lib/meadow_web/resolvers/helpers.ex
@@ -25,4 +25,8 @@ defmodule MeadowWeb.Resolvers.Helpers do
   def digital_collections_url(_, _args, _) do
     {:ok, %{url: Config.digital_collections_url()}}
   end
+
+  def work_archiver_endpoint(_, _args, _) do
+    {:ok, %{url: Config.work_archiver_endpoint()}}
+  end
 end

--- a/lib/meadow_web/schema/types/helper_types.ex
+++ b/lib/meadow_web/schema/types/helper_types.ex
@@ -27,6 +27,12 @@ defmodule MeadowWeb.Schema.HelperTypes do
       middleware(Middleware.Authenticate)
       resolve(&Resolvers.Helpers.get_presigned_url/3)
     end
+
+    @desc "Get work archiver endpoint"
+    field :work_archiver_endpoint, :url do
+      middleware(Middleware.Authenticate)
+      resolve(&Resolvers.Helpers.work_archiver_endpoint/3)
+    end
   end
 
   enum :s3_upload_type do

--- a/terraform/ec2_files/meadowrc
+++ b/terraform/ec2_files/meadowrc
@@ -34,6 +34,7 @@ export SECRET_KEY_BASE="${secret_key_base}"
 export SITEMAP_BUCKET="${digital_collections_bucket}"
 export STREAMING_BUCKET="${streaming_bucket}
 export UPLOAD_BUCKET="${upload_bucket}"
+export WORK_ARCHIVER_ENDPOINT="${work_archiver_endpoint}"
 export PRESERVATION_CHECK_BUCKET="${preservation_check_bucket}"
 export MEDIACONVERT_QUEUE="${mediaconvert_queue}"
 export MEDIACONVERT_ROLE="${mediaconvert_role}"

--- a/terraform/ecs_services.tf
+++ b/terraform/ecs_services.tf
@@ -39,6 +39,7 @@ locals {
     streaming_url              = "https://${aws_route53_record.meadow_streaming_cloudfront.fqdn}/"
     mediaconvert_queue         = aws_media_convert_queue.transcode_queue.arn
     mediaconvert_role          = aws_iam_role.transcode_role.arn
+    work_archiver_endpoint     = var.work_archiver_endpoint
   }
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -14,7 +14,7 @@ module "rds" {
   allocated_storage         = var.db_size
   backup_window             = "04:00-05:00"
   engine                    = "postgres"
-  engine_version            = "11.10"
+  engine_version            = "11.12"
   final_snapshot_identifier = "meadow-final"
   identifier                = "${var.stack_name}-db"
   instance_class            = "db.t3.medium"
@@ -29,14 +29,14 @@ module "rds" {
 
   parameters = [
     {
-      name = "client_encoding",
-      value = "UTF8",
+      name         = "client_encoding",
+      value        = "UTF8",
       apply_method = "pending-reboot"
     },
-    { 
-      name = "max_locks_per_transaction",
-      value = 256,
-      apply_method = "pending-reboot" 
+    {
+      name         = "max_locks_per_transaction",
+      value        = 256,
+      apply_method = "pending-reboot"
     }
   ]
 
@@ -85,9 +85,9 @@ resource "aws_s3_bucket" "meadow_preservation" {
   }
 
   lifecycle_rule {
-    id = "retain-on-delete"
+    id      = "retain-on-delete"
     enabled = true
-    
+
     noncurrent_version_expiration {
       days = var.deleted_object_expiration
     }
@@ -453,10 +453,10 @@ resource "aws_s3_bucket_policy" "allow_cloudfront_streaming_access" {
 }
 
 resource "aws_cloudfront_function" "meadow_streaming_cors" {
-  name = "${var.stack_name}-cors-streaming-headers"
+  name    = "${var.stack_name}-cors-streaming-headers"
   runtime = "cloudfront-js-1.0"
   publish = true
-  code = file("${path.module}/js/cors_streaming_headers.js")
+  code    = file("${path.module}/js/cors_streaming_headers.js")
 }
 
 data "aws_cloudfront_cache_policy" "caching_optimized" {
@@ -490,7 +490,7 @@ resource "aws_cloudfront_distribution" "meadow_streaming" {
     target_origin_id       = "${var.stack_name}-origin"
     viewer_protocol_policy = "allow-all"
 
-    cache_policy_id = data.aws_cloudfront_cache_policy.caching_optimized.id
+    cache_policy_id          = data.aws_cloudfront_cache_policy.caching_optimized.id
     origin_request_policy_id = data.aws_cloudfront_origin_request_policy.cors_s3_origin.id
 
     function_association {

--- a/terraform/task-definitions/meadow_app.json
+++ b/terraform/task-definitions/meadow_app.json
@@ -152,6 +152,10 @@
         "value": "${upload_bucket}"
       },
       {
+        "name": "WORK_ARCHIVER_ENDPOINT",
+        "value": "${work_archiver_endpoint}"
+      },
+      {
         "name": "AGENTLESS_SSO_KEY",
         "value": "${agentless_sso_key}"
       },

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -152,3 +152,7 @@ variable "ezid_user" {
 variable "ffmpeg_layer_sha256" {
   type = string
 }
+
+variable "work_archiver_endpoint" {
+  type = string
+}


### PR DESCRIPTION
**Terraform applied on staging**

- Adds the staging work archiver endpoint to deployment infrastructure as environment variable
- Exposes endpoint in GraphQL so that the client can retrieve an environment specific URL and call the API. 