### PR TITLE
Fix text alignment issues in metadata links

### DIFF
--- a/assets/js/components/UI/ControlledTerm/List.jsx
+++ b/assets/js/components/UI/ControlledTerm/List.jsx
@@ -11,42 +11,43 @@ const UIControlledTermList = ({ items = [], title }) => {
 
   return (
     <div className="content mb-4">
-      <ul data-testid="controlled-term-list" className="ml-0">
+      <ul data-testid="controlled-term-list">
         {items.map((item) => (
           <li
             key={`${item.term.id}-${item.role ? item.role.id : ""}`}
             data-testid="controlled-term-list-row"
-            className="is-flex is-flex-direction-column is-align-items-flex-start"
           >
-            <UITooltip>
-              <div className="tooltip-header">
-                {componentId ? (
-                  <UIFacetLink facetComponentId={componentId} item={item} />
-                ) : (
-                  item.term.label
-                )}
-              </div>
-              <div className="tooltip-content">
-                {item.term.id && (
-                  <a
-                    href={item.term.id}
-                    target="_blank"
-                    className="button is-text is-small"
-                    style={{
-                      textTransform: "none",
-                      backgroundColor: "#4e2a84",
-                      color: "white",
-                    }}
-                    data-testid="external-link"
-                  >
-                    <span className="icon" title={item.term.id}>
-                      <IconExternalLink />
-                    </span>
-                    <span>{item.term.id}</span>
-                  </a>
-                )}
-              </div>
-            </UITooltip>
+            <div className="is-flex is-flex-direction-column is-align-items-flex-start">
+              <UITooltip>
+                <div className="tooltip-header">
+                  {componentId ? (
+                    <UIFacetLink facetComponentId={componentId} item={item} />
+                  ) : (
+                    item.term.label
+                  )}
+                </div>
+                <div className="tooltip-content">
+                  {item.term.id && (
+                    <a
+                      href={item.term.id}
+                      target="_blank"
+                      className="button is-text is-small"
+                      style={{
+                        textTransform: "none",
+                        backgroundColor: "#4e2a84",
+                        color: "white",
+                      }}
+                      data-testid="external-link"
+                    >
+                      <span className="icon" title={item.term.id}>
+                        <IconExternalLink />
+                      </span>
+                      <span>{item.term.id}</span>
+                    </a>
+                  )}
+                </div>
+              </UITooltip>
+            </div>
           </li>
         ))}
       </ul>

--- a/assets/js/components/UI/FacetLink.jsx
+++ b/assets/js/components/UI/FacetLink.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { useHistory } from "react-router-dom";
-import { Button } from "@nulib/design-system";
 
 function UIFacetLink({ facetComponentId, item }) {
   const history = useHistory();
@@ -24,15 +23,9 @@ function UIFacetLink({ facetComponentId, item }) {
   };
 
   return (
-    <Button
-      isText
-      data-testid="facet-link"
-      className="break-word"
-      onClick={handleClick}
-      css={{ padding: "0", textTransform: "none !important" }}
-    >
-      <span>{facetValue}</span>
-    </Button>
+    <a data-testid="facet-link" className="break-word" onClick={handleClick}>
+      {facetValue}
+    </a>
   );
 }
 

--- a/assets/js/components/UI/FacetLink.test.js
+++ b/assets/js/components/UI/FacetLink.test.js
@@ -13,7 +13,7 @@ describe("UIFacetLink component", () => {
   it("renders faceted label as a link", () => {
     render(<UIFacetLink facetComponentId="Genre" item={item} />);
     expect(screen.getByTestId("facet-link"));
-    expect(document.querySelector("button")).toHaveTextContent(item.term.label);
+    expect(document.querySelector("a")).toHaveTextContent(item.term.label);
   });
 
   it("renders faceted label plus role if the facet item contains a role", () => {

--- a/assets/js/components/Work/Tabs/About/ControlledMetadata.jsx
+++ b/assets/js/components/Work/Tabs/About/ControlledMetadata.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import UIControlledTermList from "../../../UI/ControlledTerm/List";
 import UIFormField from "../../../UI/Form/Field";
-import UIError from "../../../UI/Error";
 import UIFormControlledTermArray from "../../../UI/Form/ControlledTermArray";
 import { CONTROLLED_METADATA } from "../../../../services/metadata";
 import { useCodeLists } from "@js/context/code-list-context";

--- a/assets/js/components/Work/Tabs/Administrative/Administrative.jsx
+++ b/assets/js/components/Work/Tabs/Administrative/Administrative.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import { useMutation } from "@apollo/client";
 import useIsEditing from "@js/hooks/useIsEditing";
@@ -169,33 +169,29 @@ const WorkTabsAdministrative = ({ work }) => {
 
               <UIFormField label="Ingest Project">
                 {project ? (
-                  <Button
-                    isText
+                  <a
                     data-testid="view-project-works"
                     className="break-word"
                     onClick={() =>
                       handleFacetLinkClick("IngestProject", project.title)
                     }
-                    css={{ padding: "0", textTransform: "none !important" }}
                   >
-                    <span>{project.title}</span>
-                  </Button>
+                    {project.title}
+                  </a>
                 ) : null}
               </UIFormField>
 
               <UIFormField label="Ingest Sheet">
                 {project && ingestSheet ? (
-                  <Button
-                    isText
+                  <a
                     data-testid="view-ingest-sheet-works"
                     className="break-word"
                     onClick={() =>
                       handleFacetLinkClick("IngestSheet", ingestSheet.title)
                     }
-                    css={{ padding: "0", textTransform: "none !important" }}
                   >
-                    <span>{ingestSheet.title}</span>
-                  </Button>
+                    {ingestSheet.title}
+                  </a>
                 ) : null}
               </UIFormField>
 
@@ -210,17 +206,15 @@ const WorkTabsAdministrative = ({ work }) => {
                     defaultValue={projectCycle}
                   />
                 ) : projectCycle ? (
-                  <Button
-                    isText
+                  <a
                     data-testid="project-cycle-link"
                     className="break-word"
                     onClick={() =>
                       handleFacetLinkClick("ProjectCycle", projectCycle)
                     }
-                    css={{ padding: "0", textTransform: "none !important" }}
                   >
-                    <span>{projectCycle}</span>
-                  </Button>
+                    {projectCycle}
+                  </a>
                 ) : null}
               </UIFormField>
 
@@ -235,17 +229,15 @@ const WorkTabsAdministrative = ({ work }) => {
                     defaultValue={projectName}
                   />
                 ) : projectName.length > 0 ? (
-                  <Button
-                    isText
+                  <a
                     data-testid="project-name-link"
                     className="break-word"
                     onClick={() =>
                       handleFacetLinkClick("ProjectName", projectName)
                     }
-                    css={{ padding: "0", textTransform: "none !important" }}
                   >
                     <span>{projectName}</span>
-                  </Button>
+                  </a>
                 ) : null}
               </UIFormField>
 
@@ -260,8 +252,7 @@ const WorkTabsAdministrative = ({ work }) => {
                     defaultValue={projectDesc}
                   />
                 ) : projectDesc.length > 0 ? (
-                  <Button
-                    isText
+                  <a
                     data-testid="project-description-link"
                     className="break-word"
                     onClick={() =>
@@ -270,10 +261,9 @@ const WorkTabsAdministrative = ({ work }) => {
                         projectDesc || null
                       )
                     }
-                    css={{ padding: "0", textTransform: "none !important" }}
                   >
-                    <span>{projectDesc}</span>
-                  </Button>
+                    {projectDesc}
+                  </a>
                 ) : null}
               </UIFormField>
 
@@ -288,17 +278,15 @@ const WorkTabsAdministrative = ({ work }) => {
                     defaultValue={projectManager}
                   />
                 ) : projectManager.length > 0 ? (
-                  <Button
-                    isText
+                  <a
                     data-testid="project-manager-link"
                     className="break-word"
                     onClick={() =>
                       handleFacetLinkClick("ProjectManager", projectManager)
                     }
-                    css={{ padding: "0", textTransform: "none !important" }}
                   >
-                    <span>{projectManager}</span>
-                  </Button>
+                    {projectManager}
+                  </a>
                 ) : null}
               </UIFormField>
 
@@ -313,17 +301,15 @@ const WorkTabsAdministrative = ({ work }) => {
                     defaultValue={projectProposer}
                   />
                 ) : projectProposer.length > 0 ? (
-                  <Button
-                    isText
+                  <a
                     data-testid="project-proposer-link"
                     className="break-word"
                     onClick={() =>
                       handleFacetLinkClick("ProjectProposer", projectProposer)
                     }
-                    css={{ padding: "0", textTransform: "none !important" }}
                   >
                     <span>{projectProposer}</span>
-                  </Button>
+                  </a>
                 ) : null}
               </UIFormField>
 
@@ -338,8 +324,7 @@ const WorkTabsAdministrative = ({ work }) => {
                     defaultValue={projectTaskNumber}
                   />
                 ) : projectTaskNumber.length > 0 ? (
-                  <Button
-                    isText
+                  <a
                     data-testid="project-task-number-link"
                     className="break-word"
                     onClick={() =>
@@ -348,10 +333,9 @@ const WorkTabsAdministrative = ({ work }) => {
                         projectTaskNumber
                       )
                     }
-                    css={{ padding: "0", textTransform: "none !important" }}
                   >
                     <span>{projectTaskNumber}</span>
-                  </Button>
+                  </a>
                 ) : null}
               </UIFormField>
 

--- a/assets/js/components/Work/Tabs/Administrative/Collection.jsx
+++ b/assets/js/components/Work/Tabs/Administrative/Collection.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import UIFormField from "@js/components/UI/Form/Field";
 import UIFormSelect from "@js/components/UI/Form/Select";
 import { toastWrapper, sortItemsArray } from "@js/services/helpers";
-import { Button, Notification } from "@nulib/design-system";
+import { Notification } from "@nulib/design-system";
 import { useMutation, useQuery, useLazyQuery } from "@apollo/client";
 import {
   GET_COLLECTION,
@@ -133,13 +133,13 @@ function WorkTabsAdministrativeCollection({
         ) : (
           <p>
             {collection ? (
-              <Button
-                className="button is-text"
+              <a
                 onClick={() => handleViewAllWorksClick(collection.title)}
                 data-testid="view-collection-works-button"
+                className="break-word"
               >
                 {collection.title}
-              </Button>
+              </a>
             ) : (
               "Not part of a collection"
             )}

--- a/assets/js/components/Work/Tabs/Administrative/General.jsx
+++ b/assets/js/components/Work/Tabs/Administrative/General.jsx
@@ -3,11 +3,9 @@ import PropTypes from "prop-types";
 import UIFormField from "@js/components/UI/Form/Field";
 import UIFormSelect from "@js/components/UI/Form/Select";
 import { useCodeLists } from "@js/context/code-list-context";
-import UICodedTermItem from "@js/components/UI/CodedTerm/Item";
 import UIFormReadingRoom from "@js/components/UI/Form/ReadingRoom";
 import useFacetLinkClick from "@js/hooks/useFacetLinkClick";
 import usePassedInSearchTerm from "@js/hooks/usePassedInSearchTerm";
-import { Button } from "@nulib/design-system";
 
 function WorkAdministrativeTabsGeneral({
   administrativeMetadata,
@@ -38,17 +36,15 @@ function WorkAdministrativeTabsGeneral({
             defaultValue={libraryUnit ? libraryUnit.id : ""}
           />
         ) : libraryUnit ? (
-          <Button
-            isText
+          <a
             data-testid="library-unit-link"
             className="break-word"
             onClick={() =>
               handleFacetLinkClick("LibraryUnit", libraryUnit.label)
             }
-            css={{ padding: "0", textTransform: "none !important" }}
           >
-            <span>{libraryUnit.label}</span>
-          </Button>
+            {libraryUnit.label}
+          </a>
         ) : (
           <p>None selected</p>
         )}
@@ -73,8 +69,7 @@ function WorkAdministrativeTabsGeneral({
             defaultValue={preservationLevel ? preservationLevel.id : ""}
           />
         ) : preservationLevel ? (
-          <Button
-            isText
+          <a
             data-testid="preservation-level-link"
             className="break-word"
             onClick={() =>
@@ -83,10 +78,9 @@ function WorkAdministrativeTabsGeneral({
                 preservationLevel.label
               )
             }
-            css={{ padding: "0", textTransform: "none !important" }}
           >
-            <span>{preservationLevel.label}</span>
-          </Button>
+            {preservationLevel.label}
+          </a>
         ) : (
           <p>None selected</p>
         )}
@@ -104,8 +98,7 @@ function WorkAdministrativeTabsGeneral({
             defaultValue={status ? status.id : ""}
           />
         ) : status ? (
-          <Button
-            isText
+          <a
             data-testid="status-link"
             className="break-word"
             onClick={() =>
@@ -114,10 +107,9 @@ function WorkAdministrativeTabsGeneral({
                 status.label
               )
             }
-            css={{ padding: "0", textTransform: "none !important" }}
           >
-            <span>{status.label}</span>
-          </Button>
+            {status.label}
+          </a>
         ) : (
           <p>None selected</p>
         )}
@@ -136,15 +128,13 @@ function WorkAdministrativeTabsGeneral({
             defaultValue={visibility ? visibility.id : ""}
           />
         ) : visibility ? (
-          <Button
-            isText
+          <a
             data-testid="visibility-link"
             className="break-word"
             onClick={() => handleFacetLinkClick("Visibility", visibility.label)}
-            css={{ padding: "0", textTransform: "none !important" }}
           >
-            <span>{visibility.label}</span>
-          </Button>
+            {visibility.label}
+          </a>
         ) : (
           <p>None selected</p>
         )}


### PR DESCRIPTION
# Summary 
Update Metadata links to be anchor elements instead of button elements.  I think they were set up as `button`s as part of an early implementation to get tool tips to work maybe, and then the pattern got extended to all links.  This should clean things up and be more semantically accurate. 

![image](https://user-images.githubusercontent.com/3020266/154540545-24ff4dd6-cf7d-42c0-b88b-a6610abbf409.png)


# Specific Changes in this PR
- Swapped out our Design System's `Button` component for standard `a` element in metadata links.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Go to a Work page and click and of the metadata links.  Also ensure tool tips still load and function as expected.


# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

