### PR TITLE
Supplemental role accepts all mime-types

### DIFF
--- a/lib/meadow/ingest/validator.ex
+++ b/lib/meadow/ingest/validator.ex
@@ -377,19 +377,8 @@ defmodule Meadow.Ingest.Validator do
   end
 
   defp mime_type_accepted?(_, "X", "image/" <> _rest), do: true
-  defp mime_type_accepted?(_, "S", "text/" <> _rest), do: true
 
-  defp mime_type_accepted?(_, "S", "application/" <> rest)
-       when rest in [
-              "json",
-              "xml",
-              "pdf",
-              "msword",
-              "vnd.ms-excel",
-              "vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-            ],
-       do: true
-
+  defp mime_type_accepted?(_, "S", _), do: true
   defp mime_type_accepted?("IMAGE", role, "image/" <> _rest) when role in ["A", "P"], do: true
   defp mime_type_accepted?("VIDEO", "A", "video/x-matroska"), do: false
   defp mime_type_accepted?("VIDEO", role, "video/" <> _rest) when role in ["A", "P"], do: true


### PR DESCRIPTION
# Summary 

Ingest sheet validation adjusted so that file sets of Supplemental (S) role should accept any mime-type. 

# Specific Changes in this PR
- Ingest sheet validation for "S" role now accepts anything and everything

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
- Create an ingest sheet with an "S" file that is any mime-type/file extension
- It should not report validation errors. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `master` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

