### PR TITLE
Don't look for pyramid files if pyramid uri is nil

### DIFF
--- a/lib/meadow/data/preservation_check_writer.ex
+++ b/lib/meadow/data/preservation_check_writer.ex
@@ -159,7 +159,13 @@ defmodule Meadow.Data.PreservationCheckWriter do
   defp validate_pyramid_present(%{role: %{id: "A"}}, "AUDIO"), do: "N/A"
 
   defp validate_pyramid_present(file_set, _work_type_id) do
-    Meadow.Utils.Stream.exists?(FileSets.pyramid_uri_for(file_set))
+    case FileSets.pyramid_uri_for(file_set) do
+      nil ->
+        "N/A"
+
+      uri ->
+        Meadow.Utils.Stream.exists?(uri)
+    end
   end
 
   defp validate_preservation_file(location) do


### PR DESCRIPTION
This should get rid of the error that  the Preservation check on staging is experiencing which was caused by this work (and the presence of bad data on staging): https://github.com/nulib/meadow/issues/2515

There is bad data on staging where works of type image have video or audio access files attached to them and yet the preservation check writer is trying to look validate the presence of the pyramid with a value of `nil` for the pyramid uri.

<img width="1304" alt="Screen Shot 2021-09-20 at 3 43 58 PM" src="https://user-images.githubusercontent.com/6372022/134080218-178684c2-0b23-46e4-9c96-00369ca475e3.png">
