### PR TITLE
Write IIIF 3.0 manifests for audio and video works

### DIFF
--- a/lib/meadow/data/schemas/iiif/V2/collection.ex
+++ b/lib/meadow/data/schemas/iiif/V2/collection.ex
@@ -1,8 +1,8 @@
-alias IIIF.Presentation.{Canvas, Collection, ImageResource, Manifest, Sequence}
+alias IIIF.V2.Presentation.{Canvas, Collection, ImageResource, Manifest, Sequence}
 
 alias Meadow.IIIF
 
-defimpl Meadow.IIIF.Resource, for: Meadow.Data.Schemas.Collection do
+defimpl Meadow.IIIF.V2.Resource, for: Meadow.Data.Schemas.Collection do
   def encode(collection) do
     %Collection{
       id: collection.id,
@@ -10,7 +10,7 @@ defimpl Meadow.IIIF.Resource, for: Meadow.Data.Schemas.Collection do
       manifests:
         Enum.map(collection.works, fn work ->
           %Manifest{
-            id: IIIF.manifest_id(work.id),
+            id: IIIF.V2.manifest_id(work.id),
             label: work.descriptive_metadata.title,
             sequences:
               Enum.map(work.file_sets, fn file_set ->
@@ -18,7 +18,7 @@ defimpl Meadow.IIIF.Resource, for: Meadow.Data.Schemas.Collection do
                   canvases: [
                     %Canvas{
                       images: %ImageResource{
-                        id: IIIF.image_id(file_set.id),
+                        id: IIIF.V2.image_id(file_set.id),
                         label: file_set.core_metadata.description
                       }
                     }

--- a/lib/meadow/data/schemas/iiif/V2/work.ex
+++ b/lib/meadow/data/schemas/iiif/V2/work.ex
@@ -1,10 +1,10 @@
-alias IIIF.Presentation.{Canvas, Image, ImageResource, Manifest, Sequence, Service}
+alias IIIF.V2.Presentation.{Canvas, Image, ImageResource, Manifest, Sequence, Service}
 alias Meadow.IIIF
 
-defimpl Meadow.IIIF.Resource, for: Meadow.Data.Schemas.Work do
+defimpl Meadow.IIIF.V2.Resource, for: Meadow.Data.Schemas.Work do
   def encode(work) do
     %Manifest{
-      id: IIIF.manifest_id(work.id),
+      id: IIIF.V2.manifest_id(work.id),
       label: work.descriptive_metadata.title,
       description: work.descriptive_metadata.description,
       sequences: [
@@ -12,16 +12,16 @@ defimpl Meadow.IIIF.Resource, for: Meadow.Data.Schemas.Work do
           canvases:
             Enum.map(work.file_sets, fn file_set ->
               %Canvas{
-                id: "#{IIIF.manifest_id(work.id)}/canvas/#{file_set.id}",
+                id: "#{IIIF.V2.manifest_id(work.id)}/canvas/#{file_set.id}",
                 label: file_set.core_metadata.label,
                 images: [
                   %Image{
                     resource: %ImageResource{
-                      id: IIIF.image_id(file_set.id),
+                      id: IIIF.V2.image_id(file_set.id),
                       label: file_set.core_metadata.label,
                       description: file_set.core_metadata.description,
                       service: %Service{
-                        id: IIIF.image_service_id(file_set.id)
+                        id: IIIF.V2.image_service_id(file_set.id)
                       }
                     }
                   }

--- a/lib/meadow/data/schemas/iiif/V3/work.ex
+++ b/lib/meadow/data/schemas/iiif/V3/work.ex
@@ -1,0 +1,146 @@
+alias IIIF.V3.Presentation.{
+  Annotation,
+  AnnotationPage,
+  Canvas,
+  Content,
+  Label,
+  LabelValue,
+  Manifest,
+  Service,
+  Thumbnail
+}
+
+alias Meadow.Data.FileSets
+alias Meadow.IIIF
+
+defimpl Meadow.IIIF.V3.Resource, for: Meadow.Data.Schemas.Work do
+  def encode(%{work_type: %{id: work_type}} = work) when work_type in ["VIDEO", "AUDIO"] do
+    %Manifest{
+      id: IIIF.V3.manifest_id(work.id),
+      label: manifest_label(work),
+      summary: summary(work.descriptive_metadata.description),
+      rights: rights_statement(work.descriptive_metadata.rights_statement),
+      requiredStatement: %LabelValue{
+        label: %Label{en: ["Attribution"]},
+        value: %Label{en: ["Courtesy of Northwestern University Libraries"]}
+      },
+      items: [
+        work.file_sets
+        |> Enum.filter(&FileSets.access?/1)
+        |> Enum.map(fn file_set ->
+          %Canvas{
+            id: IIIF.V3.canvas_id(work.id, file_set.id),
+            label: %Label{en: [file_set.core_metadata.label]},
+            thumbnail:
+              case FileSets.representative_image_url_for(file_set) do
+                nil ->
+                  nil
+
+                thumbnail_url ->
+                  [
+                    %Thumbnail{
+                      id: thumbnail_url <> "/full/!300,300/0/default.jpg",
+                      type: "Image",
+                      format: "image/jpeg",
+                      height: 300,
+                      width: 300,
+                      service: [
+                        %Service{
+                          id: IIIF.V3.image_service_id(file_set.id, "posters"),
+                          profile: "http://iiif.io/api/image/2/level2.json",
+                          type: "ImageService2"
+                        }
+                      ]
+                    }
+                  ]
+              end,
+            items: [
+              %AnnotationPage{
+                id: IIIF.V3.annotation_page_id(work.id, file_set.id, "1"),
+                items: [
+                  %Annotation{
+                    id: IIIF.V3.annotation_id(work.id, file_set.id, "1", "1"),
+                    body: %Content{
+                      id: FileSets.distribution_streaming_uri_for(file_set),
+                      type: String.capitalize(resource_type(work_type)),
+                      format: file_set.core_metadata.mime_type,
+                      height: FileSets.height(file_set),
+                      width: FileSets.width(file_set),
+                      duration: duration_in_seconds(FileSets.duration_in_milliseconds(file_set))
+                    }
+                  },
+                  with %{type: "webvtt", value: _value} <- file_set.structural_metadata do
+                    %Annotation{
+                      id: IIIF.V3.annotation_id(work.id, file_set.id, "1", "2"),
+                      motivation: "supplementing",
+                      body: %Content{
+                        id: FileSets.public_vtt_url_for(file_set.id),
+                        type: "Text",
+                        format: "text/vtt",
+                        label: %Label{
+                          en: ["Transcript"]
+                        },
+                        language: "en"
+                      },
+                      target: IIIF.V3.canvas_id(work.id, file_set.id)
+                    }
+                  end
+                ]
+              }
+            ]
+          }
+        end),
+        work.file_sets
+        |> Enum.filter(&FileSets.auxiliary?/1)
+        |> Enum.map(fn file_set ->
+          %Canvas{
+            id: IIIF.V3.canvas_id(work.id, file_set.id),
+            label: %Label{en: [file_set.core_metadata.label]},
+            items: [
+              %AnnotationPage{
+                id: IIIF.V3.annotation_page_id(work.id, file_set.id, "1"),
+                items: [
+                  %Annotation{
+                    id: IIIF.V3.annotation_id(work.id, file_set.id, "1", "1"),
+                    body: %Content{
+                      id: IIIF.V3.image_id(file_set.id, "/full/max/0/default.jpg"),
+                      type: "Image",
+                      format: file_set.core_metadata.mime_type,
+                      height: FileSets.height(file_set),
+                      width: FileSets.width(file_set),
+                      service: [
+                        %Service{
+                          id: IIIF.V3.image_service_id(file_set.id),
+                          profile: "http://iiif.io/api/image/2/level2.json",
+                          type: "ImageService2"
+                        }
+                      ]
+                    },
+                    target: IIIF.V3.canvas_id(work.id, file_set.id)
+                  }
+                ]
+              }
+            ]
+          }
+        end)
+      ]
+    }
+  end
+
+  defp resource_type("AUDIO"), do: "Sound"
+  defp resource_type(work_type), do: work_type
+
+  defp duration_in_seconds(nil), do: nil
+  defp duration_in_seconds(duration) when duration > 0, do: duration / 1000
+  defp duration_in_seconds(_), do: nil
+
+  defp manifest_label(%{descriptive_metadata: %{title: nil}}), do: nil
+  defp manifest_label(%{descriptive_metadata: %{title: title}}), do: %Label{en: [title]}
+  defp manifest_label(_), do: nil
+
+  defp summary([]), do: nil
+  defp summary(summary), do: %Label{en: summary}
+
+  defp rights_statement(%{id: id}), do: id
+  defp rights_statement(_), do: nil
+end

--- a/lib/meadow/data/works.ex
+++ b/lib/meadow/data/works.ex
@@ -372,19 +372,27 @@ defmodule Meadow.Data.Works do
 
   @doc """
   Retrieves the IIIF Manifest URL for a work
-  iex> iiif_manifest_url("f352eb30-ae2f-4b49-81f9-6eb4659a3f47")
+  iex> iiif_manifest_url("f352eb30-ae2f-4b49-81f9-6eb4659a3f47", "IMAGE")
   "https://iiif.stack.rdc.library.northwestern.edu/public/f3/52/eb/30/-a/e2/f-/4b/49/-8/1f/9-/6e/b4/65/9a/3f/47-manifest.json"
 
-  iex> iiif_manifest_url(%Work{id:"f352eb30-ae2f-4b49-81f9-6eb4659a3f47"})
+  iex> iiif_manifest_url(%Work{id:"f352eb30-ae2f-4b49-81f9-6eb4659a3f47", work_type: %{id: "IMAGE"}})
   "https://iiif.stack.rdc.library.northwestern.edu/public/f3/52/eb/30/-a/e2/f-/4b/49/-8/1f/9-/6e/b4/65/9a/3f/47-manifest.json"
 
   """
-  def iiif_manifest_url(%Work{id: id}) do
-    iiif_manifest_url(id)
+  def iiif_manifest_url(%Work{id: id, work_type: %{id: work_type}}) do
+    iiif_manifest_url(id, work_type)
   end
 
-  def iiif_manifest_url(work_id) do
+  def iiif_manifest_url(work_id, "IMAGE") do
     Config.iiif_manifest_url() <> Pairtree.manifest_path(work_id)
+  end
+
+  def iiif_manifest_url(work_id, "VIDEO") do
+    Config.iiif_manifest_url() <> "iiif3/" <> Pairtree.manifest_path(work_id)
+  end
+
+  def iiif_manifest_url(work_id, "AUDIO") do
+    Config.iiif_manifest_url() <> "iiif3/" <> Pairtree.manifest_path(work_id)
   end
 
   @doc """

--- a/lib/meadow/iiif/manifest_listener.ex
+++ b/lib/meadow/iiif/manifest_listener.ex
@@ -16,11 +16,16 @@ defmodule Meadow.IIIF.ManifestListener do
     with_log_metadata module: __MODULE__, id: id do
       case Works.get_work!(id) do
         %{work_type: %{id: "IMAGE"}} ->
-          Logger.info("Writing manifest for #{id}")
-          id |> IIIF.write_manifest()
-        _ -> Logger.info("Skipping manifest writing for non-image work #{id}")
-      end
+          Logger.info("Writing IIIF 2.1.x manifest for image: #{id}")
+          id |> IIIF.V2.write_manifest()
 
+        %{work_type: %{id: work_type}} ->
+          Logger.info("Writing manifest IIIF 3.0.x for #{work_type}: #{id}")
+          id |> IIIF.V3.write_manifest()
+
+        _ ->
+          Logger.warn("Skipping manifest writing for work of unknown type. Work id: #{id}")
+      end
     end
 
     {:noreply, state}

--- a/lib/meadow/iiif/v2/generator.ex
+++ b/lib/meadow/iiif/v2/generator.ex
@@ -1,11 +1,11 @@
-defmodule Meadow.IIIF.Generator do
+defmodule Meadow.IIIF.V2.Generator do
   @moduledoc """
   Generates resources in accordance with the IIIF Presentation API 2.x
   based on the encoding defined in the schema
   """
   alias Meadow.Data.{Collections, Works}
   alias Meadow.Data.Schemas.{Collection, Work}
-  alias Meadow.IIIF.Resource
+  alias Meadow.IIIF.V2.Resource
 
   import Ecto.Query, warn: false
 

--- a/lib/meadow/iiif/v2/iiif.ex
+++ b/lib/meadow/iiif/v2/iiif.ex
@@ -1,11 +1,11 @@
-defmodule Meadow.IIIF do
+defmodule Meadow.IIIF.V2 do
   @moduledoc """
   API for IIIF related functions
   """
 
   alias Meadow.Config
   alias Meadow.Data.Works
-  alias Meadow.IIIF.Generator
+  alias Meadow.IIIF.V2.Generator
   alias Meadow.Utils.Pairtree
 
   def write_manifest(work_id) do

--- a/lib/meadow/iiif/v2/presentation/canvas.ex
+++ b/lib/meadow/iiif/v2/presentation/canvas.ex
@@ -1,4 +1,4 @@
-defmodule IIIF.Presentation.Canvas do
+defmodule IIIF.V2.Presentation.Canvas do
   @moduledoc """
   IIIF Presentation API 2.1.x Canvas resource
   """

--- a/lib/meadow/iiif/v2/presentation/collection.ex
+++ b/lib/meadow/iiif/v2/presentation/collection.ex
@@ -1,4 +1,4 @@
-defmodule IIIF.Presentation.Collection do
+defmodule IIIF.V2.Presentation.Collection do
   @moduledoc """
   IIIF Presentation API 2.1.x Collection Resource
   """

--- a/lib/meadow/iiif/v2/presentation/image.ex
+++ b/lib/meadow/iiif/v2/presentation/image.ex
@@ -1,4 +1,4 @@
-defmodule IIIF.Presentation.Image do
+defmodule IIIF.V2.Presentation.Image do
   @moduledoc """
   IIIF Presentation API 2.1.x Image resource
   """

--- a/lib/meadow/iiif/v2/presentation/image_resource.ex
+++ b/lib/meadow/iiif/v2/presentation/image_resource.ex
@@ -1,4 +1,4 @@
-defmodule IIIF.Presentation.ImageResource do
+defmodule IIIF.V2.Presentation.ImageResource do
   @moduledoc """
   IIIF Presentation API 2.1.x ImageResource
   """

--- a/lib/meadow/iiif/v2/presentation/manifest.ex
+++ b/lib/meadow/iiif/v2/presentation/manifest.ex
@@ -1,4 +1,4 @@
-defmodule IIIF.Presentation.Manifest do
+defmodule IIIF.V2.Presentation.Manifest do
   @moduledoc """
   IIIF Presentation API 2.1.x Manifest resource
   """

--- a/lib/meadow/iiif/v2/presentation/sequence.ex
+++ b/lib/meadow/iiif/v2/presentation/sequence.ex
@@ -1,0 +1,28 @@
+defmodule IIIF.V2.Presentation.Sequence do
+  @moduledoc """
+  IIIF Presentation API 2.1.x Sequence
+  """
+  @default_context "http://iiif.io/api/presentation/2/context.json"
+  @rdf_type "sc:Sequence"
+  @default_id "/sequence/normal"
+
+  defstruct id: @default_id,
+            context: @default_context,
+            type: @rdf_type,
+            label: nil,
+            metadata: [],
+            description: nil,
+            thumbnail: nil,
+            viewingHint: nil,
+            viewingDirection: nil,
+            license: nil,
+            attribution: nil,
+            logo: nil,
+            related: nil,
+            service: nil,
+            seeAlso: nil,
+            rendering: nil,
+            within: nil,
+            canvases: [],
+            startCanvas: nil
+end

--- a/lib/meadow/iiif/v2/presentation/service.ex
+++ b/lib/meadow/iiif/v2/presentation/service.ex
@@ -1,4 +1,4 @@
-defmodule IIIF.Presentation.Service do
+defmodule IIIF.V2.Presentation.Service do
   @moduledoc """
   IIIF Presentation API 2.1.x Service
   """

--- a/lib/meadow/iiif/v2/resource.ex
+++ b/lib/meadow/iiif/v2/resource.ex
@@ -1,4 +1,4 @@
-defprotocol Meadow.IIIF.Resource do
+defprotocol Meadow.IIIF.V2.Resource do
   @moduledoc """
   A protocol for converting a struct into a 2.0 IIIF Manifest
   """

--- a/lib/meadow/iiif/v3/generator.ex
+++ b/lib/meadow/iiif/v3/generator.ex
@@ -1,0 +1,60 @@
+defmodule Meadow.IIIF.V3.Generator do
+  @moduledoc """
+  Generates resources in accordance with the IIIF Presentation API 2.x
+  based on the encoding defined in the schema
+  """
+  alias Meadow.Data.{Collections, Works}
+  alias Meadow.Data.Schemas.{Collection, Work}
+  alias Meadow.IIIF.V3.Resource
+
+  import Ecto.Query, warn: false
+
+  def create_manifest(%Work{id: id}) do
+    id
+    |> Works.with_file_sets()
+    |> encode!()
+  end
+
+  def create_collection(%Collection{id: id}) do
+    id
+    |> Collections.with_works_and_file_sets()
+    |> encode!()
+  end
+
+  defp encode!(object) do
+    object
+    |> Resource.encode()
+    |> to_json()
+    |> Jason.encode!(pretty: true)
+  end
+
+  defp to_json(manifest) do
+    manifest
+    |> Map.from_struct()
+    |> Enum.map(&set_property/1)
+    |> Enum.filter(&filter_property/1)
+    |> Enum.into(%{})
+  end
+
+  defp set_property({:context, value}), do: {"@context", value}
+  # defp set_property({:id, value}), do: {"@id", value}
+  # defp set_property({:type, value}), do: {"@type", value}
+
+  defp set_property({key, elements}) when is_list(elements) do
+    {key, Enum.map(elements, &elem(set_property({key, &1}), 1))}
+  end
+
+  defp set_property({key, map = %{}}) do
+    {key, to_json(map)}
+  end
+
+  defp set_property({_, nil}), do: nil
+  defp set_property(tuple), do: tuple
+
+  defp filter_property(nil), do: false
+  defp filter_property({:sequences, _}), do: true
+  defp filter_property({:canvases, _}), do: true
+  defp filter_property({_, []}), do: false
+  defp filter_property({_, nil}), do: false
+  defp filter_property(_), do: true
+end

--- a/lib/meadow/iiif/v3/iiif.ex
+++ b/lib/meadow/iiif/v3/iiif.ex
@@ -1,0 +1,109 @@
+defmodule Meadow.IIIF.V3 do
+  @moduledoc """
+  API for IIIF related functions
+  """
+
+  alias Meadow.Config
+  alias Meadow.Data.Works
+  alias Meadow.IIIF.V3.Generator
+  alias Meadow.Utils.Pairtree
+
+  def write_manifest(work_id) do
+    work_id
+    |> Works.get_work!()
+    |> Generator.create_manifest()
+    |> write_to_s3(Pairtree.manifest_v3_key(work_id))
+  end
+
+  @doc """
+  Generate manifest id
+
+  Examples:
+    iex> manifest_id("37ad25ec-7eff-45d0-b759-eca65c9d560f")
+    "http://localhost:9002/minio/test-pyramids/public/iiif3/37/ad/25/ec/-7/ef/f-/45/d0/-b/75/9-/ec/a6/5c/9d/56/0f-manifest.json"
+  """
+  def manifest_id(work_id) do
+    Config.iiif_manifest_url() <> "iiif3/" <> Pairtree.manifest_path(work_id)
+  end
+
+  @doc """
+  Generate image id
+
+  Examples:
+    iex> image_id("37ad25ec-7eff-45d0-b759-eca65c9d560f", "/full/600,/0/default.jpg")
+    "http://localhost:8184/iiif/2/37ad25ec-7eff-45d0-b759-eca65c9d560f/full/600,/0/default.jpg"
+  """
+  def image_id(file_set_id, dimensions) do
+    Config.iiif_server_url() <> file_set_id <> dimensions
+  end
+
+  @doc """
+  Generate image service id
+
+  Examples:
+    iex> image_service_id("37ad25ec-7eff-45d0-b759-eca65c9d560f")
+    "http://localhost:8184/iiif/2/37ad25ec-7eff-45d0-b759-eca65c9d560f"
+  """
+  def image_service_id(file_set_id) do
+    case file_set_id do
+      nil ->
+        nil
+
+      id ->
+        Config.iiif_server_url() <> id
+    end
+  end
+
+  def image_service_id(file_set_id, prefix) do
+    case file_set_id do
+      nil ->
+        nil
+
+      id ->
+        Config.iiif_server_url() <> prefix <> "/" <> id
+    end
+  end
+
+  @doc """
+  Generate annotation id
+
+  Examples:
+    iex> annotation_id("37ad25ec-7eff-45d0-b759-eca65c9d560f", "030ac101-58cc-4e1e-8a13-ad6d95a6adbe",1,2)
+    "http://localhost:9002/minio/test-pyramids/public/iiif3/37/ad/25/ec/-7/ef/f-/45/d0/-b/75/9-/ec/a6/5c/9d/56/0f-manifest.json/canvas/030ac101-58cc-4e1e-8a13-ad6d95a6adbe/annotation_page/1/annotation/2"
+  """
+  def annotation_id(work_id, file_set_id, page_number, annotation_number) do
+    "#{manifest_id(work_id)}/canvas/#{file_set_id}/annotation_page/#{page_number}/annotation/#{annotation_number}"
+  end
+
+  @doc """
+  Generate annotation page id
+
+  Examples:
+    iex> annotation_page_id("37ad25ec-7eff-45d0-b759-eca65c9d560f", "030ac101-58cc-4e1e-8a13-ad6d95a6adbe",1)
+    "http://localhost:9002/minio/test-pyramids/public/iiif3/37/ad/25/ec/-7/ef/f-/45/d0/-b/75/9-/ec/a6/5c/9d/56/0f-manifest.json/canvas/030ac101-58cc-4e1e-8a13-ad6d95a6adbe/annotation_page/1"
+  """
+  def annotation_page_id(work_id, file_set_id, page_number) do
+    "#{manifest_id(work_id)}/canvas/#{file_set_id}/annotation_page/#{page_number}"
+  end
+
+  @doc """
+  Generate canvas id
+
+  Examples:
+    iex> canvas_id("37ad25ec-7eff-45d0-b759-eca65c9d560f", "030ac101-58cc-4e1e-8a13-ad6d95a6adbe")
+    "http://localhost:9002/minio/test-pyramids/public/iiif3/37/ad/25/ec/-7/ef/f-/45/d0/-b/75/9-/ec/a6/5c/9d/56/0f-manifest.json/canvas/030ac101-58cc-4e1e-8a13-ad6d95a6adbe"
+  """
+  def canvas_id(work_id, file_set_id) do
+    "#{manifest_id(work_id)}/canvas/#{file_set_id}"
+  end
+
+  defp write_to_s3(manifest, key) do
+    ExAws.S3.put_object(
+      Meadow.Config.pyramid_bucket(),
+      key,
+      manifest,
+      content_type: "application/json"
+    )
+    |> ExAws.request()
+  end
+end

--- a/lib/meadow/iiif/v3/presentation/annotation.ex
+++ b/lib/meadow/iiif/v3/presentation/annotation.ex
@@ -1,0 +1,12 @@
+defmodule IIIF.V3.Presentation.Annotation do
+  @moduledoc """
+  IIIF Presentation API 3.0.x Annotation
+  """
+  @rdf_type "Annotation"
+
+  defstruct id: nil,
+            type: @rdf_type,
+            motivation: "painting",
+            body: nil,
+            target: nil
+end

--- a/lib/meadow/iiif/v3/presentation/annotation_page.ex
+++ b/lib/meadow/iiif/v3/presentation/annotation_page.ex
@@ -1,0 +1,11 @@
+defmodule IIIF.V3.Presentation.AnnotationPage do
+  @moduledoc """
+  IIIF Presentation API 3.0.x Annotation Page
+  """
+  @rdf_type "AnnotationPage"
+
+  defstruct id: nil,
+            type: @rdf_type,
+            items: [],
+            target: nil
+end

--- a/lib/meadow/iiif/v3/presentation/canvas.ex
+++ b/lib/meadow/iiif/v3/presentation/canvas.ex
@@ -1,0 +1,18 @@
+defmodule IIIF.V3.Presentation.Canvas do
+  @moduledoc """
+  IIIF Presentation API 2.1.x Canvas resource
+  """
+  @rdf_type "Canvas"
+  @default_width "640"
+  @default_height "480"
+
+  defstruct id: nil,
+            type: @rdf_type,
+            label: nil,
+            metadata: [],
+            items: [],
+            duration: nil,
+            height: @default_height,
+            width: @default_width,
+            thumbnail: nil
+end

--- a/lib/meadow/iiif/v3/presentation/content.ex
+++ b/lib/meadow/iiif/v3/presentation/content.ex
@@ -1,0 +1,16 @@
+defmodule IIIF.V3.Presentation.Content do
+  @moduledoc """
+  IIIF Presentation API 3.0.x Content
+  """
+
+  defstruct type: nil,
+            id: nil,
+            format: nil,
+            width: nil,
+            height: nil,
+            duration: nil,
+            label: nil,
+            language: nil,
+            target: nil,
+            service: []
+end

--- a/lib/meadow/iiif/v3/presentation/label.ex
+++ b/lib/meadow/iiif/v3/presentation/label.ex
@@ -1,0 +1,7 @@
+defmodule IIIF.V3.Presentation.Label do
+  @moduledoc """
+  IIIF Presentation API 3.0.x Label
+  """
+
+  defstruct en: []
+end

--- a/lib/meadow/iiif/v3/presentation/label_value.ex
+++ b/lib/meadow/iiif/v3/presentation/label_value.ex
@@ -1,0 +1,8 @@
+defmodule IIIF.V3.Presentation.LabelValue do
+  @moduledoc """
+  IIIF Presentation API 3.0.x Label
+  """
+
+  defstruct label: nil,
+            value: nil
+end

--- a/lib/meadow/iiif/v3/presentation/manifest.ex
+++ b/lib/meadow/iiif/v3/presentation/manifest.ex
@@ -1,28 +1,30 @@
-defmodule IIIF.Presentation.Sequence do
+defmodule IIIF.V3.Presentation.Manifest do
   @moduledoc """
-  IIIF Presentation API 2.1.x Sequence
+  IIIF Presentation API 2.1.x Manifest resource
   """
-  @default_context "http://iiif.io/api/presentation/2/context.json"
-  @rdf_type "sc:Sequence"
-  @default_id "/sequence/normal"
+  @default_context "http://iiif.io/api/presentation/3/context.json"
 
-  defstruct id: @default_id,
+  @rdf_type "Manifest"
+
+  defstruct id: nil,
             context: @default_context,
             type: @rdf_type,
+            items: [],
             label: nil,
             metadata: [],
             description: nil,
             thumbnail: nil,
             viewingHint: nil,
             viewingDirection: nil,
+            navDate: nil,
             license: nil,
             attribution: nil,
             logo: nil,
             related: nil,
+            requiredStatement: nil,
+            rights: nil,
             service: nil,
             seeAlso: nil,
-            rendering: nil,
-            within: nil,
-            canvases: [],
-            startCanvas: nil
+            summary: nil,
+            rendering: nil
 end

--- a/lib/meadow/iiif/v3/presentation/service.ex
+++ b/lib/meadow/iiif/v3/presentation/service.ex
@@ -1,0 +1,11 @@
+defmodule IIIF.V3.Presentation.Service do
+  @moduledoc """
+  IIIF Presentation API 2.1.x Service
+  """
+
+  @default_profile "http://iiif.io/api/image/2/level2.json"
+
+  defstruct id: nil,
+            profile: @default_profile,
+            type: nil
+end

--- a/lib/meadow/iiif/v3/presentation/thumbnail.ex
+++ b/lib/meadow/iiif/v3/presentation/thumbnail.ex
@@ -1,0 +1,12 @@
+defmodule IIIF.V3.Presentation.Thumbnail do
+  @moduledoc """
+  IIIF Presentation API 3.0.x Thumbnail
+  """
+
+  defstruct type: nil,
+            id: nil,
+            format: nil,
+            width: nil,
+            height: nil,
+            service: []
+end

--- a/lib/meadow/iiif/v3/resource.ex
+++ b/lib/meadow/iiif/v3/resource.ex
@@ -1,0 +1,10 @@
+defprotocol Meadow.IIIF.V3.Resource do
+  @moduledoc """
+  A protocol for converting a struct into a 2.0 IIIF Manifest
+  """
+
+  @doc """
+  returns a map of fields which will be encoded into a IIIF manifest
+  """
+  def encode(object)
+end

--- a/lib/meadow/indexing/work.ex
+++ b/lib/meadow/indexing/work.ex
@@ -30,7 +30,7 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Work do
           }
         end),
       id: work.id,
-      iiifManifest: IIIF.manifest_id(work.id),
+      iiifManifest: manifest_id(work),
       model: %{application: "Meadow", name: "Image"},
       modifiedDate: work.updated_at,
       project: format(work.project),
@@ -78,4 +78,7 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Work do
   defp copy_field(%{displayFacet: display_facet}), do: display_facet
   defp copy_field(%{humanized: humanized}), do: humanized
   defp copy_field(value), do: value
+
+  defp manifest_id(%{work_type: %{id: "IMAGE"}} = work), do: IIIF.V2.manifest_id(work.id)
+  defp manifest_id(work), do: IIIF.V3.manifest_id(work.id)
 end

--- a/lib/meadow/ingest/sheets.ex
+++ b/lib/meadow/ingest/sheets.ex
@@ -498,7 +498,7 @@ defmodule Meadow.Ingest.Sheets do
     |> Repo.all()
   end
 
-  def update_completed_sheets() do
+  def update_completed_sheets do
     from(s in Sheet, where: s.status == "approved")
     |> Repo.all()
     |> Enum.each(&check_sheet_for_completeness/1)

--- a/lib/meadow/seed/import.ex
+++ b/lib/meadow/seed/import.ex
@@ -142,7 +142,7 @@ defmodule Meadow.Seed.Import do
       |> Repo.stream()
       |> Stream.each(fn %{id: work_id} ->
         Logger.info("Writing manifest for #{work_id}")
-        IIIF.write_manifest(work_id)
+        IIIF.V2.write_manifest(work_id)
       end)
       |> Stream.run()
     end)

--- a/lib/meadow/structural_metadata_listener.ex
+++ b/lib/meadow/structural_metadata_listener.ex
@@ -7,7 +7,7 @@ defmodule Meadow.StructuralMetadataListener do
   use Meadow.Utils.Logging
   alias Meadow.Config
   alias Meadow.Data.FileSets
-  alias Meadow.Utils.{AWS, Pairtree}
+  alias Meadow.Utils.AWS
   require Logger
 
   @impl true
@@ -33,16 +33,16 @@ defmodule Meadow.StructuralMetadataListener do
        when is_binary(vtt) do
     Logger.info("Writing structural metadata for #{id}")
 
-    ExAws.S3.put_object(Config.streaming_bucket(), vtt_location(id), vtt, content_type: "text/vtt")
+    ExAws.S3.put_object(Config.pyramid_bucket(), FileSets.vtt_location(id), vtt,
+      content_type: "text/vtt"
+    )
     |> AWS.request()
   end
 
   defp write_structural_metadata(%{id: id}) do
     Logger.info("Deleting structural metadata for #{id}")
 
-    ExAws.S3.delete_object(Config.streaming_bucket(), vtt_location(id))
+    ExAws.S3.delete_object(Config.pyramid_bucket(), FileSets.vtt_location(id))
     |> AWS.request()
   end
-
-  defp vtt_location(id), do: Path.join(Pairtree.generate!(id), id <> ".vtt")
 end

--- a/lib/meadow/utils/pairtree.ex
+++ b/lib/meadow/utils/pairtree.ex
@@ -70,6 +70,17 @@ defmodule Meadow.Utils.Pairtree do
   end
 
   @doc """
+  Generate an S3 Key for a IIIF v3.x manifest
+
+  Examples:
+    iex> Meadow.Utils.Pairtree.manifest_v3_key("a13d45b1-69a6-447f-9d42-90b989a2949c")
+    "public/iiif3/a1/3d/45/b1/-6/9a/6-/44/7f/-9/d4/2-/90/b9/89/a2/94/9c-manifest.json"
+  """
+  def manifest_v3_key(id) do
+    "public/" <> "iiif3/" <> with_extension(id, "manifest", "json")
+  end
+
+  @doc """
   Generate a Pairtree with ending and extension
 
   Examples:

--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -115,7 +115,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
 
     field :manifest_url, :string do
       resolve(fn work, _, _ ->
-        {:ok, Works.iiif_manifest_url(work.id)}
+        {:ok, Works.iiif_manifest_url(work.id, work.work_type.id)}
       end)
     end
 

--- a/test/meadow/iiif/generator_v2_test.exs
+++ b/test/meadow/iiif/generator_v2_test.exs
@@ -1,7 +1,7 @@
-defmodule Meadow.IIIF.GeneratorTest do
+defmodule Meadow.IIIF.V2.GeneratorTest do
   use Meadow.DataCase
   alias Meadow.IIIF
-  alias Meadow.IIIF.Generator
+  alias Meadow.IIIF.V2.Generator
   import Meadow.TestHelpers
 
   describe "Manifest generation" do
@@ -49,9 +49,9 @@ defmodule Meadow.IIIF.GeneratorTest do
                       \"service\": {
                         \"profile\": \"http://iiif.io/api/image/2/level2.json\",
                         \"@context\": \"http://iiif.io/api/image/2/context.json\",
-                        \"@id\": \"#{IIIF.image_service_id(file_set.id)}\"
+                        \"@id\": \"#{IIIF.V2.image_service_id(file_set.id)}\"
                       },
-                      \"@id\": \"#{IIIF.image_id(file_set.id)}\",
+                      \"@id\": \"#{IIIF.V2.image_id(file_set.id)}\",
                       \"@type\": \"dctypes:Image\"
                     },
                     \"@type\": \"oa:Annotation\"
@@ -59,7 +59,7 @@ defmodule Meadow.IIIF.GeneratorTest do
                 ],
                 \"label\": \"This is the label\",
                 \"width\": \"640\",
-                \"@id\": \"#{IIIF.manifest_id(work.id)}/canvas/#{file_set.id}\",
+                \"@id\": \"#{IIIF.V2.manifest_id(work.id)}/canvas/#{file_set.id}\",
                 \"@type\": \"sc:Canvas\"
               }
             ],
@@ -69,7 +69,7 @@ defmodule Meadow.IIIF.GeneratorTest do
           }
         ],
         \"@context\": \"http://iiif.io/api/presentation/2/context.json\",
-        \"@id\": \"#{IIIF.manifest_id(work.id)}\",
+        \"@id\": \"#{IIIF.V2.manifest_id(work.id)}\",
         \"@type\": \"sc:Manifest\"
       }\
       """
@@ -91,7 +91,7 @@ defmodule Meadow.IIIF.GeneratorTest do
             \"label\": \"Test title\",
             \"sequences\": [],
             \"@context\": \"http://iiif.io/api/presentation/2/context.json\",
-            \"@id\": \"#{IIIF.manifest_id(work.id)}\",
+            \"@id\": \"#{IIIF.V2.manifest_id(work.id)}\",
             \"@type\": \"sc:Manifest\"
           }
         ],

--- a/test/meadow/iiif/generator_v3_test.exs
+++ b/test/meadow/iiif/generator_v3_test.exs
@@ -1,0 +1,134 @@
+defmodule Meadow.IIIF.V3.GeneratorTest do
+  use Meadow.DataCase
+  alias Meadow.IIIF
+  alias Meadow.IIIF.V3.Generator
+  import Meadow.TestHelpers
+
+  describe "Manifest generation" do
+    test "create_manifest/1" do
+      work = work_fixture(%{work_type: %{id: "VIDEO", scheme: "work_type"}})
+
+      file_set =
+        file_set_fixture(%{
+          work_id: work.id,
+          role: %{id: "A", scheme: "FILE_SET_ROLE"},
+          core_metadata: %{
+            location: "foo",
+            description: "bar",
+            original_filename: "something",
+            label: "This is the label"
+          }
+        })
+
+      file_set2 =
+        file_set_fixture(%{
+          work_id: work.id,
+          role: %{id: "X", scheme: "FILE_SET_ROLE"},
+          core_metadata: %{
+            location: "foo",
+            description: "preservation master",
+            original_filename: "something",
+            label: "This should not be in the manifest"
+          }
+        })
+
+      json = """
+      {
+        \"id\": \"#{IIIF.V3.manifest_id(work.id)}\",
+        \"items\": [
+          [
+            {
+              \"height\": \"480\",
+              \"id\": \"#{IIIF.V3.canvas_id(work.id, file_set.id)}\",
+              \"items\": [
+                {
+                  \"id\": \"#{IIIF.V3.annotation_page_id(work.id, file_set.id, 1)}\",
+                  \"items\": [
+                    {
+                      \"body\": {
+                        \"id\": \"https://test-streaming-url/bar.m3u8\",
+                        \"type\": \"Video\"
+                      },
+                      \"id\": \"#{IIIF.V3.annotation_id(work.id, file_set.id, 1, 1)}\",
+                      \"motivation\": \"painting\",
+                      \"type\": \"Annotation\"
+                    },
+                    {}
+                  ],
+                  \"type\": \"AnnotationPage\"
+                }
+              ],
+              \"label\": {
+                \"en\": [
+                  \"This is the label\"
+                ]
+              },
+              \"type\": \"Canvas\",
+              \"width\": \"640\"
+            }
+          ],
+          [
+            {
+              \"height\": \"480\",
+              \"id\": \"#{IIIF.V3.canvas_id(work.id, file_set2.id)}\",
+              \"items\": [
+                {
+                  \"id\": \"#{IIIF.V3.annotation_page_id(work.id, file_set2.id, 1)}\",
+                  \"items\": [
+                    {
+                      \"body\": {
+                        \"id\": \"http://localhost:8184/iiif/2/#{file_set2.id}/full/max/0/default.jpg\",
+                        \"service\": [
+                          {
+                            \"id\": \"http://localhost:8184/iiif/2/#{file_set2.id}\",
+                            \"profile\": \"http://iiif.io/api/image/2/level2.json\",
+                            \"type\": \"ImageService2\"
+                          }
+                        ],
+                        \"type\": \"Image\"
+                      },
+                      \"id\": \"#{IIIF.V3.annotation_id(work.id, file_set2.id, 1, 1)}\",
+                      \"motivation\": \"painting\",
+                      \"target\": \"#{IIIF.V3.canvas_id(work.id, file_set2.id)}\",
+                      \"type\": \"Annotation\"
+                    }
+                  ],
+                  \"type\": \"AnnotationPage\"
+                }
+              ],
+              \"label\": {
+                \"en\": [
+                  \"This should not be in the manifest\"
+                ]
+              },
+              \"type\": \"Canvas\",
+              \"width\": \"640\"
+            }
+          ]
+        ],
+        \"label\": {
+          \"en\": [
+            \"Test title\"
+          ]
+        },
+        \"requiredStatement\": {
+          \"label\": {
+            \"en\": [
+              \"Attribution\"
+            ]
+          },
+          \"value\": {
+            \"en\": [
+              \"Courtesy of Northwestern University Libraries\"
+            ]
+          }
+        },
+        \"type\": \"Manifest\",
+        \"@context\": \"http://iiif.io/api/presentation/3/context.json\"
+      }\
+      """
+
+      assert Generator.create_manifest(work) == json
+    end
+  end
+end

--- a/test/meadow/iiif/iiif_v2_test.exs
+++ b/test/meadow/iiif/iiif_v2_test.exs
@@ -1,12 +1,13 @@
-defmodule Meadow.IIIFTest do
+defmodule Meadow.IIIF.V2.Test do
   use Meadow.DataCase
   use Meadow.S3Case
   alias Meadow.Config
+  alias Meadow.IIIF
   alias Meadow.Utils.Pairtree
 
   import ExUnit.DocTest
 
-  doctest Meadow.IIIF, import: true
+  doctest Meadow.IIIF.V2, import: true
 
   @pyramid_bucket Config.pyramid_bucket()
 
@@ -23,7 +24,7 @@ defmodule Meadow.IIIFTest do
     end
 
     test "writes a IIIF manifest for a valid work to S3", %{work: work, destination: destination} do
-      assert {:ok, %{status_code: 200}} = Meadow.IIIF.write_manifest(work.id)
+      assert {:ok, %{status_code: 200}} = IIIF.V2.write_manifest(work.id)
 
       with {:ok, result} <- ExAws.S3.head_object(@pyramid_bucket, destination) |> ExAws.request() do
         assert result.status_code == 200

--- a/test/meadow/iiif/iiif_v3_test.exs
+++ b/test/meadow/iiif/iiif_v3_test.exs
@@ -1,0 +1,35 @@
+defmodule Meadow.IIIF.V3.Test do
+  use Meadow.DataCase
+  use Meadow.S3Case
+  alias Meadow.Config
+  alias Meadow.IIIF
+  alias Meadow.Utils.Pairtree
+
+  import ExUnit.DocTest
+
+  doctest Meadow.IIIF.V3, import: true
+
+  @pyramid_bucket Config.pyramid_bucket()
+
+  describe "write_manifest/1" do
+    setup do
+      work = work_fixture(%{work_type: %{id: "VIDEO", scheme: "work_type"}})
+      destination = Pairtree.manifest_v3_key(work.id)
+
+      on_exit(fn ->
+        delete_object(@pyramid_bucket, destination)
+      end)
+
+      {:ok, work: work, destination: destination}
+    end
+
+    test "writes a IIIF manifest for a valid work to S3", %{work: work, destination: destination} do
+      assert {:ok, %{status_code: 200}} = IIIF.V3.write_manifest(work.id)
+
+      with {:ok, result} <- ExAws.S3.head_object(@pyramid_bucket, destination) |> ExAws.request() do
+        assert result.status_code == 200
+        assert result.headers |> Enum.member?({"Content-Type", "application/json"})
+      end
+    end
+  end
+end

--- a/test/meadow/iiif/manifest_listener_test.exs
+++ b/test/meadow/iiif/manifest_listener_test.exs
@@ -1,4 +1,4 @@
-defmodule Meadow.IIIF.ManifestListenerTest do
+defmodule Meadow.IIIF.V2.ManifestListenerTest do
   use Meadow.DataCase
   use Meadow.S3Case
 
@@ -11,11 +11,30 @@ defmodule Meadow.IIIF.ManifestListenerTest do
   @pyramid_bucket Config.pyramid_bucket()
 
   describe "handle_notification/4" do
-    test "writes a manifest to S3 when it receives a Postgres INSERT/UPDATE notification" do
-      work = work_fixture()
+    test "writes a 2.x manifest to S3 when it receives a Postgres INSERT/UPDATE notification for an IMAGE work" do
+      work = work_fixture(%{work_type: %{id: "IMAGE", scheme: "work_type"}})
       destination = Pairtree.manifest_key(work.id)
-      assert capture_log(fn -> ManifestListener.handle_notification(:works, :insert, %{id: work.id}, nil) end)
-               |> String.contains?("Writing manifest for #{work.id}")
+
+      assert capture_log(fn ->
+               ManifestListener.handle_notification(:works, :insert, %{id: work.id}, nil)
+             end)
+             |> String.contains?("Writing IIIF 2.1.x manifest for image: #{work.id}")
+
+      assert(object_exists?(@pyramid_bucket, destination))
+
+      on_exit(fn ->
+        delete_object(@pyramid_bucket, destination)
+      end)
+    end
+
+    test "writes a 3.x manifest to S3 when it receives a Postgres INSERT/UPDATE notification for an AUDIO or VIDEO work" do
+      work = work_fixture(%{work_type: %{id: "VIDEO", scheme: "work_type"}})
+      destination = Pairtree.manifest_v3_key(work.id)
+
+      assert capture_log(fn ->
+               ManifestListener.handle_notification(:works, :insert, %{id: work.id}, nil)
+             end)
+             |> String.contains?("Writing manifest IIIF 3.0.x for VIDEO: #{work.id}")
 
       assert(object_exists?(@pyramid_bucket, destination))
 
@@ -25,20 +44,19 @@ defmodule Meadow.IIIF.ManifestListenerTest do
     end
 
     test "fails gracefully when work is not found" do
-      assert {:noreply, nil} == ManifestListener.handle_notification(:works, :insert, %{id: Ecto.UUID.generate()}, nil)
+      assert {:noreply, nil} ==
+               ManifestListener.handle_notification(
+                 :works,
+                 :insert,
+                 %{id: Ecto.UUID.generate()},
+                 nil
+               )
     end
 
     test "ignores DELETE notification" do
       work = work_fixture()
       Repo.delete(work)
       ManifestListener.handle_notification(:works, :delete, %{id: work.id}, nil)
-    end
-
-    test "only writes manifests for the image work type" do
-      work = work_fixture(%{work_type: %{id: "VIDEO", scheme: "work_type"}})
-
-      assert capture_log(fn -> ManifestListener.handle_notification(:works, :insert, %{id: work.id}, nil) end)
-               |> String.contains?("Skipping manifest writing for non-image work #{work.id}")
     end
   end
 end

--- a/test/meadow/structural_metadata_listener_test.exs
+++ b/test/meadow/structural_metadata_listener_test.exs
@@ -4,9 +4,8 @@ defmodule Meadow.StructuralMetadataListenerTest do
   alias Meadow.Config
   alias Meadow.Data.FileSets
   alias Meadow.StructuralMetadataListener
-  alias Meadow.Utils.Pairtree
 
-  @streaming_bucket Config.streaming_bucket()
+  @pyramid_bucket Config.pyramid_bucket()
   @vtt """
   WEBVTT
 
