### PR TITLE
Make some sequins scaling settings configurable from the environment

### DIFF
--- a/config/releases.exs
+++ b/config/releases.exs
@@ -163,72 +163,43 @@ config :meadow, :lambda,
   mime_type: {:lambda, "meadow-mime-type"},
   tiff: {:lambda, "meadow-pyramid-tiff"}
 
-config :sequins, Actions.GenerateFileSetDigests,
-  queue_config: [
-    producer_concurrency: 10,
-    receive_interval: 1000,
-    wait_time_seconds: 1,
-    max_number_of_messages: 10,
-    processor_concurrency: 100,
-    visibility_timeout: 360
-  ]
+get_sequins_var = fn key, attribute, default ->
+  [key, attribute]
+  |> Enum.join("_")
+  |> String.upcase()
+  |> System.get_env(default)
+  |> String.to_integer()
+end
 
-config :sequins, Actions.ExtractExifMetadata,
-  queue_config: [
-    producer_concurrency: 10,
-    receive_interval: 1000,
-    wait_time_seconds: 1,
-    max_number_of_messages: 10,
-    processor_concurrency: 100,
-    visibility_timeout: 360
-  ]
-
-config :sequins, Actions.ExtractMediaMetadata,
-  queue_config: [
-    producer_concurrency: 10,
-    receive_interval: 1000,
-    wait_time_seconds: 1,
-    max_number_of_messages: 10,
-    processor_concurrency: 100,
-    visibility_timeout: 360
-  ]
-
-config :sequins, Actions.ExtractMimeType,
-  queue_config: [
-    producer_concurrency: 10,
-    receive_interval: 1000,
-    wait_time_seconds: 1,
-    max_number_of_messages: 10,
-    processor_concurrency: 100,
-    visibility_timeout: 120
-  ]
-
-config :sequins, Actions.CreatePyramidTiff,
-  queue_config: [
-    producer_concurrency: 10,
-    receive_interval: 1000,
-    wait_time_seconds: 1,
-    max_number_of_messages: 10,
-    processor_concurrency: 100,
-    visibility_timeout: 360
-  ]
-
-config :sequins, Actions.CreateTranscodeJob,
-  queue_config: [
-    producer_concurrency: 10,
-    receive_interval: 1000,
-    wait_time_seconds: 1,
-    max_number_of_messages: 10,
-    processor_concurrency: 100,
-    visibility_timeout: 360
-  ]
-
-config :sequins, Actions.TranscodeComplete,
-  queue_config: [
-    producer_concurrency: 10,
-    receive_interval: 1000,
-    wait_time_seconds: 1,
-    max_number_of_messages: 10,
-    processor_concurrency: 100,
-    visibility_timeout: 360
-  ]
+[
+  {IngestFileSet, "INGEST_FILE_SET"},
+  {ExtractMimeType, "EXTRACT_MIME_TYPE"},
+  {InitializeDispatch, "INITIALIZE_DISPATCH"},
+  {Dispatcher, "DISPATCHER"},
+  {GenerateFileSetDigests, "GENERATE_FILE_SET_DIGESTS"},
+  {ExtractExifMetadata, "EXTRACT_EXIF_METADATA"},
+  {CopyFileToPreservation, "COPY_FILE_TO_PRESERVATION"},
+  {CreatePyramidTiff, "CREATE_PYRAMID_TIFF"},
+  {ExtractMediaMetadata, "EXTRACT_MEDIA_METADATA"},
+  {CreateTranscodeJob, "CREATE_TRANSCODE_JOB"},
+  {TranscodeComplete, "TRANSCODE_COMPLETE"},
+  {GeneratePosterImage, "GENERATE_POSTER_IMAGE"},
+  {FileSetComplete, "FILE_SET_COMPLETE"}
+]
+|> Enum.each(fn {action, key} ->
+  with receive_interval <- 1000,
+       wait_time_seconds <- 1,
+       max_number_of_messages <- 10 do
+    config :sequins, action,
+      queue_config: [
+        producer_concurrency: 1,
+        receive_interval: receive_interval,
+        wait_time_seconds: wait_time_seconds,
+        max_number_of_messages: max_number_of_messages,
+        processor_concurrency: get_sequins_var.(key, :processor_concurrency, "10"),
+        visibility_timeout: get_sequins_var.(key, :visibility_timeout, "300"),
+        max_demand: get_sequins_var.(key, :max_demand, "10"),
+        min_demand: get_sequins_var.(key, :min_demand, "5")
+      ]
+  end
+end)


### PR DESCRIPTION
# Summary 

Replaces hardcoded pipeline scaling values with configurable options.

# Specific Changes in this PR
- Allows processor `concurrency`, `max_demand`, `min_demand` to be configured from the environment
- Allows producer `visibility_timeout` to be configured from the environment
- Pins producer `concurrency` at 1 and `max_messages_per_request` at 10

Terraform changes to add/change the above environment variables will be applied, tested, and iterated on in staging, with a separate PR to follow once reasonable values are settled on.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

