### PR TITLE
Fix double nesting in manifest items array

### DIFF
--- a/lib/meadow/data/schemas/iiif/V3/work.ex
+++ b/lib/meadow/data/schemas/iiif/V3/work.ex
@@ -24,115 +24,120 @@ defimpl Meadow.IIIF.V3.Resource, for: Meadow.Data.Schemas.Work do
         label: %Label{en: ["Attribution"]},
         value: %Label{en: ["Courtesy of Northwestern University Libraries"]}
       },
-      items: [
-        work.file_sets
-        |> Enum.filter(&FileSets.access?/1)
-        |> Enum.map(fn file_set ->
-          %Canvas{
-            id: IIIF.V3.canvas_id(work.id, file_set.id),
-            label: %Label{en: [file_set.core_metadata.label]},
-            thumbnail:
-              case FileSets.representative_image_url_for(file_set) do
-                nil ->
-                  nil
-
-                thumbnail_url ->
-                  [
-                    %Thumbnail{
-                      id: thumbnail_url <> "/full/!300,300/0/default.jpg",
-                      type: "Image",
-                      format: "image/jpeg",
-                      height: 300,
-                      width: 300,
-                      service: [
-                        %Service{
-                          id: IIIF.V3.image_service_id(file_set.id, "posters"),
-                          profile: "http://iiif.io/api/image/2/level2.json",
-                          type: "ImageService2"
-                        }
-                      ]
-                    }
-                  ]
-              end,
-            items: [
-              %AnnotationPage{
-                id: IIIF.V3.annotation_page_id(work.id, file_set.id, "1"),
-                items: [
-                  %Annotation{
-                    id: IIIF.V3.annotation_id(work.id, file_set.id, "1", "1"),
-                    body: %Content{
-                      id: FileSets.distribution_streaming_uri_for(file_set),
-                      type: String.capitalize(resource_type(work_type)),
-                      format: file_set.core_metadata.mime_type,
-                      height: FileSets.height(file_set),
-                      width: FileSets.width(file_set),
-                      duration: duration_in_seconds(FileSets.duration_in_milliseconds(file_set))
-                    }
-                  },
-                  with %{type: "webvtt", value: _value} <- file_set.structural_metadata do
-                    %Annotation{
-                      id: IIIF.V3.annotation_id(work.id, file_set.id, "1", "2"),
-                      motivation: "supplementing",
-                      body: %Content{
-                        id: FileSets.public_vtt_url_for(file_set.id),
-                        type: "Text",
-                        format: "text/vtt",
-                        label: %Label{
-                          en: ["Transcript"]
-                        },
-                        language: "en"
-                      },
-                      target: IIIF.V3.canvas_id(work.id, file_set.id)
-                    }
-                  end
-                ]
-              }
-            ]
-          }
-        end),
-        work.file_sets
-        |> Enum.filter(&FileSets.auxiliary?/1)
-        |> Enum.map(fn file_set ->
-          %Canvas{
-            id: IIIF.V3.canvas_id(work.id, file_set.id),
-            label: %Label{en: [file_set.core_metadata.label]},
-            items: [
-              %AnnotationPage{
-                id: IIIF.V3.annotation_page_id(work.id, file_set.id, "1"),
-                items: [
-                  %Annotation{
-                    id: IIIF.V3.annotation_id(work.id, file_set.id, "1", "1"),
-                    body: %Content{
-                      id: IIIF.V3.image_id(file_set.id, "/full/max/0/default.jpg"),
-                      type: "Image",
-                      format: file_set.core_metadata.mime_type,
-                      height: FileSets.height(file_set),
-                      width: FileSets.width(file_set),
-                      service: [
-                        %Service{
-                          id: IIIF.V3.image_service_id(file_set.id),
-                          profile: "http://iiif.io/api/image/2/level2.json",
-                          type: "ImageService2"
-                        }
-                      ]
-                    },
-                    target: IIIF.V3.canvas_id(work.id, file_set.id)
-                  }
-                ]
-              }
-            ]
-          }
-        end)
-      ]
+      items: access_files(work) ++ auxiliary_files(work)
     }
   end
 
