### PR TITLE
Add search filter links on administrative tab.

### DIFF
--- a/assets/js/components/Work/Tabs/Administrative/Administrative.jsx
+++ b/assets/js/components/Work/Tabs/Administrative/Administrative.jsx
@@ -16,6 +16,7 @@ import WorkTabsAdministrativeCollection from "@js/components/Work/Tabs/Administr
 import useFacetLinkClick from "@js/hooks/useFacetLinkClick";
 import { formatDate } from "@js/services/helpers";
 import { IconEdit } from "@js/components/Icon";
+import usePassedInSearchTerm from "@js/hooks/usePassedInSearchTerm";
 
 const WorkTabsAdministrative = ({ work }) => {
   const {
@@ -33,6 +34,7 @@ const WorkTabsAdministrative = ({ work }) => {
   const [isEditing, setIsEditing] = useIsEditing();
   const methods = useForm();
   const { handleFacetLinkClick } = useFacetLinkClick();
+  const { handlePassedInSearchTerm } = usePassedInSearchTerm();
 
   const [updateWork, { loading: updateWorkLoading, error: updateWorkError }] =
     useMutation(UPDATE_WORK, {
@@ -43,7 +45,14 @@ const WorkTabsAdministrative = ({ work }) => {
       refetchQueries: [{ query: GET_WORK, variables: { id: work.id } }],
       awaitRefetchQueries: true,
     });
-  const { projectCycle } = administrativeMetadata;
+  const {
+    projectCycle,
+    projectDesc,
+    projectManager,
+    projectName,
+    projectProposer,
+    projectTaskNumber,
+  } = administrativeMetadata;
 
   const onSubmit = (data) => {
     const currentFormValues = methods.getValues();
@@ -160,34 +169,34 @@ const WorkTabsAdministrative = ({ work }) => {
 
               <UIFormField label="Ingest Project">
                 {project ? (
-                  <p>
-                    <Button
-                      isText
-                      onClick={() =>
-                        handleFacetLinkClick("Project", project.title || null)
-                      }
-                      data-testid="view-project-works"
-                    >
-                      {project.title || ""}
-                    </Button>
-                  </p>
+                  <Button
+                    isText
+                    data-testid="view-project-works"
+                    className="break-word"
+                    onClick={() =>
+                      handleFacetLinkClick("IngestProject", project.title)
+                    }
+                    css={{ padding: "0", textTransform: "none !important" }}
+                  >
+                    <span>{project.title}</span>
+                  </Button>
                 ) : null}
               </UIFormField>
 
               <UIFormField label="Ingest Sheet">
-                <p>
-                  {project && ingestSheet && (
-                    <Button
-                      isText
-                      onClick={() =>
-                        handleFacetLinkClick("IngestSheet", ingestSheet.title)
-                      }
-                      data-testid="view-ingest-sheet-works"
-                    >
-                      {ingestSheet.title}
-                    </Button>
-                  )}
-                </p>
+                {project && ingestSheet ? (
+                  <Button
+                    isText
+                    data-testid="view-ingest-sheet-works"
+                    className="break-word"
+                    onClick={() =>
+                      handleFacetLinkClick("IngestSheet", ingestSheet.title)
+                    }
+                    css={{ padding: "0", textTransform: "none !important" }}
+                  >
+                    <span>{ingestSheet.title}</span>
+                  </Button>
+                ) : null}
               </UIFormField>
 
               <UIFormField label="Project Cycle">
@@ -200,33 +209,152 @@ const WorkTabsAdministrative = ({ work }) => {
                     label="Project Cycle"
                     defaultValue={projectCycle}
                   />
-                ) : (
-                  <p>{projectCycle}</p>
-                )}
+                ) : projectCycle ? (
+                  <Button
+                    isText
+                    data-testid="project-cycle-link"
+                    className="break-word"
+                    onClick={() =>
+                      handleFacetLinkClick("ProjectCycle", projectCycle)
+                    }
+                    css={{ padding: "0", textTransform: "none !important" }}
+                  >
+                    <span>{projectCycle}</span>
+                  </Button>
+                ) : null}
               </UIFormField>
 
-              {PROJECT_METADATA.map((item) => {
-                return (
-                  <UIFormField
-                    label={item.label}
-                    key={item.name}
-                    data-testid={item.name}
+              <UIFormField label="Project / Job Name">
+                {isEditing ? (
+                  <UIFormInput
+                    data-testid="project-name"
+                    isReactHookForm
+                    placeholder="Project Name"
+                    name="projectName"
+                    label="Project Name"
+                    defaultValue={projectName}
+                  />
+                ) : projectName.length > 0 ? (
+                  <Button
+                    isText
+                    data-testid="project-name-link"
+                    className="break-word"
+                    onClick={() =>
+                      handleFacetLinkClick("ProjectName", projectName)
+                    }
+                    css={{ padding: "0", textTransform: "none !important" }}
                   >
-                    {isEditing ? (
-                      <UIFormInput
-                        isReactHookForm
-                        // NOTE: Eventually Project data will come in as single values instead of an array
-                        defaultValue={administrativeMetadata[item.name][0]}
-                        label={item.label}
-                        name={item.name}
-                        placeholder={item.label}
-                      />
-                    ) : (
-                      <p>{administrativeMetadata[item.name][0]}</p>
-                    )}
-                  </UIFormField>
-                );
-              })}
+                    <span>{projectName}</span>
+                  </Button>
+                ) : null}
+              </UIFormField>
+
+              <UIFormField label="Project / Job Description">
+                {isEditing ? (
+                  <UIFormInput
+                    data-testid="project-description"
+                    isReactHookForm
+                    placeholder="Project Description"
+                    name="projectDescription"
+                    label="Project Description"
+                    defaultValue={projectDesc}
+                  />
+                ) : projectDesc.length > 0 ? (
+                  <Button
+                    isText
+                    data-testid="project-description-link"
+                    className="break-word"
+                    onClick={() =>
+                      handlePassedInSearchTerm(
+                        "administrativeMetadata.projectDesc",
+                        projectDesc || null
+                      )
+                    }
+                    css={{ padding: "0", textTransform: "none !important" }}
+                  >
+                    <span>{projectDesc}</span>
+                  </Button>
+                ) : null}
+              </UIFormField>
+
+              <UIFormField label="Project / Job Manager">
+                {isEditing ? (
+                  <UIFormInput
+                    data-testid="project-manager"
+                    isReactHookForm
+                    placeholder="Project Manager"
+                    name="projectManager"
+                    label="Project Manager"
+                    defaultValue={projectManager}
+                  />
+                ) : projectManager.length > 0 ? (
+                  <Button
+                    isText
+                    data-testid="project-manager-link"
+                    className="break-word"
+                    onClick={() =>
+                      handleFacetLinkClick("ProjectManager", projectManager)
+                    }
+                    css={{ padding: "0", textTransform: "none !important" }}
+                  >
+                    <span>{projectManager}</span>
+                  </Button>
+                ) : null}
+              </UIFormField>
+
+              <UIFormField label="Project / Job Proposer">
+                {isEditing ? (
+                  <UIFormInput
+                    data-testid="project-proposer"
+                    isReactHookForm
+                    placeholder="Project Proposer"
+                    name="projectProposer"
+                    label="Project Proposer"
+                    defaultValue={projectProposer}
+                  />
+                ) : projectProposer.length > 0 ? (
+                  <Button
+                    isText
+                    data-testid="project-proposer-link"
+                    className="break-word"
+                    onClick={() =>
+                      handleFacetLinkClick("ProjectProposer", projectProposer)
+                    }
+                    css={{ padding: "0", textTransform: "none !important" }}
+                  >
+                    <span>{projectProposer}</span>
+                  </Button>
+                ) : null}
+              </UIFormField>
+
+              <UIFormField label="Project / Job Tasker Number">
+                {isEditing ? (
+                  <UIFormInput
+                    data-testid="project-task-number"
+                    isReactHookForm
+                    placeholder="Project Task Number"
+                    name="projectTaskNumber"
+                    label="Project Task Number"
+                    defaultValue={projectTaskNumber}
+                  />
+                ) : projectTaskNumber.length > 0 ? (
+                  <Button
+                    isText
+                    data-testid="project-task-number-link"
+                    className="break-word"
+                    onClick={() =>
+                      handleFacetLinkClick(
+                        "ProjectTaskNumber",
+                        projectTaskNumber
+                      )
+                    }
+                    css={{ padding: "0", textTransform: "none !important" }}
+                  >
+                    <span>{projectTaskNumber}</span>
+                  </Button>
+                ) : null}
+              </UIFormField>
+
               <div className="field content">
                 <p data-testid="inserted-at-label">
                   <strong>Work Created</strong>: {formatDate(insertedAt)}

--- a/assets/js/components/Work/Tabs/Administrative/General.jsx
+++ b/assets/js/components/Work/Tabs/Administrative/General.jsx
@@ -5,6 +5,9 @@ import UIFormSelect from "@js/components/UI/Form/Select";
 import { useCodeLists } from "@js/context/code-list-context";
 import UICodedTermItem from "@js/components/UI/CodedTerm/Item";
 import UIFormReadingRoom from "@js/components/UI/Form/ReadingRoom";
+import useFacetLinkClick from "@js/hooks/useFacetLinkClick";
+import usePassedInSearchTerm from "@js/hooks/usePassedInSearchTerm";
+import { Button } from "@nulib/design-system";
 
 function WorkAdministrativeTabsGeneral({
   administrativeMetadata,
@@ -14,12 +17,15 @@ function WorkAdministrativeTabsGeneral({
 }) {
   const codeLists = useCodeLists();
   const { libraryUnit, preservationLevel, status } = administrativeMetadata;
+  const { handleFacetLinkClick } = useFacetLinkClick();
+  const { handlePassedInSearchTerm } = usePassedInSearchTerm();
 
   return (
     <div>
       <UIFormField label="Library Unit" data-testid="library-unit-wrapper">
         {isEditing ? (
           <UIFormSelect
+            data-testid="library-unit"
             isReactHookForm
             name="libraryUnit"
             showHelper={true}
@@ -31,8 +37,20 @@ function WorkAdministrativeTabsGeneral({
             }
             defaultValue={libraryUnit ? libraryUnit.id : ""}
           />
+        ) : libraryUnit ? (
+          <Button
+            isText
+            data-testid="library-unit-link"
+            className="break-word"
+            onClick={() =>
+              handleFacetLinkClick("LibraryUnit", libraryUnit.label)
+            }
+            css={{ padding: "0", textTransform: "none !important" }}
+          >
+            <span>{libraryUnit.label}</span>
+          </Button>
         ) : (
-          <p>{libraryUnit ? libraryUnit.label : "None selected"}</p>
+          <p>None selected</p>
         )}
       </UIFormField>
 
@@ -42,6 +60,7 @@ function WorkAdministrativeTabsGeneral({
       >
         {isEditing ? (
           <UIFormSelect
+            data-testid="preservation-level"
             isReactHookForm
             name="preservationLevel"
             showHelper={true}
@@ -53,8 +72,23 @@ function WorkAdministrativeTabsGeneral({
             }
             defaultValue={preservationLevel ? preservationLevel.id : ""}
           />
+        ) : preservationLevel ? (
+          <Button
+            isText
+            data-testid="preservation-level-link"
+            className="break-word"
+            onClick={() =>
+              handlePassedInSearchTerm(
+                "administrativeMetadata.preservationLevel.label",
+                preservationLevel.label
+              )
+            }
+            css={{ padding: "0", textTransform: "none !important" }}
+          >
+            <span>{preservationLevel.label}</span>
+          </Button>
         ) : (
-          <p>{preservationLevel ? preservationLevel.label : "None selected"}</p>
+          <p>None selected</p>
         )}
       </UIFormField>
 
@@ -69,8 +103,23 @@ function WorkAdministrativeTabsGeneral({
             options={codeLists.statusData ? codeLists.statusData.codeList : []}
             defaultValue={status ? status.id : ""}
           />
+        ) : status ? (
+          <Button
+            isText
+            data-testid="status-link"
+            className="break-word"
+            onClick={() =>
+              handlePassedInSearchTerm(
+                "administrativeMetadata.status.label",
+                status.label
+              )
+            }
+            css={{ padding: "0", textTransform: "none !important" }}
+          >
+            <span>{status.label}</span>
+          </Button>
         ) : (
-          <p>{status ? status.label : "None selected"}</p>
+          <p>None selected</p>
         )}
       </UIFormField>
       <UIFormField label="Visibility" data-testid="visibility-wrapper">
@@ -86,8 +135,18 @@ function WorkAdministrativeTabsGeneral({
             }
             defaultValue={visibility ? visibility.id : ""}
           />
+        ) : visibility ? (
+          <Button
+            isText
+            data-testid="visibility-link"
+            className="break-word"
+            onClick={() => handleFacetLinkClick("Visibility", visibility.label)}
+            css={{ padding: "0", textTransform: "none !important" }}
+          >
+            <span>{visibility.label}</span>
+          </Button>
         ) : (
-          <UICodedTermItem item={visibility} />
+          <p>None selected</p>
         )}
       </UIFormField>
       <UIFormReadingRoom isEditing={isEditing} value={readingRoom} />

--- a/assets/js/hooks/usePassedInSearchTerm.js
+++ b/assets/js/hooks/usePassedInSearchTerm.js
@@ -1,0 +1,14 @@
+import { useHistory } from "react-router-dom";
+
+export default function usePassedInSearchTerm() {
+  const history = useHistory();
+  const handlePassedInSearchTerm = (field, value) => {
+    if (!field || !value) return;
+
+    history.push("/search", {
+      passedInSearchTerm: `${field}:\"${value}\"`,
+    });
+  };
+
+  return { handlePassedInSearchTerm };
+}


### PR DESCRIPTION
# Summary 
This adds facet links to the requests fields on the Administrative tab. We use the existing hook for this if some of these have  associated with them. For the status, preservation level, and project job description, a  new search term hook was created.

![image](https://user-images.githubusercontent.com/7376450/145896214-51074ffc-1ead-4a09-a746-c1d247ce7401.png)

# Specific Changes in this PR
- Uses facet link hook where  ReactiveSearch facets exist
- Creates search term hook and uses on status, pres level, and project job description.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Test out various works with administrative data associated with them. Also test for those without fields with values.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

