### PR TITLE
Move download all button to Structure tab from Preservation tab

### DIFF
--- a/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
@@ -222,8 +222,6 @@ const WorkTabsPreservation = ({ work }) => {
               <span>Add a fileset</span>
             </Button>
           </AuthDisplayAuthorized>
-
-          {work?.workType?.id === "IMAGE" && <DownloadAll workId={work?.id} />}
         </div>
       </UITabsStickyHeader>
       <div className="box mt-4">

--- a/assets/js/components/Work/Tabs/Preservation/Preservation.test.js
+++ b/assets/js/components/Work/Tabs/Preservation/Preservation.test.js
@@ -5,7 +5,6 @@ import { renderWithRouterApollo } from "@js/services/testing-helpers";
 import {
   mockWork,
   verifyFileSetsMock,
-  workArchiverEndpointMock,
 } from "@js/components/Work/work.gql.mock";
 import { mockUser } from "@js/components/Auth/auth.gql.mock";
 import useIsAuthorized from "@js/hooks/useIsAuthorized";
@@ -25,11 +24,7 @@ describe("WorkTabsPreservation component", () => {
         <WorkTabsPreservation work={mockWork} />
       </CodeListProvider>,
       {
-        mocks: [
-          verifyFileSetsMock,
-          workArchiverEndpointMock,
-          ...allCodeListMocks,
-        ],
+        mocks: [verifyFileSetsMock, ...allCodeListMocks],
       }
     );
   });

--- a/assets/js/components/Work/Tabs/Structure/Structure.jsx
+++ b/assets/js/components/Work/Tabs/Structure/Structure.jsx
@@ -17,6 +17,7 @@ import WorkFilesetList from "@js/components/Work/Fileset/List";
 import classNames from "classnames";
 import { IconEdit, IconSort } from "@js/components/Icon";
 import useFileSet from "@js/hooks/useFileSet";
+import DownloadAll from "@js/components/UI/Modal/DownloadAll";
 
 const parseWorkRepresentativeImage = (work) => {
   if (!work.representativeImage) return;
@@ -166,6 +167,8 @@ const WorkTabsStructure = ({ work }) => {
             </span>{" "}
             <span>Re-order</span>
           </Button>
+
+          {work?.workType?.id === "IMAGE" && <DownloadAll workId={work?.id} />}
         </UITabsStickyHeader>
 
         <div className="mt-4">

--- a/assets/js/components/Work/Work.test.js
+++ b/assets/js/components/Work/Work.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Work from "./Work";
 import { renderWithRouterApollo } from "@js/services/testing-helpers";
-import { mockWork } from "./work.gql.mock";
+import { mockWork, workArchiverEndpointMock } from "./work.gql.mock";
 import { iiifServerUrlMock } from "@js/components/IIIF/iiif.gql.mock";
 import { screen } from "@testing-library/react";
 import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
@@ -23,6 +23,7 @@ const mocks = [
   iiifServerUrlMock,
   getCollectionMock,
   getCollectionsMock,
+  workArchiverEndpointMock,
   ...allCodeListMocks,
 ];
 


### PR DESCRIPTION
# Summary 
Moves download all button from Preservation to Structure tab on Work screen

# Specific Changes in this PR
- Moves download all button from Preservation to Structure tab on Work screen

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Go to Work screen and notice the download all button only appears on the Structure tab

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `master` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

