### PR TITLE
Revert ReactiveSearch to previous pinned version.

### DIFF
--- a/assets/js/screens/Search/Search.jsx
+++ b/assets/js/screens/Search/Search.jsx
@@ -46,13 +46,19 @@ const ScreensSearch = () => {
   const dispatch = useBatchDispatch();
   const { loadDataLayer } = useGTM();
 
+  /** 
+   * This helper function doesn't appear to be doing it's job any more
+   * of allowing a single click to go back into a saved Search.  But
+   * since we're pinning to a previous version of ReactiveSearch, maybe
+   * this has some value into the future.
+   * 
   React.useEffect(() => {
     loadDataLayer({ pageTitle: "Search" });
 
     function handlePopState(e) {
       // If ReactiveSearch pushed a state onto the history stack
       // take user directly to the previous screen.
-      if (e.state.state) {
+      if (e.state?.state) {
         window.history.go(-1);
       }
     }
@@ -61,6 +67,7 @@ const ScreensSearch = () => {
 
     return () => window.removeEventListener("popstate", handlePopState);
   }, []);
+   */
 
   const handleEditAllItems = async () => {
     const parsedAggregations = await getParsedAggregations(filteredQuery);

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -10,7 +10,7 @@
         "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
-        "@appbaseio/reactivesearch": "3.24.3",
+        "@appbaseio/reactivesearch": "3.23.1",
         "@emotion/react": "^11.7.1",
         "@fortawesome/fontawesome-svg-core": "^1.2.36",
         "@fortawesome/free-brands-svg-icons": "^5.15.4",
@@ -258,9 +258,9 @@
       }
     },
     "node_modules/@appbaseio/reactivecore": {
-      "version": "9.12.5",
-      "resolved": "https://registry.npmjs.org/@appbaseio/reactivecore/-/reactivecore-9.12.5.tgz",
-      "integrity": "sha512-vEskPndbDynVwvMlLnTggkMx9IEGyrDqfQLRzqlrV6+17NGVyDsncIKKqqxtPMopqURoxSt3u1oRkyvzpSViRA==",
+      "version": "9.12.1",
+      "resolved": "https://registry.npmjs.org/@appbaseio/reactivecore/-/reactivecore-9.12.1.tgz",
+      "integrity": "sha512-ZLb24K8RLwry4as/rk5PwDR7VPAQYYhdP9n7sZDWLjPO1HzQXckyz7CnzYgzdxt7NbLkarhCcYFYzpEZB6i7NA==",
       "dependencies": {
         "cross-fetch": "^3.0.4",
         "prop-types": "^15.6.0",
@@ -273,11 +273,11 @@
       }
     },
     "node_modules/@appbaseio/reactivesearch": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/@appbaseio/reactivesearch/-/reactivesearch-3.24.3.tgz",
-      "integrity": "sha512-ro5+kNfQU3t+4KSmaMq9ZbhSHfMpV3SwXns3Z/f2dybutUFWJ8tQ0cK6XBWM1CcoecUgI9Wu1hk9Jad1/+kGIg==",
+      "version": "3.23.1",
+      "resolved": "https://registry.npmjs.org/@appbaseio/reactivesearch/-/reactivesearch-3.23.1.tgz",
+      "integrity": "sha512-QhCA1XsIkErax6R1tpjEdlablJ79TRw1MB/GaAsoyz7/UtulqNAEwv+FhbTNY2uTwygM7a1CdM4UDjNazLZZtA==",
       "dependencies": {
-        "@appbaseio/reactivecore": "9.12.5",
+        "@appbaseio/reactivecore": "9.12.1",
         "@emotion/core": "^10.0.28",
         "@emotion/styled": "^10.0.27",
         "appbase-js": "^4.1.5",
@@ -285,7 +285,6 @@
         "downshift": "^1.31.2",
         "emotion-theming": "^10.0.27",
         "hoist-non-react-statics": "^3.2.1",
-        "hotkeys-js": "^3.8.7",
         "polished": "^1.9.3",
         "prop-types": "^15.6.0",
         "react-day-picker": "^7.0.5",
@@ -9849,11 +9848,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/hotkeys-js": {
-      "version": "3.8.7",
-      "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.8.7.tgz",
-      "integrity": "sha512-ckAx3EkUr5XjDwjEHDorHxRO2Kb7z6Z2Sxul4MbBkN8Nho7XDslQsgMJT+CiJ5Z4TgRxxvKHEpuLE3imzqy4Lg=="
     },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
