### PR TITLE
Update parent trigger so that work notifactions are sent on file set insert, update and delete

### DIFF
--- a/lib/meadow/utils/dependency_triggers.ex
+++ b/lib/meadow/utils/dependency_triggers.ex
@@ -50,7 +50,7 @@ defmodule Meadow.Utils.DependencyTriggers do
           WHEN 'INSERT' THEN
             IF EXISTS (SELECT FROM new_table) THEN
               UPDATE #{parent} SET updated_at = NOW()
-              WHERE id = ANY (SELECT DISTINCT new_table.id FROM new_table);
+              WHERE id = ANY (SELECT DISTINCT new_table.#{Inflex.singularize(parent)}_id FROM new_table);
             END IF;
           WHEN 'UPDATE' THEN
             IF EXISTS (SELECT FROM new_table) THEN
@@ -63,7 +63,7 @@ defmodule Meadow.Utils.DependencyTriggers do
           WHEN 'DELETE' THEN
             IF EXISTS (SELECT FROM old_table) THEN
               UPDATE #{parent} SET updated_at = NOW()
-              WHERE id = ANY (SELECT DISTINCT old_table.id FROM old_table);
+              WHERE id = ANY (SELECT DISTINCT old_table.#{Inflex.singularize(parent)}_id FROM old_table);
             END IF;
         END CASE;
         RETURN NULL;

--- a/priv/repo/migrations/20211124195931_update_file_set_work_parent_trigger.exs
+++ b/priv/repo/migrations/20211124195931_update_file_set_work_parent_trigger.exs
@@ -1,0 +1,15 @@
+defmodule Meadow.Repo.Migrations.UpdateFileSetWorkParentTrigger do
+  use Ecto.Migration
+
+  import Meadow.Utils.DependencyTriggers
+
+  def up do
+    drop_parent_trigger(:works, :file_sets)
+    create_parent_trigger(:works, :file_sets, [:core_metadata, :derivatives, :poster_offset, :rank, :structural_metadata])
+  end
+
+  def down do
+    drop_parent_trigger(:works, :file_sets)
+    create_parent_trigger(:works, :file_sets, [:core_metadata, :derivatives, :rank])
+  end
+end


### PR DESCRIPTION

# Summary 

Fixes a bug where IIIF manifests are not updated if file sets are inserted or deleted, or structural metadata is updated. 
Bug would also be affecting indexing. 

# Specific Changes in this PR
- fix bug in dependency trigger code referencing parent column in child tables
- Create migration to add structural metadata to file set / work parent trigger


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Migrate your database

```
mix ecto.migrate
```

- add and delete file sets from works
- add/erase/update structural metadata (VTT)
- Notice that IIIF manifests are updated

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

