### PR TITLE
Include responsive updates to a/v iiif media player.

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -19,7 +19,7 @@
         "@honeybadger-io/js": "^3.2.5",
         "@honeybadger-io/react": "^1.0.1",
         "@nulib/design-system": "^1.3.5",
-        "@nulib/react-media-player": "^1.5.3",
+        "@nulib/react-media-player": "^1.6.1",
         "@radix-ui/react-dialog": "^0.1.1",
         "@samvera/image-downloader": "^1.1.0",
         "bulma": "^0.9.3",
@@ -3414,15 +3414,16 @@
       "dev": true
     },
     "node_modules/@nulib/react-media-player": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.5.3.tgz",
-      "integrity": "sha512-kpSdtd9DjsWntAFSQ6QIXbcVmVsKf5eip6dHDKhdGDYCiO0DFNIoo9lHv2MdskYjDPgNhwHxLmkhhHuRRbM3/g==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.6.1.tgz",
+      "integrity": "sha512-rpW1SSLs7b3+K1ejyfJwnW0ZG6/JCUXRe6BGhM+gDRAWNMysEA9Vg0rVzv6mAaQxX9x2golRtAd3SGYY90if+w==",
       "dependencies": {
         "@hyperion-framework/parser": "^1.0.0",
         "@hyperion-framework/types": "^1.0.0",
         "@hyperion-framework/validator": "^1.0.0",
         "@hyperion-framework/vault": "^1.0.2",
         "@nulib/design-system": "^1.3.5",
+        "@radix-ui/react-collapsible": "^0.1.1",
         "@radix-ui/react-radio-group": "^0.1.1",
         "@radix-ui/react-tabs": "^0.1.1",
         "@stitches/react": "^1.2.0",
@@ -3519,6 +3520,77 @@
       }
     },
     "node_modules/@radix-ui/react-arrow/node_modules/regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-0.1.4.tgz",
+      "integrity": "sha512-1qKR5Y3grdqYTjtZmUSIbOt5d/hj6tzT8Lc5cpGH71rI/AP20W13FhNQSDSZpq7kZO6FUGFOPUGK6tapjs4bBA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "0.1.0",
+        "@radix-ui/react-compose-refs": "0.1.0",
+        "@radix-ui/react-context": "0.1.1",
+        "@radix-ui/react-id": "0.1.3",
+        "@radix-ui/react-presence": "0.1.1",
+        "@radix-ui/react-primitive": "0.1.2",
+        "@radix-ui/react-use-controllable-state": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@babel/runtime": {
+      "version": "7.16.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+      "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-id": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.1.3.tgz",
+      "integrity": "sha512-kA7erDg8S/bad9O6RTC+laW11gm2pvmEqlZA+rvzI+WEkQXStIgnVp+wA420be4q20UiLQw9cmIP01AIhDVdZQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-use-layout-effect": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-primitive": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.2.tgz",
+      "integrity": "sha512-mVgeBkuNRZRCzHuDm2DWjZEIs3ntp4m3GtKWPXUn+SgmJXIIpVLt7KhvEmNkgXURq/DJgxG9GmJJMXkACioH/A==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "0.1.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-slot": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
+      "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "0.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0"
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
       "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
@@ -22358,15 +22430,16 @@
       "dev": true
     },
     "@nulib/react-media-player": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.5.3.tgz",
-      "integrity": "sha512-kpSdtd9DjsWntAFSQ6QIXbcVmVsKf5eip6dHDKhdGDYCiO0DFNIoo9lHv2MdskYjDPgNhwHxLmkhhHuRRbM3/g==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.6.1.tgz",
+      "integrity": "sha512-rpW1SSLs7b3+K1ejyfJwnW0ZG6/JCUXRe6BGhM+gDRAWNMysEA9Vg0rVzv6mAaQxX9x2golRtAd3SGYY90if+w==",
       "requires": {
         "@hyperion-framework/parser": "^1.0.0",
         "@hyperion-framework/types": "^1.0.0",
         "@hyperion-framework/validator": "^1.0.0",
         "@hyperion-framework/vault": "^1.0.2",
         "@nulib/design-system": "^1.3.5",
+        "@radix-ui/react-collapsible": "^0.1.1",
         "@radix-ui/react-radio-group": "^0.1.1",
         "@radix-ui/react-tabs": "^0.1.1",
         "@stitches/react": "^1.2.0",
@@ -22452,6 +22525,64 @@
           "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+        }
+      }
+    },
+    "@radix-ui/react-collapsible": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-0.1.4.tgz",
+      "integrity": "sha512-1qKR5Y3grdqYTjtZmUSIbOt5d/hj6tzT8Lc5cpGH71rI/AP20W13FhNQSDSZpq7kZO6FUGFOPUGK6tapjs4bBA==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "0.1.0",
+        "@radix-ui/react-compose-refs": "0.1.0",
+        "@radix-ui/react-context": "0.1.1",
+        "@radix-ui/react-id": "0.1.3",
+        "@radix-ui/react-presence": "0.1.1",
+        "@radix-ui/react-primitive": "0.1.2",
+        "@radix-ui/react-use-controllable-state": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "0.1.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+          "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@radix-ui/react-id": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-0.1.3.tgz",
+          "integrity": "sha512-kA7erDg8S/bad9O6RTC+laW11gm2pvmEqlZA+rvzI+WEkQXStIgnVp+wA420be4q20UiLQw9cmIP01AIhDVdZQ==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-use-layout-effect": "0.1.0"
+          }
+        },
+        "@radix-ui/react-primitive": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-0.1.2.tgz",
+          "integrity": "sha512-mVgeBkuNRZRCzHuDm2DWjZEIs3ntp4m3GtKWPXUn+SgmJXIIpVLt7KhvEmNkgXURq/DJgxG9GmJJMXkACioH/A==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-slot": "0.1.2"
+          }
+        },
+        "@radix-ui/react-slot": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-0.1.2.tgz",
+          "integrity": "sha512-ADkqfL+agEzEguU3yS26jfB50hRrwf7U4VTwAOZEmi/g+ITcBWe12yM46ueS/UCIMI9Py+gFUaAdxgxafFvY2Q==",
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@radix-ui/react-compose-refs": "0.1.0"
           }
         },
         "regenerator-runtime": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -27,7 +27,7 @@
     "@honeybadger-io/js": "^3.2.5",
     "@honeybadger-io/react": "^1.0.1",
     "@nulib/design-system": "^1.3.5",
-    "@nulib/react-media-player": "^1.5.3",
+    "@nulib/react-media-player": "^1.6.1",
     "@radix-ui/react-dialog": "^0.1.1",
     "@samvera/image-downloader": "^1.1.0",
     "bulma": "^0.9.3",


### PR DESCRIPTION
# Summary 
Bumps React Media Player to include responsive updates in 
https://github.com/nulib/react-media-player/pull/45 and https://github.com/nulib/react-media-player/pull/46.

# Specific Changes in this PR
- React Media Player now has baseline responsiveness at a small breakpoint.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Test an Audio or Video work in responsive mode. The viewer should fluidly work when rendered on the Work screen.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

