### PR TITLE
Support .framemd5 Supplemental files in FileSet upload

### DIFF
--- a/assets/js/hooks/useAcceptedMimeTypes.js
+++ b/assets/js/hooks/useAcceptedMimeTypes.js
@@ -2,6 +2,11 @@
 
 export default function useAcceptedMimeTypes() {
   function isFileValid(fileSetRole, workTypeId, mimeType) {
+    // Automatically pass through Supplemental file types
+    if (fileSetRole === "S") {
+      return { code: "", message: "", isValid: true };
+    }
+
     if (!fileSetRole || !workTypeId || !mimeType) {
       return { isValid: false };
     }
@@ -15,9 +20,6 @@ export default function useAcceptedMimeTypes() {
     let isValid = true;
 
     switch (fileSetRole) {
-      case "S":
-        return { code, message, isValid };
-
       case "X":
         if (!isImage) {
           isValid = false;

--- a/assets/js/hooks/useAcceptedMimeTypes.test.js
+++ b/assets/js/hooks/useAcceptedMimeTypes.test.js
@@ -16,6 +16,9 @@ describe("useAcceptedMimeTypes hook", () => {
     const { isFileValid } = useAcceptedMimeTypes();
     const result = isFileValid("S", "IMAGE", "application/*");
     expect(result.isValid).toBeTruthy();
+
+    const resultNoMimeType = isFileValid("S", "", "");
+    expect(resultNoMimeType.isValid).toBeTruthy();
   });
 
   it("returns valid states for a auxiliary role", () => {


### PR DESCRIPTION
# Summary 
Allow any Supplemental Fileset upload to pass through, regardless of whether the file has a mime type or not

# Specific Changes in this PR
- Refactor how we're processing Supplemental file uploads, to not care about `mime type`.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
- Select a video work
- Go to Preservation tab, and upload a new file (`test/fixtures/supplemental_file.framemd5`)
- Notice the file upload is allowed

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

