### PR TITLE
File set count query tallies file sets via work associations rather than ingest sheet row counts

### DIFF
--- a/lib/meadow/ingest/sheets.ex
+++ b/lib/meadow/ingest/sheets.ex
@@ -3,9 +3,7 @@ defmodule Meadow.Ingest.Sheets do
   API for Ingest Sheets
   """
   import Ecto.Query, warn: false
-  alias Meadow.Data.Schemas.ActionState
-  alias Meadow.Data.Schemas.FileSet
-  alias Meadow.Data.Schemas.Work
+  alias Meadow.Data.Schemas.{ActionState, FileSet, Work}
   alias Meadow.Data.Works
   alias Meadow.Ingest.Schemas.{Progress, Project, Row, Sheet}
   alias Meadow.Repo
@@ -370,11 +368,11 @@ defmodule Meadow.Ingest.Sheets do
   def file_set_count(%Sheet{} = ingest_sheet), do: file_set_count(ingest_sheet.id)
 
   def file_set_count(sheet_id) do
-    from(r in Row,
-      where: r.sheet_id == ^sheet_id,
-      select: count(r.sheet_id)
+    from(w in Work,
+      left_join: f in assoc(w, :file_sets),
+      where: w.ingest_sheet_id == ^sheet_id
     )
-    |> Repo.one()
+    |> Repo.aggregate(:count)
   end
 
   def ingest_errors(%Sheet{} = ingest_sheet), do: ingest_errors(ingest_sheet.id)

--- a/lib/meadow/pipeline/actions/common.ex
+++ b/lib/meadow/pipeline/actions/common.ex
@@ -44,7 +44,7 @@ defmodule Meadow.Pipeline.Actions.Common do
 
       defp precheck(file_set, %{overwrite: "false"} = attrs) do
         if already_complete?(file_set, attrs) do
-          "Marking #{__MODULE__} for #{file_set.id} as already complete without overwriting"
+          "Marking #{__MODULE__} for #{file_set.id} as already complete without overwriting"
           |> Logger.warn()
 
           ActionStates.set_state!(file_set, __MODULE__, "ok")
@@ -54,7 +54,7 @@ defmodule Meadow.Pipeline.Actions.Common do
       defp precheck(_, _), do: :noop
 
       defp process(%{id: file_set_id}, _, true) do
-        Logger.warn("Skipping #{__MODULE__} for #{file_set_id} – already complete")
+        Logger.warn("Skipping #{__MODULE__} for #{file_set_id} - already complete")
         :ok
       end
 

--- a/lib/meadow/pipeline/actions/copy_file_to_preservation.ex
+++ b/lib/meadow/pipeline/actions/copy_file_to_preservation.ex
@@ -17,12 +17,18 @@ defmodule Meadow.Pipeline.Actions.CopyFileToPreservation do
 
   @actiondoc "Copy File to Preservation"
 
-  defp already_complete?(file_set, _) do
+  defp already_complete?(file_set, %{overwrite: "false"}) do
     with dest_location <- FileSets.preservation_location(file_set) do
       if file_set.core_metadata.location == dest_location,
         do: Meadow.Utils.Stream.exists?(dest_location),
         else: false
     end
+  end
+
+  defp already_complete?(file_set, _) do
+    file_set
+    |> FileSets.preservation_location()
+    |> Meadow.Utils.Stream.exists?()
   end
 
   defp process(file_set, attributes, _) do

--- a/test/meadow/ingest/sheets_test.exs
+++ b/test/meadow/ingest/sheets_test.exs
@@ -148,6 +148,19 @@ defmodule Meadow.Ingest.SheetsTest do
 
       assert Sheets.work_count(ingest_sheet) == 30
     end
+
+    test "file_set_count/1" do
+      project = project_fixture()
+      ingest_sheet = ingest_sheet_fixture(Map.put(@valid_attrs, :project_id, project.id))
+      work_1 = work_with_file_sets_fixture(Faker.random_between(1, 5), %{ingest_sheet_id: ingest_sheet.id})
+      work_2 = work_with_file_sets_fixture(Faker.random_between(1, 3), %{ingest_sheet_id: ingest_sheet.id})
+
+      assert Sheets.file_set_count(ingest_sheet) == length(work_1.file_sets) + length(work_2.file_sets)
+
+      Works.delete_work(work_1)
+
+      assert Sheets.file_set_count(ingest_sheet) == length(work_2.file_sets)
+    end
   end
 
   describe "update_completed_sheets/0" do

--- a/test/meadow_web/schema/query/ingest_sheet_work_count.exs
+++ b/test/meadow_web/schema/query/ingest_sheet_work_count.exs
@@ -3,8 +3,6 @@ defmodule MeadowWeb.Schema.Query.IngestSheetWorkCount do
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 
-  alias Meadow.Ingest.Rows
-
   load_gql(MeadowWeb.Schema, "test/gql/IngestSheetWorkCount.gql")
 
   test "ingestSheetWorkCount query returns total works in an ingest sheet", %{ingest_sheet: sheet} do

--- a/test/pipeline/actions/create_pyramid_tiff_test.exs
+++ b/test/pipeline/actions/create_pyramid_tiff_test.exs
@@ -61,7 +61,7 @@ defmodule Meadow.Pipeline.Actions.CreatePyramidTiffTest do
 
       assert capture_log(fn ->
                CreatePyramidTiff.process(%{file_set_id: file_set_id}, %{})
-             end) =~ "Skipping #{CreatePyramidTiff} for #{file_set_id} – already complete"
+             end) =~ "Skipping #{CreatePyramidTiff} for #{file_set_id} - already complete"
 
       on_exit(fn ->
         delete_object(@pyramid_bucket, dest)
@@ -94,7 +94,7 @@ defmodule Meadow.Pipeline.Actions.CreatePyramidTiffTest do
 
       assert capture_log(fn ->
                CreatePyramidTiff.process(%{file_set_id: file_set_id}, %{})
-             end) =~ "Skipping #{CreatePyramidTiff} for #{file_set_id} – already complete"
+             end) =~ "Skipping #{CreatePyramidTiff} for #{file_set_id} - already complete"
 
       on_exit(fn ->
         delete_object(@pyramid_bucket, dest)

--- a/test/pipeline/actions/create_transcode_job_test.exs
+++ b/test/pipeline/actions/create_transcode_job_test.exs
@@ -33,7 +33,7 @@ defmodule Meadow.Pipeline.Actions.CreateTranscodeJobTest do
 
       assert capture_log(fn ->
                CreateTranscodeJob.process(%{file_set_id: object.id}, %{})
-             end) =~ "Skipping #{CreateTranscodeJob} for #{object.id} – already complete"
+             end) =~ "Skipping #{CreateTranscodeJob} for #{object.id} - already complete"
     end
   end
 

--- a/test/pipeline/actions/extract_exif_metadata_test.exs
+++ b/test/pipeline/actions/extract_exif_metadata_test.exs
@@ -111,7 +111,7 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadataTest do
 
       assert capture_log(fn ->
                ExtractExifMetadata.process(%{file_set_id: file_set_id}, %{})
-             end) =~ "Skipping #{ExtractExifMetadata} for #{file_set_id} – already complete"
+             end) =~ "Skipping #{ExtractExifMetadata} for #{file_set_id} - already complete"
     end
   end
 
@@ -129,7 +129,7 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadataTest do
 
       assert capture_log(fn ->
                ExtractExifMetadata.process(%{file_set_id: file_set_id}, %{})
-             end) =~ "Skipping #{ExtractExifMetadata} for #{file_set_id} – already complete"
+             end) =~ "Skipping #{ExtractExifMetadata} for #{file_set_id} - already complete"
     end
   end
 

--- a/test/pipeline/actions/extract_media_metadata_test.exs
+++ b/test/pipeline/actions/extract_media_metadata_test.exs
@@ -80,7 +80,7 @@ defmodule Meadow.Pipeline.Actions.ExtractMediaMetadataTest do
 
       assert capture_log(fn ->
                ExtractMediaMetadata.process(%{file_set_id: file_set_id}, %{})
-             end) =~ "Skipping #{ExtractMediaMetadata} for #{file_set_id} – already complete"
+             end) =~ "Skipping #{ExtractMediaMetadata} for #{file_set_id} - already complete"
     end
   end
 
@@ -99,7 +99,7 @@ defmodule Meadow.Pipeline.Actions.ExtractMediaMetadataTest do
 
       assert capture_log(fn ->
                ExtractMediaMetadata.process(%{file_set_id: file_set_id}, %{})
-             end) =~ "Skipping #{ExtractMediaMetadata} for #{file_set_id} – already complete"
+             end) =~ "Skipping #{ExtractMediaMetadata} for #{file_set_id} - already complete"
     end
   end
 

--- a/test/pipeline/actions/extract_mime_type_test.exs
+++ b/test/pipeline/actions/extract_mime_type_test.exs
@@ -40,7 +40,7 @@ defmodule Meadow.Pipeline.Actions.ExtractMimeTypeTest do
 
       assert capture_log(fn ->
                ExtractMimeType.process(%{file_set_id: file_set_id}, %{})
-             end) =~ "Skipping #{ExtractMimeType} for #{file_set_id} – already complete"
+             end) =~ "Skipping #{ExtractMimeType} for #{file_set_id} - already complete"
     end
 
     @tag fixture_file: @bad_tiff, file_set_role_id: "P"
@@ -65,7 +65,7 @@ defmodule Meadow.Pipeline.Actions.ExtractMimeTypeTest do
 
       assert capture_log(fn ->
                ExtractMimeType.process(%{file_set_id: file_set_id}, %{})
-             end) =~ "Skipping #{ExtractMimeType} for #{file_set_id} – already complete"
+             end) =~ "Skipping #{ExtractMimeType} for #{file_set_id} - already complete"
     end
 
     @tag fixture_file: @framemd5_file, file_set_role_id: "S"

--- a/test/pipeline/actions/file_set_complete_test.exs
+++ b/test/pipeline/actions/file_set_complete_test.exs
@@ -12,6 +12,6 @@ defmodule Meadow.Pipeline.Actions.FileSetCompleteTest do
 
     assert capture_log(fn ->
              FileSetComplete.process(%{file_set_id: object.id}, %{})
-           end) =~ "Skipping #{FileSetComplete} for #{object.id} – already complete"
+           end) =~ "Skipping #{FileSetComplete} for #{object.id} - already complete"
   end
 end

--- a/test/pipeline/actions/generate_file_set_digests_test.exs
+++ b/test/pipeline/actions/generate_file_set_digests_test.exs
@@ -48,7 +48,7 @@ defmodule Meadow.Pipeline.Actions.GenerateFileSetDigestsTest do
 
     assert capture_log(fn ->
              GenerateFileSetDigests.process(%{file_set_id: file_set_id}, %{})
-           end) =~ "Skipping #{GenerateFileSetDigests} for #{file_set_id} – already complete"
+           end) =~ "Skipping #{GenerateFileSetDigests} for #{file_set_id} - already complete"
   end
 
   describe "overwrite flag" do

--- a/test/pipeline/actions/ingest_file_set_test.exs
+++ b/test/pipeline/actions/ingest_file_set_test.exs
@@ -13,7 +13,7 @@ defmodule Meadow.Pipeline.Actions.IngestFileSetTest do
 
       assert capture_log(fn ->
                IngestFileSet.process(%{file_set_id: object.id}, %{})
-             end) =~ "Skipping #{IngestFileSet} for #{object.id} – already complete"
+             end) =~ "Skipping #{IngestFileSet} for #{object.id} - already complete"
     end
   end
 


### PR DESCRIPTION
# Summary 
Ingest Sheet previews show work and file set counts, but it is confusing to end users when file sets are deleted because the query uses the ingest sheet rows to produce the number. This PR modifies the query to use work associations instead so that the count is always accurate.

# Specific Changes in this PR
- `Meadow.Ingest.Sheets.file_set_count/1` uses the new query
- `Meadow.Ingest.SheetsTest` updated with a new test for `Meadow.Ingest.Sheets.file_set_count/1`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
- Run an ingest sheet for a work with two file sets
- The Ingest Sheet preview page should show `2 file_sets in 1 works`
- Delete one of the file sets manually. The Ingest Sheet preview should show `1 works containing 1 file_sets`
- The Ingest Sheet preview page should now show `1 file_sets in 1 works

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [x] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

