### PR TITLE
Extract digest generation from pipeline to S3 (or Minio) event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,8 +143,16 @@ jobs:
           MINIO_ROOT_PASSWORD: minio123
           MINIO_ACCESS_KEY: minio
           MINIO_SECRET_KEY: minio123
+          MINIO_NOTIFY_WEBHOOK_ENABLE_checksum: on
+          MINIO_NOTIFY_WEBHOOK_ENDPOINT_checksum: http://minio-checksum:8000/fixity
         ports:
           - 9002:9000
+      minio-checksum:
+        image: nulib/minio-checksum
+        env:
+          AWS_ACCESS_KEY_ID: minio
+          AWS_SECRET_ACCESS_KEY: minio123
+          AWS_S3_ENDPOINT: http://minio:9000/
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
@@ -277,12 +277,14 @@ const WorkTabsPreservation = ({ work }) => {
                             </UIDropdownItem>
                             <UIDropdownItem
                               data-testid="button-copy-checksum"
-                              onClick={() =>
-                                clipboard.copy(fileset.coreMetadata.sha256)
-                              }
+                              onClick={() => {
+                                let digests = { ...fileset.coreMetadata.digests };
+                                delete digests["__typename"];
+                                return clipboard.copy(JSON.stringify(digests));
+                              }}
                             >
                               <UIIconText icon={<IconBinaryFile />}>
-                                Copy checksum (sha256) to clipboard
+                                Copy checksums to clipboard
                               </UIIconText>
                             </UIDropdownItem>
                             <UIDropdownItem

--- a/assets/js/components/Work/work.gql.js
+++ b/assets/js/components/Work/work.gql.js
@@ -215,7 +215,11 @@ export const GET_WORK = gql`
           location
           mimeType
           originalFilename
-          sha256
+          digests {
+            md5
+            sha1
+            sha256
+          }
         }
         extractedMetadata
         insertedAt
@@ -277,7 +281,11 @@ export const GET_WORKS = gql`
           originalFilename
           location
           label
-          sha256
+          digests {
+            md5
+            sha1
+            sha256
+          }
         }
         representativeImageUrl
         insertedAt
