### PR TITLE
Make private the default visibility

### DIFF
--- a/lib/meadow/data/schemas/work.ex
+++ b/lib/meadow/data/schemas/work.ex
@@ -26,7 +26,11 @@ defmodule Meadow.Data.Schemas.Work do
   schema "works" do
     field(:accession_number, :string)
     field(:published, :boolean, default: false)
-    field(:visibility, Types.CodedTerm)
+
+    field(:visibility, Types.CodedTerm,
+      default: %{id: "RESTRICTED", scheme: "visibility", label: "Private"}
+    )
+
     field(:work_type, Types.CodedTerm)
 
     timestamps()


### PR DESCRIPTION
- Make private the default visibility
- ~~Note that it seemed to be necessary to add it manually to the work returned via the GraphQL resolver or else it did not contain the label.~~