### PR TITLE
Use mediainfo lambda layer instead of mediainfo.js for extract mediainfo

### DIFF
--- a/config/sequins.exs
+++ b/config/sequins.exs
@@ -83,7 +83,7 @@ config :sequins, ExtractMediaMetadata,
     receive_interval: 1000,
     wait_time_seconds: 1,
     processor_concurrency: 1,
-    visibility_timeout: 960
+    visibility_timeout: 300
   ],
   notify_on: [ExtractMediaMetadata: [status: :retry]]
 

--- a/lib/meadow/pipeline/actions/extract_media_metadata.ex
+++ b/lib/meadow/pipeline/actions/extract_media_metadata.ex
@@ -14,7 +14,7 @@ defmodule Meadow.Pipeline.Actions.ExtractMediaMetadata do
   require Logger
 
   @actiondoc "Extract media metadata from FileSet"
-  @timeout 900_000
+  @timeout 240_000
 
   defp already_complete?(file_set, _) do
     with existing_metadata <-

--- a/priv/nodejs/mediainfo/index.js
+++ b/priv/nodejs/mediainfo/index.js
@@ -1,75 +1,45 @@
-const AWS = require('aws-sdk');
-const MediaInfo = require('mediainfo.js');
-const URI = require('uri-js');
+const AWS = require("aws-sdk");
+const URI = require("uri-js");
+const mediainfoPath = process.env.MEDIAINFO_PATH || "mediainfo";
+const util = require("util");
+const exec = util.promisify(require("child_process").exec);
 
-const makeCallbacks = (input) => {
-  const s3 = new AWS.S3();
+async function mediainfoVersion() {
+  const { stdout, _stderr } = await exec(`${mediainfoPath} --Version`);
+  return stdout.includes("- v")
+    ? stdout.substring(stdout.indexOf("- v") + 3).trim()
+    : "unknown";
+}
 
-  const getSize = () => {
-    return new Promise((resolve, reject) => {
-      s3.headObject(input, (err, data) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(data.ContentLength);
-        };
-      })
-    });  
-  };
+async function extractMediainfoMetadata(url) {
+  const version = await mediainfoVersion();
 
-  const readChunk = (length, offset) => {
-    return new Promise((resolve, _reject) => {
-      if (length < 1) {
-        resolve("");
-      } else {
-        let params = {...input};
-    
-        if (typeof offset === 'number') {
-          let end = length ? offset + length - 1 : undefined;
-          params.Range = `bytes=${[offset, end].join('-')}`;
-        }
-    
-        s3.getObject(params, (err, data) => {
-          if (err) {
-            console.error(err);
-            resolve(undefined);
-          } else {
-            resolve(data.Body);
-          }
-        });
-      }
-    });
-  };
+  const { stdout, _stderr } = await exec(
+    `${mediainfoPath} --Full --Output=JSON "${url}"`
+  );
+  result = JSON.parse(stdout);
 
-  return { getSize, readChunk };
-};
-
-const handler = async (event, _context, _callback) => {
-  const analyzer = await MediaInfo();
-  const uri = URI.parse(event.source);
-  const s3Location = { 
-    Bucket: uri.host, 
-    Key: uri.path.replace(/^\/+/, "")
-  };
-  const { getSize, readChunk } = makeCallbacks(s3Location);
-  
-  try {
-    const objectSize = await getSize();
-    const result = await analyzer.analyzeData(() => objectSize, readChunk);
-
-    if (result === null || result === undefined) {
-      return null;
-    }
-  
+  if (result.media == null) {
+    throw "404 Not Found";
+  } else {
     return {
       tool: "mediainfo",
-      tool_version: require('mediainfo.js/package.json').version,
-      value: result
+      tool_version: version,
+      value: result,
     };
-  } catch(err) {
-    const message = err.code ? `${err.statusCode} ${err.code}` : err.toString();
-    throw new Error(`Cannot access ${event.source}: ${message}`);
+  }
+}
+
+const handler = async (event, _context) => {
+  const uri = URI.parse(event.source);
+  const s3Location = {
+    Bucket: uri.host,
+    Key: uri.path.replace(/^\/+/, ""),
   };
+  const s3 = new AWS.S3();
+  const url = s3.getSignedUrl("getObject", s3Location);
+
+  return await extractMediainfoMetadata(url);
 };
 
 module.exports = { handler };

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -93,8 +93,13 @@ module "mediainfo_function" {
   description = "Function to extract technical metadata from an A/V S3 object"
   role        = aws_iam_role.lambda_role.arn
   stack_name  = var.stack_name
-  memory_size = 1024
-  timeout     = 900
+  memory_size = 512
+  timeout     = 240
+  layers      = [aws_lambda_layer_version.mediainfo.arn]
+  environment = {
+    MEDIAINFO_PATH = "/opt/bin/mediainfo"
+  }
+
 
   tags = merge(
     var.tags,

--- a/terraform/layers.tf
+++ b/terraform/layers.tf
@@ -5,3 +5,11 @@ resource "aws_lambda_layer_version" "ffmpeg" {
   compatible_runtimes = ["nodejs14.x"]
   description         = "FFMPEG runtime for nodejs lambdas"
 }
+
+resource "aws_lambda_layer_version" "mediainfo" {
+  s3_bucket           = "nul-public"
+  s3_key              = "mediainfo_lambda_layer.zip"
+  layer_name          = "mediainfo"
+  compatible_runtimes = ["nodejs14.x"]
+  description         = "mediainfo binaries for nodejs lambdas from https://mediaarea.net/en/MediaInfo/Download/Lambda"
+}

--- a/test/pipeline/actions/extract_media_metadata_test.exs
+++ b/test/pipeline/actions/extract_media_metadata_test.exs
@@ -87,7 +87,7 @@ defmodule Meadow.Pipeline.Actions.ExtractMediaMetadataTest do
   describe "missing file" do
     test "process/2", %{missing_media_file_set_id: file_set_id} do
       assert {:error, message} = ExtractMediaMetadata.process(%{file_set_id: file_set_id}, %{})
-      assert message |> String.contains?("404 NotFound")
+      assert message |> String.contains?("404 Not Found")
 
       assert ActionStates.error?(file_set_id, ExtractMediaMetadata)
 


### PR DESCRIPTION
# Summary 

`mediainfo.js` was proving to be really slow in our lambda. Use https://mediaarea.net/en/MediaInfo/Download/Lambda instead. 

# Specific Changes in this PR
- Use Mediainfo AWS Lambda layer in the ExtractMediaMetadata action instead of `mediainfo.js`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- ingest sheets with various audio and video formats and expect not to see `ExtractMediaMetadata` timeout errors
- In the "Preservation" tab actions column, make sure the file set extracted metadata shows

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `master` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

