### PR TITLE
Add better error handling for multipart copies

### DIFF
--- a/lib/meadow/utils/aws/multipart_copy.ex
+++ b/lib/meadow/utils/aws/multipart_copy.ex
@@ -123,7 +123,7 @@ defmodule Meadow.Utils.AWS.MultipartCopy do
   end
 
   defp complete_upload({:error, other}) do
-    Logger.debug("Error encountered. #{other}")
+    Logger.debug("Error encountered. #{inspect(other)}")
     {:error, parse_error(other)}
   end
 
@@ -176,6 +176,16 @@ defmodule Meadow.Utils.AWS.MultipartCopy do
       )
 
     {:ok, %{resp | body: parsed_body}}
+  end
+
+  defp parse_complete_result({:error, error}) do
+    Logger.warn("Error in multipart copy: #{inspect(error)}")
+    {:error, error}
+  end
+
+  defp parse_complete_result(response) do
+    Logger.warn("Unknown response in multipart copy: #{inspect(response)}")
+    {:unknown, response}
   end
 
   defp parse_copy_part_result({:ok, %{body: xml} = resp}) do


### PR DESCRIPTION
# Summary 

Add better error handling for the S3 `CompleteMultipartUpload` call

# Specific Changes in this PR
- Add `{:error, error}` and `other` cases for the `parse_complete_result/1` function

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

