### PR TITLE
Add highlight to active thumbnail in OpenSeadragon viewer

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -41,7 +41,7 @@
         "moment": "^2.29.1",
         "node-webvtt": "^1.9.3",
         "openseadragon": "^2.4.2",
-        "openseadragon-react-viewer": "^3.3.0",
+        "openseadragon-react-viewer": "^3.4.1",
         "phoenix": "file:../deps/phoenix",
         "phoenix_html": "file:../deps/phoenix_html",
         "prop-types": "^15.7.2",
@@ -2239,12 +2239,12 @@
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
     "node_modules/@emotion/react": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.7.0.tgz",
-      "integrity": "sha512-WL93hf9+/2s3cA1JVJlz8+Uy6p6QWukqQFOm2OZO5ki51hfucHMOmbSjiyC3t2Y4RI8XUmBoepoc/24ny/VBbA==",
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.7.1.tgz",
+      "integrity": "sha512-DV2Xe3yhkF1yT4uAUoJcYL1AmrnO5SVsdfvu+fBuS7IbByDeTVx9+wFmvx9Idzv7/78+9Mgx2Hcmr7Fex3tIyw==",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
-        "@emotion/cache": "^11.6.0",
+        "@emotion/cache": "^11.7.1",
         "@emotion/serialize": "^1.0.2",
         "@emotion/sheet": "^1.1.0",
         "@emotion/utils": "^1.0.0",
@@ -2276,15 +2276,15 @@
       }
     },
     "node_modules/@emotion/react/node_modules/@emotion/cache": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.6.0.tgz",
-      "integrity": "sha512-ElbsWY1KMwEowkv42vGo0UPuLgtPYfIs9BxxVrmvsaJVvktknsHYYlx5NQ5g6zLDcOTyamlDc7FkRg2TAcQDKQ==",
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
+      "integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
       "dependencies": {
         "@emotion/memoize": "^0.7.4",
         "@emotion/sheet": "^1.1.0",
         "@emotion/utils": "^1.0.0",
         "@emotion/weak-memoize": "^0.2.5",
-        "stylis": "^4.0.10"
+        "stylis": "4.0.13"
       }
     },
     "node_modules/@emotion/react/node_modules/@emotion/serialize": {
@@ -5270,6 +5270,14 @@
         "redux": "^4.0.0"
       }
     },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.4.tgz",
+      "integrity": "sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/react/node_modules/csstype": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
@@ -8178,9 +8186,9 @@
       }
     },
     "node_modules/dom-helpers/node_modules/@babel/runtime": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
-      "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+      "version": "7.16.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+      "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -13884,22 +13892,19 @@
       "integrity": "sha512-398KbZwRtOYA6OmeWRY4Q0737NTacQ9Q6whmr9Lp1MNQO3p0eBz5LIASRne+4gwequcSM1vcHcjfy3dIndQziw=="
     },
     "node_modules/openseadragon-react-viewer": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/openseadragon-react-viewer/-/openseadragon-react-viewer-3.3.1.tgz",
-      "integrity": "sha512-o9ZaB2iWW7WPbVqHyFfSWcAEO1e+jUlmEPQKW3fg9P3bQvN+ZN2zqVDp0HrqSidmkyLfGfdtD/i4kD+A9ctDzA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/openseadragon-react-viewer/-/openseadragon-react-viewer-3.4.1.tgz",
+      "integrity": "sha512-TtZrgEYibPSu/rnCoJnnOM3tLYHp5Es2cQGtSZJQhHqbfGFtmB33u6o8/iuZ5kxhRFOoC2fdcZaBEehX7cPhQA==",
       "dependencies": {
-        "@emotion/react": "^11.1.5",
+        "@emotion/react": "^11.7.1",
         "@reglendo/canvas2image": "^1.0.5-2",
-        "react-device-detect": "^1.12.1",
-        "react-select": "^4.1.0"
+        "react-device-detect": "^2.1.2",
+        "react-select": "^5.2.1"
       },
       "peerDependencies": {
-        "@emotion/react": "^11.1.5",
         "openseadragon": "^2.4.0",
         "react": "^17.0.2",
-        "react-device-detect": "^1.12.1",
-        "react-dom": "^17.0.2",
-        "react-select": "^4.1.0"
+        "react-dom": "^17.0.2"
       }
     },
     "node_modules/optimism": {
@@ -15356,11 +15361,11 @@
       }
     },
     "node_modules/react-device-detect": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-1.17.0.tgz",
