### PR TITLE
Label on vtt in manifest should be "Chapters" not "Transcript"

### DIFF
--- a/lib/meadow/data/schemas/iiif/V3/work.ex
+++ b/lib/meadow/data/schemas/iiif/V3/work.ex
@@ -139,7 +139,7 @@ defimpl Meadow.IIIF.V3.Resource, for: Meadow.Data.Schemas.Work do
               type: "Text",
               format: "text/vtt",
               label: %Label{
-                en: ["Transcript"]
+                en: ["Chapters"]
               },
               language: "en"
             },


### PR DESCRIPTION
# Summary 

The supplemental annotation for structural metadata in our IIIF v3 A/V manifests should have the label "Chapters" not "Transcript" 

# Specific Changes in this PR
- change label from "Transcript" to "Chapters" in manifest generator (v3)

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Create an AV work (or edit & save an existing one) with structural metadata for one of it's file sets and observe when that file set is active in the player that the structural metadata navigator displays the heading "Chapters"


# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [x] Other specific instructions/tasks
  - Requires IIIF manifest regeneration for AV works
```

Repo.transaction(fn ->
      from(w in Work, select: %{id: w.id}, where: fragment("work_type ->> 'id' in ('AUDIO', 'VIDEO')"))
      |> Repo.stream()
      |> Stream.each(fn %{id: work_id} ->
        IIIF.V2.write_manifest(work_id)
      end)
      |> Stream.run()
    end,
    timeout: :infinity)
```


# Tested/Verified
- [ ] End users/stakeholders