@@ -19776,9 +19770,9 @@
       }
     },
     "@appbaseio/reactivecore": {
-      "version": "9.12.5",
-      "resolved": "https://registry.npmjs.org/@appbaseio/reactivecore/-/reactivecore-9.12.5.tgz",
-      "integrity": "sha512-vEskPndbDynVwvMlLnTggkMx9IEGyrDqfQLRzqlrV6+17NGVyDsncIKKqqxtPMopqURoxSt3u1oRkyvzpSViRA==",
+      "version": "9.12.1",
+      "resolved": "https://registry.npmjs.org/@appbaseio/reactivecore/-/reactivecore-9.12.1.tgz",
+      "integrity": "sha512-ZLb24K8RLwry4as/rk5PwDR7VPAQYYhdP9n7sZDWLjPO1HzQXckyz7CnzYgzdxt7NbLkarhCcYFYzpEZB6i7NA==",
       "requires": {
         "cross-fetch": "^3.0.4",
         "prop-types": "^15.6.0",
@@ -19788,11 +19782,11 @@
       }
     },
     "@appbaseio/reactivesearch": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/@appbaseio/reactivesearch/-/reactivesearch-3.24.3.tgz",
-      "integrity": "sha512-ro5+kNfQU3t+4KSmaMq9ZbhSHfMpV3SwXns3Z/f2dybutUFWJ8tQ0cK6XBWM1CcoecUgI9Wu1hk9Jad1/+kGIg==",
+      "version": "3.23.1",
+      "resolved": "https://registry.npmjs.org/@appbaseio/reactivesearch/-/reactivesearch-3.23.1.tgz",
+      "integrity": "sha512-QhCA1XsIkErax6R1tpjEdlablJ79TRw1MB/GaAsoyz7/UtulqNAEwv+FhbTNY2uTwygM7a1CdM4UDjNazLZZtA==",
       "requires": {
-        "@appbaseio/reactivecore": "9.12.5",
+        "@appbaseio/reactivecore": "9.12.1",
         "@emotion/core": "^10.0.28",
         "@emotion/styled": "^10.0.27",
         "appbase-js": "^4.1.5",
@@ -19800,7 +19794,6 @@
         "downshift": "^1.31.2",
         "emotion-theming": "^10.0.27",
         "hoist-non-react-statics": "^3.2.1",
-        "hotkeys-js": "^3.8.7",
         "polished": "^1.9.3",
         "prop-types": "^15.6.0",
         "react-day-picker": "^7.0.5",
@@ -27421,11 +27414,6 @@
       "requires": {
         "parse-passwd": "^1.0.0"
       }
-    },
-    "hotkeys-js": {
-      "version": "3.8.7",
-      "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.8.7.tgz",
-      "integrity": "sha512-ckAx3EkUr5XjDwjEHDorHxRO2Kb7z6Z2Sxul4MbBkN8Nho7XDslQsgMJT+CiJ5Z4TgRxxvKHEpuLE3imzqy4Lg=="
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",

--- a/assets/package.json
+++ b/assets/package.json
@@ -18,7 +18,7 @@
     "@apollo/client": "latest",
     "@apollo/react-hooks": "^4.0.0",
     "@apollo/react-testing": "^4.0.0",
-    "@appbaseio/reactivesearch": "3.24.3",
+    "@appbaseio/reactivesearch": "3.23.1",
     "@emotion/react": "^11.7.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-brands-svg-icons": "^5.15.4",


### PR DESCRIPTION
# Summary 
Revert ReactiveSearch to previous pinned version. This fixes various navigation issues such as navigating between Search and Work screens.

# Specific Changes in this PR
- Revert ReactiveSearch to previous pinned version

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
1. Enter a search on Search screen, and click into a Work
2. Click browser Back button.
3. Notice the page doesn't crash

These scenarios should also now be fixed:

> If you click on any facet link into search (like from a work page, click on the collection or any of the project facet links - or if you are on a collection and click on view collection works or on the CSV metadata update dashboard clicking to see affected works) it's broken.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

