### PR TITLE
Fix local authority search bug and view icon sizing

### DIFF
--- a/assets/js/components/Dashboards/LocalAuthorities/List.jsx
+++ b/assets/js/components/Dashboards/LocalAuthorities/List.jsx
@@ -12,7 +12,7 @@ import {
 } from "@js/components/Dashboards/dashboards.gql";
 import { AUTHORITIES_SEARCH } from "@js/components/Work/controlledVocabulary.gql";
 import { Button, Notification } from "@nulib/design-system";
-import { Link } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import { toastWrapper } from "@js/services/helpers";
 import DashboardsLocalAuthoritiesModalEdit from "@js/components/Dashboards/LocalAuthorities/ModalEdit";
 import UIFormInput from "@js/components/UI/Form/Input";
@@ -23,6 +23,7 @@ const colHeaders = ["Label", "Hint"];
 
 export default function DashboardsLocalAuthoritiesList() {
   const client = useApolloClient();
+  const history = useHistory();
   const [currentAuthority, setCurrentAuthority] = React.useState();
   const [filteredAuthorities, setFilteredAuthorities] = React.useState([]);
   const [modalsState, setModalsState] = React.useState({
@@ -51,7 +52,7 @@ export default function DashboardsLocalAuthoritiesList() {
         },
       });
     } else {
-      setFilteredAuthorities(data.nulAuthorityRecords);
+      setFilteredAuthorities([...data.nulAuthorityRecords]);
     }
   }
 
@@ -109,7 +110,7 @@ export default function DashboardsLocalAuthoritiesList() {
   ] = useLazyQuery(AUTHORITIES_SEARCH, {
     fetchPolicy: "network-only",
     onCompleted: (data) => {
-      setFilteredAuthorities(dataAuthoritiesSearch.authoritiesSearch);
+      setFilteredAuthorities([...data.authoritiesSearch]);
     },
     onError({ graphQLErrors, networkError }) {
       console.error("graphQLErrors", graphQLErrors);
@@ -170,6 +171,12 @@ export default function DashboardsLocalAuthoritiesList() {
     setSearchValue(e.target.value);
   };
 
+  const handleViewClick = (id) => {
+    history.push("/search", {
+      passedInSearchTerm: `all_controlled_terms:\"${id}\"`,
+    });
+  };
+
   return (
     <React.Fragment>
       <SearchBarRow isCentered>
@@ -218,6 +225,14 @@ export default function DashboardsLocalAuthoritiesList() {
                         <IconEdit />
                       </Button>
                       <Button
+                        onClick={() => handleViewClick(id)}
+                        isLight
+                        data-testid="button-to-search"
+                        title="View works containing this record"
+                      >
+                        <IconImages />
+                      </Button>
+                      <Button
                         isLight
                         data-testid="delete-button"
                         className="is-small"
@@ -225,19 +240,6 @@ export default function DashboardsLocalAuthoritiesList() {
                       >
                         <IconTrashCan />
                       </Button>
-                      <Link
-                        data-testid="button-to-search"
-                        className="button is-small is-light"
-                        title="View works containing this record"
-                        to={{
-                          pathname: "/search",
-                          state: {
-                            passedInSearchTerm: `all_controlled_terms:\"${id}\"`,
-                          },
-                        }}
-                      >
-                        <IconImages />
-                      </Link>
                     </div>
                   </td>
                 </tr>


### PR DESCRIPTION
# Summary 
Fix local authority search bug

# Specific Changes in this PR
- Fix local authority search bug
- Update "view images" button icon sizing (make it a `Button` instead of a `Link`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Go to Local Authorities Dashboard and notice search/filter now works.

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

