### PR TITLE
Don't make UI wait for checksumming on file set upload

### DIFF
--- a/priv/repo/seeds/coded_terms.exs
+++ b/priv/repo/seeds/coded_terms.exs
@@ -1,6 +1,5 @@
 defmodule Meadow.Repo.Seeds.CodedTerms do
   alias Meadow.Data.CodedTerms
-  alias Meadow.Repo
 
   def run do
     Path.relative_to_cwd(__ENV__.file)


### PR DESCRIPTION
# Summary 

UI was sometimes freezing when uploading a file set due to waiting for checksumming. Waiting for checksumming should happen asynchronously so as not to affect the UI.

# Specific Changes in this PR
- return the file set to the front end after creation and wait for the checksumming + kick off the pipeline in an async task.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- upload a file set in the UI. There should not be any freezing or noticeable lag


# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