-      "integrity": "sha512-bBblIStwpHmoS281JFIVqeimcN3LhpoP5YKDWzxQdBIUP8S2xPvHDgizLDhUq2ScguLfVPmwfF5y268EEQR60w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.1.2.tgz",
+      "integrity": "sha512-N42xttwez3ECgu4KpOL2ICesdfoz8NCBfmc1rH9FRYSjH7NmMyANPSrQ3EvAtJyj/6TzJNhrANSO38iXjCB2Ug==",
       "dependencies": {
-        "ua-parser-js": "^0.7.24"
+        "ua-parser-js": "^0.7.30"
       },
       "peerDependencies": {
         "react": ">= 0.14.0 < 18.0.0",
@@ -15464,17 +15469,6 @@
       "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
       "peerDependencies": {
         "react": "*"
-      }
-    },
-    "node_modules/react-input-autosize": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-3.0.0.tgz",
-      "integrity": "sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==",
-      "dependencies": {
-        "prop-types": "^15.5.8"
-      },
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0"
       }
     },
     "node_modules/react-is": {
@@ -15699,16 +15693,16 @@
       "dev": true
     },
     "node_modules/react-select": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-4.3.1.tgz",
-      "integrity": "sha512-HBBd0dYwkF5aZk1zP81Wx5UsLIIT2lSvAY2JiJo199LjoLHoivjn9//KsmvQMEFGNhe58xyuOITjfxKCcGc62Q==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.2.1.tgz",
+      "integrity": "sha512-OOyNzfKrhOcw/BlembyGWgdlJ2ObZRaqmQppPFut1RptJO423j+Y+JIsmxkvsZ4D/3CpOmwIlCvWbbAWEdh12A==",
       "dependencies": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
         "@emotion/react": "^11.1.1",
+        "@types/react-transition-group": "^4.4.0",
         "memoize-one": "^5.0.0",
         "prop-types": "^15.6.0",
-        "react-input-autosize": "^3.0.0",
         "react-transition-group": "^4.3.0"
       },
       "peerDependencies": {
@@ -15717,9 +15711,9 @@
       }
     },
     "node_modules/react-select/node_modules/@babel/runtime": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
-      "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+      "version": "7.16.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+      "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -15728,15 +15722,15 @@
       }
     },
     "node_modules/react-select/node_modules/@emotion/cache": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.6.0.tgz",
-      "integrity": "sha512-ElbsWY1KMwEowkv42vGo0UPuLgtPYfIs9BxxVrmvsaJVvktknsHYYlx5NQ5g6zLDcOTyamlDc7FkRg2TAcQDKQ==",
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
+      "integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
       "dependencies": {
         "@emotion/memoize": "^0.7.4",
         "@emotion/sheet": "^1.1.0",
         "@emotion/utils": "^1.0.0",
         "@emotion/weak-memoize": "^0.2.5",
-        "stylis": "^4.0.10"
+        "stylis": "4.0.13"
       }
     },
     "node_modules/react-select/node_modules/@emotion/sheet": {
@@ -15900,9 +15894,9 @@
       }
     },
     "node_modules/react-transition-group/node_modules/@babel/runtime": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
-      "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+      "version": "7.16.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+      "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -17482,9 +17476,9 @@
       }
     },
     "node_modules/stylis": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.10.tgz",
