### PR TITLE
Add new field weight structure to search bar on Search page

### DIFF
--- a/assets/js/components/UI/SearchBar.jsx
+++ b/assets/js/components/UI/SearchBar.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { DataSearch } from "@appbaseio/reactivesearch";
-import { ELASTICSEARCH_FIELDS_TO_SEARCH } from "../../services/elasticsearch";
-import { RESULT_SENSOR, SEARCH_SENSOR } from "../../services/reactive-search";
+import { RESULT_SENSOR, SEARCH_SENSOR } from "@js/services/reactive-search";
 import userPreviousQueryParts from "@js/hooks/usePreviousQueryParts";
 import useSearchTerm from "@js/hooks/useSearchTerm";
 import { IconSearch } from "@js/components/Icon";
@@ -20,12 +19,43 @@ const UISearchBar = () => {
     return "";
   };
 
+  const dataField = [
+    {
+      field: "title",
+      weight: 5,
+    },
+    {
+      field: "descriptiveMetadata.description",
+      weight: 3,
+    },
+    {
+      field: "collection.title",
+      weight: 2,
+    },
+    {
+      field: "subject",
+      weight: 2,
+    },
+    {
+      field: "contributor",
+      weight: 2,
+    },
+    {
+      field: "full_text",
+      weight: 1,
+    },
+    {
+      field: "accessionNumber",
+      weight: 1,
+    },
+  ];
+
   return (
     <div data-testid="reactive-search-wrapper">
       <DataSearch
         componentId={SEARCH_SENSOR}
         autosuggest={false}
-        dataField={ELASTICSEARCH_FIELDS_TO_SEARCH}
+        dataField={dataField}
         debounce={500}
         defaultValue={prepDefaultValue()}
         fieldWeights={[5, 2, 2]} // These weights correspond to the index positions of ELASTICSEARCH_FIELDS_TO_SEARCH

--- a/assets/js/services/elasticsearch.js
+++ b/assets/js/services/elasticsearch.js
@@ -12,15 +12,6 @@ const client = new Elasticsearch.Client({
   //log: 'trace'
 });
 
-// ES Index fields we tell ReactiveSearch to search against
-export const ELASTICSEARCH_FIELDS_TO_SEARCH = [
-  "all_titles",
-  "descriptiveMetadata.description",
-  "collection.title",
-  "full_text",
-  "accessionNumber",
-];
-
 export const ELASTICSEARCH_AGGREGATION_FIELDS = {
   contributor: {
     terms: {


### PR DESCRIPTION
# Summary 
Update the weighting of Search against our indexed fields to match new ReactiveSearch API.

# Specific Changes in this PR
- Updated field weight structure, and added support for 2 new metadata fields to search upon

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Go to the Search page and search on Subject, Contributor, Title, Description, Accession Number and make sure all work as expected.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

