### PR TITLE
Resolve RMP errors on new A/V work.

### DIFF
--- a/assets/js/components/UI/MediaPlayer/Wrapper.jsx
+++ b/assets/js/components/UI/MediaPlayer/Wrapper.jsx
@@ -1,27 +1,30 @@
-import React from "react";
+import React, { useState } from "react";
 import PropTypes from "prop-types";
 import MediaPlayerPosterSelector from "@js/components/UI/MediaPlayer/PosterSelector";
 import ReactMediaPlayer from "@nulib/react-media-player";
 import { useWorkDispatch, useWorkState } from "@js/context/work-context";
 
-function MediaPlayerWrapper({ fileSets, manifestId }) {
+const MediaPlayerWrapper = ({ fileSets, manifestId, canvasReady = false }) => {
   const workState = useWorkState();
   const dispatch = useWorkDispatch();
 
   const { activeMediaFileSet, workTypeId } = workState;
+  const [isCanvasReady, setIsCanvasReady] = useState(canvasReady);
 
   const handleCanvasIdCallback = (canvasId) => {
-    if (canvasId !== "")
+    if (canvasId !== "") {
+      setIsCanvasReady(true);
       dispatch({
         type: "updateActiveMediaFileSet",
         fileSet: fileSets.find(
           (fileSet) => fileSet.id === canvasId.split("/").pop()
         ),
       });
+    }
     return;
   };
 
-  if (!activeMediaFileSet) return <></>;
+  if (!activeMediaFileSet?.id) return <></>;
 
   return (
     <div className="container" data-testid="media-player-wrapper">
@@ -29,12 +32,12 @@ function MediaPlayerWrapper({ fileSets, manifestId }) {
         manifestId={manifestId}
         canvasIdCallback={handleCanvasIdCallback}
       />
-      {workTypeId !== "AUDIO" && activeMediaFileSet?.id && (
+      {isCanvasReady && workTypeId !== "AUDIO" && activeMediaFileSet?.id && (
         <MediaPlayerPosterSelector />
       )}
     </div>
   );
-}
+};
 
 MediaPlayerWrapper.propTypes = {
   fileSets: PropTypes.array,

--- a/assets/js/components/UI/MediaPlayer/Wrapper.test.js
+++ b/assets/js/components/UI/MediaPlayer/Wrapper.test.js
@@ -37,7 +37,11 @@ describe("MediaPlayerWrapper component", () => {
   it("renders the poster selector button for a Video work type", async () => {
     renderWithRouterApollo(
       <WorkProvider initialState={initialState}>
-        <MediaPlayerWrapper fileSets={[...mockFileSets]} manifestId="ABC123" />
+        <MediaPlayerWrapper
+          fileSets={[...mockFileSets]}
+          manifestId="ABC123"
+          canvasReady={true}
+        />
       </WorkProvider>
     );
     expect(await screen.findByTestId("set-poster-image-button"));

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -19,7 +19,7 @@
         "@honeybadger-io/js": "^3.2.5",
         "@honeybadger-io/react": "^1.0.1",
         "@nulib/design-system": "^1.2.1",
-        "@nulib/react-media-player": "^1.4.1",
+        "@nulib/react-media-player": "^1.4.2-beta.0",
         "@samvera/image-downloader": "^1.1.0",
         "bulma": "^0.9.3",
         "bulma-checkradio": "^1.1.1",
@@ -3601,9 +3601,9 @@
       "dev": true
     },
     "node_modules/@nulib/react-media-player": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.4.1.tgz",
-      "integrity": "sha512-Ai6l4QRHYA5NDG9ZIHcgMhXjk0pUY4szn7SudHOWa0v0Rxs/M43qi9gu9XoR5KHfUlH84J9CuwvJkfmDOezeow==",
+      "version": "1.4.2-beta.0",
+      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.4.2-beta.0.tgz",
+      "integrity": "sha512-K+pBd6I6sbQ3VcaKqnTEC8kMlk1v4YndKWHD/vABVxpa60/t2sWpLtnmM1nB/st1QH0Fypeja2KZVn5iQiFUgg==",
       "dependencies": {
         "@hyperion-framework/parser": "^1.0.0",
         "@hyperion-framework/types": "^1.0.0",
@@ -22972,9 +22972,9 @@
       "dev": true
     },
     "@nulib/react-media-player": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.4.1.tgz",
-      "integrity": "sha512-Ai6l4QRHYA5NDG9ZIHcgMhXjk0pUY4szn7SudHOWa0v0Rxs/M43qi9gu9XoR5KHfUlH84J9CuwvJkfmDOezeow==",
+      "version": "1.4.2-beta.0",
+      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.4.2-beta.0.tgz",
+      "integrity": "sha512-K+pBd6I6sbQ3VcaKqnTEC8kMlk1v4YndKWHD/vABVxpa60/t2sWpLtnmM1nB/st1QH0Fypeja2KZVn5iQiFUgg==",
       "requires": {
         "@hyperion-framework/parser": "^1.0.0",
         "@hyperion-framework/types": "^1.0.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -25,7 +25,7 @@
     "@honeybadger-io/js": "^3.2.5",
     "@honeybadger-io/react": "^1.0.1",
     "@nulib/design-system": "^1.2.1",
-    "@nulib/react-media-player": "^1.4.1",
+    "@nulib/react-media-player": "^1.4.2-beta.0",
     "@samvera/image-downloader": "^1.1.0",
     "bulma": "^0.9.3",
     "bulma-checkradio": "^1.1.1",


### PR DESCRIPTION
# Summary 
This updates issues in meadow when a new work type of Video or Audio are created. To resolve, I made a more explicit check for an activeMediaFileset ID and do not render the ReactMediaPlayer component until this is ready. Secondarily, I updated the ReactMediaPlayer package to its most current build using a prepatch `1.4.2-beta.0`. There was issue in our `1.4.1` version, I believe related to a faulty NPM publish, causing the manifests without canvases to pass through. Finally, I now do not render the Poster Selector button unless ReactMediaPlayer returns to Meadow a ready state.

# Specific Changes in this PR
- Render RMP only if activeMediaFileset id exists.
- Update RMP version, add state logic to not render poster selector in cases.
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

1. `cd assets`
2. `npm install @nulib/react-media-player@1.4.2-beta.0` 
3. `cd ../`
3. `mix phx.server`
2. Create a new work in Meadow devstack
2. Select Video or Audio
3. No error should show as it did before
4. Go to preservation tab, add a fileset.
5. No error should show, but the media player will not render yet as Manifest has not yet been regenerated.
6. Go to About tab
7. Edit the description to anything
8. Save and refresh
9. The player (and the poster selector if Video) should be there.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

