### PR TITLE
Make default canvas width and height ints

### DIFF
--- a/lib/meadow/data/file_sets.ex
+++ b/lib/meadow/data/file_sets.ex
@@ -305,9 +305,9 @@ defmodule Meadow.Data.FileSets do
   Get the path for a structural metadata file (vtt) for a file set
   """
   def public_vtt_url_for(id) do
-    with uri <- URI.parse(Meadow.Config.iiif_server_url()) do
+    with uri <- URI.parse(Config.iiif_manifest_url()) do
       uri
-      |> URI.merge(vtt_location(id))
+      |> URI.merge("vtt/" <> Pairtree.generate!(id) <> "/" <> id <> ".vtt")
       |> URI.to_string()
     end
   end

--- a/lib/meadow/iiif/v3/presentation/canvas.ex
+++ b/lib/meadow/iiif/v3/presentation/canvas.ex
@@ -3,8 +3,8 @@ defmodule IIIF.V3.Presentation.Canvas do
   IIIF Presentation API 2.1.x Canvas resource
   """
   @rdf_type "Canvas"
-  @default_width "640"
-  @default_height "480"
+  @default_width 640
+  @default_height 480
 
   defstruct id: nil,
             type: @rdf_type,

--- a/test/meadow/iiif/generator_v3_test.exs
+++ b/test/meadow/iiif/generator_v3_test.exs
@@ -38,7 +38,7 @@ defmodule Meadow.IIIF.V3.GeneratorTest do
         \"items\": [
           [
             {
-              \"height\": \"480\",
+              \"height\": 480,
               \"id\": \"#{IIIF.V3.canvas_id(work.id, file_set.id)}\",
               \"items\": [
                 {
@@ -64,12 +64,12 @@ defmodule Meadow.IIIF.V3.GeneratorTest do
                 ]
               },
               \"type\": \"Canvas\",
-              \"width\": \"640\"
+              \"width\": 640
             }
           ],
           [
             {
-              \"height\": \"480\",
+              \"height\": 480,
               \"id\": \"#{IIIF.V3.canvas_id(work.id, file_set2.id)}\",
               \"items\": [
                 {
@@ -102,7 +102,7 @@ defmodule Meadow.IIIF.V3.GeneratorTest do
                 ]
               },
               \"type\": \"Canvas\",
-              \"width\": \"640\"
+              \"width\": 640
             }
           ]
         ],


### PR DESCRIPTION
- Fix staging vtt path (should not contain `/iiif/2`)
```
 iex(1)> Meadow.Config.iiif_manifest_url()
"https://iiif.stack.rdc-staging.library.northwestern.edu/public/"
iex(2)> Meadow.Config.iiif_server_url()
"https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/"
```
- Integers not strings for default widths and heights in manifest