### PR TITLE
Add GraphQL query to get IIIF manifest headers

### DIFF
--- a/lib/meadow_web/resolvers/data.ex
+++ b/lib/meadow_web/resolvers/data.ex
@@ -191,4 +191,17 @@ defmodule MeadowWeb.Resolvers.Data do
   def verify_file_sets(_, %{work_id: work_id}, _) do
     {:ok, Works.verify_file_sets(work_id)}
   end
+
+  def iiif_manifest_headers(_, %{work_id: work_id}, _) do
+    case Works.iiif_manifest_headers(work_id) do
+      {:ok, headers} ->
+        {:ok, headers}
+
+      {:error, _error} ->
+        {
+          :error,
+          message: "Error retrieving manifest headers"
+        }
+    end
+  end
 end

--- a/lib/meadow_web/schema/types/data/work_types.ex
+++ b/lib/meadow_web/schema/types/data/work_types.ex
@@ -41,6 +41,13 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
       middleware(Middleware.Authenticate)
       resolve(&MeadowWeb.Resolvers.Data.verify_file_sets/3)
     end
+
+    @desc "Get last modified timestamp and etag for IIIF manifest"
+    field :iiif_manifest_headers, :iiif_manifest_headers do
+      arg(:work_id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      resolve(&MeadowWeb.Resolvers.Data.iiif_manifest_headers/3)
+    end
   end
 
   object :work_mutations do
@@ -221,6 +228,14 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
   object :file_set_verification_status do
     field :file_set_id, :id
     field :verified, :boolean
+  end
+
+  @desc "IIIF Manifest etag and last modified headers"
+  object :iiif_manifest_headers do
+    field :work_id, :id
+    field :manifest_url, :string
+    field :etag, :string
+    field :last_modified, :string
   end
 
   #

--- a/test/gql/IiifManifestHeadersQuery.gql
+++ b/test/gql/IiifManifestHeadersQuery.gql
@@ -1,0 +1,8 @@
+query IiifManifestHeaders($workId: ID!) {
+  iiifManifestHeaders(workId: $workId) {
+    manifestUrl
+    etag
+    lastModified
+    workId
+  }
+}

--- a/test/meadow_web/schema/query/iiif_manifest_headers_test.exs
+++ b/test/meadow_web/schema/query/iiif_manifest_headers_test.exs
@@ -1,0 +1,51 @@
+defmodule MeadowWeb.Schema.Query.IiifManifestHeadersTest do
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+  use Meadow.S3Case
+
+  alias Meadow.Config
+  alias Meadow.IIIF
+  alias Meadow.Utils.Pairtree
+
+  @pyramid_bucket Config.pyramid_bucket()
+
+  load_gql(MeadowWeb.Schema, "test/gql/IiifManifestHeadersQuery.gql")
+
+  describe "iiifManifestHeaders query/1" do
+    setup do
+      work = work_fixture()
+      destination = Pairtree.manifest_key(work.id)
+
+      on_exit(fn ->
+        delete_object(@pyramid_bucket, destination)
+      end)
+
+      {:ok, work: work, destination: destination}
+    end
+
+    test "should be a valid query", %{work: work, destination: destination} do
+      assert {:ok, %{status_code: 200}} = IIIF.V2.write_manifest(work.id)
+
+      result =
+        query_gql(
+          variables: %{"workId" => work.id},
+          context: gql_context()
+        )
+
+      assert {:ok, query_data} = result
+      work_id = get_in(query_data, [:data, "iiifManifestHeaders", "workId"])
+      assert work_id == work.id
+
+      with {:ok, result} <- ExAws.S3.head_object(@pyramid_bucket, destination) |> ExAws.request() do
+        assert result.status_code == 200
+
+        last_modified =
+          result.headers
+          |> Enum.into(%{})
+          |> Map.get("Last-Modified")
+
+        assert last_modified == get_in(query_data, [:data, "iiifManifestHeaders", "lastModified"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Summary 

The front end needs to know when IIIF manifests have changed and it's easier to do this with a GraphQL query rather than requesting the manifest directly since is easier to integrate with the other components on the page.


# Specific Changes in this PR

Adds GraphQL query

```
query{
  iiifManifestHeaders(workId: "11e92978-8f53-4917-bed2-69fb764464d1"){
    workId
    etag
    lastModified
    manifestUrl
  }
}

{
  "data": {
    "iiifManifestHeaders": [
      {
        "etag": "0ab0038b1bea78bd26e2b0e7ae95cccf",
        "lastModified": "Tue, 14 Dec 2021 23:12:41 GMT",
        "manifestUrl": "https://devbox.library.northwestern.edu:9001/dev-pyramids/public/11/e9/29/78/-8/f5/3-/49/17/-b/ed/2-/69/fb/76/44/64/d1-manifest.json",
        "workId": "11e92978-8f53-4917-bed2-69fb764464d1"
      }
    ]
  }
}
```


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor (compatible API change)
- [ ] Major

# Steps to Test

Go to the GraphQL playground and run the above query supplying a different work id. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [x] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