-      "integrity": "sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg=="
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
+      "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
     },
     "node_modules/subtitles-parser-vtt": {
       "version": "0.1.0",
@@ -21490,12 +21484,12 @@
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
     "@emotion/react": {
-      "version": "11.7.0",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.7.0.tgz",
-      "integrity": "sha512-WL93hf9+/2s3cA1JVJlz8+Uy6p6QWukqQFOm2OZO5ki51hfucHMOmbSjiyC3t2Y4RI8XUmBoepoc/24ny/VBbA==",
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.7.1.tgz",
+      "integrity": "sha512-DV2Xe3yhkF1yT4uAUoJcYL1AmrnO5SVsdfvu+fBuS7IbByDeTVx9+wFmvx9Idzv7/78+9Mgx2Hcmr7Fex3tIyw==",
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@emotion/cache": "^11.6.0",
+        "@emotion/cache": "^11.7.1",
         "@emotion/serialize": "^1.0.2",
         "@emotion/sheet": "^1.1.0",
         "@emotion/utils": "^1.0.0",
@@ -21512,15 +21506,15 @@
           }
         },
         "@emotion/cache": {
-          "version": "11.6.0",
-          "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.6.0.tgz",
-          "integrity": "sha512-ElbsWY1KMwEowkv42vGo0UPuLgtPYfIs9BxxVrmvsaJVvktknsHYYlx5NQ5g6zLDcOTyamlDc7FkRg2TAcQDKQ==",
+          "version": "11.7.1",
+          "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
+          "integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
           "requires": {
             "@emotion/memoize": "^0.7.4",
             "@emotion/sheet": "^1.1.0",
             "@emotion/utils": "^1.0.0",
             "@emotion/weak-memoize": "^0.2.5",
-            "stylis": "^4.0.10"
+            "stylis": "4.0.13"
           }
         },
         "@emotion/serialize": {
@@ -23988,6 +23982,14 @@
         "redux": "^4.0.0"
       }
     },
+    "@types/react-transition-group": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.4.tgz",
+      "integrity": "sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/resize-observer-browser": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.6.tgz",
@@ -26420,9 +26422,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.16.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
-          "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -30815,14 +30817,14 @@
       "integrity": "sha512-398KbZwRtOYA6OmeWRY4Q0737NTacQ9Q6whmr9Lp1MNQO3p0eBz5LIASRne+4gwequcSM1vcHcjfy3dIndQziw=="
     },
     "openseadragon-react-viewer": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/openseadragon-react-viewer/-/openseadragon-react-viewer-3.3.1.tgz",
-      "integrity": "sha512-o9ZaB2iWW7WPbVqHyFfSWcAEO1e+jUlmEPQKW3fg9P3bQvN+ZN2zqVDp0HrqSidmkyLfGfdtD/i4kD+A9ctDzA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/openseadragon-react-viewer/-/openseadragon-react-viewer-3.4.1.tgz",
+      "integrity": "sha512-TtZrgEYibPSu/rnCoJnnOM3tLYHp5Es2cQGtSZJQhHqbfGFtmB33u6o8/iuZ5kxhRFOoC2fdcZaBEehX7cPhQA==",
       "requires": {
-        "@emotion/react": "^11.1.5",
+        "@emotion/react": "^11.7.1",
         "@reglendo/canvas2image": "^1.0.5-2",
-        "react-device-detect": "^1.12.1",
-        "react-select": "^4.1.0"
+        "react-device-detect": "^2.1.2",
+        "react-select": "^5.2.1"
       }
     },
     "optimism": {
@@ -31884,11 +31886,11 @@
       }
     },
     "react-device-detect": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-1.17.0.tgz",
