### PR TITLE
Add download all button to Work Preservation tab

### DIFF
--- a/assets/js/components/UI/Modal/DownloadAll.jsx
+++ b/assets/js/components/UI/Modal/DownloadAll.jsx
@@ -1,0 +1,166 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Button } from "@nulib/admin-react-components";
+import { IconDownload } from "@js/components/Icon";
+import classNames from "classnames";
+import UIFormField from "@js/components/UI/Form/Field";
+import useIsAuthorized from "@js/hooks/useIsAuthorized";
+import { WORK_ARCHIVER_ENDPOINT } from "@js/components/Work/work.gql";
+import { useQuery } from "@apollo/client";
+import { toastWrapper } from "@js/services/helpers";
+
+/** @jsx jsx */
+import { jsx } from "@emotion/react";
+import styled from "@emotion/styled";
+
+const Radio = styled.input`
+  margin-right: 3px;
+`;
+
+const UIDownloadAll = ({ workId }) => {
+  const [isModalVisible, setIsModalVisible] = React.useState(false);
+  const [width, setWidth] = React.useState("1500");
+  const { user } = useIsAuthorized();
+
+  const { loading, error, data } = useQuery(WORK_ARCHIVER_ENDPOINT);
+
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p>{error}</p>;
+
+  function handleCancelClick() {
+    setIsModalVisible(false);
+  }
+
+  function handleRadioChange(e) {
+    setWidth(e.target.value);
+  }
+
+  function handleSubmit() {
+    const url = data.workArchiverEndpoint.url;
+
+    // Keep this for local dev testing
+    const testStagingUrl =
+      "https://hqlgk8g5ja.execute-api.us-east-1.amazonaws.com/latest/archiver";
+    const testStagingWorkId = "b524801b-5f97-4ab1-a2b9-b590d9fe14e3";
+
+    fetch(
+      `${url}?${new URLSearchParams({
+        workId,
+        email: user.email,
+        width,
+      })}`,
+      {
+        method: "POST",
+      }
+    )
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(
+            "Bad network request posting to work archiver endpoint"
+          );
+        }
+        toastWrapper(
+          "is-success",
+          `Your images are being packaged and you'll receive an email shortly with a link to download.`
+        );
+        setIsModalVisible(false);
+      })
+      .catch((error) => console.error(`Error: ${error}`));
+  }
+
+  return (
+    <>
+      <Button
+        data-testid="download-all-button"
+        onClick={() => setIsModalVisible(true)}
+      >
+        <span className="icon">
+          <IconDownload />
+        </span>
+        <span>Download all</span>
+      </Button>
+
+      <div
+        className={classNames("modal", {
+          "is-active": isModalVisible,
+        })}
+        data-testid="download-all-modal"
+      >
+        <div className="modal-background"></div>
+        <div className="modal-card">
+          <div className="modal-card-head">
+            <p className="modal-card-title">Download all filesets</p>
+            <button
+              className="delete"
+              aria-label="close"
+              onClick={handleCancelClick}
+            ></button>
+          </div>
+          <section className="modal-card-body">
+            <UIFormField label="Email">
+              <p data-testid="email">{user.email}</p>
+            </UIFormField>
+
+            <UIFormField label="Select image width">
+              <div className="control" data-testid="radio-image-size">
+                <label className="radio">
+                  <Radio
+                    type="radio"
+                    name="width"
+                    value="1500"
+                    checked={width === "1500"}
+                    onChange={handleRadioChange}
+                  />
+                  1500
+                </label>
+                <label className="radio">
+                  <Radio
+                    type="radio"
+                    name="width"
+                    value="3000"
+                    checked={width === "3000"}
+                    onChange={handleRadioChange}
+                  />
+                  3000
+                </label>
+                <label className="radio">
+                  <Radio
+                    type="radio"
+                    name="width"
+                    value="full"
+                    checked={width === "full"}
+                    onChange={handleRadioChange}
+                  />
+                  full
+                </label>
+              </div>
+            </UIFormField>
+          </section>
+          <footer className="modal-card-foot buttons is-right">
+            <Button
+              isText
+              onClick={handleCancelClick}
+              aria-label="close"
+              data-testid="cancel-button"
+            >
+              Cancel
+            </Button>
+            <Button
+              isPrimary
+              onClick={handleSubmit}
+              data-testid="submit-button"
+            >
+              Start download job
+            </Button>
+          </footer>
+        </div>
+      </div>
+    </>
+  );
+};
+
+UIDownloadAll.propTypes = {
+  workId: PropTypes.string,
+};
+
+export default UIDownloadAll;

