### PR TITLE
Notify the manifest listener when a fileset changes

### DIFF
--- a/lib/meadow/ark_listener.ex
+++ b/lib/meadow/ark_listener.ex
@@ -31,6 +31,8 @@ defmodule Meadow.ARKListener do
     Ecto.NoResultsError -> {:noreply, state}
   end
 
+  def handle_notification(_, _, _, state), do: {:noreply, state}
+
   defp update_ark_metadata(work) do
     Logger.info(
       "Updating ARK metadata for work: #{work.id}, with ark: #{work.descriptive_metadata.ark}"

--- a/lib/meadow/iiif/manifest_listener.ex
+++ b/lib/meadow/iiif/manifest_listener.ex
@@ -12,7 +12,19 @@ defmodule Meadow.IIIF.ManifestListener do
   @impl true
   def handle_notification(:works, :delete, _key, state), do: {:noreply, state}
 
+  def handle_notification(:file_sets, _op, %{id: id}, state) do
+    update_manifest(id)
+    {:noreply, state}
+  end
+
   def handle_notification(:works, _op, %{id: id}, state) do
+    update_manifest(id)
+    {:noreply, state}
+  end
+
+  def handle_notification(_, _, _, state), do: {:noreply, state}
+
+  defp update_manifest(id) do
     with_log_metadata module: __MODULE__, id: id do
       case Works.get_work!(id) do
         %{work_type: %{id: "IMAGE"}} ->
@@ -27,9 +39,7 @@ defmodule Meadow.IIIF.ManifestListener do
           Logger.warn("Skipping manifest writing for work of unknown type. Work id: #{id}")
       end
     end
-
-    {:noreply, state}
   rescue
-    Ecto.NoResultsError -> {:noreply, state}
+    Ecto.NoResultsError -> :noop
   end
 end

--- a/lib/meadow/ingest/sheet_notifier.ex
+++ b/lib/meadow/ingest/sheet_notifier.ex
@@ -17,4 +17,6 @@ defmodule Meadow.Ingest.SheetNotifier do
   rescue
     Ecto.NoResultsError -> {:noreply, state}
   end
+
+  def handle_notification(_, _, _, state), do: {:noreply, state}
 end

--- a/lib/meadow/structural_metadata_listener.ex
+++ b/lib/meadow/structural_metadata_listener.ex
@@ -29,6 +29,8 @@ defmodule Meadow.StructuralMetadataListener do
     Ecto.NoResultsError -> {:noreply, state}
   end
 
+  def handle_notification(_, _, _, state), do: {:noreply, state}
+
   defp write_structural_metadata(%{id: id, structural_metadata: %{type: "webvtt", value: vtt}})
        when is_binary(vtt) do
     Logger.info("Writing structural metadata for #{id}")

--- a/lib/meadow/utils/dependency_triggers.ex
+++ b/lib/meadow/utils/dependency_triggers.ex
@@ -15,21 +15,27 @@ defmodule Meadow.Utils.DependencyTriggers do
         CASE TG_OP
           WHEN 'INSERT' THEN
             IF EXISTS (SELECT FROM new_table) THEN
-              UPDATE #{child} SET updated_at = NOW()
-              WHERE #{Inflex.singularize(column_name)}_id = ANY (SELECT DISTINCT new_table.id FROM new_table);
+              DELETE FROM index_times
+              USING #{child}
+              WHERE index_times.id = #{child}.id
+              AND #{child}.#{Inflex.singularize(column_name)}_id = ANY (SELECT DISTINCT new_table.id FROM new_table);
             END IF;
           WHEN 'UPDATE' THEN
             IF EXISTS (SELECT FROM new_table) THEN
-              UPDATE #{child} SET updated_at = NOW()
-              WHERE #{Inflex.singularize(column_name)}_id = ANY (
+              DELETE FROM index_times
+              USING #{child}
+              WHERE index_times.id = #{child}.id
+              AND #{child}.#{Inflex.singularize(column_name)}_id = ANY (
                 SELECT DISTINCT new_table.id
                 FROM new_table JOIN old_table ON new_table.id = old_table.id AND (#{condition})
               );
             END IF;
           WHEN 'DELETE' THEN
             IF EXISTS (SELECT FROM old_table) THEN
-              UPDATE #{child} SET updated_at = NOW()
-              WHERE #{Inflex.singularize(column_name)}_id = ANY (SELECT DISTINCT old_table.id FROM old_table);
+              DELETE FROM index_times
+              USING #{child}
+              WHERE index_times.id = #{child}.id
+              AND #{child}.#{Inflex.singularize(column_name)}_id = ANY (SELECT DISTINCT old_table.id FROM old_table);
             END IF;
         END CASE;
         RETURN NULL;
@@ -49,21 +55,27 @@ defmodule Meadow.Utils.DependencyTriggers do
         CASE TG_OP
           WHEN 'INSERT' THEN
             IF EXISTS (SELECT FROM new_table) THEN
-              UPDATE #{parent} SET updated_at = NOW()
-              WHERE id = ANY (SELECT DISTINCT new_table.id FROM new_table);
+              DELETE FROM index_times
+              USING #{parent}
+              WHERE index_times.id = #{parent}.id
+              AND #{parent}.id = ANY (SELECT DISTINCT new_table.#{Inflex.singularize(parent)}_id FROM new_table);
             END IF;
           WHEN 'UPDATE' THEN
             IF EXISTS (SELECT FROM new_table) THEN
-              UPDATE #{parent} SET updated_at = NOW()
-              WHERE id = ANY (
+              DELETE FROM index_times
+              USING #{parent}
+              WHERE index_times.id = #{parent}.id
+              AND #{parent}.id = ANY (
                 SELECT DISTINCT new_table.#{Inflex.singularize(parent)}_id
                 FROM new_table JOIN old_table ON new_table.id = old_table.id AND (#{condition})
               );
             END IF;
           WHEN 'DELETE' THEN
             IF EXISTS (SELECT FROM old_table) THEN
-              UPDATE #{parent} SET updated_at = NOW()
-              WHERE id = ANY (SELECT DISTINCT old_table.id FROM old_table);
+              DELETE FROM index_times
+              USING #{parent}
+              WHERE index_times.id = #{parent}.id
+              AND #{parent}.id = ANY (SELECT DISTINCT old_table.#{Inflex.singularize(parent)}_id FROM old_table);
             END IF;
         END CASE;
         RETURN NULL;

--- a/priv/repo/migrations/20201102222710_create_notification_triggers.exs
+++ b/priv/repo/migrations/20201102222710_create_notification_triggers.exs
@@ -7,11 +7,13 @@ defmodule Meadow.Repo.Migrations.CreateNotificationTriggers do
     create_notification_trigger(:works, :all)
     create_notification_trigger(:ingest_sheets, :all)
     create_notification_trigger(:file_sets, ["structural_metadata"])
+    create_notification_trigger(:file_sets, ["structural_metadata"], :works, :work_id)
   end
 
   def down do
     drop_notification_trigger(:works)
     drop_notification_trigger(:ingest_sheets)
     drop_notification_trigger(:file_sets)
+    drop_notification_trigger(:file_sets, :works)
   end
 end

--- a/priv/repo/migrations/20211124195931_update_file_set_work_parent_trigger.exs
+++ b/priv/repo/migrations/20211124195931_update_file_set_work_parent_trigger.exs
@@ -1,0 +1,15 @@
+defmodule Meadow.Repo.Migrations.UpdateFileSetWorkParentTrigger do
+  use Ecto.Migration
+
+  import Meadow.Utils.DependencyTriggers
+
+  def up do
+    drop_parent_trigger(:works, :file_sets)
+    create_parent_trigger(:works, :file_sets, [:core_metadata, :derivatives, :poster_offset, :rank, :structural_metadata])
+  end
+
+  def down do
+    drop_parent_trigger(:works, :file_sets)
+    create_parent_trigger(:works, :file_sets, [:core_metadata, :derivatives, :rank])
+  end
+end

--- a/priv/repo/migrations/20211124223140_recreate_triggers.exs
+++ b/priv/repo/migrations/20211124223140_recreate_triggers.exs
@@ -1,0 +1,42 @@
+defmodule Meadow.Repo.Migrations.RecreateTriggers do
+  use Ecto.Migration
+
+  import Meadow.DatabaseNotification
+  import Meadow.Utils.DependencyTriggers
+
+  require Logger
+
+  def up do
+    drop_dependency_trigger(:ingest_sheets, :works)
+    drop_dependency_trigger(:collections, :works)
+    drop_dependency_trigger(:works, :file_sets)
+    drop_dependency_trigger(:works, :collections)
+
+    drop_parent_trigger(:works, :file_sets)
+    drop_old_notification_trigger(:works)
+    drop_old_notification_trigger(:ingest_sheets)
+    drop_old_notification_trigger(:file_sets)
+
+    create_dependency_trigger(:ingest_sheets, :works, [:title])
+    create_dependency_trigger(:collections, :works, [:title])
+    create_dependency_trigger(:works, :file_sets, [:published, :visibility])
+
+    create_dependency_trigger(
+      :works,
+      :collections,
+      [:representative_file_set_id],
+      :representative_work
+    )
+
+    create_parent_trigger(:works, :file_sets, [:core_metadata, :derivatives, :rank])
+
+    create_notification_trigger(:works, :all)
+    create_notification_trigger(:ingest_sheets, :all)
+    create_notification_trigger(:file_sets, ["structural_metadata"])
+    create_notification_trigger(:file_sets, :all, :works, :work_id)
+  end
+
+  def down do
+    Logger.warn("Irreversible Migration")
+  end
+end

--- a/test/meadow/database_notification_test.exs
+++ b/test/meadow/database_notification_test.exs
@@ -9,7 +9,7 @@ defmodule Meadow.DatabaseNotificationTest do
     use Ecto.Migration
     import DatabaseNotification
 
-    @table :database_notification_test
+    @table :notify_test
 
     def up do
       create table(@table) do
@@ -26,10 +26,10 @@ defmodule Meadow.DatabaseNotificationTest do
   end
 
   defmodule NotificationTestListener do
-    use DatabaseNotification, tables: [:database_notification_test]
+    use DatabaseNotification, tables: [:notify_test]
 
     @impl true
-    def handle_notification(:database_notification_test, op, key, listener) do
+    def handle_notification(:notify_test, op, key, listener) do
       send(listener, {op, key})
       {:noreply, listener}
     end
@@ -43,7 +43,7 @@ defmodule Meadow.DatabaseNotificationTest do
       Ecto.Migrator.down(repo, @migration_version, NotificationTestMigration)
     end)
 
-    sql = "INSERT INTO database_notification_test (data) VALUES ('initial value') RETURNING id"
+    sql = "INSERT INTO notify_test (data) VALUES ('initial value') RETURNING id"
 
     [[uuid]] =
       repo
@@ -65,7 +65,7 @@ defmodule Meadow.DatabaseNotificationTest do
   describe "update" do
     setup %{repo: repo} do
       assert_receive({:insert, _})
-      SQL.query!(repo, "UPDATE database_notification_test SET data = 'updated value'")
+      SQL.query!(repo, "UPDATE notify_test SET data = 'updated value'")
       :ok
     end
 
@@ -79,7 +79,7 @@ defmodule Meadow.DatabaseNotificationTest do
   describe "delete" do
     setup %{repo: repo} do
       assert_receive({:insert, _})
-      SQL.query!(repo, "DELETE FROM database_notification_test")
+      SQL.query!(repo, "DELETE FROM notify_test")
       :ok
     end
 

--- a/test/meadow/iiif/manifest_listener_test.exs
+++ b/test/meadow/iiif/manifest_listener_test.exs
@@ -43,6 +43,38 @@ defmodule Meadow.IIIF.V2.ManifestListenerTest do
       end)
     end
 
