### PR TITLE
Rename branch from master to main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ Also please let developers know if there are any special instructions to test th
 
 # :rocket: Deployment Notes
 
-**Note** - __if you check any of these boxes go to the [(always open) `master` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__
+**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__
 
 - Backward compatible API changes
   - [ ] Database Schema changes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,13 +198,13 @@ jobs:
     needs:
       - elixir-test
       - js-test
-    if: ${{ (!github.event.pull_request) && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/deploy/') || startsWith(github.ref, 'refs/heads/build/')) }}
+    if: ${{ (!github.event.pull_request) && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/deploy/') || startsWith(github.ref, 'refs/heads/build/')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set DEPLOY_ENV from Branch Name
         run: |
-          if [[ $BRANCH == 'refs/heads/master' ]]; then
+          if [[ $BRANCH == 'refs/heads/main' ]]; then
             echo "DEPLOY_ENV=production" >> $GITHUB_ENV
           else
             echo "DEPLOY_ENV=$(echo $BRANCH | awk -F/ '{print $NF}')" >> $GITHUB_ENV
@@ -215,7 +215,7 @@ jobs:
         run: echo "MEADOW_VERSION=$(grep '@app_version "' mix.exs | sed -n 's/^.*"\(.*\)".*/\1/p')" >> $GITHUB_ENV
       - run: echo "Building Meadow v${MEADOW_VERSION} as nulib/meadow:${DEPLOY_ENV}"
       - name: Tag Meadow Release
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           git config --global user.email "$(git log --pretty=format:"%ae" | head -1)"
           git config --global user.name "$(git log --pretty=format:"%an" | head -1)"
@@ -248,7 +248,7 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.REPO_PRIVATE_KEY }}
       - name: Push Release Tag
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           git push origin v${MEADOW_VERSION}
   deploy:
@@ -261,7 +261,7 @@ jobs:
           fetch-depth: 2
       - name: Set DEPLOY_ENV from Branch Name
         run: |
-          if [[ $BRANCH == 'refs/heads/master' ]]; then
+          if [[ $BRANCH == 'refs/heads/main' ]]; then
             echo "DEPLOY_ENV=production" >> $GITHUB_ENV
           else
             echo "DEPLOY_ENV=$(echo $BRANCH | awk -F/ '{print $NF}')" >> $GITHUB_ENV

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 node {
   def aws_region = "us-east-1"
   def tag_name = env.BRANCH_NAME.split('/').last()
-  if ( tag_name == "master" ) {
+  if ( tag_name == "main" ) {
     tag_name = "production"
   }
   checkout scm

--- a/assets/js/components/Work/Tabs/Structure/Structure.jsx
+++ b/assets/js/components/Work/Tabs/Structure/Structure.jsx
@@ -7,7 +7,7 @@ import {
   GET_WORK,
   SET_WORK_IMAGE,
   UPDATE_FILE_SETS,
-  UPDATE_ACCESS_MASTER_ORDER,
+  UPDATE_ACCESS_FILE_ORDER,
 } from "@js/components/Work/work.gql.js";
 import { toastWrapper } from "@js/services/helpers";
 import UITabsStickyHeader from "@js/components/UI/Tabs/StickyHeader";
@@ -67,7 +67,7 @@ const WorkTabsStructure = ({ work }) => {
       },
     }
   );
-  const [updateAccessMasterOrder] = useMutation(UPDATE_ACCESS_MASTER_ORDER, {
+  const [updateAccessFileOrder] = useMutation(UPDATE_ACCESS_FILE_ORDER, {
     onCompleted() {
       setIsReordering(false);
       toastWrapper(
@@ -87,7 +87,7 @@ const WorkTabsStructure = ({ work }) => {
   };
 
   const handleSaveReorder = (orderedFileSets = []) => {
-    updateAccessMasterOrder({
+    updateAccessFileOrder({
       variables: { workId: work.id, fileSetIds: orderedFileSets },
     });
   };

--- a/assets/js/components/Work/work.gql.js
+++ b/assets/js/components/Work/work.gql.js
@@ -473,9 +473,9 @@ export const INGEST_FILE_SET = gql`
   }
 `;
 
-export const UPDATE_ACCESS_MASTER_ORDER = gql`
-  mutation UpdateAccessMasterOrder($workId: ID!, $fileSetIds: [ID]) {
-    updateAccessMasterOrder(workId: $workId, fileSetIds: $fileSetIds) {
+export const UPDATE_ACCESS_FILE_ORDER = gql`
+  mutation UpdateAccessFileOrder($workId: ID!, $fileSetIds: [ID]) {
+    updateAccessFileOrder(workId: $workId, fileSetIds: $fileSetIds) {
       id
     }
   }

--- a/doc/architecture/decisions/0027-semantic-versioning.md
+++ b/doc/architecture/decisions/0027-semantic-versioning.md
@@ -14,13 +14,13 @@ Supersedes [24. Version Management](0024-version-management.md)
 
 ## Decision
 
-When merging from staging to master:
+When merging from staging to main:
 
 - Update the `@app_version` attribute in `mix.exs` on the staging branch:
   - Major version: Backward-incompatible database and/or API changes
   - Minor version: New features or backward-compatible database and/or API changes
   - Point version: All other changes
-- PR staging to master
+- PR staging to main
 - After CircleCI is finished building and deploying the new version, it will
   automatically tag the correct revision with the version number and push
   the tag to Github

--- a/doc/architecture/specs/ingest_pipeline.md
+++ b/doc/architecture/specs/ingest_pipeline.md
@@ -4,7 +4,7 @@
 
 ### Action
 
-A single idempotent unit of work performed on an Object as part of a pipeline. _Examples: Attach FileSet to Work, Create Derivatives, Move Master to Permanent Storage._
+A single idempotent unit of work performed on an Object as part of a pipeline. _Examples: Attach FileSet to Work, Create Derivatives, Move File to Permanent Storage._
 
 Every Action has three pieces:
 

--- a/lib/meadow/data/works.ex
+++ b/lib/meadow/data/works.ex
@@ -138,7 +138,7 @@ defmodule Meadow.Data.Works do
     |> add_representative_image()
   end
 
-  def get_access_masters(work_id) do
+  def get_access_files(work_id) do
     map = %{"id" => "A"}
 
     Repo.all(
@@ -620,7 +620,7 @@ defmodule Meadow.Data.Works do
 
   def set_default_representative_image(%Work{} = work) do
     work
-    |> set_representative_image(get_access_masters(work.id) |> List.first())
+    |> set_representative_image(get_access_files(work.id) |> List.first())
   end
 
   @doc """

--- a/lib/meadow_web/resolvers/data.ex
+++ b/lib/meadow_web/resolvers/data.ex
@@ -164,7 +164,7 @@ defmodule MeadowWeb.Resolvers.Data do
     end
   end
 
-  def update_access_master_order(
+  def update_access_file_order(
         _,
         %{work_id: work_id, file_set_ids: file_set_ids},
         _

--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -67,7 +67,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
       resolve(&Resolvers.Data.update_work/3)
     end
 
-    @desc "Set the representative FileSet (Access Master) for a Work"
+    @desc "Set the representative FileSet (Access or Auxiliary) for a Work"
     field :set_work_image, :work do
       arg(:work_id, non_null(:id))
       arg(:file_set_id, non_null(:id))
@@ -93,13 +93,13 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
       resolve(&Resolvers.Data.add_work_to_collection/3)
     end
 
-    @desc "Change the order of a work's access masters"
-    field :update_access_master_order, :work do
+    @desc "Change the order of a work's access files"
+    field :update_access_file_order, :work do
       arg(:work_id, non_null(:id))
       arg(:file_set_ids, list_of(:id))
       middleware(Middleware.Authenticate)
       middleware(Middleware.Authorize, "Editor")
-      resolve(&Resolvers.Data.update_access_master_order/3)
+      resolve(&Resolvers.Data.update_access_file_order/3)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Meadow.MixProject do
   use Mix.Project
 
-  @app_version "4.1.1"
+  @app_version "4.2.0"
 
   def project do
     [

--- a/test/gql/UpdateAccessFileOrder.gql
+++ b/test/gql/UpdateAccessFileOrder.gql
@@ -1,0 +1,8 @@
+mutation ($workId: ID!, $fileSetIds: [ID!]) {
+  updateAccessFileOrder(workId: $workId, fileSetIds: $fileSetIds) {
+    id
+    fileSets {
+      id
+    }
+  }
+}

--- a/test/gql/UpdateAccessMasterOrder.gql
+++ b/test/gql/UpdateAccessMasterOrder.gql
@@ -1,8 +1,0 @@
-mutation($workId: ID!, $fileSetIds: [ID!]) {
-  updateAccessMasterOrder(workId: $workId, fileSetIds: $fileSetIds) {
-    id
-    fileSets {
-      id
-    }
-  }
-}

--- a/test/meadow/data/works_test.exs
+++ b/test/meadow/data/works_test.exs
@@ -213,7 +213,7 @@ defmodule Meadow.Data.WorksTest do
       assert(is_nil(Works.get_work!(work.id) |> Map.get(:representative_image)))
     end
 
-    test "set_representative_image/2 with a preservation master does not set the representative image" do
+    test "set_representative_image/2 with a preservation file does not set the representative image" do
       work = work_with_file_sets_fixture(1, %{}, %{role: %{id: "P", scheme: "FILE_SET_ROLE"}})
       file_set = work.file_sets |> Enum.at(1)
 

--- a/test/meadow/iiif/generator_v2_test.exs
+++ b/test/meadow/iiif/generator_v2_test.exs
@@ -26,7 +26,7 @@ defmodule Meadow.IIIF.V2.GeneratorTest do
           role: %{id: "P", scheme: "FILE_SET_ROLE"},
           core_metadata: %{
             location: "foo",
-            description: "preservation master",
+            description: "preservation file",
             original_filename: "something",
             label: "This should not be in the manifest"
           }

--- a/test/meadow/iiif/generator_v3_test.exs
+++ b/test/meadow/iiif/generator_v3_test.exs
@@ -26,7 +26,7 @@ defmodule Meadow.IIIF.V3.GeneratorTest do
           role: %{id: "X", scheme: "FILE_SET_ROLE"},
           core_metadata: %{
             location: "foo",
-            description: "preservation master",
+            description: "preservation file",
             original_filename: "something",
             label: "This should not be in the manifest"
           }

--- a/test/meadow_web/schema/mutation/update_access_file_order_test.exs
+++ b/test/meadow_web/schema/mutation/update_access_file_order_test.exs
@@ -1,8 +1,8 @@
-defmodule MeadowWeb.Schema.Mutation.UpdateAccessMasterOrderTest do
+defmodule MeadowWeb.Schema.Mutation.UpdateAccessFileOrderTest do
   use MeadowWeb.ConnCase, acync: true
   use Wormwood.GQLCase
 
-  load_gql(MeadowWeb.Schema, "test/gql/UpdateAccessMasterOrder.gql")
+  load_gql(MeadowWeb.Schema, "test/gql/UpdateAccessFileOrder.gql")
 
   describe "mutation" do
     setup do
@@ -10,7 +10,7 @@ defmodule MeadowWeb.Schema.Mutation.UpdateAccessMasterOrderTest do
       {:ok, %{work: work, ids: work.file_sets |> Enum.map(& &1.id)}}
     end
 
-    test "changes the access master order", %{work: work, ids: ids} do
+    test "changes the access file order", %{work: work, ids: ids} do
       new_order = Enum.shuffle(ids)
 
       result =
@@ -22,7 +22,7 @@ defmodule MeadowWeb.Schema.Mutation.UpdateAccessMasterOrderTest do
       assert {:ok, query_data} = result
 
       with %{"id" => returned_work_id, "fileSets" => returned_file_sets} <-
-             get_in(query_data, [:data, "updateAccessMasterOrder"]) do
+             get_in(query_data, [:data, "updateAccessFileOrder"]) do
         assert returned_work_id == work.id
         assert returned_file_sets |> Enum.map(&Map.get(&1, "id")) == new_order
       end


### PR DESCRIPTION
# Summary 

Rename branch from master to main

Developers need to run the following in order to update their local git branchs

```
git fetch --prune -a
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

# Specific Changes in this PR

- update build/deployment code that looked to `master` to look to `main`
- remove references to "master" in code and change to "file"

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test

Developers need to run the following in order to update their local git branchs

```
git fetch --prune -a
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `master` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

