### PR TITLE
Support copying files > 5GB to preservation

### DIFF
--- a/lib/meadow/pipeline/actions/copy_file_to_preservation.ex
+++ b/lib/meadow/pipeline/actions/copy_file_to_preservation.ex
@@ -8,6 +8,7 @@ defmodule Meadow.Pipeline.Actions.CopyFileToPreservation do
 
   """
   alias Meadow.Data.{ActionStates, FileSets}
+  alias Meadow.Utils.AWS
   alias Sequins.Pipeline.Action
   use Action
   use Meadow.Pipeline.Actions.Common
@@ -74,7 +75,7 @@ defmodule Meadow.Pipeline.Actions.CopyFileToPreservation do
         |> Enum.map(fn {tag, value} -> ["computed-#{tag}", value] |> Enum.join("=") end)
         |> Enum.join("&")
 
-      case ExAws.S3.put_object_copy(
+      case AWS.copy_object(
              dest_bucket,
              dest_key,
              src_bucket,
@@ -84,8 +85,7 @@ defmodule Meadow.Pipeline.Actions.CopyFileToPreservation do
              meta: s3_metadata,
              tagging: tagging,
              tagging_directive: :REPLACE
-           )
-           |> ExAws.request() do
+           ) do
         {:ok, _} -> {:ok, dest_location}
         {:error, {:http_error, _status, %{body: body}}} -> {:error, extract_error(body)}
         {:error, other} -> {:error, inspect(other)}

--- a/lib/meadow/utils/aws.ex
+++ b/lib/meadow/utils/aws.ex
@@ -5,6 +5,8 @@ defmodule Meadow.Utils.AWS do
   Utility functions for AWS requests and object management
   """
   alias Meadow.Error
