### PR TITLE
Put default work type value on select element when manually creating …

### DIFF
--- a/assets/js/components/Work/WorkForm.jsx
+++ b/assets/js/components/Work/WorkForm.jsx
@@ -15,11 +15,13 @@ const WorkForm = ({ showWorkForm, setShowWorkForm }) => {
   const [formError, setFormError] = useState();
   const methods = useForm();
   const history = useHistory();
+
   let {
     data: workTypeData,
     loading: workTypeLoading,
     error: workTypeError,
   } = useQuery(GET_WORK_TYPES);
+
   let [createWork, { loading, error: mutationError, data }] = useMutation(
     CREATE_WORK,
     {
@@ -40,6 +42,13 @@ const WorkForm = ({ showWorkForm, setShowWorkForm }) => {
       },
     }
   );
+
+  React.useEffect(() => {
+    // Because we're getting the <select> options values asynchronously
+    // need to manually set the default value once we get the data returned
+    if (!workTypeData) return;
+    methods.setValue("workType", workTypeData.codeList[0].id);
+  }, [workTypeData]);
 
   if (mutationError || workTypeError)
     return (
@@ -111,6 +120,7 @@ const WorkForm = ({ showWorkForm, setShowWorkForm }) => {
                   name="workType"
                   options={workTypeData?.codeList}
                   data-testid="work-type"
+                  required
                 />
               </UIFormField>
             </div>

--- a/assets/js/components/Work/WorkForm.test.jsx
+++ b/assets/js/components/Work/WorkForm.test.jsx
@@ -6,7 +6,7 @@ import {
   getWorkTypesMock,
 } from "@js/components/Work/work.gql.mock";
 import userEvent from "@testing-library/user-event";
-import { screen, within } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 
 describe("ProjectForm component", () => {
   beforeEach(() => {
@@ -34,5 +34,11 @@ describe("ProjectForm component", () => {
   it("displays input error when empty form is submitted", async () => {
     userEvent.click(screen.getByTestId("submit-button"));
     expect(await screen.findByTestId("input-errors"));
+  });
+
+  it("should give a default value for the work type select element", async () => {
+    const el = await screen.findByTestId("work-type");
+    const mockDefaultValue = getWorkTypesMock.result.data.codeList[0].id;
+    expect(el).toHaveValue(mockDefaultValue);
   });
 });


### PR DESCRIPTION
…a new Work from homepage

# Summary 
This handles the scenario when manually adding a work from the homepage, where the Work Type option values are fetched asynchronously.  Now after we get the data back from GraphQL, we manually set the value for Work Type to the first item in list of possible values.

![image](https://user-images.githubusercontent.com/3020266/139303548-35b5f3f1-b5fb-4366-9ad6-80d7387192ca.png)


# Specific Changes in this PR
- Account for asynchronous data fetching of form values for Work Type `select` `options`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
1. Go to homepage
2. Add a new work, click button for it
3. Enter values for Accession Number and Work Title, but don't touch Work Type
4. Submit form and it should create the work without error

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `master` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

