### PR TITLE
Remove unnecessary update to metadata on form submit

### DIFF
--- a/assets/js/components/Work/Tabs/Administrative/Administrative.jsx
+++ b/assets/js/components/Work/Tabs/Administrative/Administrative.jsx
@@ -44,25 +44,9 @@ const WorkTabsAdministrative = ({ work }) => {
     });
   const { projectCycle } = administrativeMetadata;
 
-  useEffect(() => {
-    // Update a Work after the form has been submitted
-    let resetValues = {};
-    for (let group of [PROJECT_METADATA]) {
-      for (let obj of group) {
-        resetValues[obj.name] = administrativeMetadata[obj.name][0];
-      }
-    }
-    methods.reset({
-      ...resetValues,
-      projectCycle: administrativeMetadata.projectCycle,
-    });
-  }, [work]);
-
   const onSubmit = (data) => {
-    let currentFormValues = methods.getValues();
-    console.log(`currentFormValues`, currentFormValues);
-
-    let workUpdateInput = {
+    const currentFormValues = methods.getValues();
+    const workUpdateInput = {
       administrativeMetadata: {
         libraryUnit: currentFormValues.libraryUnit
           ? { id: currentFormValues.libraryUnit, scheme: "LIBRARY_UNIT" }


### PR DESCRIPTION
# Summary 
Removes unnecessary manual update code on the Work Administrative tab when a form submits.  This was creating a timing issue, where our manual update (not even sure why that was ever put in place, probably copy and pasted over), was firing before the GraphQL callback function which runs after the Mutation has successfully processed (where we re-fetch the Work Query to get fresh data).

# Specific Changes in this PR
- Remove unnecessary code

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
1. Go to Work Administrative tab
2. Edit some data, click Save
3. Click Edit button again and verify saved data is reflected in the form elements as current values

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `master` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