@@ -467,7 +475,11 @@ export const INGEST_FILE_SET = gql`
         label
         description
         original_filename
-        sha256
+        digests {
+          md5
+          sha1
+          sha256
+        }
       }
     }
   }

--- a/assets/js/components/Work/work.gql.mock.js
+++ b/assets/js/components/Work/work.gql.mock.js
@@ -155,7 +155,9 @@ export const mockWork = {
         label: "foo.tiff",
         mimeType: "image",
         originalFilename: "coffee.jpg",
-        sha256: "foobar",
+        digests: {
+          sha256: "foobar",
+        }
       },
       extractedMetadata:
         '{"exif": {"tool": "exifr", "tool_version": "6.1.1", "value": {"Artist":"Artist Name","BitsPerSample":{"0":8,"1":8,"2":8},"Compression":1,"Copyright":"In Copyright","FillOrder":1,"ImageDescription":"inu-wint-58.6, 8/20/07, 11:16 AM,  8C, 9990x9750 (0+3570), 125%, bent 6 b/w adj,  1/30 s, R43.0, G4.4, B12.6","ImageHeight":1024,"ImageWidth":1024,"Make":"Better Light","Model":"Model Super8K","Orientation":"Horizontal (normal)","PhotometricInterpretation":2,"PlanarConfiguration":1,"ResolutionUnit":"inches","SamplesPerPixel":3,"Software":"Adobe Photoshop CC 2015.5 (Windows)","XResolution":72,"YResolution":72}}}',
@@ -173,7 +175,9 @@ export const mockWork = {
         originalFilename: "coffee.jpg",
         location: "s3://bucket/foo/bar",
         label: "foo.tiff",
-        sha256: "foobar",
+        digests: {
+          sha256: "foobar",
+        }
       },
       extractedMetadata:
         '{"exif": {"tool": "exifr", "tool_version": "6.1.1", "value": {"Artist":"Artist Name","BitsPerSample":{"0":8,"1":8,"2":8},"Compression":1,"Copyright":"In Copyright","FillOrder":1,"ImageDescription":"inu-wint-58.6, 8/20/07, 11:16 AM,  8C, 9990x9750 (0+3570), 125%, bent 6 b/w adj,  1/30 s, R43.0, G4.4, B12.6","ImageHeight":1024,"ImageWidth":1024,"Make":"Better Light","Model":"Model Super8K","Orientation":"Horizontal (normal)","PhotometricInterpretation":2,"PlanarConfiguration":1,"ResolutionUnit":"inches","SamplesPerPixel":3,"Software":"Adobe Photoshop CC 2015.5 (Windows)","XResolution":72,"YResolution":72}}}',
@@ -190,7 +194,9 @@ export const mockWork = {
         location: "s3://bucket/foo/bar",
         mimeType: "image",
         label: "foo.tiff",
-        sha256: "foobar",
+        digests: {
+          sha256: "foobar",
+        }
       },
       insertedAt: "2020-04-12T10:01:01",
       updatedAt: "2020-04-18T09:01:01",
@@ -205,7 +211,9 @@ export const mockWork = {
         location: "s3://bucket/foo/bar",
         label: "foo.tiff",
         mimeType: "image",
-        sha256: "foobar",
+        digests: {
+          sha256: "foobar",
+        }
       },
       insertedAt: "2020-06-12T10:01:01",
       updatedAt: "2020-06-18T09:01:01",
@@ -324,8 +332,10 @@ const mockWork2 = {
           "s3://dev-preservation/0a/fa/26/f5/6b94a88f3a357a1fabec803412ebfaa8972c8f8784e25b723898035b3863f303",
         mimeType: "image",
         originalFilename: "painting7.JPG",
-        sha256:
-          "6b94a88f3a357a1fabec803412ebfaa8972c8f8784e25b723898035b3863f303",
+        digests: {
+          sha256:
+            "6b94a88f3a357a1fabec803412ebfaa8972c8f8784e25b723898035b3863f303",
+        }
       },
       role: { id: "A", label: "Access" },
       insertedAt: "2020-07-12T10:01:01",
@@ -340,8 +350,10 @@ const mockWork2 = {
         location:
           "s3://dev-preservation/38/62/0e/42/a2fe39ca86723eaecb9a6e2557c3daf4698e2e5d4b124c81ad557b5854376a5b",
         originalFilename: "painting5.JPG",
-        sha256:
-          "a2fe39ca86723eaecb9a6e2557c3daf4698e2e5d4b124c81ad557b5854376a5b",
+        digests: {
+          sha256:
+            "a2fe39ca86723eaecb9a6e2557c3daf4698e2e5d4b124c81ad557b5854376a5b",
+        }
       },
       role: { id: "A", label: "Access" },
     },
@@ -354,8 +366,10 @@ const mockWork2 = {
         location:
           "s3://dev-preservation/25/1a/0c/80/7c69abf311b0da097edc8c54d30e27b41b8fcbca7b5e962c86b8604c5072cfb6",
         originalFilename: "painting6.JPG",
-        sha256:
-          "7c69abf311b0da097edc8c54d30e27b41b8fcbca7b5e962c86b8604c5072cfb6",
+        digests: {
+          sha256:
+            "7c69abf311b0da097edc8c54d30e27b41b8fcbca7b5e962c86b8604c5072cfb6",
+        }
       },
       role: { id: "A", label: "Access" },
     },

--- a/assets/js/mock-data/filesets.js
+++ b/assets/js/mock-data/filesets.js
@@ -10,8 +10,10 @@ export const mockFileSets = [
       location:
         "s3://dev-preservation/45/22/6a/50/6be181760c0adb1f3425a0ae3438f3633b0baa9a6f74afa973c94ae6de6f45cb",
       mimeType: "image/jpeg",
-      sha256:
-        "6be181760c0adb1f3425a0ae3438f3633b0baa9a6f74afa973c94ae6de6f45cb",
+      digests: {
+        sha256:
+          "6be181760c0adb1f3425a0ae3438f3633b0baa9a6f74afa973c94ae6de6f45cb",
+      },
     },
   },
   {
@@ -27,8 +29,10 @@ export const mockFileSets = [
       location:
         "s3://dev-preservation/10/9b/9a/5c/1477fbefbeeb04f0d02ac3cbd9594df0d9e7edca993ec076272d7fea67ab26a8",
       mimeType: "image/jpeg",
-      sha256:
-        "1477fbefbeeb04f0d02ac3cbd9594df0d9e7edca993ec076272d7fea67ab26a8",
+      digests: {
+        sha256:
+          "1477fbefbeeb04f0d02ac3cbd9594df0d9e7edca993ec076272d7fea67ab26a8",
+      },
     },
   },
   {
@@ -44,8 +48,10 @@ export const mockFileSets = [
       location:
         "s3://dev-preservation/d4/14/d3/d4/f7f1324a418e2c7c6ef17c45fc14ec6ce5a6124e636cb96272a7f35dc72d9664",
       mimeType: "image/jpeg",
-      sha256:
-        "f7f1324a418e2c7c6ef17c45fc14ec6ce5a6124e636cb96272a7f35dc72d9664",
+      digests: {
+        sha256:
+          "f7f1324a418e2c7c6ef17c45fc14ec6ce5a6124e636cb96272a7f35dc72d9664",
+      },
     },
   },
 ];

--- a/assets/js/services/helpers.test.js
+++ b/assets/js/services/helpers.test.js
@@ -86,8 +86,10 @@ describe("Sort file sets", () => {
         label: "inu-fava-5145080-6.jpg",
         location:
           "s3://dev-preservation/23/57/ea/03/83397074acde5c737ede5ea7b09b267940d1ddba93eaef2456ae85c928e7abe2",
-        sha256:
-          "83397074acde5c737ede5ea7b09b267940d1ddba93eaef2456ae85c928e7abe2",
+        digests: {
+          sha256:
+            "83397074acde5c737ede5ea7b09b267940d1ddba93eaef2456ae85c928e7abe2",
+        },
       },
     },
     {
@@ -101,8 +103,10 @@ describe("Sort file sets", () => {
         label: "inu-fava-5145080-5.jpg",
         location:
           "s3://dev-preservation/26/35/7d/25/033a20e54f4ef254749c0e554e0378ba96242be159c7ed6e8d57810297423f69",
-        sha256:
-          "033a20e54f4ef254749c0e554e0378ba96242be159c7ed6e8d57810297423f69",
+        digests: {
+          sha256:
+            "033a20e54f4ef254749c0e554e0378ba96242be159c7ed6e8d57810297423f69",
+        },
       },
     },
     {
@@ -116,8 +120,10 @@ describe("Sort file sets", () => {
         label: "inu-fava-5145080-1.jpg",
         location:
           "s3://dev-preservation/06/07/a7/35/e3420d439e9770bdc804a19c559ca818120f67e81c303a92a33f774eab199056",
-        sha256:
-          "e3420d439e9770bdc804a19c559ca818120f67e81c303a92a33f774eab199056",
+        digests: {
+          sha256:
+            "e3420d439e9770bdc804a19c559ca818120f67e81c303a92a33f774eab199056",
+        },
       },
     },
   ];

--- a/config/config.exs
+++ b/config/config.exs
@@ -77,6 +77,11 @@ config :meadow,
     ]
   }
 
+# Configure checksum requirements
+config :meadow,
+  required_checksum_tags: ["computed-md5"],
+  checksum_wait_timeout: 3_600_000
+
 # Configures the pyramid TIFF processor
 with val <- System.get_env("PYRAMID_PROCESSOR") do
   unless is_nil(val), do: config(:meadow, pyramid_processor: val)

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -104,6 +104,12 @@ config :meadow,
   validation_ping_interval: System.get_env("VALIDATION_PING_INTERVAL", "1000"),
   work_archiver_endpoint: ""
 
+config :meadow,
+  checksum_notification: %{
+    arn: "arn:minio:sqs::checksum:webhook",
+    buckets: ["dev-ingest", "dev-uploads"]
+  }
+
 config :elastix,
   custom_headers: {Meadow.Utils.AWS, :add_aws_signature, ["us-east-1", "fake", "fake"]}
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -49,6 +49,14 @@ config :meadow,
   work_archiver_endpoint: ""
 
 config :meadow,
+  checksum_notification: %{
+    arn: "arn:minio:sqs::checksum:webhook",
+    buckets: ["test-ingest", "test-uploads"]
+  },
+  required_checksum_tags: ["computed-md5"],
+  checksum_wait_timeout: 5_000
+
+config :meadow,
   ark: %{
     default_shoulder: "ark:/12345/nu2",
     user: "mockuser",

--- a/lib/meadow/config.ex
+++ b/lib/meadow/config.ex
@@ -208,6 +208,12 @@ defmodule Meadow.Config do
 
   def meadow_version, do: @meadow_version
 
+  @doc "Retrieve checksum timeout"
+  def checksum_wait_timeout, do: Application.get_env(:meadow, :checksum_wait_timeout)
+
+  @doc "Retrieve required checksum tags"
+  def required_checksum_tags, do: Application.get_env(:meadow, :required_checksum_tags)
+
   defp configured_integer_value(key, default \\ 0) do
     case Application.get_env(:meadow, key, default) do
       n when is_binary(n) -> String.to_integer(n)

--- a/lib/meadow/pipeline.ex
+++ b/lib/meadow/pipeline.ex
@@ -4,11 +4,22 @@ defmodule Meadow.Pipeline do
   """
   use Sequins.Pipeline
 
+  alias Meadow.Config
   alias Meadow.Data.{ActionStates, FileSets}
   alias Meadow.Data.Schemas.FileSet
   alias Meadow.Pipeline.Actions.Dispatcher
+  alias Meadow.Utils.AWS
+
+  import WaitForIt
 
   def ingest_file_set(attrs \\ %{}) do
+    case wait_for_checksum_tags(attrs) do
+      :ok -> do_ingest_file_set(attrs)
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+
+  defp do_ingest_file_set(attrs) do
     case FileSets.create_file_set(attrs) do
       {:ok, file_set} ->
         kickoff(file_set, %{role: file_set.role.id})
@@ -29,6 +40,26 @@ defmodule Meadow.Pipeline do
 
     with initial_action <- List.first(actions) do
       initial_action.send_message(%{file_set_id: file_set_id}, context)
+    end
+  end
+
+  defp wait_for_checksum_tags(%{core_metadata: %{location: location}} = attrs) do
+    with %{host: bucket, path: "/" <> key} <- URI.parse(location) do
+      case wait(AWS.check_object_tags!(bucket, key, Config.required_checksum_tags()),
+             timeout: Config.checksum_wait_timeout(),
+             frequency: 1_000
+           ) do
+        {:ok, true} ->
+          :ok
+
+        {:timeout, timeout} ->
+          {:error,
+           FileSet.changeset(attrs)
+           |> Ecto.Changeset.add_error(
+             :checksums,
+             "Timed out after #{timeout}ms waiting for checksum tags"
+           )}
+      end
     end
   end
 end

--- a/lib/meadow/pipeline/actions/copy_file_to_preservation.ex
+++ b/lib/meadow/pipeline/actions/copy_file_to_preservation.ex
@@ -69,6 +69,11 @@ defmodule Meadow.Pipeline.Actions.CopyFileToPreservation do
           mime_type -> mime_type
         end
 
+      tagging =
+        file_set.core_metadata.digests
+        |> Enum.map(fn {tag, value} -> ["computed-#{tag}", value] |> Enum.join("=") end)
+        |> Enum.join("&")
+
       case ExAws.S3.put_object_copy(
              dest_bucket,
              dest_key,
@@ -77,8 +82,7 @@ defmodule Meadow.Pipeline.Actions.CopyFileToPreservation do
              content_type: content_type,
              metadata_directive: :REPLACE,
              meta: s3_metadata,
-             tagging:
-               "computed-sha1=#{file_set.core_metadata.digests["sha1"]}&computed-sha256=#{file_set.core_metadata.digests["sha256"]}",
+             tagging: tagging,
              tagging_directive: :REPLACE
            )
            |> ExAws.request() do

--- a/lib/meadow/release_tasks.ex
+++ b/lib/meadow/release_tasks.ex
@@ -4,6 +4,7 @@ defmodule Meadow.ReleaseTasks do
   """
 
   alias Meadow.Config
+  alias Meadow.Data.Indexer
 
   @app :meadow
   @modules [
@@ -34,7 +35,7 @@ defmodule Meadow.ReleaseTasks do
 
     if reindex? do
       Logger.info("Hot swapping Elasticsearch index #{Config.elasticsearch_index()}")
-      Meadow.Data.Indexer.hot_swap()
+      Indexer.hot_swap()
     end
   after
     resume!()

--- a/lib/meadow_web/schema/types/data/file_set_types.ex
+++ b/lib/meadow_web/schema/types/data/file_set_types.ex
@@ -148,15 +148,14 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
     field(:mime_type, :string)
     field(:original_filename, :string)
     field(:description, :string)
+    field(:digests, :digests)
+  end
 
-    field :sha256, :string do
-      resolve(fn metadata, _, _ ->
-        case metadata.digests do
-          nil -> {:ok, nil}
-          digests -> {:ok, digests["sha256"]}
-        end
-      end)
-    end
+  @desc "`digests` represents the possible digest hashes for a file set."
+  object :digests do
+    field :md5, :string, do: resolve(fn digests, _, _ -> {:ok, Map.get(digests, "md5")} end)
+    field :sha1, :string, do: resolve(fn digests, _, _ -> {:ok, Map.get(digests, "sha1")} end)
+    field :sha256, :string, do: resolve(fn digests, _, _ -> {:ok, Map.get(digests, "sha256")} end)
   end
 
   @desc "`file_set_structural_metadata` represents the structural metadata within a file set object."

--- a/lib/mix/tasks/meadow.ex
+++ b/lib/mix/tasks/meadow.ex
@@ -21,6 +21,9 @@ defmodule Mix.Tasks.Meadow.Buckets.Create do
       end
     end)
 
+    Application.get_env(:meadow, :checksum_notification, nil)
+    |> configure_bucket_notifications()
+
     with bucket <- Meadow.Config.pyramid_bucket() do
       policy =
         %{
@@ -45,6 +48,31 @@ defmodule Mix.Tasks.Meadow.Buckets.Create do
       bucket |> ExAws.S3.put_bucket_policy(policy) |> ExAws.request!()
     end
   end
+
+  defp configure_bucket_notifications(%{arn: notification_arn, buckets: buckets}) do
+    notification_configuration = """
+      <NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+        <QueueConfiguration>
+          <Event>s3:ObjectCreated:*</Event>
+          <Queue>#{notification_arn}</Queue>
+        </QueueConfiguration>
+      </NotificationConfiguration>
+    """
+
+    Enum.each(buckets, fn bucket ->
+      Logger.info("Configuring #{bucket} for fixity notification")
+
+      %ExAws.Operation.S3{
+        http_method: :put,
+        bucket: bucket,
+        resource: "notification",
+        body: notification_configuration
+      }
+      |> ExAws.request()
+    end)
+  end
+
+  defp configure_bucket_notifications(_), do: :noop
 end
 
 defmodule Mix.Tasks.Meadow.Reset do

--- a/mix.exs
+++ b/mix.exs
@@ -93,6 +93,7 @@ defmodule Meadow.MixProject do
       {:telemetry_metrics, "~> 0.4"},
       {:tzdata, "~> 1.1.0"},
       {:ueberauth_nusso, "~> 0.2.4"},
+      {:wait_for_it, "~> 1.3.0"},
       {:wormwood, "~> 0.1.0"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -93,6 +93,7 @@
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
   "unsafe": {:hex, :unsafe, "1.0.1", "a27e1874f72ee49312e0a9ec2e0b27924214a05e3ddac90e91727bc76f8613d8", [:mix], [], "hexpm", "6c7729a2d214806450d29766abc2afaa7a2cbecf415be64f36a6691afebb50e5"},
   "vex": {:hex, :vex, "0.8.0", "0a04e3aebe5ec443525c88f3833b4481d97de272f891243b62b18efbda85b121", [:mix], [], "hexpm", "36a37f264b36fe4b0430c9f174d71c59845cf56d9e2ae32960038432b16961ea"},
+  "wait_for_it": {:hex, :wait_for_it, "1.3.0", "9a96ff1994f7574844995cbe3f7ce7197411abeab4af85e8d2abba64171024cd", [:mix], [], "hexpm", "07c0d16af2e0b63271ac3d1d63ccbf27bbccd21090fa8d49157d451db55280e8"},
   "wormwood": {:hex, :wormwood, "0.1.3", "7dfd322ea33f74526f9c904693276a387b48daf6931020e02b9ca7cadeadc821", [:mix], [{:absinthe, "~> 1.4", [hex: :absinthe, repo: "hexpm", optional: false]}], "hexpm", "dcd8ca257b70065edaa4788a4ce006347dfa65d3a28adfcb99a7f71acacc265b"},
   "xml_builder": {:hex, :xml_builder, "2.2.0", "cc5f1eeefcfcde6e90a9b77fb6c490a20bc1b856a7010ce6396f6da9719cbbab", [:mix], [], "hexpm", "9d66d52fb917565d358166a4314078d39ef04d552904de96f8e73f68f64a62c9"},
 }

--- a/terraform/digest_event.tf
+++ b/terraform/digest_event.tf
@@ -1,0 +1,127 @@
+resource "aws_s3_bucket" "cloudtrail_events" {
+  bucket = "${var.stack_name}-${var.environment}-cloudtrail-logs"
+  acl    = "private"
+  tags   = var.tags
+
+  lifecycle_rule {
+    id      = "expire-daily"
+    enabled = true
+
+    noncurrent_version_expiration {
+      days = 1
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "cloudtrail_events_bucket_policy" {
+  bucket = aws_s3_bucket.cloudtrail_events.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid = "acl-check"
+        Effect = "Allow"
+        Principal = { 
+          Service = "cloudtrail.amazonaws.com"
+        }
+        Action = "s3:GetBucketAcl"
+        Resource = aws_s3_bucket.cloudtrail_events.arn
+      },
+      {
+        Sid = "write-events"
+        Effect = "Allow"
+        Principal = { 
+          Service = "cloudtrail.amazonaws.com"
+        }
+        Action = "s3:PutObject"
+        Resource = "${aws_s3_bucket.cloudtrail_events.arn}/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
+      }
+    ]
+  })
+}
+
+resource "aws_cloudtrail" "meadow_bucket_upload_trail" {
+  name           = "${var.stack_name}-upload-trail"
+  s3_bucket_name = aws_s3_bucket.cloudtrail_events.id
+  tags           = var.tags
+
+  event_selector {
+    read_write_type = "WriteOnly"
+    include_management_events = false
+    data_resource {
+      type = "AWS::S3::Object"
+      values = [
+        "${aws_s3_bucket.meadow_ingest.arn}/",
+        "${aws_s3_bucket.meadow_uploads.arn}/"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "fixity_function_caller" {
+  name = "${var.stack_name}-fixity-function-caller"
+  tags = var.tags
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "events.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  inline_policy {
+    name = "${var.stack_name}-allow-fixity-function"
+    policy = jsonencode({
+       Version  = "2012-10-17"
+       Statement = [
+         {
+           Effect   = "Allow"
+           Action   = "states:StartExecution"
+           Resource = "arn:aws:states:${var.aws_region}:${data.aws_caller_identity.current.account_id}:stateMachine:${var.fixity_function}"
+         }
+       ]
+    })
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "notify_fixity_function" {
+  name          = "${var.stack_name}-notify-fixity-function"
+  description   = "Notify fixity function when file is uploaded to certain buckets"
+  tags          = var.tags
+  event_pattern = jsonencode({
+    source        = ["aws.s3"]
+    "detail-type" = ["AWS API Call via CloudTrail"]
+    detail = {
+      eventSource = ["s3.amazonaws.com"]
+      eventName = ["PutObject", "CompleteMultipartUpload"]
+      requestParameters = {
+        "bucketName" = [
+          aws_s3_bucket.meadow_ingest.id,
+          aws_s3_bucket.meadow_uploads.id
+        ]
+      }
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "notify_fixity_function" {
+  rule      = aws_cloudwatch_event_rule.notify_fixity_function.name
+  target_id = "SendNotificationToFixityStepFuntion"
+  arn       = "arn:aws:states:${var.aws_region}:${data.aws_caller_identity.current.account_id}:stateMachine:${var.fixity_function}"
+  role_arn  = aws_iam_role.fixity_function_caller.arn
+
+  input_transformer {
+    input_paths = {
+      bucket = "$.detail.requestParameters.bucketName",
+      key = "$.detail.requestParameters.key"
+    }
+
+    input_template = "{\"Bucket\": <bucket>, \"Key\": <key>}"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -40,6 +40,10 @@ variable "deleted_object_expiration" {
   default = 180
 }
 
+variable "fixity_function" {
+  type = string
+}
+
 variable "geonames_username" {
   type = string
 }

--- a/test/gql/FileSetFields.frag.gql
+++ b/test/gql/FileSetFields.frag.gql
@@ -17,7 +17,9 @@ fragment FileSetFields on FileSet {
   }
   coreMetadata {
     description
-    sha256
+    digests {
+      md5
+    }
     label
     location
     originalFilename

--- a/test/meadow/bucket_notification_test.exs
+++ b/test/meadow/bucket_notification_test.exs
@@ -1,0 +1,51 @@
+defmodule Meadow.BucketNotificationTest do
+  use Meadow.S3Case
+  import Assertions
+
+  @test_content "Test Content"
+  @test_object "path/to/test-object"
+  @md5 "d65cdbadce081581e7de64a5a44b4617"
+  @sha1 "bebfefe6bd0a8175e99a83f217ed3d2dbfe55bc8"
+
+  describe "notifications" do
+    @tag s3: [%{bucket: "test-ingest", key: @test_object, content: @test_content}]
+    test "object uploaded to ingest bucket gets checksum tagged" do
+      assert_async(timeout: 2000, sleep_time: 150) do
+        with %{body: %{tags: tags}} <-
+               ExAws.S3.get_object_tagging("test-ingest", @test_object) |> ExAws.request!() do
+          assert tags |> length() >= 4
+          assert Enum.find(tags, &(&1.key == "computed-md5")) |> Map.get(:value) == @md5
+          assert Enum.find(tags, &(&1.key == "computed-sha1")) |> Map.get(:value) == @sha1
+
+          assert Enum.find(tags, &(&1.key == "computed-md5-last-modified"))
+                 |> Map.get(:value)
+                 |> String.match?(~r/^[0-9]+$/)
+
+          assert Enum.find(tags, &(&1.key == "computed-sha1-last-modified"))
+                 |> Map.get(:value)
+                 |> String.match?(~r/^[0-9]+$/)
+        end
+      end
+    end
+
+    @tag s3: [%{bucket: "test-uploads", key: @test_object, content: @test_content}]
+    test "object uploaded to uploads bucket gets checksum tagged" do
+      assert_async(timeout: 2000, sleep_time: 150) do
+        with %{body: %{tags: tags}} <-
+               ExAws.S3.get_object_tagging("test-uploads", @test_object) |> ExAws.request!() do
+          assert tags |> length() >= 4
+          assert Enum.find(tags, &(&1.key == "computed-md5")) |> Map.get(:value) == @md5
+          assert Enum.find(tags, &(&1.key == "computed-sha1")) |> Map.get(:value) == @sha1
+
+          assert Enum.find(tags, &(&1.key == "computed-md5-last-modified"))
+                 |> Map.get(:value)
+                 |> String.match?(~r/^[0-9]+$/)
+
+          assert Enum.find(tags, &(&1.key == "computed-sha1-last-modified"))
+                 |> Map.get(:value)
+                 |> String.match?(~r/^[0-9]+$/)
+        end
+      end
+    end
+  end
+end

--- a/test/meadow/pipeline_test.exs
+++ b/test/meadow/pipeline_test.exs
@@ -3,25 +3,38 @@ defmodule Meadow.Data.PipelineTest do
   Tests for Pipeline API
   """
   use Meadow.DataCase
+  use Meadow.S3Case
   use ExUnit.Case
 
+  alias Meadow.Config
   alias Meadow.Data.ActionStates
   alias Meadow.Data.Schemas.{ActionState, FileSet}
   alias Meadow.Pipeline
   alias Meadow.Pipeline.Actions.Dispatcher
+  alias Meadow.Utils.AWS
 
   import Assertions
+  import WaitForIt
+
+  @tiff_fixture File.read!("test/fixtures/coffee.tif")
+  @tiff_bucket Config.ingest_bucket()
+  @tiff_key "pipeline-test/coffee.tif"
+  @tiff_location "s3://#{@tiff_bucket}/#{@tiff_key}"
+
+  @s3_fixture %{bucket: @tiff_bucket, key: @tiff_key, content: @tiff_fixture}
+
+  @valid_attrs %{
+    accession_number: "12345",
+    role: %{id: "A", scheme: "FILE_SET_ROLE"},
+    core_metadata: %{
+      description: "yes",
+      location: @tiff_location,
+      original_filename: "test.tiff"
+    }
+  }
 
   describe "ingesting file set" do
-    @valid_attrs %{
-      accession_number: "12345",
-      role: %{id: "A", scheme: "FILE_SET_ROLE"},
-      core_metadata: %{
-        description: "yes",
-        location: "https://example.com",
-        original_filename: "test.tiff"
-      }
-    }
+    @describetag s3: [@s3_fixture]
 
     test "ingest_file_set/1 creates a file_set" do
       assert {:ok, %FileSet{} = _file_set} = Pipeline.ingest_file_set(@valid_attrs)
@@ -36,9 +49,9 @@ defmodule Meadow.Data.PipelineTest do
       preservation_attrs = %{
         accession_number: "12345",
         role: %{id: "A", scheme: "FILE_SET_ROLE"},
-        metadata: %{
+        core_metadata: %{
           description: "yes",
-          location: "https://example.com",
+          location: @tiff_location,
           original_filename: "test.tiff"
         }
       }
@@ -59,6 +72,40 @@ defmodule Meadow.Data.PipelineTest do
 
       ActionStates.get_states(file_set.id)
       |> Enum.each(fn action -> assert action.outcome == "waiting" end)
+    end
+  end
+
+  describe "checksum timeout" do
+    @describetag s3: [@s3_fixture]
+
+    setup do
+      wait(
+        AWS.check_object_tags!(
+          @tiff_bucket,
+          @tiff_key,
+          Config.required_checksum_tags()
+        ),
+        timeout: Config.checksum_wait_timeout(),
+        frequency: 250
+      )
+
+      ExAws.S3.delete_object_tagging(@tiff_bucket, @tiff_key)
+      |> ExAws.request!()
+
+      old_timeout = Application.get_env(:meadow, :checksum_wait_timeout)
+      Application.put_env(:meadow, :checksum_wait_timeout, 1_000)
+
+      on_exit(fn ->
+        Application.put_env(:meadow, :checksum_wait_timeout, old_timeout)
+      end)
+
+      :ok
+    end
+
+    test "ingest_file_set/1 times out waiting for checksums" do
+      assert {:error, %Ecto.Changeset{} = changeset} = Pipeline.ingest_file_set(@valid_attrs)
+      assert {message, []} = changeset |> Map.get(:errors) |> Keyword.get(:checksums)
+      assert message |> String.contains?("Timed out")
     end
   end
 end

--- a/test/pipeline/actions/generate_file_set_digests_test.exs
+++ b/test/pipeline/actions/generate_file_set_digests_test.exs
@@ -1,16 +1,19 @@
 defmodule Meadow.Pipeline.Actions.GenerateFileSetDigestsTest do
   use Meadow.S3Case
   use Meadow.DataCase
+  alias Meadow.Config
   alias Meadow.Data.{ActionStates, FileSets}
   alias Meadow.Pipeline.Actions.GenerateFileSetDigests
+  alias Meadow.Utils.AWS
   import ExUnit.CaptureLog
+  import WaitForIt
 
   @bucket "test-ingest"
   @key "generate_file_set_digests_test/test.tif"
   @content "test/fixtures/coffee.tif"
   @fixture %{bucket: @bucket, key: @key, content: File.read!(@content)}
-  @sha256 "509ecd36cbb1ba4dc57430de5418ad64cf106aa209ca839ef753fa853c972753"
   @sha1 "0f4e109d2a4c8f954e940ceb356b40bd393120d0"
+  @md5 "85062e8c916f55ae0c514cb0732cfb1f"
 
   setup do
     file_set =
@@ -23,6 +26,16 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigestsTest do
         }
       })
 
+    wait(
+      AWS.check_object_tags!(
+        @bucket,
+        @key,
+        Config.required_checksum_tags()
+      ),
+      timeout: Config.checksum_wait_timeout(),
+      frequency: 250
+    )
+
     {:ok, file_set_id: file_set.id}
   end
 
@@ -32,7 +45,7 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigestsTest do
     assert(ActionStates.ok?(file_set_id, GenerateFileSetDigests))
 
     file_set = FileSets.get_file_set!(file_set_id)
-    assert(file_set.core_metadata.digests == %{"sha256" => @sha256, "sha1" => @sha1})
+    assert(file_set.core_metadata.digests == %{"md5" => @md5, "sha1" => @sha1})
 
     assert capture_log(fn ->
              GenerateFileSetDigests.process(%{file_set_id: file_set_id}, %{})
@@ -44,7 +57,7 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigestsTest do
 
     setup %{file_set_id: file_set_id} do
       FileSets.get_file_set!(file_set_id)
-      |> FileSets.update_file_set(%{core_metadata: %{digests: %{sha1: @sha1, sha256: @sha256}}})
+      |> FileSets.update_file_set(%{core_metadata: %{digests: %{sha1: @sha1, md5: @md5}}})
 
       :ok
     end
@@ -55,7 +68,7 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigestsTest do
           assert(GenerateFileSetDigests.process(%{file_set_id: file_set_id}, %{}) == :ok)
           assert(ActionStates.ok?(file_set_id, GenerateFileSetDigests))
           file_set = FileSets.get_file_set!(file_set_id)
-          assert(file_set.core_metadata.digests == %{"sha256" => @sha256, "sha1" => @sha1})
+          assert(file_set.core_metadata.digests == %{"md5" => @md5, "sha1" => @sha1})
         end)
 
       refute log =~ ~r/already complete without overwriting/
@@ -71,7 +84,7 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigestsTest do
 
           assert(ActionStates.ok?(file_set_id, GenerateFileSetDigests))
           file_set = FileSets.get_file_set!(file_set_id)
-          assert(file_set.core_metadata.digests == %{"sha256" => @sha256, "sha1" => @sha1})
+          assert(file_set.core_metadata.digests == %{"md5" => @md5, "sha1" => @sha1})
         end)
 
       assert log =~ ~r/already complete without overwriting/


### PR DESCRIPTION
# Summary 


The checksum generation was taking too long to complete (1 hour +) for super large video files (50G and up) as a step in our ingest pipeline. We decided to extract checksum generation from the pipeline and use AWS's [Serverless Fixity for Digital Preservation Compliance](https://docs.aws.amazon.com/solutions/latest/serverless-fixity-for-digital-preservation-compliance/welcome.html) step function triggered by an upload to the uploads or ingest buckets. For now, we are generating an `md5` checksum (staging/prod)


# Specific Changes in this PR

- Adds auto-checksum functionality to ingest and upload minio buckets in dev and test environments
- Update the `meadow.buckets.create` task to configure bucket notifications
- Add configuration info to `dev.exs` and `test.exs` to support the above 
- Terraform for Cloud Trail and Event Bridge to invoke the step function
- Refactor `GenerateFileSetDigests` pipeline action to use the checksums stored in the object tags rather than calculate them
- Use the Elixir `WaitForIt` package where appropriate to wait for checksums to be generated before kicking off ingest
- Update GraphQL API to return map of all checksums
- Update Preservation tab's checksum copy functionality to accommodate new API
- Update `Validator` to check for object tags and report error (we consider this to be the easiest first iteration - not necessarily the best long term solution) [Discussion issue for future](https://github.com/nulib/repodev_planning_and_docs/issues/2469)
- Update preservation check with `md5` column
- __NOTE: for now - 1st iteration - the step function itself has been manually installed__

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [ ] Minor
- [x] Major (backwards incompatible GraphQL API change)

# Steps to Test

1. Set up the environment
    ```
    devstack down
    devstack update
    devstack up -d meadow
    mix meadow.buckets.create
    ```
2. Start your dev environment server
3. Run an ingest sheet ingest
4. Verify that checksum hash is present in the GraphQL API
5. Verify that the copy checksum functionality on the preservation tab in the UI 
6. Perform a UI file uplopad
7. Verify that the copy checksum functionality on the preservation tab in the UI 
7. Verify that checksum hash is present in the GraphQL API
3. Launch the Minio console in a web browser
3. Upload an object to the `dev-ingest` (or `dev-uploads`) bucket
4. Click on the newly uploaded object to see its details
5. Make sure there are `computed-[hash]` and `computed-[hash]-last-modified` tags for each hash type (`md5` and `sha1`). If the uploaded object it large, it might take several seconds for the tags to show up.
6. Make sure the auto-tagging does _not_ happen on other buckets.
7. You can `devstack logs -f minio-checksum` if you want to see the log output from the hash-tagging webhook
8. Let the preservation check run, download it and observe the md5 column

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [x] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [x] Adds/requires new or changed Terraform variables [`fixity_function`](https://github.com/nulib/tfvars/commit/9a6ece5f8d6dabc7f7063f775d58dd38c5c0d021) - we still need prod added to `tfvars`
- [x] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [x] Other specific instructions/tasks
  -  **__Do not merge until after both #2682 and nulib/devstack#9 have been merged__**
  - requires all developers to run `devstack update` and restart the stack before using meadow again
  - Manually install and configure [Serverless Fixity for Digital Preservation Compliance](https://docs.aws.amazon.com/solutions/latest/serverless-fixity-for-digital-preservation-compliance/welcome.html) on production


# Tested/Verified
- [ ] End users/stakeholders

