### PR TITLE
Improve dev and test ExAws configuration

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -115,14 +115,14 @@ config :elastix,
   custom_headers: {Meadow.Utils.AWS, :add_aws_signature, ["us-east-1", "fake", "fake"]}
 
 unless System.get_env("REAL_AWS_CONFIG", "false") == "true" do
-  [:s3, :sns, :sqs]
+  [:mediaconvert, :s3, :sns, :sqs]
   |> Enum.each(fn service ->
     config :ex_aws, service,
-      access_key_id: "fake",
-      secret_access_key: "fake",
+      scheme: "https://",
       host: "localhost.localstack.cloud",
       port: 4566,
-      scheme: "https://",
+      access_key_id: "fake",
+      secret_access_key: "fake",
       region: "us-east-1"
   end)
 end

--- a/config/test.exs
+++ b/config/test.exs
@@ -84,17 +84,16 @@ config :ueberauth, Ueberauth,
        ]}
   ]
 
-with aws_config <- [
-       access_key_id: "fake",
-       secret_access_key: "fake",
-       host: "localhost.localstack.cloud",
-       port: 4568,
-       scheme: "http://",
-       region: "us-east-1"
-     ] do
-  config :ex_aws, aws_config
-  [:s3, :sqs, :sns, :lambda] |> Enum.each(&config(:ex_aws, &1, aws_config))
-end
+[:mediaconvert, :s3, :sns, :sqs]
+|> Enum.each(fn service ->
+  config :ex_aws, service,
+    scheme: "http://",
+    host: "localhost.localstack.cloud",
+    port: 4568,
+    access_key_id: "fake",
+    secret_access_key: "fake",
+    region: "us-east-1"
+end)
 
 config :exldap, :settings,
   server: "localhost",


### PR DESCRIPTION
# Summary 

Fix ExAws configs for dev and test mode

# Specific Changes in this PR
- Add `:mediaconvert` to the list of configured services
- Make `dev.exs` and `test.exs` match better

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Run an ingest that includes audio and/or video

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

