### PR TITLE
.mkv and .flac fail ingest sheet validation as access files

### DIFF
--- a/lib/meadow/ingest/validator.ex
+++ b/lib/meadow/ingest/validator.ex
@@ -390,13 +390,12 @@ defmodule Meadow.Ingest.Validator do
             ],
        do: true
 
-  defp mime_type_accepted?("IMAGE", "A", "image/" <> _rest), do: true
-  defp mime_type_accepted?("IMAGE", "P", "image/" <> _rest), do: true
-  defp mime_type_accepted?("VIDEO", "A", "video/" <> _rest), do: true
-  defp mime_type_accepted?("VIDEO", "P", "video/" <> _rest), do: true
-  defp mime_type_accepted?("AUDIO", "A", "audio/x-aiff" <> _rest), do: false
-  defp mime_type_accepted?("AUDIO", "A", "audio/" <> _rest), do: true
-  defp mime_type_accepted?("AUDIO", "P", "audio/" <> _rest), do: true
+  defp mime_type_accepted?("IMAGE", role, "image/" <> _rest) when role in ["A", "P"], do: true
+  defp mime_type_accepted?("VIDEO", "A", "video/x-matroska"), do: false
+  defp mime_type_accepted?("VIDEO", role, "video/" <> _rest) when role in ["A", "P"], do: true
+  defp mime_type_accepted?("AUDIO", "A", "audio/x-aiff"), do: false
+  defp mime_type_accepted?("AUDIO", "A", "audio/x-flac"), do: false
+  defp mime_type_accepted?("AUDIO", role, "audio/" <> _rest) when role in ["A", "P"], do: true
   defp mime_type_accepted?(_, _, _), do: false
 
   defp load_sheet(sheet_id) do


### PR DESCRIPTION
# Summary 

`.flac` files and `.mkv` files are not supported for ingest in Access (A) file set roles

# Specific Changes in this PR
- `.flac` file extension only accepted for AUDIO works in the "P" role
- `.mkv` file extension only accepted for VIDEO works in the "P" role

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Create an ingest sheet with a `.flac` file with role "A" for an AUDIO work and a `.mkv` file with role "A" for a VIDEO work
  - both should report validation errors
- Create an ingest sheet with a `.flac` file with role "P" for an AUDIO work and a `.mkv` file with role "P" for a VIDEO work
  - both should ingest successfully

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `master` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

