### PR TITLE
Add reading room to work schema, GraphQL and Elasticsearch

### DIFF
--- a/assets/js/components/IngestSheet/ingestSheet.gql.js
+++ b/assets/js/components/IngestSheet/ingestSheet.gql.js
@@ -206,6 +206,7 @@ export const INGEST_SHEET_WORKS = gql`
       manifestUrl
       published
       representativeImage
+      readingRoom
       updatedAt
       workType {
         id

--- a/assets/js/components/Work/work.gql.js
+++ b/assets/js/components/Work/work.gql.js
@@ -243,6 +243,7 @@ export const GET_WORK = gql`
       }
       published
       representativeImage
+      readingRoom
       updatedAt
       visibility {
         id
@@ -294,6 +295,7 @@ export const GET_WORKS = gql`
         title
       }
       published
+      readingRoom
       representativeImage
       updatedAt
       workType {

--- a/assets/js/components/Work/work.gql.mock.js
+++ b/assets/js/components/Work/work.gql.mock.js
@@ -222,6 +222,7 @@ export const mockWork = {
     title: "Foo",
   },
   published: false,
+  readingRoom: false,
   representativeImage: "http://foobar",
   updatedAt: "2019-12-02T22:22:16",
   visibility: mockVisibility(),
@@ -372,6 +373,7 @@ const mockWork2 = {
     title: "Adam project",
   },
   published: false,
+  readingRoom: false,
   representativeImage:
     "https://devbox.library.northwestern.edu:8183/iiif/2/38620e42-7c71-4364-8123-8106db5fd31c",
   updatedAt: "2020-07-24T15:20:14.119629Z",

--- a/lib/meadow/data/schemas/work.ex
+++ b/lib/meadow/data/schemas/work.ex
@@ -26,6 +26,7 @@ defmodule Meadow.Data.Schemas.Work do
   schema "works" do
     field(:accession_number, :string)
     field(:published, :boolean, default: false)
+    field(:reading_room, :boolean, default: false)
 
     field(:visibility, Types.CodedTerm,
       default: %{id: "RESTRICTED", scheme: "visibility", label: "Private"}
@@ -74,8 +75,9 @@ defmodule Meadow.Data.Schemas.Work do
     {[:accession_number],
      [
        :collection_id,
-       :representative_file_set_id,
        :ingest_sheet_id,
+       :reading_room,
+       :representative_file_set_id,
        :visibility,
        :work_type
      ]}
@@ -106,6 +108,7 @@ defmodule Meadow.Data.Schemas.Work do
       :collection_id,
       :ingest_sheet_id,
       :published,
+      :reading_room,
       :representative_file_set_id,
       :visibility
     ]

--- a/lib/meadow/indexing/work.ex
+++ b/lib/meadow/indexing/work.ex
@@ -35,6 +35,7 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Work do
       modifiedDate: work.updated_at,
       project: format(work.project),
       published: work.published,
+      readingRoom: work.reading_room,
       representativeFileSet:
         case work.representative_file_set_id do
           nil ->

--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -52,6 +52,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
       arg(:work_type, :coded_term_input)
       arg(:visibility, :coded_term_input)
       arg(:published, :boolean)
+      arg(:reading_room, :boolean)
       arg(:file_sets, list_of(:file_set_input))
       middleware(Middleware.Authenticate)
       middleware(Middleware.Authorize, "Editor")
@@ -112,6 +113,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     field :work_type, :coded_term
     field :visibility, :coded_term
     field :published, :boolean
+    field :reading_room, :boolean
 
     field :manifest_url, :string do
       resolve(fn work, _, _ ->
@@ -230,6 +232,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     field :descriptive_metadata, :work_descriptive_metadata_input
     field :visibility, :coded_term_input
     field :published, :boolean
+    field :reading_room, :boolean
     field :collection_id, :id
   end
 

--- a/priv/repo/migrations/20211124123833_works_add_reading_room.exs
+++ b/priv/repo/migrations/20211124123833_works_add_reading_room.exs
@@ -1,0 +1,9 @@
+defmodule Meadow.Repo.Migrations.WorksAddReadingRoom do
+  use Ecto.Migration
+
+  def change do
+    alter table("works") do
+      add :reading_room, :boolean, default: false, null: false
+    end
+  end
+end

--- a/test/gql/WorkFields.frag.gql
+++ b/test/gql/WorkFields.frag.gql
@@ -15,6 +15,7 @@ fragment WorkFields on Work {
     title
   }
   published
+  readingRoom
   representativeImage
   ingest_sheet {
     id


### PR DESCRIPTION
# Summary 

We need to be able to support "Reading Room" functionality (IP based access) for migrated AVR content. 

# Specific Changes in this PR
- add boolean `reading_room` property to `Meadow.Data.Schemas.Work` schema
- expose `readingRoom` in GraphQL
- index `readingRoom` on the work document in Elasticsearch
- update GraphQL test
- 
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor (backwards compatible API changes (GraphQL & Elasticsearch))
- [ ] Major

# Steps to Test

- run `mix ecto.migrate` 
- Observe that existing works have `reading_room` set to `false` in DB
- in `iex` run `Meadow.Data.Indexer.hot_swap()`
- Observe that `readingRoom` is indexed on the work
- In GraphiQL update the reading room
```
# Example

mutation{
  updateWork(id: "d29cb826-1954-4cb0-aa09-c03effb483b4", work: {
    readingRoom: true
  }){
    readingRoom
  }
}
```

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [x] Database Schema changes
  - [x] GraphQL API
  - [x] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

