### PR TITLE
Bump RMP to disable autoplay.

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -19,7 +19,7 @@
         "@honeybadger-io/js": "^3.2.7",
         "@honeybadger-io/react": "^1.0.1",
         "@nulib/design-system": "^1.3.5",
-        "@nulib/react-media-player": "^1.6.8",
+        "@nulib/react-media-player": "^1.6.9",
         "@radix-ui/react-dialog": "^0.1.1",
         "@samvera/image-downloader": "^1.1.1",
         "bulma": "^0.9.3",
@@ -106,7 +106,7 @@
       }
     },
     "../deps/phoenix": {
-      "version": "1.5.13",
+      "version": "1.5.12",
       "license": "MIT"
     },
     "../deps/phoenix_html": {
@@ -3333,9 +3333,9 @@
       "dev": true
     },
     "node_modules/@nulib/react-media-player": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.6.8.tgz",
-      "integrity": "sha512-1ax2V1UHCB8eRtbqFJ34vOsytvWgl5pd1dDs4XX2hAvXOQKTG9fXLarNweEjlZwt3HIVDUzaPsGgSPEzjQbHFA==",
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.6.9.tgz",
+      "integrity": "sha512-m3ymOjzYdLhlRPrWTEgbPqiTWl7G5w72DL/qo+OSiO3QK8bnsMi22YhE1Q0/SxvkECRfqQnJA8YiVGqED6cVsw==",
       "dependencies": {
         "@hyperion-framework/parser": "^1.0.0",
         "@hyperion-framework/types": "^1.0.0",
@@ -22072,9 +22072,9 @@
       "dev": true
     },
     "@nulib/react-media-player": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.6.8.tgz",
-      "integrity": "sha512-1ax2V1UHCB8eRtbqFJ34vOsytvWgl5pd1dDs4XX2hAvXOQKTG9fXLarNweEjlZwt3HIVDUzaPsGgSPEzjQbHFA==",
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.6.9.tgz",
+      "integrity": "sha512-m3ymOjzYdLhlRPrWTEgbPqiTWl7G5w72DL/qo+OSiO3QK8bnsMi22YhE1Q0/SxvkECRfqQnJA8YiVGqED6cVsw==",
       "requires": {
         "@hyperion-framework/parser": "^1.0.0",
         "@hyperion-framework/types": "^1.0.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -27,7 +27,7 @@
     "@honeybadger-io/js": "^3.2.7",
     "@honeybadger-io/react": "^1.0.1",
     "@nulib/design-system": "^1.3.5",
-    "@nulib/react-media-player": "^1.6.8",
+    "@nulib/react-media-player": "^1.6.9",
     "@radix-ui/react-dialog": "^0.1.1",
     "@samvera/image-downloader": "^1.1.1",
     "bulma": "^0.9.3",


### PR DESCRIPTION
# Summary 
Bumps RMP node package to disable autoplay on Video and Sound canvases.

# Specific Changes in this PR
- Disable autoplay on media canvases for Audio/Video works

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Test any Audio/Video work, canvases should not autoplay.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

