### PR TITLE
Increase visibility timeout for mediainfo extraction queue

### DIFF
--- a/config/sequins.exs
+++ b/config/sequins.exs
@@ -83,7 +83,7 @@ config :sequins, ExtractMediaMetadata,
     receive_interval: 1000,
     wait_time_seconds: 1,
     processor_concurrency: 1,
-    visibility_timeout: 300
+    visibility_timeout: 960
   ],
   notify_on: [ExtractMediaMetadata: [status: :retry]]
 


### PR DESCRIPTION
# Summary 

Ingest sheets with audio and video files are timing out during mediainfo extraction. Assets currently being tested are taking 6-7 minutes to complete this step.

# Specific Changes in this PR
- update `visibility_timeout` on medianfo SQS queue to `960`. (lambda and elixir action both have 15 minute timeouts)

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `master` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [x] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