@@ -23,26 +22,25 @@ defmodule Meadow.StructuralMetadataListenerTest do
       file_set_fixture()
       |> FileSets.update_file_set(%{structural_metadata: %{type: "webvtt", value: @vtt}})
 
-    location = Path.join(Pairtree.generate!(file_set.id), file_set.id <> ".vtt")
-    on_exit(fn -> delete_object(@streaming_bucket, location) end)
+    location = FileSets.vtt_location(file_set.id)
+    on_exit(fn -> delete_object(@pyramid_bucket, location) end)
     {:ok, %{file_set: file_set, location: location}}
   end
 
   describe "create structural metadata file" do
     test "when file set is updated", %{file_set: file_set, location: location} do
-      refute object_exists?(@streaming_bucket, location)
+      refute object_exists?(@pyramid_bucket, location)
       StructuralMetadataListener.handle_notification(:file_sets, :update, %{id: file_set.id}, nil)
-      assert object_exists?(@streaming_bucket, location)
-      assert object_size(@streaming_bucket, location) == byte_size(@vtt)
+      assert object_exists?(@pyramid_bucket, location)
+      assert object_size(@pyramid_bucket, location) == byte_size(@vtt)
     end
 
     test "when file set is created" do
       file_set = file_set_fixture(%{structural_metadata: %{type: "webvtt", value: @vtt}})
       StructuralMetadataListener.handle_notification(:file_sets, :create, %{id: file_set.id}, nil)
