### PR TITLE
Allow setCollectionImage mutation to take a null work_id to clear the representative image

### DIFF
--- a/assets/js/components/Collection/collection.gql.js
+++ b/assets/js/components/Collection/collection.gql.js
@@ -57,7 +57,7 @@ export const CREATE_COLLECTION = gql`
 `;
 
 export const SET_COLLECTION_IMAGE = gql`
-  mutation SetCollectionImage($collectionId: ID!, $workId: ID!) {
+  mutation SetCollectionImage($collectionId: ID!, $workId: ID) {
     setCollectionImage(collectionId: $collectionId, workId: $workId) {
       id
       representativeWork {

--- a/lib/meadow_web/resolvers/collections.ex
+++ b/lib/meadow_web/resolvers/collections.ex
@@ -68,11 +68,26 @@ defmodule MeadowWeb.Resolvers.Data.Collections do
     end
   end
 
-  def set_collection_image(_, %{collection_id: collection_id, work_id: work_id}, _) do
+  def set_collection_image(_, %{collection_id: collection_id, work_id: work_id}, _)
+      when not is_nil(work_id) do
     collection = Collections.get_collection!(collection_id)
     work = Works.get_work!(work_id)
 
     case Collections.set_representative_image(collection, work) do
+      {:error, changeset} ->
+        {:error,
+         message: "Could not update collection",
+         details: ChangesetErrors.humanize_errors(changeset)}
+
+      {:ok, collection} ->
+        {:ok, collection}
+    end
+  end
+
+  def set_collection_image(_, %{collection_id: collection_id}, _) do
+    collection = Collections.get_collection!(collection_id)
+
+    case Collections.set_representative_image(collection, nil) do
       {:error, changeset} ->
         {:error,
          message: "Could not update collection",

--- a/lib/meadow_web/schema/types/data/collection_types.ex
+++ b/lib/meadow_web/schema/types/data/collection_types.ex
@@ -75,7 +75,7 @@ defmodule MeadowWeb.Schema.Data.CollectionTypes do
     @desc "Set the representative Work for a Collection"
     field :set_collection_image, :collection do
       arg(:collection_id, non_null(:id))
-      arg(:work_id, non_null(:id))
+      arg(:work_id, :id)
       middleware(Middleware.Authenticate)
       middleware(Middleware.Authorize, "Manager")
       resolve(&Resolvers.Data.Collections.set_collection_image/3)

--- a/test/gql/SetCollectionImage.gql
+++ b/test/gql/SetCollectionImage.gql
@@ -1,6 +1,6 @@
 #import "./CollectionFields.frag.gql"
 
-mutation($collection_id: ID!, $work_id: ID!) {
+mutation($collection_id: ID!, $work_id: ID) {
   setCollectionImage(collection_id: $collection_id, work_id: $work_id) {
     ...CollectionFields
     works {

--- a/test/meadow_web/schema/mutation/set_collection_image_test.exs
+++ b/test/meadow_web/schema/mutation/set_collection_image_test.exs
@@ -89,5 +89,33 @@ defmodule MeadowWeb.Schema.Mutation.SetCollectionImageTest do
 
       assert result.data["setCollectionImage"]
     end
+
+    test "representative image can be cleared by setting to null" do
+      collection = collection_fixture()
+      work = work_with_file_sets_fixture(1, %{collection_id: collection.id})
+
+      {:ok, collection} =
+        Collections.update_collection(collection, %{representative_work_id: work.id})
+
+      refute collection
+             |> Map.get(:representative_work_id)
+             |> is_nil()
+
+      {:ok, result} =
+        query_gql(
+          variables: %{
+            "collection_id" => collection.id,
+            "work_id" => nil
+          },
+          context: %{current_user: %{role: "Manager"}}
+        )
+
+      assert result.data["setCollectionImage"]
+
+      assert collection.id
+             |> Collections.get_collection!()
+             |> Map.get(:representative_work_id)
+             |> is_nil()
+    end
   end
 end


### PR DESCRIPTION
# Summary 
Allow `setCollectionImage` mutation to take a null `work_id` to clear the representative image

# Specific Changes in this PR
For the `set_collection_image`/`setCollectionImage` mutation:
- Update Absinthe schema to make `work_id` an optional argument
- Update front-end and test GQL to make `$workId` an optional argument
- Update the GraphQL resolver to handle `nil` `work_id`s correctly
- Add a test to make sure the mutation works as expected when `work_id` is `nil`.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test

1. Create a collection
2. Create an image work in that collection
3. Assign the work as the representative work for the collection
4. Reindex and make sure the collection's representative image is correct
5. Using graphiql, call the `setCollectionImage` mutation with the collection's ID and a `null` value (or no value) for `workId`
6. Reindex and make sure the collection's representative image has been cleared

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [x] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

