### PR TITLE
Add FileSet count to homepage statistics

### DIFF
--- a/assets/js/hooks/useRepositoryStats.js
+++ b/assets/js/hooks/useRepositoryStats.js
@@ -13,6 +13,12 @@ const matchWork = {
   },
 };
 
+const matchFileSet = {
+  match: {
+    "model.name": "FileSet",
+  },
+};
+
 function query(matchItemsArray = []) {
   return {
     query: {
@@ -108,6 +114,7 @@ export default function useRepositoryStats() {
   const [stats, setStats] = React.useState({
     collections: 0,
     works: 0,
+    fileSets: 0,
     worksPublished: 0,
   });
 
@@ -121,6 +128,7 @@ export default function useRepositoryStats() {
     ])
   );
   const worksQuery = elasticsearchDirectCount(query([matchWork]));
+  const fileSetsQuery = elasticsearchDirectCount(query([matchFileSet]));
   const worksPublishedQuery = elasticsearchDirectCount(
     query([
       matchWork,
@@ -202,6 +210,7 @@ export default function useRepositoryStats() {
     const promises = [
       collectionsQuery,
       worksQuery,
+      fileSetsQuery,
       worksPublishedQuery,
       projectsQuery,
       visibilityQuery,
@@ -215,25 +224,26 @@ export default function useRepositoryStats() {
       setStats({
         collections: resultArray[0].count,
         works: resultArray[1].count,
-        worksPublished: resultArray[2].count,
-        ...(resultArray[3] && {
-          projects: getProjectsCount(
-            resultArray[3].aggregations.projects.buckets
-          ),
-        }),
+        fileSets: resultArray[2].count,
+        worksPublished: resultArray[3].count,
         ...(resultArray[4] && {
-          visibility: getVisbilityData(
-            resultArray[4].aggregations.visibilities.buckets
+          projects: getProjectsCount(
+            resultArray[4].aggregations.projects.buckets
           ),
         }),
         ...(resultArray[5] && {
-          worksCreatedByWeek: getWorksCreatedByWeek(
-            resultArray[5].aggregations.works_created_by_week.buckets
+          visibility: getVisbilityData(
+            resultArray[5].aggregations.visibilities.buckets
           ),
         }),
         ...(resultArray[6] && {
+          worksCreatedByWeek: getWorksCreatedByWeek(
+            resultArray[6].aggregations.works_created_by_week.buckets
+          ),
+        }),
+        ...(resultArray[7] && {
           collectionsRecentlyUpdated: getRecentCollections(
-            resultArray[6].aggregations.works_recently_updated.buckets
+            resultArray[7].aggregations.works_recently_updated.buckets
           ),
         }),
       });

--- a/assets/js/screens/Home/Home.jsx
+++ b/assets/js/screens/Home/Home.jsx
@@ -31,6 +31,10 @@ const ScreensHome = () => {
       title: stats.works,
     },
     {
+      heading: "File Sets",
+      title: stats.fileSets,
+    },
+    {
       heading: "Works Published",
       title: stats.worksPublished,
     },


### PR DESCRIPTION
# Summary 
Add the total FileSet count to homepage statistics, backed by a new Elasticsearch query

Screenshot (note: my dev environment doesn't contain any Collections, can ignore the `0`):
![Screen Shot 2021-10-29 at 10 55 53 AM](https://user-images.githubusercontent.com/1395707/139492059-18aa98a6-4ff0-4a09-80b5-93172bb6c12f.png)



# Version bump required by the PR

- [X] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
- Add FileSets to your development and check the homepage for an accurate stats count.
- The easiest way to check the FileSet count in the database is to run `Meadow.Repo.aggregate(FileSet, :count)` in an `iex` session.

# :rocket: Deployment Notes

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

