### PR TITLE
Terraform meadow bucket policy needs s3:GetObjectTagging

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -167,7 +167,8 @@ data "aws_iam_policy_document" "this_bucket_access" {
       "s3:GetObject",
       "s3:DeleteObject",
       "s3:HeadObject",
-      "s3:PutObjectTagging"
+      "s3:PutObjectTagging",
+      "s3:GetObjectTagging"
     ]
 
     resources = [


### PR DESCRIPTION
# Summary 
Terraform meadow bucket policy needs s3:GetObjectTagging

# Specific Changes in this PR
- Terraform meadow bucket policy needs s3:GetObjectTagging

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

RUN AN INGEST 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