--- a/assets/js/components/UI/Modal/DownloadAll.test.js
+++ b/assets/js/components/UI/Modal/DownloadAll.test.js
@@ -1,0 +1,55 @@
+import { screen, render } from "@testing-library/react";
+import React from "react";
+import UIDownloadAll from "@js/components/UI/Modal/DownloadAll";
+import userEvent from "@testing-library/user-event";
+import { workArchiverEndpointMock } from "@js/components/Work/work.gql.mock";
+import { renderWithApollo } from "@js/services/testing-helpers";
+import useIsAuthorized from "@js/hooks/useIsAuthorized";
+import { mockUser } from "@js/components/Auth/auth.gql.mock";
+
+jest.mock("@js/hooks/useIsAuthorized");
+useIsAuthorized.mockReturnValue({
+  user: mockUser,
+  isAuthorized: () => true,
+});
+
+describe("UIDownloadAll component", () => {
+  beforeEach(() => {
+    renderWithApollo(<UIDownloadAll workId="asdf" />, {
+      mocks: [workArchiverEndpointMock],
+    });
+  });
+
+  it("renders the Download All button", async () => {
+    expect(await screen.findByTestId("download-all-button"));
+  });
+
+  it("toggles modal display", async () => {
+    const downloadButton = await screen.findByTestId("download-all-button");
+    const cancelButton = await screen.findByTestId("cancel-button");
+    const modalWrapper = await screen.findByTestId("download-all-modal");
+
+    userEvent.click(downloadButton);
+    expect(modalWrapper).toHaveClass("is-active");
+
+    userEvent.click(cancelButton);
+    expect(modalWrapper).not.toHaveClass("is-active");
+
+    userEvent.click(downloadButton);
+    expect(modalWrapper).toHaveClass("is-active");
+  });
+
+  it("renders user email", async () => {
+    expect(await screen.findByTestId("email"));
+  });
+
+  it("renders radio buttons for IIIF image sizes", async () => {
+    const radioWrapperEl = await screen.findByTestId("radio-image-size");
+    expect(radioWrapperEl.childNodes).toHaveLength(3);
+  });
+
+  it("renders the submit and cancel buttons", async () => {
+    expect(await screen.findByTestId("cancel-button"));
+    expect(await screen.findByTestId("submit-button"));
+  });
+});

