### PR TITLE
Update Tag icon spacing using variant, bump design-system.

### DIFF
--- a/assets/js/components/Work/TagsList.jsx
+++ b/assets/js/components/Work/TagsList.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Tag } from "@nulib/design-system";
+import { Icon, Tag } from "@nulib/design-system";
 import UIVisibilityTag from "@js/components/UI/VisibilityTag";
 import { IconAudio, IconImages, IconVideo } from "../Icon";
 
@@ -13,9 +13,11 @@ export default function WorkTagsList({ work }) {
     const id = work.workType.id;
     return (
       <>
-        {id === "AUDIO" && <IconAudio />}
-        {id === "VIDEO" && <IconVideo />}
-        {id === "IMAGE" && <IconImages />}
+        <Icon>
+          {id === "AUDIO" && <Icon.Audio />}
+          {id === "IMAGE" && <Icon.Image />}
+          {id === "VIDEO" && <Icon.Video />}
+        </Icon>
         <span>{work.workType.label}</span>
       </>
     );
@@ -23,7 +25,11 @@ export default function WorkTagsList({ work }) {
 
   return (
     <div className="tags">
-      {work.workType && <Tag isInfo>{renderWorkType()}</Tag>}
+      {work.workType && (
+        <Tag isInfo isIcon>
+          {renderWorkType()}
+        </Tag>
+      )}
       {work.published ? (
         <Tag isSuccess>Published</Tag>
       ) : (

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -18,7 +18,7 @@
         "@fortawesome/react-fontawesome": "^0.1.15",
         "@honeybadger-io/js": "^3.2.5",
         "@honeybadger-io/react": "^1.0.1",
-        "@nulib/design-system": "^1.3.1",
+        "@nulib/design-system": "^1.3.3",
         "@nulib/react-media-player": "^1.5.0",
         "@radix-ui/react-dialog": "^0.1.1",
         "@samvera/image-downloader": "^1.1.0",
@@ -3392,9 +3392,9 @@
       }
     },
     "node_modules/@nulib/design-system": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@nulib/design-system/-/design-system-1.3.1.tgz",
-      "integrity": "sha512-eTuNkcVirKi3LNosmG19hB8ZRS2rEpF7Fzv4yLDeCq0DVEzkYxFbbVVa7ey4gHsI1Q4tqUdhzf1KKAOulpBuQA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@nulib/design-system/-/design-system-1.3.3.tgz",
+      "integrity": "sha512-5fa/l99BAfJXbsTpQn50rscYF9oMRd02xl4GIEBEy8uZnf1SGH1Yt3PglXfymxDhR5ZjmLBLxuBF3Iq8eTl5OA==",
       "dependencies": {
         "@radix-ui/colors": "^0.1.7",
         "@radix-ui/react-popover": "^0.1.1",
@@ -22339,9 +22339,9 @@
       }
     },
     "@nulib/design-system": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@nulib/design-system/-/design-system-1.3.1.tgz",
-      "integrity": "sha512-eTuNkcVirKi3LNosmG19hB8ZRS2rEpF7Fzv4yLDeCq0DVEzkYxFbbVVa7ey4gHsI1Q4tqUdhzf1KKAOulpBuQA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@nulib/design-system/-/design-system-1.3.3.tgz",
+      "integrity": "sha512-5fa/l99BAfJXbsTpQn50rscYF9oMRd02xl4GIEBEy8uZnf1SGH1Yt3PglXfymxDhR5ZjmLBLxuBF3Iq8eTl5OA==",
       "requires": {
         "@radix-ui/colors": "^0.1.7",
         "@radix-ui/react-popover": "^0.1.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -26,7 +26,7 @@
     "@fortawesome/react-fontawesome": "^0.1.15",
     "@honeybadger-io/js": "^3.2.5",
     "@honeybadger-io/react": "^1.0.1",
-    "@nulib/design-system": "^1.3.1",
+    "@nulib/design-system": "^1.3.3",
     "@nulib/react-media-player": "^1.5.0",
     "@radix-ui/react-dialog": "^0.1.1",
     "@samvera/image-downloader": "^1.1.0",


### PR DESCRIPTION
# Summary 
This fixes the icon spacing issue by updating the `<Tag/>` icon with a **isIcon** variant wrapping a `@nulib/design-system` `<Icon/>`. 

# Specific Changes in this PR
- Fixes <Tag/> icon spacing issue
- Bumps `@nulib/design-system` to 1.3.3
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

1. Go to Search
2. Click a work
3. Tag/Icon spacing should look pretty clean

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

