### PR TITLE
Break-word on long title on search cards

### DIFF
--- a/assets/js/components/Work/CardItem.jsx
+++ b/assets/js/components/Work/CardItem.jsx
@@ -56,7 +56,9 @@ const WorkCardItem = ({
             />
           )}
         </div>
-        <p data-testid={`work-title-${id}`}>{title}</p>
+        <p data-testid={`work-title-${id}`} css={breakWord}>
+          {title}
+        </p>
         <p data-testid="accession-number" css={breakWord}>
           {accessionNumber}
         </p>

--- a/assets/js/components/Work/ListItem.jsx
+++ b/assets/js/components/Work/ListItem.jsx
@@ -10,6 +10,12 @@ import UIWorkImage from "../UI/WorkImage";
 import { Tag } from "@nulib/design-system";
 import UIVisibilityTag from "@js/components/UI/VisibilityTag";
 
+/** @jsx jsx */
+import { css, jsx } from "@emotion/react";
+const breakWord = css`
+  word-break: break-all;
+`;
+
 const WorkListItem = ({
   id,
   representativeImage,
@@ -37,7 +43,9 @@ const WorkListItem = ({
         </figure>
         <div className="media-content">
           <p className="small-title block">
-            <Link to={`/work/${id}`}>{title ? title : "Untitled"}</Link>
+            <Link to={`/work/${id}`} css={breakWord}>
+              {title ? title : "Untitled"}
+            </Link>
           </p>
           <div className="tags">
             <Tag isInfo>{workType.label}</Tag>


### PR DESCRIPTION
# Summary 
This address a minor styling issue where long titles do not wrap to the next line and extend beyond the constraints of their container.

# Specific Changes in this PR
- Breaks word on long title 

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

1. Search
2. Find/Create a work with a long title, ex: `new_work_0130213302124012241412421122_assda9dasudas90udassadsdaassa_12_02_2021_copy.jpg`
3. Check if it wraps in list and grid views.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