-      location = Path.join(Pairtree.generate!(file_set.id), file_set.id <> ".vtt")
 
-      assert object_exists?(@streaming_bucket, location)
-      assert object_size(@streaming_bucket, location) == byte_size(@vtt)
+      assert object_exists?(@pyramid_bucket, FileSets.vtt_location(file_set.id))
+      assert object_size(@pyramid_bucket, FileSets.vtt_location(file_set.id)) == byte_size(@vtt)
     end
   end
 
@@ -53,24 +51,24 @@ defmodule Meadow.StructuralMetadataListenerTest do
     end
 
     test "when structural_metadata.value is nil", %{file_set: file_set, location: location} do
-      assert object_exists?(@streaming_bucket, location)
+      assert object_exists?(@pyramid_bucket, location)
       file_set |> FileSets.update_file_set(%{structural_metadata: %{value: nil}})
       StructuralMetadataListener.handle_notification(:file_sets, :update, %{id: file_set.id}, nil)
-      refute object_exists?(@streaming_bucket, location)
+      refute object_exists?(@pyramid_bucket, location)
     end
 
     test "when structural_metadata is nil", %{file_set: file_set, location: location} do
-      assert object_exists?(@streaming_bucket, location)
+      assert object_exists?(@pyramid_bucket, location)
       file_set |> FileSets.update_file_set(%{structural_metadata: nil})
       StructuralMetadataListener.handle_notification(:file_sets, :update, %{id: file_set.id}, nil)
-      refute object_exists?(@streaming_bucket, location)
+      refute object_exists?(@pyramid_bucket, location)
     end
 
     test "when file set is deleted", %{file_set: file_set, location: location} do
-      assert object_exists?(@streaming_bucket, location)
+      assert object_exists?(@pyramid_bucket, location)
       file_set |> FileSets.delete_file_set()
       StructuralMetadataListener.handle_notification(:file_sets, :delete, %{id: file_set.id}, nil)
-      refute object_exists?(@streaming_bucket, location)
+      refute object_exists?(@pyramid_bucket, location)
     end
   end
 end


### PR DESCRIPTION
- Writes a IIIF v3 manifest for works with work_type VIDEO or AUDIO
  -  manifests are written to `/public/iiif3`
- Leaves image (v2) implementation alone (for now)
- Exposes the manifest url in GraphQL and Elasticsearch in the work's `manifest_url` property (same as v2 manifests)
- Moves `vtt` writing into the pyramids bucket instead of streaming bucket @ `/public/vtt`

Note: manifests aren't yet passing validation. 