### PR TITLE
Use custom Meadow video presets for MediaConvert

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -71,9 +71,9 @@ config :meadow,
       %{NameModifier: "-medium", Preset: "meadow-audio-medium"}
     ],
     video: [
-      %{NameModifier: "-1080", Preset: "System-Avc_16x9_1080p_29_97fps_8500kbps"},
-      %{NameModifier: "-720", Preset: "System-Avc_16x9_720p_29_97fps_5000kbps"},
-      %{NameModifier: "-540", Preset: "System-Avc_16x9_540p_29_97fps_3500kbps"}
+      %{NameModifier: "-1080", Preset: "meadow-video-high"},
+      %{NameModifier: "-720", Preset: "meadow-video-medium"},
+      %{NameModifier: "-540", Preset: "meadow-video-low"}
     ]
   }
 


### PR DESCRIPTION
# Summary 
Use `meadow-video-(low|medium|high)` presets for video transcoding to avoid MediaConvert Pro Tier charges

# Specific Changes in this PR
- update `config.exs` to use new presets

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Unfortunately, this can't be tested locally; only on staging.

1. Run a video through the pipeline
2. Find the transcoding job in the [AWS MediaConvert Console](https://console.aws.amazon.com/mediaconvert/home#/jobs/list), click `Details`, and make sure all of the H.264 Output Groups have a Quality Tuning Level of `SINGLE_PASS_HQ`
3. Bonus: Check the Cost Explorer to make sure the job's Usage Type starts with `IAD-B-AVC-` and not `IAD-P-AVC-` (this may require @davidschober's help)

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `master` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [x] Other specific instructions/tasks
  - [x] Create `meadow-video-*` presets in AWS manually, because Terraform doesn't define a resource for it. (This is already done on both staging and production.)

# Tested/Verified
- [ ] End users/stakeholders

