### PR TITLE
Only send bucket notifications on Put and CompleteMultipartUpload, not all Put* events

### DIFF
--- a/lib/mix/tasks/meadow.ex
+++ b/lib/mix/tasks/meadow.ex
@@ -53,7 +53,8 @@ defmodule Mix.Tasks.Meadow.Buckets.Create do
     notification_configuration = """
       <NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
         <QueueConfiguration>
-          <Event>s3:ObjectCreated:*</Event>
+          <Event>s3:ObjectCreated:Put</Event>
+          <Event>s3:ObjectCreated:CompleteMultipartUpload</Event>
           <Queue>#{notification_arn}</Queue>
         </QueueConfiguration>
       </NotificationConfiguration>


### PR DESCRIPTION
# Summary 
Small update to the Minio bucket events configured in dev mode

# Specific Changes in this PR
- Send a more specific list of bucket events to `PutBucketNotificationConfiguration`

# Version bump required by the PR

- [x] None (dev environment only)
- [ ] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

