### PR TITLE
Fix bug in setting poster image for a Video Work

### DIFF
--- a/assets/js/components/UI/MediaPlayer/PosterSelector.jsx
+++ b/assets/js/components/UI/MediaPlayer/PosterSelector.jsx
@@ -43,9 +43,15 @@ function MediaPlayerPosterSelector() {
   });
 
   const handleSave = () => {
-    const el = document.getElementById("react-media-player");
-    const posterOffset = parseInt(el.currentTime * 1000);
+    const el = document.getElementById("clover-iiif-video");
+    if (!el?.currentTime) {
+      return toastWrapper(
+        "is-danger",
+        "Error saving poster image. Current time is undefined on video element."
+      );
+    }
 
+    const posterOffset = parseInt(el.currentTime * 1000);
     updateFileSet({
       variables: {
         id: workState.activeMediaFileSet.id,


### PR DESCRIPTION
# Summary 
After updating the repo location/title of the "React Media Player" to "Clover IIIF", we were referencing an `id` on the `video` tag in Meadow which had an old reference.  

# Specific Changes in this PR
- Now handling that error better, and updated the reference to the video element in our code.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Go to a Video Work and set the poster image.



# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

