### PR TITLE
Fix two bugs in batch edit

### DIFF
--- a/priv/repo/migrations/20220207213036_lengthen_batch_error_field.exs
+++ b/priv/repo/migrations/20220207213036_lengthen_batch_error_field.exs
@@ -1,0 +1,15 @@
+defmodule Meadow.Repo.Migrations.LengthenBatchErrorField do
+  use Ecto.Migration
+
+  def up do
+    alter table(:batches) do
+      modify :error, :text
+    end
+  end
+
+  def down do
+    alter table(:batches) do
+      modify :error, :string
+    end
+  end
+end


### PR DESCRIPTION
# Summary 

Fix the constraint violation that occurs when a batch query references a deleted work ID. Also fix the Postgrex exception that occurs when a batch operation produces an error message longer than 255 characters.

# Specific Changes in this PR

- Exclude nonexistent work IDs from batch operations even if they're in the index
- Convert the batches error field from varchar(255) to text

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

1. Create several works that can be found with the same query.
2. Synchronize the index.
3. Delete one of the works.
4. Before the index synchronizes again, submit a batch edit operation that would include the deleted work.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [x] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

