### PR TITLE
Add file set digests to Elasticsearch index

### DIFF
--- a/lib/meadow/indexing/file_set.ex
+++ b/lib/meadow/indexing/file_set.ex
@@ -10,6 +10,8 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.FileSet do
       accessionNumber: file_set.accession_number,
       createDate: file_set.inserted_at,
       description: file_set.core_metadata.description,
+      digests: file_set.core_metadata.digests,
+      extractedMetadata: ExtractedMetadata.transform(file_set.extracted_metadata),
       id: file_set.id,
       label: file_set.core_metadata.label,
       mime_type: file_set.core_metadata.mime_type,
@@ -18,12 +20,11 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.FileSet do
       posterOffset: file_set.poster_offset,
       rank: file_set.rank,
       representativeImageUrl: FileSets.representative_image_url_for(file_set),
-      streamingUrl: FileSets.distribution_streaming_uri_for(file_set),
       role: format(file_set.role),
+      streamingUrl: FileSets.distribution_streaming_uri_for(file_set),
       visibility: format(file_set.work.visibility),
+      webvtt: file_set.structural_metadata.value,
       workId: file_set.work.id,
-      extractedMetadata: ExtractedMetadata.transform(file_set.extracted_metadata),
-      webvtt: file_set.structural_metadata.value
     }
   end
 

--- a/test/meadow/data/indexer_test.exs
+++ b/test/meadow/data/indexer_test.exs
@@ -352,6 +352,7 @@ defmodule Meadow.Data.IndexerTest do
       assert doc |> get_in(["model", "application"]) == "Meadow"
       assert doc |> get_in(["model", "name"]) == "FileSet"
       assert doc |> get_in(["description"]) == subject.core_metadata.description
+      assert doc |> get_in(["digests"]) == subject.core_metadata.digests
       assert doc |> get_in(["label"]) == subject.core_metadata.label
       assert doc |> get_in(["posterOffset"]) == 100
       assert doc |> get_in(["webvtt"]) == subject.structural_metadata.value


### PR DESCRIPTION
# Summary 
Adds file set digests to Elasticsearch index for two reasons:
- Support the preservation name change (sha256 -> id)
- Good information to have in the document

# Specific Changes in this PR
- FileSet indexed with digests map

# Screenshot
![file_set_digests](https://user-images.githubusercontent.com/1395707/141183150-5f6aaa7d-0d79-4547-9e2c-b1beaed3b356.png)



# Version bump required by the PR

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test
Add a file set to Meadow and check the Elasticsearch index for the digests.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [x] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

