### PR TITLE
Update Bulma dependency Sass imports, minor UI fixes to Bulma upgrade

### DIFF
--- a/assets/js/components/Collection/collection.gql.js
+++ b/assets/js/components/Collection/collection.gql.js
@@ -121,18 +121,18 @@ export const GET_COLLECTIONS = gql`
   query GetCollections {
     collections {
       adminEmail
+      description
       featured
       findingAidUrl
-      published
-      title
-      description
       id
       keywords
-      totalWorks
+      published
       representativeWork {
         id
         representativeImage
       }
+      title
+      totalWorks
       visibility {
         id
         label

--- a/assets/js/components/UI/Breadcrumbs.jsx
+++ b/assets/js/components/UI/Breadcrumbs.jsx
@@ -28,7 +28,7 @@ const Breadcrumbs = ({ items = [], ...props }) => (
 Breadcrumbs.propTypes = {
   items: PropTypes.arrayOf(
     PropTypes.shape({
-      label: PropTypes.string.isRequred,
+      label: PropTypes.string.isRequired,
       route: PropTypes.string,
       isActive: PropTypes.bool,
     })

--- a/assets/js/components/UI/Layout/NavBar.jsx
+++ b/assets/js/components/UI/Layout/NavBar.jsx
@@ -98,15 +98,13 @@ const UILayoutNavBar = () => {
             aria-label="menu"
             aria-expanded={mobileNavOpen}
             aria-controls="navbarMenu"
-            className={`button navbar-burger burger ${
-              mobileNavOpen ? "is-active" : ""
-            }`}
+            className={`navbar-burger ${mobileNavOpen ? "is-active" : ""}`}
             data-target="navbarMenu"
             onClick={handleMobileMenuClick}
           >
-            <span></span>
-            <span></span>
-            <span></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
+            <span aria-hidden="true"></span>
           </button>
         </div>
 

--- a/assets/js/components/Work/Tabs/Administrative/Collection.jsx
+++ b/assets/js/components/Work/Tabs/Administrative/Collection.jsx
@@ -103,7 +103,7 @@ function WorkTabsAdministrativeCollection({
   if (error)
     return (
       <p className="noticiation is-danger">
-        Error loading collections: {error}
+        Error loading collections: {error.toString()}
       </p>
     );
 

--- a/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
@@ -498,6 +498,7 @@ const DialogOverlay = styled(Dialog.Overlay, {
   backgroundColor: "#000a",
   position: "fixed",
   inset: 0,
+  zIndex: 10,
 });
 
 const DialogTrigger = styled(Dialog.Trigger, {
@@ -523,6 +524,7 @@ const DialogContent = styled(Dialog.Content, {
   maxHeight: "85vh",
   padding: "1rem",
   overflowY: "scroll",
+  zIndex: 11,
 });
 
 const DialogClose = styled(Dialog.Close, {

--- a/assets/js/screens/Work/Work.jsx
+++ b/assets/js/screens/Work/Work.jsx
@@ -53,7 +53,7 @@ const ScreensWork = () => {
 
   const { data, loading, error } = useQuery(GET_WORK, {
     variables: { id },
-    onError() {
+    onError(error) {
       history.push("/404", {
         message:
           "There was an error retrieving the work, or the work id does not exist.",

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -16201,9 +16201,9 @@
       "dev": true
     },
     "node_modules/sass": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.48.0.tgz",
-      "integrity": "sha512-hQi5g4DcfjcipotoHZ80l7GNJHGqQS5LwMBjVYB/TaT0vcSSpbgM8Ad7cgfsB2M0MinbkEQQPO9+sjjSiwxqmw==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.0.tgz",
+      "integrity": "sha512-TVwVdNDj6p6b4QymJtNtRS2YtLJ/CqZriGg0eIAbAKMlN8Xy6kbv33FsEZSF7FufFFM705SQviHjjThfaQ4VNw==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -32258,9 +32258,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.48.0.tgz",
-      "integrity": "sha512-hQi5g4DcfjcipotoHZ80l7GNJHGqQS5LwMBjVYB/TaT0vcSSpbgM8Ad7cgfsB2M0MinbkEQQPO9+sjjSiwxqmw==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.0.tgz",
+      "integrity": "sha512-TVwVdNDj6p6b4QymJtNtRS2YtLJ/CqZriGg0eIAbAKMlN8Xy6kbv33FsEZSF7FufFFM705SQviHjjThfaQ4VNw==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -6,10 +6,10 @@
 
 @import "~bulma/bulma";
 @import "~bulma-switch";
-@import "~bulma-checkradio/dist/css/bulma-checkradio";
-@import "~bulma-pageloader/dist/css/bulma-pageloader";
-@import "~@creativebulma/bulma-tooltip/src/sass";
-@import "~@creativebulma/bulma-divider/src/sass";
+@import "~bulma-checkradio";
+@import "~bulma-pageloader";
+@import "@creativebulma/bulma-tooltip";
+@import "@creativebulma/bulma-divider";
 
 @import "./scss/mixins";
 @import "./scss/base";


### PR DESCRIPTION
# Summary 
This fixes a few of the oddball UI issues which popped up in the last day related to a Bulma dependency upgrade, and some associated Bulma packages we're using. 

# Specific Changes in this PR
- Updated Sass imports of Bulma dependencies
- Updated Navbar CSS classname syntax
- General UI fixes
- Form field input element outlines have returned

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Just run through the app and notice visually everything looks as expected.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

