### PR TITLE
Update UI to display an empty string for blank Title and Terms of Use…

### DIFF
--- a/assets/js/components/IngestSheet/Completed.jsx
+++ b/assets/js/components/IngestSheet/Completed.jsx
@@ -43,9 +43,11 @@ const IngestSheetCompleted = ({ sheetId, title }) => {
   if (errorsError) return <Error error={errorsError} />;
   if (workCountError) return <Error error={workCountError} />;
 
-  const works = worksData.ingestSheetWorks.map((item) => {
-    return { workTypeId: item.workType.id, ...item };
-  });
+  const works = worksData.ingestSheetWorks.map(
+    ({ workType, id, representativeImage }) => {
+      return { workTypeId: workType.id, id, representativeImage };
+    }
+  );
   const handleClick = () => {
     history.push("/search", {
       externalFacet: {

--- a/assets/js/components/UI/PreviewItems.js
+++ b/assets/js/components/UI/PreviewItems.js
@@ -44,10 +44,10 @@ UIPreviewItems.propTypes = {
   items: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string,
-      representativeImage: PropTypes.shape({
-        fileSetId: PropTypes.string,
-        url: PropTypes.string,
-      }),
+      representativeImage: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.string,
+      ]),
       workTypeId: PropTypes.oneOf(["AUDIO", "IMAGE", "VIDEO"]).isRequired,
     })
   ),

--- a/assets/js/components/Work/Tabs/About/CoreMetadata.jsx
+++ b/assets/js/components/Work/Tabs/About/CoreMetadata.jsx
@@ -41,7 +41,7 @@ const WorkTabsAboutCoreMetadata = ({
               defaultValue={descriptiveMetadata.title}
             />
           ) : (
-            <p>{descriptiveMetadata.title || "No value"}</p>
+            <p>{descriptiveMetadata.title}</p>
           )}
         </UIFormField>
       </div>

--- a/assets/js/components/Work/Tabs/About/RightsMetadata.jsx
+++ b/assets/js/components/Work/Tabs/About/RightsMetadata.jsx
@@ -69,7 +69,7 @@ const WorkTabsAboutRightsMetadata = ({ descriptiveMetadata, isEditing }) => {
               defaultValue={descriptiveMetadata.termsOfUse}
             />
           ) : (
-            <p>{descriptiveMetadata.termsOfUse || "No value"}</p>
+            <p>{descriptiveMetadata.termsOfUse}</p>
           )}
         </UIFormField>
       </div>

--- a/assets/js/components/Work/Tabs/About/RightsMetadata.test.js
+++ b/assets/js/components/Work/Tabs/About/RightsMetadata.test.js
@@ -2,10 +2,10 @@ import React from "react";
 import {
   renderWithRouterApollo,
   withReactHookForm,
-} from "../../../../services/testing-helpers";
-import { mockWork } from "../../work.gql.mock";
+} from "@js/services/testing-helpers";
+import { mockWork } from "@js/components/Work/work.gql.mock";
 import WorkTabsAboutRightsMetadata from "./RightsMetadata";
-import { RIGHTS_METADATA } from "../../../../services/metadata";
+import { RIGHTS_METADATA } from "@js/services/metadata";
 import { screen } from "@testing-library/react";
 import { CodeListProvider } from "@js/context/code-list-context";
 import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";


### PR DESCRIPTION
Update UI to display an empty string for blank Title and Terms of Use fields in metadata form. 

# Summary 
Update UI to display an empty string for blank Title and Terms of Use fields in metadata form

# Specific Changes in this PR
- removed default values
- Made another update to the shape of what `PreviewItems` component expects

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
1. Go to a work with empty Title or Terms of Use fields
2. Notice no default values appear.

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `master` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

