### PR TITLE
Add caption configuration to RMP

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "@absinthe/socket-apollo-link": "^0.2.1",
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",
@@ -19,7 +19,7 @@
         "@honeybadger-io/js": "^3.2.7",
         "@honeybadger-io/react": "^1.0.1",
         "@nulib/design-system": "^1.3.5",
-        "@nulib/react-media-player": "^1.6.9",
+        "@nulib/react-media-player": "^1.6.10",
         "@radix-ui/react-dialog": "^0.1.1",
         "@samvera/image-downloader": "^1.1.1",
         "bulma": "^0.9.3",
@@ -3365,9 +3365,9 @@
       "dev": true
     },
     "node_modules/@nulib/react-media-player": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.6.9.tgz",
-      "integrity": "sha512-m3ymOjzYdLhlRPrWTEgbPqiTWl7G5w72DL/qo+OSiO3QK8bnsMi22YhE1Q0/SxvkECRfqQnJA8YiVGqED6cVsw==",
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.6.10.tgz",
+      "integrity": "sha512-oaka64TrFE4ptW3hrwqV4Fgx2IQCHTIxEgNzg4Ojz/0wd1mWD961rLDZQfOP4x2nRKIwMVG58gm5ZUwgkKJjzQ==",
       "dependencies": {
         "@hyperion-framework/parser": "^1.0.0",
         "@hyperion-framework/types": "^1.0.0",
@@ -22136,9 +22136,9 @@
       "dev": true
     },
     "@nulib/react-media-player": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.6.9.tgz",
-      "integrity": "sha512-m3ymOjzYdLhlRPrWTEgbPqiTWl7G5w72DL/qo+OSiO3QK8bnsMi22YhE1Q0/SxvkECRfqQnJA8YiVGqED6cVsw==",
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/@nulib/react-media-player/-/react-media-player-1.6.10.tgz",
+      "integrity": "sha512-oaka64TrFE4ptW3hrwqV4Fgx2IQCHTIxEgNzg4Ojz/0wd1mWD961rLDZQfOP4x2nRKIwMVG58gm5ZUwgkKJjzQ==",
       "requires": {
         "@hyperion-framework/parser": "^1.0.0",
         "@hyperion-framework/types": "^1.0.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -27,7 +27,7 @@
     "@honeybadger-io/js": "^3.2.7",
     "@honeybadger-io/react": "^1.0.1",
     "@nulib/design-system": "^1.3.5",
-    "@nulib/react-media-player": "^1.6.9",
+    "@nulib/react-media-player": "^1.6.10",
     "@radix-ui/react-dialog": "^0.1.1",
     "@samvera/image-downloader": "^1.1.1",
     "bulma": "^0.9.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "meadow",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
# Summary 
Updates React Media Player, allowing configuration of closed captioning from source VTTs in IIIF manifest annotations.

# Specific Changes in this PR
- Updates `@nulib/react-media-player` package to 1.6.10

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

