### PR TITLE
Improve Ecto Sandbox connection management

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Meadow.MixProject do
   use Mix.Project
 
-  @app_version "5.1.2"
+  @app_version "5.1.3"
 
   def project do
     [
@@ -57,7 +57,7 @@ defmodule Meadow.MixProject do
       {:ecto_enum, "~> 1.4.0"},
       {:ecto_psql_extras, "~> 0.2"},
       {:ecto_ranked, "~> 0.5.0"},
-      {:ecto_sql, "~> 3.0"},
+      {:ecto_sql, "~> 3.0 and >= 3.4.4"},
       {:elastix, "~> 0.10.0"},
       {:elasticsearch, "~> 1.0.0"},
       {:ets, "~> 0.8.0"},

--- a/test/meadow/batch_driver_test.exs
+++ b/test/meadow/batch_driver_test.exs
@@ -1,5 +1,4 @@
 defmodule Meadow.BatchDriverTest do
-  use ExUnit.Case
   use Meadow.DataCase
   use Meadow.IndexCase
 

--- a/test/meadow/csv_metadata_update_driver_test.exs
+++ b/test/meadow/csv_metadata_update_driver_test.exs
@@ -1,4 +1,5 @@
 defmodule Meadow.CSVMetadataUpdateDriverTest do
+  use Meadow.DataCase
   use Meadow.CSVMetadataUpdateCase
 
   alias Meadow.CSVMetadataUpdateDriver

--- a/test/meadow/data/csv/metadata_update_jobs_test.exs
+++ b/test/meadow/data/csv/metadata_update_jobs_test.exs
@@ -1,4 +1,5 @@
 defmodule Meadow.Data.CSV.MetadataUpdateJobsTest do
+  use Meadow.DataCase
   use Meadow.CSVMetadataUpdateCase
   use Meadow.IndexCase
   alias Meadow.Data.{CSV.MetadataUpdateJobs, Indexer, Works}

--- a/test/meadow/data/indexer_test.exs
+++ b/test/meadow/data/indexer_test.exs
@@ -294,7 +294,9 @@ defmodule Meadow.Data.IndexerTest do
 
       Indexer.synchronize_index()
       [_header, doc] = subject |> Indexer.encode!(:index) |> decode_njson()
-      assert doc |> get_in(["thumbnail"]) == "http://localhost:8184/iiif/2/posters/#{file_set.id}/full/!300,300/0/default.jpg"
+
+      assert doc |> get_in(["thumbnail"]) ==
+               "http://localhost:8184/iiif/2/posters/#{file_set.id}/full/!300,300/0/default.jpg"
     end
 
     test "work encode of copy fields", %{work: subject} do

--- a/test/meadow/data/preservation_checks_test.exs
+++ b/test/meadow/data/preservation_checks_test.exs
@@ -1,5 +1,4 @@
 defmodule Meadow.Data.PreservationChecksTest do
-  use ExUnit.Case
   use Meadow.DataCase
   use Meadow.S3Case
 

--- a/test/meadow/error_test.exs
+++ b/test/meadow/error_test.exs
@@ -1,6 +1,8 @@
 defmodule Meadow.ErrorTest do
   use Honeybadger.Case
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
+
   use Meadow.Utils.Logging
 
   alias Meadow.Config

--- a/test/meadow/ingest/work_creator_test.exs
+++ b/test/meadow/ingest/work_creator_test.exs
@@ -1,4 +1,5 @@
 defmodule Meadow.Ingest.WorkCreatorTest do
+  use Meadow.DataCase, async: false
   use Meadow.IngestCase, async: false
   use Meadow.S3Case
   alias Ecto.Adapters.SQL.Sandbox

--- a/test/meadow/ingest/work_redriver_test.exs
+++ b/test/meadow/ingest/work_redriver_test.exs
@@ -1,4 +1,5 @@
 defmodule Meadow.Ingest.WorkRedriverTest do
+  use Meadow.DataCase
   use Meadow.IngestCase
   alias Meadow.Ingest.{Progress, Rows, WorkRedriver}
   alias Meadow.Ingest.Schemas.Progress, as: ProgressSchema

--- a/test/meadow_web/controllers/export_controller_test.exs
+++ b/test/meadow_web/controllers/export_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule MeadowWeb.ExportControllerTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
-  use Meadow.DataCase, async: true
+
   alias Meadow.Data.Indexer
 
   @query ~s({"query":{"term":{"model.name.keyword": "Work"}}})

--- a/test/meadow_web/controllers/shared_links_controller_test.exs
+++ b/test/meadow_web/controllers/shared_links_controller_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.SharedLinksControllerTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
-  use Meadow.DataCase, async: true
   alias Meadow.Data.Indexer
 
   @query ~s({"query":{"term":{"model.name.keyword": "Work"}}})

--- a/test/meadow_web/plugs/elasticsearch_test.exs
+++ b/test/meadow_web/plugs/elasticsearch_test.exs
@@ -1,4 +1,5 @@
 defmodule ElasticsearchTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: false
   use Meadow.IndexCase
 

--- a/test/meadow_web/schema/mutation/add_work_to_collection_test.exs
+++ b/test/meadow_web/schema/mutation/add_work_to_collection_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Mutation.AddWorkToCollectionTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, acync: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/mutation/add_works_to_collection_test.exs
+++ b/test/meadow_web/schema/mutation/add_works_to_collection_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Mutation.AddWorksToCollectionTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, acync: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/mutation/batch_delete_test.exs
+++ b/test/meadow_web/schema/mutation/batch_delete_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.BatchDeleteTest do
-  use MeadowWeb.ConnCase, async: true
   use Meadow.DataCase
+  use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
   alias Meadow.Data.Indexer
 

--- a/test/meadow_web/schema/mutation/batch_update_test.exs
+++ b/test/meadow_web/schema/mutation/batch_update_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.BatchUpdateTest do
-  use MeadowWeb.ConnCase, async: true
   use Meadow.DataCase
+  use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
   alias Meadow.Data.Indexer
 

--- a/test/meadow_web/schema/mutation/create_collection_test.exs
+++ b/test/meadow_web/schema/mutation/create_collection_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Mutation.CreateCollectionTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/mutation/create_ingest_sheet_test.exs
+++ b/test/meadow_web/schema/mutation/create_ingest_sheet_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Mutation.CreateSheet do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Meadow.S3Case
   use Wormwood.GQLCase

--- a/test/meadow_web/schema/mutation/create_nul_authority_record.exs
+++ b/test/meadow_web/schema/mutation/create_nul_authority_record.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Mutation.CreateNULAuthorityRecordTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/mutation/create_project_test.exs
+++ b/test/meadow_web/schema/mutation/create_project_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Mutation.CreateProjectTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/mutation/create_shared_link_test.exs
+++ b/test/meadow_web/schema/mutation/create_shared_link_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Resolvers.Data.SharedLinkTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/mutation/create_work_test.exs
+++ b/test/meadow_web/schema/mutation/create_work_test.exs
@@ -1,5 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.CreateWorkTest do
   use Meadow.AuthorityCase
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/mutation/delete_collection_test.exs
+++ b/test/meadow_web/schema/mutation/delete_collection_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Mutation.DeleteCollectionTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/mutation/delete_file_set_test.exs
+++ b/test/meadow_web/schema/mutation/delete_file_set_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Mutation.DeleteFileSetTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/mutation/ingest_file_set_test.exs
+++ b/test/meadow_web/schema/mutation/ingest_file_set_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Mutation.IngestFileSetTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Meadow.S3Case
   use Wormwood.GQLCase

--- a/test/meadow_web/schema/mutation/metadata_update_test.exs
+++ b/test/meadow_web/schema/mutation/metadata_update_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Mutation.MetadataUpdateTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Meadow.CSVMetadataUpdateCase
   use Wormwood.GQLCase

--- a/test/meadow_web/schema/mutation/remove_works_from_collection_test.exs
+++ b/test/meadow_web/schema/mutation/remove_works_from_collection_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Mutation.RemoveWorksFromCollectionTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, acync: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/mutation/set_collection_image_test.exs
+++ b/test/meadow_web/schema/mutation/set_collection_image_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Mutation.SetCollectionImageTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
   alias Meadow.Data.Collections

--- a/test/meadow_web/schema/mutation/set_work_image_test.exs
+++ b/test/meadow_web/schema/mutation/set_work_image_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Mutation.SetWorkImageTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
   alias Meadow.Data.Works

--- a/test/meadow_web/schema/mutation/update_access_file_order_test.exs
+++ b/test/meadow_web/schema/mutation/update_access_file_order_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Mutation.UpdateAccessFileOrderTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, acync: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/mutation/update_file_set_test.exs
+++ b/test/meadow_web/schema/mutation/update_file_set_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Mutation.UpdateFileSetTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/mutation/update_file_sets_test.exs
+++ b/test/meadow_web/schema/mutation/update_file_sets_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Mutation.UpdateFileSetsTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/mutation/update_project_test.exs
+++ b/test/meadow_web/schema/mutation/update_project_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Mutation.UpdateProjectTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/mutation/update_work_test.exs
+++ b/test/meadow_web/schema/mutation/update_work_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Mutation.UpdateWorkTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/query/action_states_test.exs
+++ b/test/meadow_web/schema/query/action_states_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Query.ActionStatesTest do
+  use Meadow.DataCase
   use Meadow.IngestCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase

--- a/test/meadow_web/schema/query/collections_test.exs
+++ b/test/meadow_web/schema/query/collections_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Query.CollectionsTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/query/controlled_types/authorities_search_test.exs
+++ b/test/meadow_web/schema/query/controlled_types/authorities_search_test.exs
@@ -1,5 +1,6 @@
 defmodule MeadowWeb.Schema.Query.AuthoritiesSearchTest do
   use Meadow.AuthorityCase
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/query/controlled_types/code_list_test.exs
+++ b/test/meadow_web/schema/query/controlled_types/code_list_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Query.CodeListTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/query/controlled_types/fetch_coded_term_label_test.exs
+++ b/test/meadow_web/schema/query/controlled_types/fetch_coded_term_label_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Query.FetchCodedTermLabelTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/query/controlled_types/fetch_controlled_term_label_test.exs
+++ b/test/meadow_web/schema/query/controlled_types/fetch_controlled_term_label_test.exs
@@ -1,5 +1,6 @@
 defmodule MeadowWeb.Schema.Query.FetchControlledTermLabelTest do
   use Meadow.AuthorityCase
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/query/describe_fields_test.exs
+++ b/test/meadow_web/schema/query/describe_fields_test.exs
@@ -1,5 +1,6 @@
 defmodule MeadowWeb.Schema.Query.DescribeFieldsTest do
   defmodule All do
+    use Meadow.DataCase
     use MeadowWeb.ConnCase, async: true
     use Wormwood.GQLCase
     load_gql(MeadowWeb.Schema, "test/gql/DescribeFields.gql")
@@ -11,6 +12,7 @@ defmodule MeadowWeb.Schema.Query.DescribeFieldsTest do
   end
 
   defmodule ByID do
+    use Meadow.DataCase
     use MeadowWeb.ConnCase, async: true
     use Wormwood.GQLCase
     load_gql(MeadowWeb.Schema, "test/gql/DescribeField.gql")

--- a/test/meadow_web/schema/query/file_sets_test.exs
+++ b/test/meadow_web/schema/query/file_sets_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Query.FileSetsTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
 
   @query """

--- a/test/meadow_web/schema/query/get_batch_by_id_test.exs
+++ b/test/meadow_web/schema/query/get_batch_by_id_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Query.GetBatchByIdTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/query/get_batches_test.exs
+++ b/test/meadow_web/schema/query/get_batches_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Query.BatchesTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/query/get_collection_by_id_test.exs
+++ b/test/meadow_web/schema/query/get_collection_by_id_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Query.GetCollectionByIdTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/query/get_metadata_update_job_by_id_test.exs
+++ b/test/meadow_web/schema/query/get_metadata_update_job_by_id_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Query.GetMetadataUpdateJobByIdTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Meadow.CSVMetadataUpdateCase
   use Wormwood.GQLCase

--- a/test/meadow_web/schema/query/get_metadata_update_jobs_test.exs
+++ b/test/meadow_web/schema/query/get_metadata_update_jobs_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Query.GetMetadataUpdateJobsTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
   alias Meadow.Data.CSV.MetadataUpdateJobs

--- a/test/meadow_web/schema/query/get_preservation_checks.exs
+++ b/test/meadow_web/schema/query/get_preservation_checks.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Query.PreservationChecksTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/query/iiif_manifest_headers_test.exs
+++ b/test/meadow_web/schema/query/iiif_manifest_headers_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Query.IiifManifestHeadersTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
   use Meadow.S3Case

--- a/test/meadow_web/schema/query/ingest_errors_test.exs
+++ b/test/meadow_web/schema/query/ingest_errors_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Query.IngestErrorsTest do
+  use Meadow.DataCase
   use Meadow.IngestCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase

--- a/test/meadow_web/schema/query/ingest_job_test.exs
+++ b/test/meadow_web/schema/query/ingest_job_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Query.SheetTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
 
   @query """

--- a/test/meadow_web/schema/query/ingest_sheet_work_count.exs
+++ b/test/meadow_web/schema/query/ingest_sheet_work_count.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Query.IngestSheetWorkCount do
+  use Meadow.DataCase
   use Meadow.IngestCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase

--- a/test/meadow_web/schema/query/project_test.exs
+++ b/test/meadow_web/schema/query/project_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Query.ProjectTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
 
   @query """

--- a/test/meadow_web/schema/query/projects_test.exs
+++ b/test/meadow_web/schema/query/projects_test.exs
@@ -1,21 +1,23 @@
 defmodule MeadowWeb.Schema.Query.ProjectsTest do
   defmodule All do
+    use Meadow.DataCase
     use MeadowWeb.ConnCase, async: true
     use Wormwood.GQLCase
 
-    set_gql MeadowWeb.Schema, """
+    set_gql(MeadowWeb.Schema, """
     query {
       projects{
         id
         title
       }
     }
-    """
+    """)
 
     test "projects query returns all projects" do
       projects_fixture()
 
       assert {:ok, %{data: query_data}} = query_gql(context: gql_context())
+
       assert [
                %{"title" => "Project 3"},
                %{"title" => "Project 2"},
@@ -25,22 +27,26 @@ defmodule MeadowWeb.Schema.Query.ProjectsTest do
   end
 
   defmodule Limit do
+    use Meadow.DataCase
     use MeadowWeb.ConnCase, async: true
     use Wormwood.GQLCase
 
-    set_gql MeadowWeb.Schema, """
+    set_gql(MeadowWeb.Schema, """
     query($limit: Int) {
       projects(limit: $limit){
         id
         title
       }
     }
-    """
+    """)
+
     @tag variables: %{"limit" => "2"}
     test "projects query limits the number of projects returned" do
       projects_fixture()
 
-      assert {:ok, %{data: query_data}} = query_gql(variables: %{"limit" => 2}, context: gql_context())
+      assert {:ok, %{data: query_data}} =
+               query_gql(variables: %{"limit" => 2}, context: gql_context())
+
       assert [
                %{"title" => "Project 3"},
                %{"title" => "Project 2"}
@@ -49,22 +55,22 @@ defmodule MeadowWeb.Schema.Query.ProjectsTest do
   end
 
   defmodule Order do
+    use Meadow.DataCase
     use MeadowWeb.ConnCase, async: true
     use Wormwood.GQLCase
 
-    set_gql MeadowWeb.Schema, """
+    set_gql(MeadowWeb.Schema, """
     query($order: SortOrder!) {
       projects(order: $order){
         id
         title
       }
     }
-    """
+    """)
 
     setup tags do
       projects_fixture()
-      {:ok,
-       %{result: query_gql(variables: tags[:variables], context: gql_context())}}
+      {:ok, %{result: query_gql(variables: tags[:variables], context: gql_context())}}
     end
 
     @tag variables: %{"order" => "ASC"}

--- a/test/meadow_web/schema/query/roles_test.exs
+++ b/test/meadow_web/schema/query/roles_test.exs
@@ -1,7 +1,7 @@
 defmodule MeadowWeb.Schema.Query.RolesTest do
   use Meadow.Constants
 
-    use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/GetRoles.gql")

--- a/test/meadow_web/schema/query/verifiy_file_sets_test.exs
+++ b/test/meadow_web/schema/query/verifiy_file_sets_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Query.VerifyFileSets do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 

--- a/test/meadow_web/schema/query/work_test.exs
+++ b/test/meadow_web/schema/query/work_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Query.WorkTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
 
   @query """

--- a/test/meadow_web/schema/query/works_test.exs
+++ b/test/meadow_web/schema/query/works_test.exs
@@ -1,5 +1,6 @@
 defmodule MeadowWeb.Schema.Query.WorksTest do
   defmodule All do
+    use Meadow.DataCase
     use MeadowWeb.ConnCase, async: true
     use Wormwood.GQLCase
 
@@ -24,6 +25,7 @@ defmodule MeadowWeb.Schema.Query.WorksTest do
   end
 
   defmodule Limit do
+    use Meadow.DataCase
     use MeadowWeb.ConnCase, async: true
     use Wormwood.GQLCase
 
@@ -52,6 +54,7 @@ defmodule MeadowWeb.Schema.Query.WorksTest do
   end
 
   defmodule TitleMatch do
+    use Meadow.DataCase
     use MeadowWeb.ConnCase, async: true
     use Wormwood.GQLCase
 
@@ -88,6 +91,7 @@ defmodule MeadowWeb.Schema.Query.WorksTest do
   end
 
   defmodule RepresentativeImage do
+    use Meadow.DataCase
     use MeadowWeb.ConnCase, async: true
     use Wormwood.GQLCase
     alias Meadow.Data.Works

--- a/test/meadow_web/schema/subscription/ingest_progress_test.exs
+++ b/test/meadow_web/schema/subscription/ingest_progress_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.Schema.Subscription.IngestProgressTest do
+  use Meadow.DataCase
   use Meadow.IngestCase
   use MeadowWeb.SubscriptionCase, async: true
   alias Meadow.Ingest.{Progress, Sheets, SheetsToWorks}

--- a/test/meadow_web/views/error_view_test.exs
+++ b/test/meadow_web/views/error_view_test.exs
@@ -1,4 +1,5 @@
 defmodule MeadowWeb.ErrorViewTest do
+  use Meadow.DataCase
   use MeadowWeb.ConnCase, async: true
 
   # Bring render/3 and render_to_string/3 for testing custom views

--- a/test/pipeline/actions/extract_exif_metadata_test.exs
+++ b/test/pipeline/actions/extract_exif_metadata_test.exs
@@ -1,6 +1,6 @@
 defmodule Meadow.Pipeline.Actions.ExtractExifMetadataTest do
-  use Meadow.S3Case
   use Meadow.DataCase
+  use Meadow.S3Case
   alias Meadow.Data.{ActionStates, FileSets}
   alias Meadow.Pipeline.Actions.ExtractExifMetadata
 

--- a/test/pipeline/actions/extract_media_metadata_test.exs
+++ b/test/pipeline/actions/extract_media_metadata_test.exs
@@ -1,6 +1,6 @@
 defmodule Meadow.Pipeline.Actions.ExtractMediaMetadataTest do
-  use Meadow.S3Case
   use Meadow.DataCase
+  use Meadow.S3Case
   alias Meadow.Data.{ActionStates, FileSets}
   alias Meadow.Pipeline.Actions.ExtractMediaMetadata
 

--- a/test/pipeline/actions/extract_mime_type_test.exs
+++ b/test/pipeline/actions/extract_mime_type_test.exs
@@ -1,6 +1,6 @@
 defmodule Meadow.Pipeline.Actions.ExtractMimeTypeTest do
-  use Meadow.S3Case
   use Meadow.DataCase
+  use Meadow.S3Case
   alias Meadow.Data.{ActionStates, FileSets}
   alias Meadow.Pipeline.Actions.ExtractMimeType
   import ExUnit.CaptureLog

--- a/test/pipeline/actions/generate_file_set_digests_test.exs
+++ b/test/pipeline/actions/generate_file_set_digests_test.exs
@@ -1,6 +1,6 @@
 defmodule Meadow.Pipeline.Actions.GenerateFileSetDigestsTest do
-  use Meadow.S3Case
   use Meadow.DataCase
+  use Meadow.S3Case
   alias Meadow.Config
   alias Meadow.Data.{ActionStates, FileSets}
   alias Meadow.Pipeline.Actions.GenerateFileSetDigests

--- a/test/pipeline/actions/initialize_dispatch_test.exs
+++ b/test/pipeline/actions/initialize_dispatch_test.exs
@@ -1,7 +1,7 @@
 defmodule Meadow.Pipeline.Actions.InitializeDispatchTest do
-  use Meadow.S3Case
   use Meadow.DataCase
   use Meadow.IngestCase
+  use Meadow.S3Case
 
   alias Meadow.Data.{ActionStates, FileSets}
   alias Meadow.Ingest.{Progress, Rows}

--- a/test/pipeline/dispatcher_test.exs
+++ b/test/pipeline/dispatcher_test.exs
@@ -1,6 +1,6 @@
 defmodule Meadow.Pipeline.Actions.DispatcherTest do
-  use Meadow.S3Case
   use Meadow.DataCase
+  use Meadow.S3Case
 
   alias Meadow.Config
 

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -14,7 +14,6 @@ defmodule MeadowWeb.ChannelCase do
   """
 
   use ExUnit.CaseTemplate
-  import Meadow.TestHelpers
 
   using do
     quote do
@@ -24,10 +23,5 @@ defmodule MeadowWeb.ChannelCase do
       # The default endpoint for testing
       @endpoint MeadowWeb.Endpoint
     end
-  end
-
-  setup tags do
-    :ok = sandbox_mode(tags)
-    :ok
   end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -14,13 +14,13 @@ defmodule MeadowWeb.ConnCase do
   """
 
   use ExUnit.CaseTemplate
-  import Meadow.TestHelpers
 
   using do
     quote do
-      # Import conveniences for testing with connections
       alias Meadow.Accounts.Schemas.User
       alias MeadowWeb.Router.Helpers, as: Routes
+
+      # Import conveniences for testing with connections
       import Meadow.TestHelpers
       import Phoenix.ConnTest
       import Plug.Conn
@@ -42,8 +42,7 @@ defmodule MeadowWeb.ConnCase do
     end
   end
 
-  setup tags do
-    :ok = sandbox_mode(tags)
+  setup do
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
 end

--- a/test/support/csv_metadata_update_case.ex
+++ b/test/support/csv_metadata_update_case.ex
@@ -8,8 +8,6 @@ defmodule Meadow.CSVMetadataUpdateCase do
   import Meadow.TestHelpers
 
   setup tags do
-    :ok = sandbox_mode(tags)
-
     prewarm_controlled_term_cache()
 
     with bucket <- Config.upload_bucket(),
@@ -28,7 +26,6 @@ defmodule Meadow.CSVMetadataUpdateCase do
 
   using do
     quote do
-      use Meadow.DataCase
       use Meadow.S3Case
     end
   end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -13,7 +13,7 @@ defmodule Meadow.DataCase do
   """
 
   use ExUnit.CaseTemplate
-  import Meadow.TestHelpers
+  alias Ecto.Adapters.SQL.Sandbox
 
   using do
     quote do
@@ -28,7 +28,11 @@ defmodule Meadow.DataCase do
   end
 
   setup tags do
-    :ok = sandbox_mode(tags)
+    with shared <- not Map.get(tags, :async, true),
+         pid <- Sandbox.start_owner!(Meadow.Repo, shared: shared) do
+      on_exit(fn -> Sandbox.stop_owner(pid) end)
+    end
+
     :ok
   end
 

--- a/test/support/ingest_case.ex
+++ b/test/support/ingest_case.ex
@@ -26,8 +26,7 @@ defmodule Meadow.IngestCase do
     end
   end
 
-  setup tags do
-    :ok = sandbox_mode(tags)
+  setup do
     sheet = ingest_sheet_rows_fixture(@fixture)
 
     sheet

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -3,8 +3,6 @@ defmodule Meadow.TestHelpers do
   Meadow test helpers, fixtures, etc
 
   """
-  alias Ecto.Adapters.SQL.Sandbox
-
   alias Meadow.Accounts.{Ldap, User}
   alias Meadow.Data.Schemas.{Batch, Collection, FileSet, Work}
   alias Meadow.Data.Works
@@ -231,21 +229,6 @@ defmodule Meadow.TestHelpers do
         role: "Administrator"
       }
     })
-  end
-
-  def sandbox_mode(tags) do
-    result =
-      case Sandbox.checkout(Meadow.Repo) do
-        :ok -> :ok
-        {:already, :owner} -> :ok
-        other -> other
-      end
-
-    unless tags[:async] do
-      Sandbox.mode(Meadow.Repo, {:shared, self()})
-    end
-
-    result
   end
 
   def delete_entry(dn) do


### PR DESCRIPTION
# Summary 

Use the Ecto Sandbox connection management code [introduced in Ecto v3.4.4](https://github.com/elixir-ecto/ecto_sql/blob/master/CHANGELOG.md#v344-2020-05-19)

# Specific Changes in this PR
- Update `Meadow.DataCase` to use `Sandbox.start_owner!/2` and `Sandbox.stop_owner/1` instead of `Sandbox.checkout/1` and `Sandbox.mode/2`
- Remove explicit Sandbox management code from other case templates and tests
- Ensure `use Meadow.DataCase` is present in all tests that touch the database

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Run tests
- Make sure you don't see any `DBConnection.Ownership` errors
- The occasional `DBConnection.Connection` error may still show up, but not cause any tests to fail

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