-  defp resource_type("AUDIO"), do: "Sound"
-  defp resource_type(work_type), do: work_type
+  defp access_files(work) do
+    work.file_sets
+    |> Enum.filter(&FileSets.access?/1)
+    |> Enum.map(fn file_set ->
+      %Canvas{
+        id: IIIF.V3.canvas_id(work.id, file_set.id),
+        label: %Label{en: [file_set.core_metadata.label]},
+        thumbnail:
+          case FileSets.representative_image_url_for(file_set) do
+            nil ->
+              nil
+
+            thumbnail_url ->
+              [
+                %Thumbnail{
+                  id: thumbnail_url <> "/full/!300,300/0/default.jpg",
+                  type: "Image",
+                  format: "image/jpeg",
+                  height: 300,
+                  width: 300,
+                  service: [
+                    %Service{
+                      id: IIIF.V3.image_service_id(file_set.id, "posters"),
+                      profile: "http://iiif.io/api/image/2/level2.json",
+                      type: "ImageService2"
+                    }
+                  ]
+                }
+              ]
+          end,
+        items: [
+          %AnnotationPage{
+            id: IIIF.V3.annotation_page_id(work.id, file_set.id, "1"),
+            items: [
+              %Annotation{
+                id: IIIF.V3.annotation_id(work.id, file_set.id, "1", "1"),
+                body: %Content{
+                  id: FileSets.distribution_streaming_uri_for(file_set),
+                  type: String.capitalize(resource_type(work.work_type.id)),
+                  format: file_set.core_metadata.mime_type,
+                  height: FileSets.height(file_set),
+                  width: FileSets.width(file_set),
+                  duration: duration_in_seconds(FileSets.duration_in_milliseconds(file_set))
+                }
+              },
+              with %{type: "webvtt", value: _value} <- file_set.structural_metadata do
+                %Annotation{
+                  id: IIIF.V3.annotation_id(work.id, file_set.id, "1", "2"),
+                  motivation: "supplementing",
+                  body: %Content{
+                    id: FileSets.public_vtt_url_for(file_set.id),
+                    type: "Text",
+                    format: "text/vtt",
+                    label: %Label{
+                      en: ["Transcript"]
+                    },
+                    language: "en"
+                  },
+                  target: IIIF.V3.canvas_id(work.id, file_set.id)
+                }
+              end
+            ]
+          }
+        ]
+      }
+    end)
+  end
+
+  defp auxiliary_files(work) do
+    work.file_sets
+    |> Enum.filter(&FileSets.auxiliary?/1)
+    |> Enum.map(fn file_set ->
+      %Canvas{
+        id: IIIF.V3.canvas_id(work.id, file_set.id),
+        label: %Label{en: [file_set.core_metadata.label]},
+        items: [
+          %AnnotationPage{
+            id: IIIF.V3.annotation_page_id(work.id, file_set.id, "1"),
+            items: [
+              %Annotation{
+                id: IIIF.V3.annotation_id(work.id, file_set.id, "1", "1"),
+                body: %Content{
+                  id: IIIF.V3.image_id(file_set.id, "/full/max/0/default.jpg"),
+                  type: "Image",
+                  format: file_set.core_metadata.mime_type,
+                  height: FileSets.height(file_set),
+                  width: FileSets.width(file_set),
+                  service: [
+                    %Service{
+                      id: IIIF.V3.image_service_id(file_set.id),
+                      profile: "http://iiif.io/api/image/2/level2.json",
+                      type: "ImageService2"
+                    }
+                  ]
+                },
+                target: IIIF.V3.canvas_id(work.id, file_set.id)
+              }
+            ]
+          }
+        ]
+      }
+    end)
+  end
 
   defp duration_in_seconds(nil), do: nil
   defp duration_in_seconds(duration) when duration > 0, do: duration / 1000
   defp duration_in_seconds(_), do: nil
+
+  def resource_type("AUDIO"), do: "Sound"
+  def resource_type(work_type), do: work_type
 
   defp manifest_label(%{descriptive_metadata: %{title: nil}}), do: nil
   defp manifest_label(%{descriptive_metadata: %{title: title}}), do: %Label{en: [title]}

--- a/lib/meadow/iiif/v2/iiif.ex
+++ b/lib/meadow/iiif/v2/iiif.ex
@@ -54,6 +54,9 @@ defmodule Meadow.IIIF.V2 do
     end
   end
 
