### PR TITLE
Remove empty return interrupting callbacks.

### DIFF
--- a/assets/js/components/UI/MediaPlayer/Wrapper.jsx
+++ b/assets/js/components/UI/MediaPlayer/Wrapper.jsx
@@ -24,8 +24,6 @@ const MediaPlayerWrapper = ({ fileSets, manifestId, canvasReady = false }) => {
     return;
   };
 
-  if (!activeMediaFileSet?.id) return <></>;
-
   return (
     <div className="container" data-testid="media-player-wrapper">
       <ReactMediaPlayer


### PR DESCRIPTION
# Summary 
In an earlier pull request https://github.com/nulib/meadow/pull/2699, I introduced a line intended to stop the rendering of the react media player if an activeMediaFileSet ID was not available. This seemed to conflict with the callback we receive from the ReactMediaPlayer component causing the player to disappear / not render when the canvas was toggled to an Aux image. Instead of stopping the render of the RMP, we'll just let the RMP handle manifest wholly and decide if the manifest is ready for render. 

## Note

In a call with @davidschober and @kdid, I was being led astray by the 403 Forbidden I was seeing on the Image Service info.json for non-public files. This was  just a case of conflating things and not realizing that my earlier PR was the culprit.

# Specific Changes in this PR
- Removes line causing RMP to not render in Aux cases.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
1. Create a new Video work.
2. Add an Access fileset.
3. Add an  Aux fileset.
4. Add a description under About.
5. Refresh and RMP should render.
6. Toggle between canvases, RMP should not disappear.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

