### PR TITLE
Fileset upload, make accepted mime-types match what type of fileset …

### DIFF
--- a/assets/js/components/Work/Tabs/Preservation/FileSetForm.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/FileSetForm.jsx
@@ -2,12 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import UIFormInput from "@js/components/UI/Form/Input.jsx";
 import UIFormField from "@js/components/UI/Form/Field.jsx";
-import UIFormSelect from "@js/components/UI/Form/Select.jsx";
-import { useCodeLists } from "@js/context/code-list-context";
 
 function WorkTabsPreservationFileSetForm({ s3UploadLocation }) {
-  const codeLists = useCodeLists();
-
   return (
     <>
       {s3UploadLocation && (
@@ -42,16 +38,6 @@ function WorkTabsPreservationFileSetForm({ s3UploadLocation }) {
               data-testid="fileset-description-input"
               name="description"
               placeholder="Description of the Fileset"
-            />
-          </UIFormField>
-
-          <UIFormField label="Role">
-            <UIFormSelect
-              isReactHookForm
-              name="fileSetRole"
-              label="Fileset Role"
-              options={codeLists.fileSetRoleData.codeList}
-              required
             />
           </UIFormField>
         </div>

--- a/assets/js/components/Work/Tabs/Preservation/FileSetModal.test.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/FileSetModal.test.jsx
@@ -7,11 +7,14 @@ import {
 import { AuthProvider } from "@js/components/Auth/Auth";
 import { getPresignedUrlForFileSetMock } from "@js/components/IngestSheet/ingestSheet.gql.mock";
 import { mockWork } from "@js/components/Work/work.gql.mock.js";
-import { screen, waitFor } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { getCurrentUserMock } from "@js/components/Auth/auth.gql.mock";
 import userEvent from "@testing-library/user-event";
 import { CodeListProvider } from "@js/context/code-list-context";
-import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
+import {
+  allCodeListMocks,
+  codeListFileSetRoleMock,
+} from "@js/components/Work/controlledVocabulary.gql.mock";
 
 let isModalOpen = true;
 
@@ -22,9 +25,10 @@ const handleClose = () => {
 describe("Add fileset to work modal", () => {
   beforeEach(() => {
     const Wrapped = withReactHookForm(FileSetModal, {
-      workId: mockWork.id,
-      isHidden: !isModalOpen,
       closeModal: handleClose,
+      isVisible: isModalOpen,
+      workId: mockWork.id,
+      workTypeId: mockWork.workType.id,
     });
     return renderWithRouterApollo(
       <AuthProvider>

--- a/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
@@ -327,6 +327,7 @@ const WorkTabsPreservation = ({ work }) => {
           closeModal={() => setIsAddFilesetModalVisible(false)}
           isVisible={isAddFilesetModalVisible}
           workId={work.id}
+          workTypeId={work.workType?.id}
         />
       </div>
       <div className="container buttons">

--- a/assets/js/components/Work/Tabs/Preservation/Preservation.test.js
+++ b/assets/js/components/Work/Tabs/Preservation/Preservation.test.js
@@ -8,6 +8,8 @@ import {
 } from "@js/components/Work/work.gql.mock";
 import { mockUser } from "@js/components/Auth/auth.gql.mock";
 import useIsAuthorized from "@js/hooks/useIsAuthorized";
+import { CodeListProvider } from "@js/context/code-list-context";
+import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
 
 jest.mock("@js/hooks/useIsAuthorized");
 useIsAuthorized.mockReturnValue({
@@ -17,9 +19,14 @@ useIsAuthorized.mockReturnValue({
 
 describe("WorkTabsPreservation component", () => {
   beforeEach(() => {
-    renderWithRouterApollo(<WorkTabsPreservation work={mockWork} />, {
-      mocks: [verifyFileSetsMock],
-    });
+    renderWithRouterApollo(
+      <CodeListProvider>
+        <WorkTabsPreservation work={mockWork} />
+      </CodeListProvider>,
+      {
+        mocks: [verifyFileSetsMock, ...allCodeListMocks],
+      }
+    );
   });
 
   it("renders the component and tab title", async () => {

--- a/assets/js/components/Work/controlledVocabulary.gql.mock.js
+++ b/assets/js/components/Work/controlledVocabulary.gql.mock.js
@@ -338,14 +338,24 @@ export const codeListFileSetRoleMock = {
     data: {
       codeList: [
         {
+          __typename: "CodedTerm",
           id: "A",
           label: "Access",
-          __typename: "CodedTerm",
         },
         {
+          __typename: "CodedTerm",
+          id: "X",
+          label: "Auxiliary",
+        },
+        {
+          __typename: "CodedTerm",
           id: "P",
           label: "Preservation",
+        },
+        {
           __typename: "CodedTerm",
+          id: "S",
+          label: "Supplemental",
         },
       ],
     },

--- a/assets/js/hooks/useAcceptedMimeTypes.js
+++ b/assets/js/hooks/useAcceptedMimeTypes.js
@@ -1,0 +1,119 @@
+// Good ref site:  https://www.digipres.org/formats/mime-types/
+
+export default function useAcceptedMimeTypes() {
+  function isFileValid(fileSetRole, workTypeId, mimeType) {
+    if (!fileSetRole || !workTypeId || !mimeType) {
+      return { isValid: false };
+    }
+
+    const mimeParts = mimeType.split("/");
+    const isImage = mimeParts[0] === "image";
+    const isAudio = mimeParts[0] === "audio";
+    const isVideo = mimeParts[0] === "video";
+    let code = "";
+    let message = "";
+    let isValid = true;
+
+    switch (fileSetRole) {
+      case "S":
+        return { code, message, isValid };
+
+      case "X":
+        if (!isImage) {
+          isValid = false;
+          code = "invalid-image";
+          message = "Auxiliary files can only be image mime types";
+        }
+        break;
+
+      case "A":
+        switch (workTypeId) {
+          case "IMAGE":
+            if (!isImage) {
+              isValid = false;
+              code = "invalid-image";
+              message =
+                "Image work types Access fileset roles must be image mime type";
+            }
+            break;
+          case "AUDIO":
+            if (mimeType.includes("aiff") || mimeType.includes("flac")) {
+              isValid = false;
+              code = "invalid-audio";
+              message =
+                "Audio work types Access filesets cannot be .aiff or .flac mime types";
+            } else if (!isAudio) {
+              isValid = false;
+              code = "invalid-audio";
+              message =
+                "Audio work types Access filesets must be audio mime type";
+            }
+            break;
+          case "VIDEO":
+            if (mimeType.includes("matroska")) {
+              isValid = false;
+              code = "invalid-video";
+              message =
+                "Video work types Access filesets cannot be *matroska mime type";
+            } else if (!isVideo) {
+              isValid = false;
+              code = "invalid-video";
+              message =
+                "Video work types Access filesets must be video mime type";
+            }
+            break;
+          default:
+            console.error(`Invalid work type id: ${workTypeId}`);
+            isValid = false;
+            code = "invalid-work-type";
+            message = "Work type is invalid";
+            break;
+        }
+        break;
+      case "P":
+        switch (workTypeId) {
+          case "IMAGE":
+            if (!isImage) {
+              isValid = false;
+              code = "invalid-image";
+              message =
+                "Image work types Preservation fileset roles must be image mime type";
+            }
+            break;
+          case "AUDIO":
+            if (!isAudio) {
+              isValid = false;
+              code = "invalid-audio";
+              message =
+                "Audio work types Preservation fileset roles must be audio mime type";
+            }
+            break;
+          case "VIDEO":
+            if (!isVideo) {
+              isValid = false;
+              code = "invalid-video";
+              message =
+                "Video work types Preservation fileset roles must be video mime type";
+            }
+            break;
+          default:
+            console.error(`Invalid work type id: ${workTypeId}`);
+            isValid = false;
+            code = "invalid-work-type";
+            message = "Work type is invalid";
+            break;
+        }
+        break;
+      default:
+        console.error(`Invalid file set role: ${fileSetRole}`);
+        isValid = false;
+        code = "invalid-fileset-role";
+        message = "Fileset role is invalid";
+        break;
+    }
+
+    return { code, isValid, message };
+  }
+
+  return { isFileValid };
+}

--- a/assets/js/hooks/useAcceptedMimeTypes.test.js
+++ b/assets/js/hooks/useAcceptedMimeTypes.test.js
@@ -1,0 +1,91 @@
+import useAcceptedMimeTypes from "./useAcceptedMimeTypes";
+
+describe("useAcceptedMimeTypes hook", () => {
+  beforeEach(() => {});
+  it("returns invalid with invalid Role or Work Type Id supplied", () => {
+    const { isFileValid } = useAcceptedMimeTypes();
+    const badRole = isFileValid("B", "AUDIO", "audio/mp3");
+    const badWorkType = isFileValid("A", "YO", "audio/mp3");
+    expect(badRole.isValid).toBeFalsy();
+    expect(badRole.code).toEqual("invalid-fileset-role");
+    expect(badWorkType.isValid).toBeFalsy();
+    expect(badWorkType.code).toEqual("invalid-work-type");
+  });
+
+  it("returns valid state for the supplemental role", () => {
+    const { isFileValid } = useAcceptedMimeTypes();
+    const result = isFileValid("S", "IMAGE", "application/*");
+    expect(result.isValid).toBeTruthy();
+  });
+
+  it("returns valid states for a auxiliary role", () => {
+    const { isFileValid } = useAcceptedMimeTypes();
+    const result = isFileValid("X", "IMAGE", "image/jpeg");
+    const resultBad = isFileValid("X", "IMAGE", "audio/mp3");
+    expect(result.isValid).toBeTruthy();
+    expect(resultBad.isValid).toBeFalsy();
+    expect(resultBad.code).toEqual("invalid-image");
+  });
+
+  describe("Access role", () => {
+    const { isFileValid } = useAcceptedMimeTypes();
+
+    it("returns valid states for Image work type", () => {
+      const result = isFileValid("A", "IMAGE", "image/tiff");
+      const resultBad = isFileValid("A", "IMAGE", "audio/tiff");
+      expect(result.isValid).toBeTruthy();
+      expect(resultBad.isValid).toBeFalsy();
+      expect(resultBad.code).toEqual("invalid-image");
+    });
+
+    it("returns valid states for Audio work type", () => {
+      const result = isFileValid("A", "AUDIO", "audio/wav");
+      const resultBad = isFileValid("A", "AUDIO", "audio/flac");
+      const resultBad2 = isFileValid("A", "AUDIO", "video/ogg");
+      expect(result.isValid).toBeTruthy();
+      expect(resultBad.isValid).toBeFalsy();
+      expect(resultBad.code).toEqual("invalid-audio");
+      expect(resultBad2.isValid).toBeFalsy();
+      expect(resultBad2.code).toEqual("invalid-audio");
+    });
+
+    it("returns valid states for Video work type", () => {
+      const result = isFileValid("A", "VIDEO", "video/wav");
+      const resultBad = isFileValid("A", "VIDEO", "video/x-matroska");
+      const resultBad2 = isFileValid("A", "VIDEO", "audio/ogg");
+      expect(result.isValid).toBeTruthy();
+      expect(resultBad.isValid).toBeFalsy();
+      expect(resultBad.code).toEqual("invalid-video");
+      expect(resultBad2.isValid).toBeFalsy();
+      expect(resultBad2.code).toEqual("invalid-video");
+    });
+  });
+
+  describe("Preservation role", () => {
+    const { isFileValid } = useAcceptedMimeTypes();
+
+    it("returns the correct mime types for Image work type", () => {
+      const result = isFileValid("P", "IMAGE", "image/tiff");
+      const resultBad = isFileValid("P", "IMAGE", "audio/tiff");
+      expect(result.isValid).toBeTruthy();
+      expect(resultBad.isValid).toBeFalsy();
+      expect(resultBad.code).toEqual("invalid-image");
+    });
+
+    it("returns the correct mime types for Audio work type", () => {
+      const result = isFileValid("P", "AUDIO", "audio/flac");
+      const resultBad = isFileValid("P", "AUDIO", "video/mp4");
+      expect(result.isValid).toBeTruthy();
+      expect(resultBad.isValid).toBeFalsy();
+      expect(resultBad.code).toEqual("invalid-audio");
+    });
+
+    it("returns the correct mime types for Video work type", () => {
+      const result = isFileValid("P", "VIDEO", "video/mp4");
+      const resultBad = isFileValid("P", "VIDEO", "audio/mp4");
+      expect(result.isValid).toBeTruthy();
+      expect(resultBad.isValid).toBeFalsy();
+      expect(resultBad.code).toEqual("invalid-video");
+    });
+  });
+});


### PR DESCRIPTION
…role has been selected

# Summary 
When uploading a fileset in the UI on the Preservation tab, we move the Role select dropdown to the beginning of the modal, and then only accept certain file mime types based on what fileset role the user selected.

# Specific Changes in this PR
- Fileset role moved to beginning of form and freezes once a file has been selected
- Options for what type of file can be uploaded is based on what type of fileset role has been selected.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
1. Go to a work
2. Preservation tab, click "Add fileset" button
3. Select "Supplemental" role, then open up the file picker.  Notice everything is allowed
4. Select "Auxiliary" role.  Notice you can only select files of mime type image.
5. Select "Access" role.  Notice you can only upload mime type images for IMAGE work types, mime type video for VIDEO work types, and mime type audio for AUDIO work types.

If you want to see the rules for what's accepted, go to this hook file:
```
assets/js/hooks/useAcceptedMimeTypes.js
```

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `master` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

