### PR TITLE
Fix edit one by one mode for a Work, OSD not loading images properly

### DIFF
--- a/assets/js/components/Work/Work.jsx
+++ b/assets/js/components/Work/Work.jsx
@@ -19,13 +19,10 @@ const osdOptions = {
 
 const Work = ({ work }) => {
   const [manifestObj, setManifestObj] = React.useState();
-  const [manifestKey, setManifestKey] = React.useState();
+  const [manifestKey, setManifestKey] = React.useState("abc");
   const workContextState = useWorkState();
   const workDispatch = useWorkDispatch();
-  const [manifestChangeItems, setManifestChangeItems] = React.useState({
-    label: "",
-    canvasCount: "",
-  });
+
   const isImageWorkType =
     work.workType?.id === "IMAGE" &&
     ["AUDIO", "VIDEO"].indexOf(work.workType?.id) === -1;
@@ -42,37 +39,23 @@ const Work = ({ work }) => {
 
   React.useEffect(() => {
     workDispatch({ type: "updateWorkType", workTypeId: work.workType.id });
-  }, []);
 
-  React.useEffect(() => {
-    // Get data for an Image Work Type
     async function getData() {
       const data = await getManifest(`${work.manifestUrl}?${Date.now()}`);
-
       if (!data) return;
-
-      // Check if watch items in manifest are different.
-      // If so, trigger a re-render of OSD viewer
-      if (
-        data.label !== manifestChangeItems.label ||
-        data.sequences[0].canvases.length !== manifestChangeItems.canvasCount
-      ) {
-        setManifestChangeItems({
-          label: data.label,
-          canvasCount: data.sequences[0].canvases.length,
-        });
-      }
       setManifestObj(data);
     }
 
     isImageWorkType && getData();
-  }, [work.fileSets, work.descriptiveMetadata.title]);
+  }, []);
 
   React.useEffect(() => {
     if (isImageWorkType) return;
 
-    // If no active media file set yet exists in Context, use the first Access file set
-    // If an active file set does exist, then put the latest data from API into the Context state
+    /**
+     * If no active media file set yet exists in Context, use the first Access file set.
+     * If an active file set does exist, then put the latest data from API into the Context state
+     */
     let fileSet = !workContextState?.activeMediaFileSet
       ? filterFileSets(work.fileSets).access[0]
       : work.fileSets.find(

--- a/assets/js/screens/Work/Work.jsx
+++ b/assets/js/screens/Work/Work.jsx
@@ -179,7 +179,7 @@ const ScreensWork = () => {
               <>
                 <ActionHeadline>
                   <PageTitle data-testid="work-page-title">
-                    {data.work.descriptiveMetadata.title || ""}{" "}
+                    {data.work.descriptiveMetadata.title || ""}
                   </PageTitle>
                   <WorkHeaderButtons
                     handleCreateSharableBtnClick={handleCreateSharableBtnClick}
@@ -242,7 +242,7 @@ const ScreensWork = () => {
       ) : (
         <ErrorBoundary FallbackComponent={FallbackErrorComponent}>
           <WorkProvider>
-            <Work work={data.work} />
+            <Work work={data.work} key={data.work.id} />
           </WorkProvider>
         </ErrorBoundary>
       )}


### PR DESCRIPTION
# Summary 
Fix edit one by one mode for a Work, OSD not loading images properly

# Specific Changes in this PR
- Added Work `id` as a React `key` prop to the `Work` component, to force a reload of the same route.
- Removed outdated code manually checking for an updated Manifest

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