+  alias Meadow.Utils.AWS.MultipartCopy
+
   import SweetXml, only: [sigil_x: 2]
 
   @doc """
@@ -68,6 +70,9 @@ defmodule Meadow.Utils.AWS do
         raise "Unexpected response: #{other}"
     end
   end
+
+  def copy_object(dest_bucket, dest_object, src_bucket, src_object, opts \\ []),
+    do: MultipartCopy.copy_object(dest_bucket, dest_object, src_bucket, src_object, opts)
 
   defp generate_aws_signature(request, region, access_key, secret) do
     signed_request =

--- a/lib/meadow/utils/aws/multipart_copy.ex
+++ b/lib/meadow/utils/aws/multipart_copy.ex
@@ -1,0 +1,203 @@
+defmodule Meadow.Utils.AWS.MultipartCopy do
+  @moduledoc """
+  Perform a multipart S3-to-S3 copy using ExAws
+  """
+
+  alias Meadow.Utils.AWS
+
+  import SweetXml, only: [sigil_x: 2]
+
+  require Logger
+
+  defstruct dest_bucket: nil,
+            dest_object: nil,
+            src_bucket: nil,
+            src_object: nil,
+            opts: [],
+            content_length: nil,
+            upload_id: nil
+
+  @chunk_size 524_288_000
+  @threshold 20_971_520
+
+  @doc """
+  Copy an object, automatically switching to multipart copy if the source object
+  is larger than 5GB.
+  """
+  def copy_object(dest_bucket, dest_object, src_bucket, src_object, opts \\ []) do
+    Logger.debug("Copying s3://#{src_bucket}/#{src_object} to s3://#{dest_bucket}/#{dest_object}")
+
+    case ExAws.S3.head_object(src_bucket, src_object) |> AWS.request() do
+      {:ok, %{status_code: 200, headers: headers}} ->
+        content_length =
+          headers
+          |> Enum.into(%{})
+          |> Map.get("Content-Length")
+          |> Integer.parse()
+          |> Tuple.to_list()
+          |> List.first()
+
+        %__MODULE__{
+          dest_bucket: dest_bucket,
+          dest_object: dest_object,
+          src_bucket: src_bucket,
+          src_object: src_object,
+          opts: opts,
+          content_length: content_length
+        }
+        |> copy_s3_object()
+
+      other ->
+        other
+    end
+  end
+
+  defp copy_s3_object(%__MODULE__{content_length: length} = op) when length > @threshold do
+    Logger.debug("File size #{length} > #{@threshold}; using MultipartUpload")
+
+    op
+    |> initiate_upload()
+    |> upload_chunks()
+    |> complete_upload()
+  end
+
+  defp copy_s3_object(%__MODULE__{content_length: length} = op) do
+    Logger.debug("File size #{length} <= #{@threshold}; using CopyObject")
+
+    ExAws.S3.put_object_copy(
+      op.dest_bucket,
+      op.dest_object,
+      op.src_bucket,
+      op.src_object,
+      op.opts
+    )
+    |> AWS.request()
+  end
+
+  defp initiate_upload(%__MODULE__{} = op) do
+    case ExAws.S3.initiate_multipart_upload(op.dest_bucket, op.dest_object, op.opts)
+         |> AWS.request() do
+      {:ok, %{body: %{upload_id: upload_id}, status_code: 200}} ->
+        {:ok, op |> Map.put(:upload_id, upload_id)}
+
+      other ->
+        other
+    end
+  end
+
+  defp upload_chunks({:ok, %__MODULE__{} = op}) do
+    with chunk_size <- extract_chunk_size(op),
+         chunks <- Float.ceil(op.content_length / chunk_size) |> trunc() do
+      Logger.debug("Splitting into #{chunks} #{chunk_size}-byte parts")
+
+      parts =
+        1..chunks
+        |> Task.async_stream(&upload_chunk(op, &1), timeout: :infinity, max_concurrency: 10)
+        |> Enum.to_list()
+
+      case parts |> Enum.map(fn {status, _} -> status end) |> Enum.uniq() do
+        [:ok] ->
+          {parts
+           |> Enum.with_index(1)
+           |> Enum.map(fn
+             {{:ok, {:ok, etag}}, part_number} -> {part_number, etag}
+           end), op}
+
+        _ ->
+          {:error, op}
+      end
+    end
+  end
+
+  defp upload_chunks({:error, payload}), do: {:error, payload}
+
+  defp complete_upload({:error, %__MODULE__{} = op}) do
+    Logger.debug("Error encountered. Aborting multipart upload.")
+
+    ExAws.S3.abort_multipart_upload(op.dest_bucket, op.dest_object, op.upload_id)
+    |> AWS.request()
+  end
+
+  defp complete_upload({:error, other}) do
+    Logger.debug("Error encountered. #{other}")
+    {:error, parse_error(other)}
+  end
+
+  defp complete_upload({parts, %__MODULE__{} = op}) do
+    Logger.debug("Completing multipart upload.")
+
+    ExAws.S3.complete_multipart_upload(op.dest_bucket, op.dest_object, op.upload_id, parts)
+    |> Map.put(:parser, &parse_complete_result/1)
+    |> AWS.request()
+  end
+
+  defp upload_chunk(%__MODULE__{} = op, chunk) do
+    with chunk_size <- extract_chunk_size(op),
+         first_byte <- (chunk - 1) * chunk_size,
+         last_byte <- min(op.content_length, first_byte + chunk_size) - 1 do
+      result =
+        %ExAws.Operation.S3{
+          body: "",
+          bucket: op.dest_bucket,
+          headers: %{
+            "x-amz-copy-source-range" => "bytes=#{first_byte}-#{last_byte}",
+            "x-amz-copy-source" => ["", op.src_bucket, op.src_object] |> Enum.join("/")
+          },
+          http_method: :put,
+          parser: &parse_copy_part_result/1,
+          path: op.dest_object,
+          params: %{
+            "partNumber" => chunk,
+            "uploadId" => op.upload_id
+          },
+          service: :s3,
+          stream_builder: nil
+        }
+        |> AWS.request()
+
+      case result do
+        {:ok, %{status_code: 200, body: %{e_tag: etag}}} -> {:ok, String.replace(etag, ~s'"', "")}
+        other -> {:error, other}
+      end
+    end
+  end
+
+  defp parse_complete_result({:ok, %{body: xml} = resp}) do
+    parsed_body =
+      SweetXml.xpath(xml, ~x"//CompleteMultipartUploadResult",
+        bucket: ~x"./Bucket/text()"s,
+        key: ~x"./Key/text()"s,
+        location: ~x"./Location/text()"s,
+        e_tag: ~x"./ETag/text()"s
+      )
+
+    {:ok, %{resp | body: parsed_body}}
+  end
+
+  defp parse_copy_part_result({:ok, %{body: xml} = resp}) do
+    parsed_body =
+      SweetXml.xpath(xml, ~x"//CopyPartResult",
+        e_tag: ~x"./ETag/text()"s,
+        last_modified: ~x"./LastModified/text()"s
+      )
+
+    {:ok, %{resp | body: parsed_body}}
+  end
+
+  defp parse_error({:http_error, _, %{body: xml} = resp}) do
+    parsed_body =
+      SweetXml.xpath(xml, ~x"//Error",
+        code: ~x"./Code/text()"s,
+        message: ~x"./Message/text()"s,
+        bucket: ~x"./BucketName/text()"s,
+        request_id: ~x"./RequestId/text()"s,
+        host_id: ~x"./HostId/text()"s
+      )
+
+    %{resp | body: parsed_body}
+  end
+
+  defp parse_error(error), do: error
+
+  defp extract_chunk_size(%__MODULE__{} = op), do: Keyword.get(op.opts, :chunk_size, @chunk_size)
+end


### PR DESCRIPTION
# Summary 

Implement automatic multipart copy and use in CopyFileToPreservation action

# Specific Changes in this PR
- Add high-level `Meadow.Utils.AWS.MultipartCopy` module
- Add `Meadow.Utils.AWS.copy_object/5` wrapper around above module
- Swap out `Meadow.Utils.AWS.copy_object/5` for `ExAws.S3.put_object_copy/5` in `CopyFileToPreservation` action

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Ingest a file > 5GB and see if it successfully passes through the pipeline and copies to preservation

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

