### PR TITLE
Disable submit buttons for batch update and CSV metadata update after form submit

### DIFF
--- a/assets/js/components/BatchEdit/Confirmation.jsx
+++ b/assets/js/components/BatchEdit/Confirmation.jsx
@@ -45,6 +45,7 @@ const BatchEditConfirmation = ({
   const history = useHistory();
   const [confirmationError, setConfirmationError] = useState({});
   const [batchNickname, setBatchNickname] = useState();
+  const [isSubmitted, setIsSubmitted] = useState(false);
   const codeLists = useCodeLists();
 
   const [batchUpdate] = useMutation(BATCH_UPDATE, {
@@ -75,6 +76,8 @@ const BatchEditConfirmation = ({
   };
 
   const handleBatchEditConfirm = () => {
+    setIsSubmitted(true);
+
     const cleanedPostValues = removeLabelsFromBatchEditPostData(
       batchAdds,
       batchDeletes,
@@ -262,7 +265,7 @@ const BatchEditConfirmation = ({
           </Button>
           <Button
             isPrimary
-            disabled={confirmationError || !hasDataToPost}
+            disabled={confirmationError || !hasDataToPost || isSubmitted}
             onClick={handleBatchEditConfirm}
             data-testid="button-submit"
           >

--- a/assets/js/components/BatchEdit/Tabs.jsx
+++ b/assets/js/components/BatchEdit/Tabs.jsx
@@ -79,9 +79,7 @@ export default function BatchEditTabs() {
 
     // Process Descriptive metadata items
     if (currentFormValues.notes?.length > 0) {
-      replaceItems.descriptive.notes = prepNotes(
-        currentFormValues.notes
-      );
+      replaceItems.descriptive.notes = prepNotes(currentFormValues.notes);
     }
     if (currentFormValues.relatedUrl?.length > 0) {
       replaceItems.descriptive.relatedUrl = prepRelatedUrl(

--- a/assets/js/components/Dashboards/Csv/Import.jsx
+++ b/assets/js/components/Dashboards/Csv/Import.jsx
@@ -82,6 +82,8 @@ function DashboardsCsvImport() {
   }
 
   const handleImportCsv = () => {
+    setIsSubmitted(true);
+
     if (currentFile) {
       uploadToS3()
         .then(

--- a/assets/js/components/Dashboards/Csv/ImportModal.jsx
+++ b/assets/js/components/Dashboards/Csv/ImportModal.jsx
@@ -19,6 +19,16 @@ function DashboardsCsvImportModal({
   isOpen,
   setCurrentFile,
 }) {
+  const [isSubmitted, setIsSubmitted] = React.useState(false);
+
+  React.useEffect(() => {
+    // Reset the isSubmitted value when re-opening the modal
+    // so user can click the Submit button once again
+    if (isSubmitted && isOpen) {
+      setIsSubmitted(false);
+    }
+  }, [isOpen]);
+
   // Handle file drop
   const onDrop = React.useCallback((acceptedFiles) => {
     setCurrentFile(acceptedFiles[0]);
@@ -31,6 +41,7 @@ function DashboardsCsvImportModal({
   };
 
   const handleImportClick = () => {
+    setIsSubmitted(true);
     handleImportCsv(currentFile);
   };
 
@@ -104,7 +115,7 @@ function DashboardsCsvImportModal({
           <Button
             isPrimary
             onClick={handleImportClick}
-            disabled={!currentFile}
+            disabled={!currentFile || isSubmitted}
             data-testid="submit-button"
           >
             Import


### PR DESCRIPTION
# Summary 
Make submit buttons disabled for batch update after submit, and for the CSV Metadata update form after submit

# Specific Changes in this PR
- Disable Batch update confirmation submit button after submitting the form.
- Disable CSV metadata update button after a submit to avoid duplicate submits.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
- You might have to turn on Network Throttling in your browser dev console, to mimic a slow network connection, which may or may not help test this in the UI.
- For a Batch Update, notice the final Confirmation submit button will be disabled immediately following the final form submit
- For a CSV metadata update from it's dashboard, upload a new CSV file, and notice the modal submit button will become deactivated immediately following a form submit.  

Note this may be hard to test in the actual UI if the UI is moving quickly.

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

