### PR TITLE
Workaround for skip_transcode? catch-22 after TranscodeComplete

### DIFF
--- a/lib/meadow/pipeline/dispatcher.ex
+++ b/lib/meadow/pipeline/dispatcher.ex
@@ -164,10 +164,10 @@ defmodule Meadow.Pipeline.Actions.Dispatcher do
   defp skip_transcode?(file_set) do
     Config.streaming_bucket()
     |> ExAws.S3.list_objects_v2(prefix: Pairtree.generate!(file_set.id))
-    |> ExAws.request!
+    |> ExAws.request!()
     |> get_in([:body, :key_count])
     |> String.to_integer()
-    |> then(& &1 > 0)
+    |> then(&(&1 > 0))
   end
 
   defp dispatch_next_action(file_set, %{process: action, status: "ok"} = attributes),
@@ -196,6 +196,8 @@ defmodule Meadow.Pipeline.Actions.Dispatcher do
 
     next_action.send_message(%{file_set_id: file_set.id}, attributes)
   end
+
+  defp next_action(TranscodeComplete, _), do: FileSetComplete
 
   defp next_action(last_action, action_queue) do
     index = action_queue |> Enum.find_index(&(&1 == last_action))

--- a/test/pipeline/dispatcher_test.exs
+++ b/test/pipeline/dispatcher_test.exs
@@ -255,5 +255,16 @@ defmodule Meadow.Pipeline.Actions.DispatcherTest do
       refute Enum.member?(Dispatcher.dispatcher_actions(file_set), CreateTranscodeJob)
       refute Enum.member?(Dispatcher.dispatcher_actions(file_set), TranscodeComplete)
     end
+
+    test "dispatches to FileSetComplete after TranscodeComplete even if skip_transcode? is true",
+         %{file_set: file_set} do
+      assert capture_log(fn ->
+               Dispatcher.process(%{file_set_id: file_set.id}, %{
+                 process: "TranscodeComplete",
+                 status: "ok"
+               })
+             end) =~
+               "Last action was: Elixir.Meadow.Pipeline.Actions.TranscodeComplete, next action is: Elixir.Meadow.Pipeline.Actions.FileSetComplete for file set id: #{file_set.id}"
+    end
   end
 end


### PR DESCRIPTION
# Summary 

Allow audio and video to get through the pipeline without being kicked back to `GenerateFileSetDigests` after `TranscodeComplete`

# Specific Changes in this PR
- Hard-code dispatch to `FileSetComplete` after `TranscodeComplete`
- Test for the above change
- 
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Add a video fileset via the UI and make sure no `already complete` warnings show up in the server output during processing. (This is easier if you run `Logger.configure(level: :info)` in the running server's `IEx` shell.)

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

