### PR TITLE
Up the fields limit

### DIFF
--- a/priv/elasticsearch/meadow.json
+++ b/priv/elasticsearch/meadow.json
@@ -1,7 +1,12 @@
 {
   "settings": {
     "index": {
-      "max_result_window": "50000"
+      "max_result_window": "50000",
+      "mapping": {
+        "total_fields": {
+          "limit": 1200
+        }
+      }
     },
     "analysis": {
       "analyzer": {
@@ -60,9 +65,9 @@
         {
           "ids": {
             "path_match": "*.id",
-            "mapping": { 
+            "mapping": {
               "type": "keyword",
-              "copy_to": ["all_controlled_terms"] 
+              "copy_to": ["all_controlled_terms"]
             }
           }
         },


### PR DESCRIPTION

# Summary 

We are exceeding the default Elasticsearch field limit of 1000.


# Specific Changes in this PR
- bump the field limit to 1200

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

 - Try to hot swap, see no errors
 - And: in `iex` call `Elasticsearch.get(Meadow.ElasticsearchCluster, "/_settings")` and look for `total_fields`.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

