### PR TITLE
Don't log requests to /api/ routes through Plug.Logger

### DIFF
--- a/lib/meadow_web/endpoint.ex
+++ b/lib/meadow_web/endpoint.ex
@@ -31,7 +31,6 @@ defmodule MeadowWeb.Endpoint do
     cookie_key: "request_logger"
 
   plug Plug.RequestId
-  plug Plug.Logger
 
   plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],

--- a/lib/meadow_web/router.ex
+++ b/lib/meadow_web/router.ex
@@ -4,6 +4,7 @@ defmodule MeadowWeb.Router do
   import Phoenix.LiveDashboard.Router
 
   pipeline :browser do
+    plug Plug.Logger
     plug :accepts, ["html"]
     plug :fetch_session
     plug :fetch_flash
@@ -12,6 +13,7 @@ defmodule MeadowWeb.Router do
   end
 
   pipeline :secure_browser do
+    plug Plug.Logger
     plug :accepts, ["html"]
     plug :fetch_session
     plug :fetch_flash


### PR DESCRIPTION
# Summary 
Turns off logging (via Plug) of every GraphQL and Elasticsearch proxy request

# Specific Changes in this PR
- Remove `Plug.Logger` from `endpoint.ex`
- Add `Plug.Logger` to the routes we want logged in `router.ex`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Run meadow as usual. Note the lack of
```
module=Plug.Logger [info]  POST /api/graphql
```
entries logged to the console.

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