--- a/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
+++ b/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
@@ -45,7 +45,7 @@ function ImageButtons({ iiifServerUrl, fileSet }) {
           <span className="icon">
             <IconDownload />
           </span>{" "}
-          <span>TIFF</span>
+          <span>TIF</span>
         </a>
       </p>
       <p className="control">

--- a/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
@@ -26,12 +26,14 @@ import {
   IconCheck,
   IconCopyToClipboard,
   IconDelete,
+  IconDownload,
   IconTrashCan,
   IconView,
 } from "@js/components/Icon";
 import UIDropdown from "@js/components/UI/Dropdown";
 import UIDropdownItem from "@js/components/UI/DropdownItem";
 import UIIconText from "@js/components/UI/IconText";
+import DownloadAll from "@js/components/UI/Modal/DownloadAll";
 
 const WorkTabsPreservation = ({ work }) => {
   if (!work) return null;
@@ -205,8 +207,8 @@ const WorkTabsPreservation = ({ work }) => {
   return (
     <div data-testid="preservation-tab">
       <UITabsStickyHeader title="Preservation and Access">
-        <AuthDisplayAuthorized>
-          <div className="buttons is-right">
+        <div className="buttons is-right">
+          <AuthDisplayAuthorized>
             <Button
               data-testid="button-new-file-set"
               isPrimary
@@ -219,8 +221,10 @@ const WorkTabsPreservation = ({ work }) => {
               </span>
               <span>Add a fileset</span>
             </Button>
-          </div>
-        </AuthDisplayAuthorized>
+          </AuthDisplayAuthorized>
+
+          {work?.workType?.id === "IMAGE" && <DownloadAll workId={work?.id} />}
+        </div>
       </UITabsStickyHeader>
       <div className="box mt-4">
         <div className="">

--- a/assets/js/components/Work/Tabs/Preservation/Preservation.test.js
+++ b/assets/js/components/Work/Tabs/Preservation/Preservation.test.js
@@ -5,6 +5,7 @@ import { renderWithRouterApollo } from "@js/services/testing-helpers";
 import {
   mockWork,
   verifyFileSetsMock,
+  workArchiverEndpointMock,
 } from "@js/components/Work/work.gql.mock";
 import { mockUser } from "@js/components/Auth/auth.gql.mock";
 import useIsAuthorized from "@js/hooks/useIsAuthorized";
@@ -24,7 +25,11 @@ describe("WorkTabsPreservation component", () => {
         <WorkTabsPreservation work={mockWork} />
       </CodeListProvider>,
       {
-        mocks: [verifyFileSetsMock, ...allCodeListMocks],
+        mocks: [
+          verifyFileSetsMock,
+          workArchiverEndpointMock,
+          ...allCodeListMocks,
+        ],
       }
     );
   });

--- a/assets/js/components/Work/Tabs/Structure/DownloadAll.jsx
+++ b/assets/js/components/Work/Tabs/Structure/DownloadAll.jsx
@@ -33,7 +33,7 @@ function WorkTabsStructureDownloadAll(props) {
         </div>
 
         <div className="column buttons has-text-right">
-          <button className="button">Download Tiffs</button>
+          <button className="button">Download Tifs</button>
           <button className="button">Download JPGs</button>
         </div>
       </div>

--- a/assets/js/components/Work/work.gql.js
+++ b/assets/js/components/Work/work.gql.js
@@ -481,6 +481,14 @@ export const UPDATE_ACCESS_MASTER_ORDER = gql`
   }
 `;
 
+export const WORK_ARCHIVER_ENDPOINT = gql`
+  query WorkArchiverEndpoint {
+    workArchiverEndpoint {
+      url
+    }
+  }
+`;
+
 export const UPDATE_FILE_SET = gql`
   mutation UpdateFileSet(
     $id: ID!

--- a/assets/js/components/Work/work.gql.mock.js
+++ b/assets/js/components/Work/work.gql.mock.js
@@ -4,6 +4,7 @@ import {
   GET_WORK,
   GET_WORK_TYPES,
   VERIFY_FILE_SETS,
+  WORK_ARCHIVER_ENDPOINT,
 } from "@js/components/Work/work.gql.js";
 import { mockVisibility, mockWorkType } from "@js/client-local";
 
@@ -502,6 +503,19 @@ export const verifyFileSetsMock = {
           verified: true,
         },
       ],
+    },
+  },
+};
+
+export const workArchiverEndpointMock = {
+  request: {
+    query: WORK_ARCHIVER_ENDPOINT,
+  },
+  result: {
+    data: {
+      workArchiverEndpoint: {
+        url: "http://mockendpoint.com/",
+      },
     },
   },
 };

--- a/assets/js/services/global-vars.js
+++ b/assets/js/services/global-vars.js
@@ -31,7 +31,7 @@ export const REACTIVESEARCH_SORT_OPTIONS = [
 export const IIIF_SIZES = {
   IIIF_SQUARE: "/square/500,500/0/default.jpg",
   IIIF_FULL: "/full/full/0/default.jpg",
-  IIIF_FULL_TIFF: "/full/full/0/default.tiff",
+  IIIF_FULL_TIFF: "/full/full/0/default.tif",
 };
 
 // Browser localStorage variable used to hold code lists


### PR DESCRIPTION
# Summary 
Add a download all button to Work preservation tab.  This kicks off a process where user receives an email with a download link.

# Specific Changes in this PR
- added the button and modal to select IIIF image width
- 
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
1. Go to an Image work type
2. Click "Preservation tab" and notice the Download All button.  Click and a modal should open
3. Go to a non Image work type
4. Repeat above process and notice Download All button does not display

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `master` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

