### PR TITLE
Update Meadow console configuration

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -57,23 +57,6 @@ provider "registry.terraform.io/hashicorp/external" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/null" {
-  version = "3.0.0"
-  hashes = [
-    "h1:V1tzrSG6t3e7zWvUwRbGbhsWU2Jd/anrJpOl9XM+R/8=",
-    "zh:05fb7eab469324c97e9b73a61d2ece6f91de4e9b493e573bfeda0f2077bc3a4c",
-    "zh:1688aa91885a395c4ae67636d411475d0b831e422e005dcf02eedacaafac3bb4",
-    "zh:24a0b1292e3a474f57c483a7a4512d797e041bc9c2fbaac42fe12e86a7fb5a3c",
-    "zh:2fc951bd0d1b9b23427acc93be09b6909d72871e464088171da60fbee4fdde03",
-    "zh:6db825759425599a326385a68acc6be2d9ba0d7d6ef587191d0cdc6daef9ac63",
-    "zh:85985763d02618993c32c294072cc6ec51f1692b803cb506fcfedca9d40eaec9",
-    "zh:a53186599c57058be1509f904da512342cfdc5d808efdaf02dec15f0f3cb039a",
-    "zh:c2e07b49b6efa676bdc7b00c06333ea1792a983a5720f9e2233db27323d2707c",
-    "zh:cdc8fe1096103cf5374751e2e8408ec4abd2eb67d5a1c5151fe2c7ecfd525bef",
-    "zh:dbdef21df0c012b0d08776f3d4f34eb0f2f229adfde07ff252a119e52c0f65b7",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.1.0"
   hashes = [

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -17,7 +17,7 @@ data "aws_ami" "amazon_linux" {
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+    values = ["amzn2-ami-hvm-*-arm64-gp2"]
   }
 }
 
@@ -105,8 +105,8 @@ data "template_file" "ec2_user_data" {
   template = file("ec2_files/startup.sh")
   vars = {
     erlang_version        = "24.2"
-    elixir_version        = "1.12.1"
-    nodejs_version        = "14.17.5"
+    elixir_version        = "1.13.3-otp-24"
+    nodejs_version        = "14.19.0"
     dev_local_exs         = file("ec2_files/dev.local.exs"),
     ec2_instance_users    = join(" ", var.ec2_instance_users),
     meadow_rc             = data.template_file.ec2_meadow_config.rendered
@@ -119,6 +119,7 @@ data "template_file" "ec2_meadow_config" {
   vars = merge(
     local.container_config,
     {
+      environment               = var.environment == "s" ? "staging" : "production"
       meadow_ec2_hostname       = "${var.stack_name}-console.${data.aws_route53_zone.app_zone.name}",
       meadow_hostname           = aws_route53_record.app_hostname.fqdn
     }
@@ -127,7 +128,7 @@ data "template_file" "ec2_meadow_config" {
 
 resource "aws_instance" "this_ec2_instance" {
   ami                           = data.aws_ami.amazon_linux.id
-  instance_type                 = "t3.small"
+  instance_type                 = "t4g.medium"
   iam_instance_profile          = aws_iam_instance_profile.meadow_instance_profile.id
   subnet_id                     = element(tolist(data.aws_subnet_ids.public_subnets.ids), 0)
   vpc_security_group_ids        = [aws_security_group.meadow.id, aws_security_group.meadow_ec2.id]

--- a/terraform/ec2_files/dev.local.exs
+++ b/terraform/ec2_files/dev.local.exs
@@ -1,3 +1,5 @@
 import Config
 
 import_config "releases.exs"
+
+config :logger, level: :debug

--- a/terraform/ec2_files/meadowrc
+++ b/terraform/ec2_files/meadowrc
@@ -9,6 +9,7 @@ export AWS_REGION=us-east-1
 export MEADOW_HOSTNAME="${host_name}"
 export MEADOW_PROCESSES="none"
 export REAL_AWS_CONFIG="true"
+export HONEYBADGER_ENVIRONMENT="${environment}-ec2"
 
 cd ~/meadow
 git fetch -pa origin


### PR DESCRIPTION
# Summary 
Update Meadow console configuration

Terraform-only change. Already applied on staging.

# Specific Changes in this PR
- Fixes to Meadow console provisioning script
- Change EC2 instance type to `t4g.medium`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

