### PR TITLE
Address player bugs, bump @nulib/react-media-player.

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -24,7 +24,7 @@
     "@honeybadger-io/js": "^3.2.5",
     "@honeybadger-io/react": "^1.0.1",
     "@nulib/admin-react-components": "^1.10.0",
-    "@nulib/react-media-player": "^1.1.2",
+    "@nulib/react-media-player": "^1.1.4",
     "@samvera/image-downloader": "^1.1.0",
     "bulma": "^0.9.3",
     "bulma-checkradio": "^1.1.1",

--- a/assets/yarn.lock
+++ b/assets/yarn.lock
@@ -1815,10 +1815,10 @@
   resolved "https://registry.yarnpkg.com/@nulib/prettier-config/-/prettier-config-1.2.0.tgz#c514ba973b18876935036a1998e5663b761cad2e"
   integrity sha512-TvNrkmyaqKiN2dkpkQG302qE0v91NPprFs+By3GpOyGHJ8cZHFKUDanhuSlt35pxvt40Bdb8ZnSLV7SsiVlS4w==
 
-"@nulib/react-media-player@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@nulib/react-media-player/-/react-media-player-1.1.2.tgz#9dc8eac87c628d12e0110f64450f2e2895a941c6"
-  integrity sha512-NnCa/aAAkQGSi1kndRhZViDj2T2irRcbYtUEjLO0hPdeZZsAZlDaOCU5Gsvnm3L5eKHg3LfRUBkllPsQ91Hsrg==
+"@nulib/react-media-player@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@nulib/react-media-player/-/react-media-player-1.1.4.tgz#b6078752ff7ba695f92ffc1f7a2df486af8b5692"
+  integrity sha512-8LbpGylAlO6w3PizAgY5grDQX1nPhS9Bwgqn4H3zfMso9pNZt1AUuo48jymoF3gdexUchwlLWm6Ep+pNZmedLA==
   dependencies:
     "@hyperion-framework/parser" "^1.0.0"
     "@hyperion-framework/types" "^1.0.0"


### PR DESCRIPTION
# Summary 
This bumps the @nulib/react-media-player up a few notches, fixing a few issues that were noted during the demo run through and earlier today.

# Specific Changes in this PR
- Fixes issue detecting media type on IIIF content resource type for **Sound**
- Fixes styling issue on active cue indicator in navigator
- Adjust label (Work Title) padding to fit better in consuming apps

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

1. Take a look at a Video work. A video work's navigator cues should render correctly with the VTT below
2. Jump into an audio work with one fileset, the player should load automatically with the audio resource ready to play.

Sample VTT
```
WEBVTT

00:00:02.000 --> 00:00:14.000
1. Consectetur Adipiscing

00:00:14.000 --> 00:00:26.000
2. Luctus Lobortis Dolor

00:00:26.000 --> 00:00:39.000
3. Dignissim Porttitor Nibh (Nec Consequat)

00:00:39.000 --> 00:00:49.000
4. Varius Euismod

00:00:55.000 --> 00:00:59.900
5.  Morbi Ullamcorper

```



# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `master` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