+  def resource_type("AUDIO"), do: "Sound"
+  def resource_type(work_type), do: work_type
+
   defp write_to_s3(manifest, key) do
     ExAws.S3.put_object(
       Meadow.Config.pyramid_bucket(),

--- a/test/meadow/iiif/generator_v3_test.exs
+++ b/test/meadow/iiif/generator_v3_test.exs
@@ -36,75 +36,71 @@ defmodule Meadow.IIIF.V3.GeneratorTest do
       {
         \"id\": \"#{IIIF.V3.manifest_id(work.id)}\",
         \"items\": [
-          [
-            {
-              \"height\": 480,
-              \"id\": \"#{IIIF.V3.canvas_id(work.id, file_set.id)}\",
-              \"items\": [
-                {
-                  \"id\": \"#{IIIF.V3.annotation_page_id(work.id, file_set.id, 1)}\",
-                  \"items\": [
-                    {
-                      \"body\": {
-                        \"id\": \"https://test-streaming-url/bar.m3u8\",
-                        \"type\": \"Video\"
-                      },
-                      \"id\": \"#{IIIF.V3.annotation_id(work.id, file_set.id, 1, 1)}\",
-                      \"motivation\": \"painting\",
-                      \"type\": \"Annotation\"
+          {
+            \"height\": 480,
+            \"id\": \"#{IIIF.V3.canvas_id(work.id, file_set.id)}\",
+            \"items\": [
+              {
+                \"id\": \"#{IIIF.V3.annotation_page_id(work.id, file_set.id, 1)}\",
+                \"items\": [
+                  {
+                    \"body\": {
+                      \"id\": \"https://test-streaming-url/bar.m3u8\",
+                      \"type\": \"Video\"
                     },
-                    {}
-                  ],
-                  \"type\": \"AnnotationPage\"
-                }
-              ],
-              \"label\": {
-                \"en\": [
-                  \"This is the label\"
-                ]
-              },
-              \"type\": \"Canvas\",
-              \"width\": 640
-            }
-          ],
-          [
-            {
-              \"height\": 480,
-              \"id\": \"#{IIIF.V3.canvas_id(work.id, file_set2.id)}\",
-              \"items\": [
-                {
-                  \"id\": \"#{IIIF.V3.annotation_page_id(work.id, file_set2.id, 1)}\",
-                  \"items\": [
-                    {
-                      \"body\": {
-                        \"id\": \"http://localhost:8184/iiif/2/#{file_set2.id}/full/max/0/default.jpg\",
-                        \"service\": [
-                          {
-                            \"id\": \"http://localhost:8184/iiif/2/#{file_set2.id}\",
-                            \"profile\": \"http://iiif.io/api/image/2/level2.json\",
-                            \"type\": \"ImageService2\"
-                          }
-                        ],
-                        \"type\": \"Image\"
-                      },
-                      \"id\": \"#{IIIF.V3.annotation_id(work.id, file_set2.id, 1, 1)}\",
-                      \"motivation\": \"painting\",
-                      \"target\": \"#{IIIF.V3.canvas_id(work.id, file_set2.id)}\",
-                      \"type\": \"Annotation\"
-                    }
-                  ],
-                  \"type\": \"AnnotationPage\"
-                }
-              ],
-              \"label\": {
-                \"en\": [
-                  \"This should not be in the manifest\"
-                ]
-              },
-              \"type\": \"Canvas\",
-              \"width\": 640
-            }
-          ]
+                    \"id\": \"#{IIIF.V3.annotation_id(work.id, file_set.id, 1, 1)}\",
+                    \"motivation\": \"painting\",
+                    \"type\": \"Annotation\"
+                  },
+                  {}
+                ],
+                \"type\": \"AnnotationPage\"
+              }
+            ],
+            \"label\": {
+              \"en\": [
+                \"This is the label\"
+              ]
+            },
+            \"type\": \"Canvas\",
+            \"width\": 640
+          },
+          {
+            \"height\": 480,
+            \"id\": \"#{IIIF.V3.canvas_id(work.id, file_set2.id)}\",
+            \"items\": [
+              {
+                \"id\": \"#{IIIF.V3.annotation_page_id(work.id, file_set2.id, 1)}\",
+                \"items\": [
+                  {
+                    \"body\": {
+                      \"id\": \"http://localhost:8184/iiif/2/#{file_set2.id}/full/max/0/default.jpg\",
+                      \"service\": [
+                        {
+                          \"id\": \"http://localhost:8184/iiif/2/#{file_set2.id}\",
+                          \"profile\": \"http://iiif.io/api/image/2/level2.json\",
+                          \"type\": \"ImageService2\"
+                        }
+                      ],
+                      \"type\": \"Image\"
+                    },
+                    \"id\": \"#{IIIF.V3.annotation_id(work.id, file_set2.id, 1, 1)}\",
+                    \"motivation\": \"painting\",
+                    \"target\": \"#{IIIF.V3.canvas_id(work.id, file_set2.id)}\",
+                    \"type\": \"Annotation\"
+                  }
+                ],
+                \"type\": \"AnnotationPage\"
+              }
+            ],
+            \"label\": {
+              \"en\": [
+                \"This should not be in the manifest\"
+              ]
+            },
+            \"type\": \"Canvas\",
+            \"width\": 640
+          }
         ],
         \"label\": {
           \"en\": [


### PR DESCRIPTION
<img width="612" alt="Screen Shot 2021-10-04 at 11 29 15 AM" src="https://user-images.githubusercontent.com/6372022/135899909-7248f52b-0ffe-416a-8aa3-c166399eab5b.png">

<hr>

- This should fix the double nesting @mathewjordan noticed.
- Here is a gist of a new manifest I created in my dev environment w/out the double nesting: https://gist.github.com/kdid/12164c5e861dc8a425765a3dcae4434c
- Nesting should look like this sample: https://github.com/nulib/react-media-player/blob/main/src/manifests/sample.json