### PR TITLE
Permissions to head objects and put object tagging in Meadow buckets

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -166,6 +166,8 @@ data "aws_iam_policy_document" "this_bucket_access" {
       "s3:PutObjectAcl",
       "s3:GetObject",
       "s3:DeleteObject",
+      "s3:HeadObject",
+      "s3:PutObjectTagging"
     ]
 
     resources = [


### PR DESCRIPTION

# Summary 

Permissions to head objects and put object tagging in Meadow buckets
Needed for renaming preservation files and storing checksums as tags rather than object metadata

# Specific Changes in this PR
- Terraform permissions necessary for preservation file tagging
- applied on staging

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

