### PR TITLE
Hide set poster image button and work image toggle for Audio work types

### DIFF
--- a/assets/js/components/UI/MediaPlayer/PosterSelector.jsx
+++ b/assets/js/components/UI/MediaPlayer/PosterSelector.jsx
@@ -61,7 +61,10 @@ function MediaPlayerPosterSelector() {
   const label = workState.activeMediaFileSet.coreMetadata.label;
 
   return (
-    <div className="block mt-5 is-flex is-justify-content-center">
+    <div
+      className="block mt-5 is-flex is-justify-content-center"
+      data-testid="set-poster-image-button"
+    >
       <Button isPrimary onClick={handleSave}>
         Set poster image for &nbsp;<strong>{label}</strong>
       </Button>

--- a/assets/js/components/UI/MediaPlayer/Wrapper.jsx
+++ b/assets/js/components/UI/MediaPlayer/Wrapper.jsx
@@ -8,6 +8,8 @@ function MediaPlayerWrapper({ fileSets, manifestId }) {
   const workState = useWorkState();
   const dispatch = useWorkDispatch();
 
+  const { activeMediaFileSet, workTypeId } = workState;
+
   const handleCanvasIdCallback = (canvasId) => {
     if (canvasId !== "")
       dispatch({
@@ -19,15 +21,17 @@ function MediaPlayerWrapper({ fileSets, manifestId }) {
     return;
   };
 
-  if (!workState.activeMediaFileSet) return <></>;
+  if (!activeMediaFileSet) return <></>;
 
   return (
-    <div className="container">
+    <div className="container" data-testid="media-player-wrapper">
       <ReactMediaPlayer
         manifestId={manifestId}
         canvasIdCallback={handleCanvasIdCallback}
       />
-      {workState.activeMediaFileSet?.id && <MediaPlayerPosterSelector />}
+      {workTypeId !== "AUDIO" && activeMediaFileSet?.id && (
+        <MediaPlayerPosterSelector />
+      )}
     </div>
   );
 }

--- a/assets/js/components/UI/MediaPlayer/Wrapper.test.js
+++ b/assets/js/components/UI/MediaPlayer/Wrapper.test.js
@@ -1,0 +1,58 @@
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+import MediaPlayerWrapper from "./Wrapper";
+import { WorkProvider } from "@js/context/work-context";
+import { mockFileSets } from "@js/mock-data/filesets";
+import { renderWithRouterApollo } from "@js/services/testing-helpers";
+
+import { mockUser } from "@js/components/Auth/auth.gql.mock";
+import useIsAuthorized from "@js/hooks/useIsAuthorized";
+
+jest.mock("@js/hooks/useIsAuthorized");
+useIsAuthorized.mockReturnValue({
+  user: mockUser,
+  isAuthorized: () => true,
+});
+
+const initialState = {
+  activeMediaFileSet: mockFileSets[0],
+  webVttModal: {
+    fileSetId: null,
+    isOpen: false,
+    webVttString: "",
+  },
+  workTypeId: "VIDEO",
+};
+
+describe("MediaPlayerWrapper component", () => {
+  it("renders", async () => {
+    renderWithRouterApollo(
+      <WorkProvider initialState={initialState}>
+        <MediaPlayerWrapper fileSets={[...mockFileSets]} manifestId="ABC123" />
+      </WorkProvider>
+    );
+    expect(await screen.findByTestId("media-player-wrapper"));
+  });
+
+  it("renders the poster selector button for a Video work type", async () => {
+    renderWithRouterApollo(
+      <WorkProvider initialState={initialState}>
+        <MediaPlayerWrapper fileSets={[...mockFileSets]} manifestId="ABC123" />
+      </WorkProvider>
+    );
+    expect(await screen.findByTestId("set-poster-image-button"));
+  });
+
+  it("does not render the poster selector button for an Audio work type", async () => {
+    renderWithRouterApollo(
+      <WorkProvider initialState={{ ...initialState, workTypeId: "AUDIO" }}>
+        <MediaPlayerWrapper fileSets={[...mockFileSets]} manifestId="ABC123" />
+      </WorkProvider>
+    );
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("set-poster-image-button")
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/assets/js/components/Work/Fileset/ListItem.jsx
+++ b/assets/js/components/Work/Fileset/ListItem.jsx
@@ -115,22 +115,24 @@ function WorkFilesetListItem({
         <div className="column is-5 has-text-right is-clearfix">
           {!isEditing && (
             <>
-              <AuthDisplayAuthorized>
-                <div className="field">
-                  <input
-                    id={`checkbox-work-switch-${id}`}
-                    type="checkbox"
-                    name={`checkbox-work-switch-${id}`}
-                    className="switch"
-                    checked={workImageFilesetId === id}
-                    onChange={() => handleWorkImageChange(id)}
-                    data-testid="work-image-selector"
-                  />
-                  <label htmlFor={`checkbox-work-switch-${id}`}>
-                    Work image
-                  </label>
-                </div>
-              </AuthDisplayAuthorized>
+              {workContextState.workTypeId !== "AUDIO" && (
+                <AuthDisplayAuthorized>
+                  <div className="field">
+                    <input
+                      id={`checkbox-work-switch-${id}`}
+                      type="checkbox"
+                      name={`checkbox-work-switch-${id}`}
+                      className="switch"
+                      checked={workImageFilesetId === id}
+                      onChange={() => handleWorkImageChange(id)}
+                      data-testid="work-image-selector"
+                    />
+                    <label htmlFor={`checkbox-work-switch-${id}`}>
+                      Work image
+                    </label>
+                  </div>
+                </AuthDisplayAuthorized>
+              )}
 
               {fileSet.role.id === "A" && (
                 <WorkFilesetActionButtonsAccess fileSet={fileSet} />

--- a/assets/js/components/Work/Fileset/ListItem.test.js
+++ b/assets/js/components/Work/Fileset/ListItem.test.js
@@ -38,19 +38,47 @@ describe("Fileset component", () => {
       });
     });
 
-    it("renders an checked Work image toggle if current fileset is a representative Work image", async () => {
-      setUpTests(mockFileSets[0].id);
-      await waitFor(() => {
-        const toggleEl = screen.getByTestId("work-image-selector");
-        expect(toggleEl).toBeChecked();
+    describe("Image and Video work types", () => {
+      it("renders an checked Work image toggle if current fileset is a representative Work image", async () => {
+        setUpTests(mockFileSets[0].id);
+        await waitFor(() => {
+          const toggleEl = screen.getByTestId("work-image-selector");
+          expect(toggleEl).toBeChecked();
+        });
+      });
+
+      it("renders an unchecked Work image toggle if current fileset is NOT a representative Work image", async () => {
+        setUpTests("ABC123");
+        await waitFor(() => {
+          const toggleEl = screen.getByTestId("work-image-selector");
+          expect(toggleEl).not.toBeChecked();
+        });
       });
     });
 
-    it("renders an unchecked Work image toggle if current fileset is NOT a representative Work image", async () => {
-      setUpTests("ABC123");
-      await waitFor(() => {
-        const toggleEl = screen.getByTestId("work-image-selector");
-        expect(toggleEl).not.toBeChecked();
+    describe("Audio work type", () => {
+      // Set up the test so the Work type id is "AUDIO"
+      const initialState = {
+        activeMediaFileSet: null,
+        webVttModal: {
+          fileSetId: null,
+          isOpen: false,
+          webVttString: "",
+        },
+        workTypeId: "AUDIO",
+      };
+      it("doesn't render the Work image toggle", () => {
+        render(
+          <WorkProvider initialState={initialState}>
+            <WorkFilesetListItemImage
+              fileSet={mockFileSets[0]}
+              workImageFilesetId={undefined}
+            />
+          </WorkProvider>
+        );
+        expect(
+          screen.queryByTestId("work-image-selector")
+        ).not.toBeInTheDocument();
       });
     });
   });

--- a/assets/js/components/Work/TagsList.jsx
+++ b/assets/js/components/Work/TagsList.jsx
@@ -22,7 +22,7 @@ export default function WorkTagsList({ work }) {
   }
 
   return (
-    <p className="tags">
+    <div className="tags">
       {work.workType && <Tag isInfo>{renderWorkType()}</Tag>}
       {work.published ? (
         <Tag isSuccess>Published</Tag>
@@ -30,7 +30,7 @@ export default function WorkTagsList({ work }) {
         <Tag isWarning>Not Published</Tag>
       )}
       {work.visibility && <UIVisibilityTag visibility={work.visibility} />}
-    </p>
+    </div>
   );
 }
 

--- a/assets/js/components/Work/Work.jsx
+++ b/assets/js/components/Work/Work.jsx
@@ -30,6 +30,10 @@ const Work = ({ work }) => {
   const { filterFileSets } = useFileSet();
 
   React.useEffect(() => {
+    workDispatch({ type: "updateWorkType", workTypeId: work.workType.id });
+  }, []);
+
+  React.useEffect(() => {
     // Get data for an Image Work Type
     async function getData() {
       const data = await getManifest(`${work.manifestUrl}?${Date.now()}`);
@@ -90,6 +94,7 @@ const Work = ({ work }) => {
           fileSet={workContextState?.activeMediaFileSet}
           fileSets={[...filterFileSets(work.fileSets).access]}
           manifestId={work.manifestUrl}
+          workTypeId={work.workType?.id}
         />
       )}
 

--- a/assets/js/context/work-context.js
+++ b/assets/js/context/work-context.js
@@ -10,6 +10,7 @@ const defaultState = {
     isOpen: false,
     webVttString: "",
   },
+  workTypeId: null,
 };
 
 function workReducer(state, action) {
@@ -25,9 +26,16 @@ function workReducer(state, action) {
       };
     }
     case "updateActiveMediaFileSet": {
+      const workTypeId = action.workTypeId || state.workTypeId;
       return {
         ...state,
         activeMediaFileSet: { ...action.fileSet },
+      };
+    }
+    case "updateWorkType": {
+      return {
+        ...state,
+        workTypeId: action.workTypeId,
       };
     }
     default: {

--- a/assets/package.json
+++ b/assets/package.json
@@ -6,7 +6,7 @@
     "watch": "webpack --mode development --watch",
     "ci": "jest --ci --coverage",
     "ci-local": "TZ=UTC jest --ci --coverage && echo \"Exit status: $?\"",
-    "test": "TZ=UTC jest --watch",
+    "test": "TZ=UTC jest --watch --silent",
     "prettier": "prettier --check js/**/*.js* styles/**/*.scss ./*.js ./*.json",
     "prettier-fix": "prettier --write js/**/*.js* styles/**/*.scss ./*.js ./*.json"
   },


### PR DESCRIPTION
# Summary 
On a Work screen, if it's an Audio work type, the Set Poster button and Work image toggle are now no longer visible.

![image](https://user-images.githubusercontent.com/3020266/142256958-69fcb820-6c92-4736-9f07-4df95cd80bf6.png)

![image](https://user-images.githubusercontent.com/3020266/142257062-606346a2-09ca-42cf-b7f7-be54bc6b8be8.png)



# Specific Changes in this PR
- Buttons are hidden for Audio work types as they're not relevant
- Silence console messages in Jest tests
- Adds Work Type to the wrapper `WorkProvider` context object, so we don't have to prop drill `workTypeId` multiple levels deep for some components to know about the info.
 
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Go to an Audio work screen.  Notice the buttons referenced in the issue are no longer present

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

