### PR TITLE
Update ARK record when work metadata changes

### DIFF
--- a/lib/meadow/application/children.ex
+++ b/lib/meadow/application/children.ex
@@ -13,6 +13,7 @@ defmodule Meadow.Application.Children do
       "csv_update_driver" => Meadow.CSVMetadataUpdateDriver,
       "index_worker" => {Meadow.Data.IndexWorker, interval: Config.index_interval()},
       "database_listeners" => [
+        Meadow.ARKListener,
         Meadow.FilesetDeleteListener,
         Meadow.IIIF.ManifestListener,
         Meadow.StructuralMetadataListener

--- a/lib/meadow/ark.ex
+++ b/lib/meadow/ark.ex
@@ -140,4 +140,25 @@ defmodule Meadow.Ark do
       {:error, error} -> {:error, error}
     end
   end
+
+  def put(attributes) do
+    put(struct!(__MODULE__, Enum.into(attributes, [])))
+  end
+
+  @doc """
+  Remove the ARK identifier
+
+  ## Examples:
+
+   iex> delete("ark:/99999/fk4n31617m")
+   {:ok,true}}
+
+   iex> delete("ark:/99999/fk4unknown")
+   {:error, "error: bad request - no such identifier"}
+  """
+  def delete(id) do
+    case Client.delete("/id/#{id}") do
+      {:ok, %{status_code: 200, body: body}} -> {:ok, Serializer.deserialize(body)}
+    end
+  end
 end

--- a/lib/meadow/ark_listener.ex
+++ b/lib/meadow/ark_listener.ex
@@ -1,0 +1,49 @@
+defmodule Meadow.ARKListener do
+  @moduledoc """
+  Listens to INSERTS/UPDATES on Postgrex.Notifications topic "works_changed" and writes
+  updates ARK metadata
+  """
+
+  use Meadow.DatabaseNotification, tables: [:works]
+  use Meadow.Utils.Logging
+  alias Meadow.Data.Works
+  require Logger
+
+  @impl true
+  def handle_notification(:works, :delete, %{id: _id}, state) do
+    {:noreply, state}
+  end
+
+  def handle_notification(:works, :insert, %{id: _id}, state) do
+    {:noreply, state}
+  end
+
+  def handle_notification(:works, _op, %{id: id}, state) do
+    with_log_metadata module: __MODULE__, id: id do
+      case Works.get_work!(id) do
+        nil -> :noop
+        work -> update_ark_metadata(work)
+      end
+    end
+
+    {:noreply, state}
+  rescue
+    Ecto.NoResultsError -> {:noreply, state}
+  end
+
+  defp update_ark_metadata(work) do
+    Logger.info(
+      "Updating ARK metadata for work: #{work.id}, with ark: #{work.descriptive_metadata.ark}"
+    )
+
+    case Works.update_ark_metatdata(work) do
+      {:ok, _result} ->
+        :noop
+
+      {:error, error_message} ->
+        Logger.error(
+          "Error updating ARK metadata for work: #{work.id}, with ark: #{work.descriptive_metadata.ark}. #{error_message}"
+        )
+    end
+  end
+end

--- a/lib/meadow/database_notification.ex
+++ b/lib/meadow/database_notification.ex
@@ -32,8 +32,21 @@ defmodule Meadow.DatabaseNotification do
   ## Creating the database notification triggers
 
   In order for the process to receive change notifications, the database has
-  to send them. #{__MODULE__} provides two functions to assist with the creation
-  (and destruction) of the necessary Postgres functions and triggers:
+  to send them.
+
+  It is currently not possible to have more than one trigger on a table,
+  each trigger listening for specific field/column changes.
+
+  So, first see if a database trigger already exists for the table you need
+  and confirm that it is listening for changes on :all fields
+  (or on the specific field you need).
+
+  Only if the trigger does not exist for the table would you need to create one.
+
+  #{__MODULE__} provides two functions to assist with the creation
+  (and destruction) of the necessary Postgres functions and triggers/
+
+  Create a database migration containing the trigger you need.
 
   ```
   defmodule MyDatabaseNotificationTrigger do


### PR DESCRIPTION
# Summary 

Update ARK record when work metadata changes.


When our ARK's are initially created, the status is set to `reserved`.  

Rules:

- when Meadow work is "published" and "open" or "authenticated"  visibility-> set ARK status to "public"
- when current ARK status is "public" and work is updated to "restricted" visibility or "published:false"-> set ARK status to "unavailable"
- when current ARK status is "reserved" or "unavailable" and work is updated to "restricted" or "published:false" -> leave ARK status as is


Note: Deleting/tombstoning broken out into this issue: https://github.com/nulib/repodev_planning_and_docs/issues/2315


# Specific Changes in this PR

- Creates an `ARKListener` to listen for notifications of works changed and updates the ARK metadata


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Create a work
- Update metadata and observe in the logs that ARKs are updated accordingly.
- Note that if you try to update a work you created in previous sessions on the dev environment, you may get an error if the ETS cache has been refreshed

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `master` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

