### PR TITLE
Return (empty) variants for NUL Authorities

### DIFF
--- a/lib/nul/authority.ex
+++ b/lib/nul/authority.ex
@@ -42,7 +42,8 @@ defmodule NUL.Authority do
         id: a.id,
         label: a.label,
         qualified_label: fragment("concat_ws(' ', ?, ?)", a.label, a.hint),
-        hint: a.hint
+        hint: a.hint,
+        variants: []
       }
     )
     |> Repo.get(id)

--- a/test/nul/authority_test.exs
+++ b/test/nul/authority_test.exs
@@ -54,7 +54,8 @@ defmodule NUL.AuthorityTest do
               %{
                 label: "Ver Steeg, Clarence L.",
                 qualified_label: "Ver Steeg, Clarence L. (The Legend)",
-                hint: "(The Legend)"
+                hint: "(The Legend)",
+                variants: []
               }} = Authority.fetch(authority_record.id)
     end
 


### PR DESCRIPTION
# Summary 

Fix for bug in https://github.com/nulib/meadow/pull/2843 to return empty variants for NUL authorities. 

# Specific Changes in this PR

- Return `variants: []` for all NUL authorities when loading from database. 

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Indexing records with NUL authorities should not fail

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

