### PR TITLE
Handle bad playlist URIs gracefully

### DIFF
--- a/lib/meadow/data/file_sets.ex
+++ b/lib/meadow/data/file_sets.ex
@@ -288,10 +288,13 @@ defmodule Meadow.Data.FileSets do
   @doc """
   Get the distribution streaming playlist url for a file set
   """
-  def distribution_streaming_uri_for(%FileSet{derivatives: %{"playlist" => playlist}}) do
+  def distribution_streaming_uri_for(%FileSet{derivatives: %{"playlist" => playlist}})
+      when is_binary(playlist) and byte_size(playlist) > 0 do
     with %{path: path} <- URI.parse(playlist) do
       Config.streaming_url() |> Path.join(path)
     end
+  rescue
+    FunctionClauseError -> nil
   end
 
   def distribution_streaming_uri_for(_), do: nil


### PR DESCRIPTION
# Summary 

`FileSets.distribution_streaming_uri_for/1` shouldn't raise a `FunctionClauseError` if given a playlist that isn't a valid URI.

# Specific Changes in this PR
- fix pattern matching in `FileSets.distribution_streaming_uri_for/1`
- add additional tests

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