+    test "writes a 2.x manifest to S3 when it receives a Postgres DELETE notification for a fileset on an IMAGE work" do
+      work = work_fixture(%{work_type: %{id: "IMAGE", scheme: "work_type"}})
+      destination = Pairtree.manifest_key(work.id)
+
+      assert capture_log(fn ->
+               ManifestListener.handle_notification(:file_sets, :delete, %{id: work.id}, nil)
+             end)
+             |> String.contains?("Writing IIIF 2.1.x manifest for image: #{work.id}")
+
+      assert(object_exists?(@pyramid_bucket, destination))
+
+      on_exit(fn ->
+        delete_object(@pyramid_bucket, destination)
+      end)
+    end
+
+    test "writes a 3.x manifest to S3 when it receives a Postgres DELETE notification for a fileset on an AUDIO or VIDEO work" do
+      work = work_fixture(%{work_type: %{id: "VIDEO", scheme: "work_type"}})
+      destination = Pairtree.manifest_v3_key(work.id)
+
+      assert capture_log(fn ->
+               ManifestListener.handle_notification(:file_sets, :delete, %{id: work.id}, nil)
+             end)
+             |> String.contains?("Writing manifest IIIF 3.0.x for VIDEO: #{work.id}")
+
+      assert(object_exists?(@pyramid_bucket, destination))
+
+      on_exit(fn ->
+        delete_object(@pyramid_bucket, destination)
+      end)
+    end
+
     test "fails gracefully when work is not found" do
       assert {:noreply, nil} ==
                ManifestListener.handle_notification(


### PR DESCRIPTION
# Summary 

Allow notifications to happen based on parent/child dependencies instead of just changes to the same table

# Specific Changes in this PR

- Update parent trigger so that work notifactions are sent on file set insert, update and delete
- Avoid circular triggering by not updating the same tables from within indexing triggers
- Allow notifications to other tables

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- `mix ecto.migrate`
- Create a work with multiple filesets
- Make sure the manifest gets written
- Edit one of the work's filesets without touching the work itself
- Make sure the manifest gets rewritten

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

