### PR TITLE
Add thumbnail field to indexed work documents

### DIFF
--- a/lib/meadow/indexing/work.ex
+++ b/lib/meadow/indexing/work.ex
@@ -48,6 +48,11 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Work do
             }
         end,
       sheet: format(work.ingest_sheet),
+      thumbnail:
+        case work.representative_image do
+          nil -> nil
+          url -> url <> "/full/!300,300/0/default.jpg"
+        end,
       visibility: format(work.visibility),
       workType: format(work.work_type)
     }


### PR DESCRIPTION
# Summary 
- Add thumbnail field to indexed work documents
- Defaults to `null` for works without representative images


# Specific Changes in this PR
- Adds the thumbnail field to `lib/meadow/indexing/work.ex `

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test
Create a work without a representative image, the document should look like this in Kibana:
![work_without_representative_image](https://user-images.githubusercontent.com/1395707/146430141-87c3c8bf-c422-4526-8138-582935d90aec.png)

Set a representative image for a work, the document should look like this in Kibana:
![work_with_representative_image](https://user-images.githubusercontent.com/1395707/146430135-7a860f53-1fc7-454f-9cc7-2436a8a9c751.png)

# :rocket: Deployment Notes

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [x] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