-      "integrity": "sha512-bBblIStwpHmoS281JFIVqeimcN3LhpoP5YKDWzxQdBIUP8S2xPvHDgizLDhUq2ScguLfVPmwfF5y268EEQR60w==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.1.2.tgz",
+      "integrity": "sha512-N42xttwez3ECgu4KpOL2ICesdfoz8NCBfmc1rH9FRYSjH7NmMyANPSrQ3EvAtJyj/6TzJNhrANSO38iXjCB2Ug==",
       "requires": {
-        "ua-parser-js": "^0.7.24"
+        "ua-parser-js": "^0.7.30"
       }
     },
     "react-dom": {
@@ -31961,14 +31963,6 @@
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
       "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
       "requires": {}
-    },
-    "react-input-autosize": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-3.0.0.tgz",
-      "integrity": "sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==",
-      "requires": {
-        "prop-types": "^15.5.8"
-      }
     },
     "react-is": {
       "version": "17.0.2",
@@ -32151,37 +32145,37 @@
       }
     },
     "react-select": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-4.3.1.tgz",
-      "integrity": "sha512-HBBd0dYwkF5aZk1zP81Wx5UsLIIT2lSvAY2JiJo199LjoLHoivjn9//KsmvQMEFGNhe58xyuOITjfxKCcGc62Q==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.2.1.tgz",
+      "integrity": "sha512-OOyNzfKrhOcw/BlembyGWgdlJ2ObZRaqmQppPFut1RptJO423j+Y+JIsmxkvsZ4D/3CpOmwIlCvWbbAWEdh12A==",
       "requires": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
         "@emotion/react": "^11.1.1",
+        "@types/react-transition-group": "^4.4.0",
         "memoize-one": "^5.0.0",
         "prop-types": "^15.6.0",
-        "react-input-autosize": "^3.0.0",
         "react-transition-group": "^4.3.0"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.16.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
-          "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
         },
         "@emotion/cache": {
-          "version": "11.6.0",
-          "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.6.0.tgz",
-          "integrity": "sha512-ElbsWY1KMwEowkv42vGo0UPuLgtPYfIs9BxxVrmvsaJVvktknsHYYlx5NQ5g6zLDcOTyamlDc7FkRg2TAcQDKQ==",
+          "version": "11.7.1",
+          "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
+          "integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
           "requires": {
             "@emotion/memoize": "^0.7.4",
             "@emotion/sheet": "^1.1.0",
             "@emotion/utils": "^1.0.0",
             "@emotion/weak-memoize": "^0.2.5",
-            "stylis": "^4.0.10"
+            "stylis": "4.0.13"
           }
         },
         "@emotion/sheet": {
@@ -32314,9 +32308,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.16.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
-          "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+          "version": "7.16.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+          "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -33586,9 +33580,9 @@
       }
     },
     "stylis": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.10.tgz",
-      "integrity": "sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg=="
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
+      "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
     },
     "subtitles-parser-vtt": {
       "version": "0.1.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -49,7 +49,7 @@
     "moment": "^2.29.1",
     "node-webvtt": "^1.9.3",
     "openseadragon": "^2.4.2",
-    "openseadragon-react-viewer": "^3.3.0",
+    "openseadragon-react-viewer": "^3.4.1",
     "phoenix": "file:../deps/phoenix",
     "phoenix_html": "file:../deps/phoenix_html",
     "prop-types": "^15.7.2",

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -18,3 +18,4 @@
 @import "./scss/hover";
 @import "./scss/collections";
 @import "./scss/react-media-player";
+@import "./scss/openseadragon-react-viewer";

--- a/assets/styles/scss/_openseadragon-react-viewer.scss
+++ b/assets/styles/scss/_openseadragon-react-viewer.scss
@@ -1,0 +1,7 @@
+.osrv-thumbnails-wrapper {
+  li.active {
+    img {
+      outline: 8px solid $rich-black-20 !important;
+    }
+  }
+}


### PR DESCRIPTION
# Summary 
Add highlight style to active thumbnail in OpenSeadragon viewer on a Work page

# Specific Changes in this PR
- Updated the CSS locally in Meadow to apply a highlighted style
- Bumped version of `openseadragon-react-viewer`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Go to an Image Work with multiple filesets.  Notice the active item has a dark-ish grey highlight color.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

