### PR TITLE
Bump react-media-player, include work type icons.

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -18,8 +18,8 @@
         "@fortawesome/react-fontawesome": "^0.1.15",
         "@honeybadger-io/js": "^3.2.5",
         "@honeybadger-io/react": "^1.0.1",
-        "@nulib/design-system": "^1.3.4",
-        "@nulib/react-media-player": "^1.5.0",
+        "@nulib/design-system": "^1.3.5",
+        "@nulib/react-media-player": "^1.5.3",
         "@radix-ui/react-dialog": "^0.1.1",
         "@samvera/image-downloader": "^1.1.0",
         "bulma": "^0.9.3",
@@ -3392,9 +3392,9 @@
       }
     },
     "node_modules/@nulib/design-system": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@nulib/design-system/-/design-system-1.3.4.tgz",
-      "integrity": "sha512-VhdH0H8JkB6Up8tMIKS1s2jg8vFzlOuENbKyMXnQL6osKO5ix2te5nFiz5c3OGLf+m8wpTsvAlytkpNfXffEHw==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@nulib/design-system/-/design-system-1.3.5.tgz",
+      "integrity": "sha512-RMoeNBYgOpcnhOg2ox7fDI71E4RIOd1HOVf8bFQRZPqR9E/qMia2SUA+YLMRPXaJWO6vKDbwIplJpl6wCdxfsw==",
       "dependencies": {
         "@radix-ui/colors": "^0.1.7",
         "@radix-ui/react-popover": "^0.1.1",
@@ -3414,14 +3414,15 @@
       "dev": true
     },
     "node_modules/@nulib/react-media-player": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.5.0.tgz",
-      "integrity": "sha512-UIFLXYPZ8KByfMz8dGTCXvptN2pYuceUN65a9pMx9gzoN5V3PKb2q5hu8TFpHSP1ZZWXf5nH/Fp0TJUCVqTzFA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.5.3.tgz",
+      "integrity": "sha512-kpSdtd9DjsWntAFSQ6QIXbcVmVsKf5eip6dHDKhdGDYCiO0DFNIoo9lHv2MdskYjDPgNhwHxLmkhhHuRRbM3/g==",
       "dependencies": {
         "@hyperion-framework/parser": "^1.0.0",
         "@hyperion-framework/types": "^1.0.0",
         "@hyperion-framework/validator": "^1.0.0",
         "@hyperion-framework/vault": "^1.0.2",
+        "@nulib/design-system": "^1.3.5",
         "@radix-ui/react-radio-group": "^0.1.1",
         "@radix-ui/react-tabs": "^0.1.1",
         "@stitches/react": "^1.2.0",
@@ -22339,9 +22340,9 @@
       }
     },
     "@nulib/design-system": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@nulib/design-system/-/design-system-1.3.4.tgz",
-      "integrity": "sha512-VhdH0H8JkB6Up8tMIKS1s2jg8vFzlOuENbKyMXnQL6osKO5ix2te5nFiz5c3OGLf+m8wpTsvAlytkpNfXffEHw==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@nulib/design-system/-/design-system-1.3.5.tgz",
+      "integrity": "sha512-RMoeNBYgOpcnhOg2ox7fDI71E4RIOd1HOVf8bFQRZPqR9E/qMia2SUA+YLMRPXaJWO6vKDbwIplJpl6wCdxfsw==",
       "requires": {
         "@radix-ui/colors": "^0.1.7",
         "@radix-ui/react-popover": "^0.1.1",
@@ -22357,14 +22358,15 @@
       "dev": true
     },
     "@nulib/react-media-player": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.5.0.tgz",
-      "integrity": "sha512-UIFLXYPZ8KByfMz8dGTCXvptN2pYuceUN65a9pMx9gzoN5V3PKb2q5hu8TFpHSP1ZZWXf5nH/Fp0TJUCVqTzFA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.5.3.tgz",
+      "integrity": "sha512-kpSdtd9DjsWntAFSQ6QIXbcVmVsKf5eip6dHDKhdGDYCiO0DFNIoo9lHv2MdskYjDPgNhwHxLmkhhHuRRbM3/g==",
       "requires": {
         "@hyperion-framework/parser": "^1.0.0",
         "@hyperion-framework/types": "^1.0.0",
         "@hyperion-framework/validator": "^1.0.0",
         "@hyperion-framework/vault": "^1.0.2",
+        "@nulib/design-system": "^1.3.5",
         "@radix-ui/react-radio-group": "^0.1.1",
         "@radix-ui/react-tabs": "^0.1.1",
         "@stitches/react": "^1.2.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -27,7 +27,7 @@
     "@honeybadger-io/js": "^3.2.5",
     "@honeybadger-io/react": "^1.0.1",
     "@nulib/design-system": "^1.3.5",
-    "@nulib/react-media-player": "^1.5.0",
+    "@nulib/react-media-player": "^1.5.3",
     "@radix-ui/react-dialog": "^0.1.1",
     "@samvera/image-downloader": "^1.1.0",
     "bulma": "^0.9.3",


### PR DESCRIPTION
# Summary 
This PR just bump RMP up from 1.5.0 to 1.5.2

# Specific Changes in this PR
- Bumps RMP to 1.5.3
- Includes Work Type Icons for RMP
- Includes box-sizing fix on OpenSeadragon controls
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
RMP functions as expected in Meadow

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

