### PR TITLE
Handle nil (and other unexpected) values in FileSets.duration_in_milliseconds/1

### DIFF
--- a/lib/meadow/data/file_sets.ex
+++ b/lib/meadow/data/file_sets.ex
@@ -325,21 +325,25 @@ defmodule Meadow.Data.FileSets do
   end
 
   def duration_in_milliseconds(%FileSet{extracted_metadata: %{"mediainfo" => mediainfo}}) do
-    with {duration, _} <-
-           Float.parse(
-             get_in(mediainfo, [
-               "value",
-               "media",
-               "track",
-               Access.at(0),
-               "Duration"
-             ])
-           ) do
-      duration * 1000
+    case mediainfo do
+      %{"value" => %{"media" => %{"track" => [%{"Duration" => duration_string} | _]}}} ->
+        parse_duration_string(duration_string)
+
+      _ ->
+        nil
     end
   end
 
   def duration_in_milliseconds(_), do: nil
+
+  defp parse_duration_string(value) when is_binary(value) do
+    case Float.parse(value) do
+      {duration, _} -> duration * 1000
+      :error -> nil
+    end
+  end
+
+  defp parse_duration_string(_), do: nil
 
   def height(%FileSet{
         role: %{id: "A"},

--- a/test/meadow/data/file_sets_test.exs
+++ b/test/meadow/data/file_sets_test.exs
@@ -283,6 +283,30 @@ defmodule Meadow.Data.FileSetsTest do
       assert FileSets.duration_in_milliseconds(file_set) == 1_000_999.0
     end
 
+    test "duration_in_milliseconds/1 for a file set with extracted mediainfo but nil duration" do
+      file_set =
+        file_set_fixture(
+          role: %{id: "A", scheme: "FILE_SET_ROLE"},
+          extracted_metadata:
+            @mediainfo
+            |> put_in(["mediainfo", "value", "media", "track", Access.at(0), "Duration"], nil)
+        )
+
+      assert is_nil(FileSets.duration_in_milliseconds(file_set))
+    end
+
+    test "duration_in_milliseconds/1 for a file set with extracted mediainfo but no tracks" do
+      file_set =
+        file_set_fixture(
+          role: %{id: "A", scheme: "FILE_SET_ROLE"},
+          extracted_metadata:
+            @mediainfo
+            |> put_in(["mediainfo", "value", "media", "track"], [])
+        )
+
+      assert is_nil(FileSets.duration_in_milliseconds(file_set))
+    end
+
     test "duration_in_milliseconds/1 for a file set without extracted mediainfo" do
       file_set = file_set_fixture()
 


### PR DESCRIPTION
# Summary 

Return `nil` instead of throwing an error when `FileSets.duration_in_milliseconds/1` can't find a proper duration string in the extracted metadata.

# Specific Changes in this PR
- Update `FileSets.duration_in_milliseconds/1`
- Add additional tests

# Version bump required by the PR

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Create an audio or video work
- Add a fileset
- Alter the fileset so that the extracted metadata doesn't contain a `Duration` (or has any shape other than `{"value": {"media": {"track": [{"Duration": FLOAT_VALUE}]}`)
- Regenerated a IIIF manifest for the work

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

