### PR TITLE
Bump up mediainfo lambda timeout to 15 minutes

### DIFF
--- a/lib/meadow/pipeline/actions/extract_media_metadata.ex
+++ b/lib/meadow/pipeline/actions/extract_media_metadata.ex
@@ -14,7 +14,7 @@ defmodule Meadow.Pipeline.Actions.ExtractMediaMetadata do
   require Logger
 
   @actiondoc "Extract media metadata from FileSet"
-  @timeout 120_000
+  @timeout 900_000
 
   defp already_complete?(file_set, _) do
     with existing_metadata <-

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -93,8 +93,8 @@ module "mediainfo_function" {
   description = "Function to extract technical metadata from an A/V S3 object"
   role        = aws_iam_role.lambda_role.arn
   stack_name  = var.stack_name
-  memory_size = 512
-  timeout     = 120
+  memory_size = 1024
+  timeout     = 900
 
   tags = merge(
     var.tags,


### PR DESCRIPTION
# Summary 

`ExtractMediaMetadata` timing out at 2 minutes. Bump up timeout and memory on lambda, and the timeout on the Elixir action waiting for the response. 

# Specific Changes in this PR
- Increase timeout to 15 minutes in `mediainfo_function` Terraform
- Increase timeout to 15 minutes in `Meadow.Pipeline.Actions.ExtractMediaMetadata` action
- Increase `meadow-mediainfo` lambda memory to 1GB

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Reingest this sheet (change accession numbers) https://meadow.rdc-staging.library.northwestern.edu/project/cecdc982-21f1-4ad2-b939-34181c67faff/ingest-sheet/c08d9823-2218-49db-9dbb-874cfccfcd84

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `master` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [x] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

