### PR TITLE
Update AWS provider to 4.2.0

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -20,21 +20,21 @@ provider "registry.terraform.io/hashicorp/archive" {
 }
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.74.0"
-  constraints = "~> 3.0"
+  version     = "4.2.0"
+  constraints = "~> 4.0"
   hashes = [
-    "h1:y9b9LluBQGrZHURGY1Xmrhb+zQ6qRit3oqFSLijkGe0=",
-    "zh:00767509c13c0d1c7ad6af702c6942e6572aa6d529b40a00baacc0e73faafea2",
-    "zh:03aafdc903ad49c2eda03889f927f44212674c50e475a9c6298850381319eec2",
-    "zh:2de8a6a97b180f909d652f215125aa4683e99db15fcf3b28d62e3d542f875ed6",
-    "zh:3ac29ebc3af99028f4230a79f56606a0c2954b68767bd749b921a76eb4f3bd30",
-    "zh:50add2e2d118a15a644360eabc5a34cec59f2560b491f8fabf9c52ab83ca7b09",
-    "zh:85dd8e81910ab79f841a4a595fdd8ac358fbfe460956144afb0be3d81f91fe10",
-    "zh:895de83d0f0941fde31bfc53fa6b1ea276901f006bec221bbdee4771a04f3693",
-    "zh:a15c9724aac52d1ba5001d2d83e42843099b52b1638ea29d84e20be0f45fa4f1",
-    "zh:c982a64463bd73e9bff2589de214b1de0a571438d9015001f9eae45cfc3a2559",
-    "zh:e9ef973c18078324e43213ea1252c12b9441e566bf054ddfdbff5dd62f3035d9",
-    "zh:f297e705b0f339c8baa27ae70db5df9aa6578adfe1ea3d2ba8edc186512464eb",
+    "h1:7xPC2b+Plr514HPRf837t3YFzlSSIY03StrScaVIfw0=",
+    "zh:297d6462055eac8eb5c6735bd1a0fec23574e27d56c4c14a39efd8f3931ce4ed",
+    "zh:457319839adca3638fd76f49fd65e15756717f97ac99bd1805a1c9387a62a250",
+    "zh:57377384fa28abc4211a0916fc0fb590af238d096ad0490434ffeb89f568df9b",
+    "zh:578e1d21bd6d38bdaef0909b30959b884e84e6c464796a50e516822955db162a",
+    "zh:5e7ff13cc976f609aee4ada3c1967ba1f0ce5d276f3102a0aeaedc586d25ea80",
+    "zh:5e94f09fe1874a2365bd566fecab8f676cd720da1c0bf70875392679549ebf20",
+    "zh:93da14d7ffb8550b161cb79fe2cfc0f66848dd5022974399ae2bf88da7b9e9c5",
+    "zh:c51e4541f3d29627974dcb7f5919012a762391accb574ade9e28bdb3c92bada5",
+    "zh:eff58c1680e3f29e514919346d937bbe47278434ae03ed62443c77e878e267b1",
+    "zh:f2b749e6c6b77b26e643bbecc829977270cfefab106d5ea57e5a83e96d49cbdd",
+    "zh:fcc17e60e55c278535c332469727cf215eaea9ec81d38e2b5f05be127ee39a5b",
   ]
 }
 

--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -130,7 +130,7 @@ resource "aws_instance" "this_ec2_instance" {
   ami                           = data.aws_ami.amazon_linux.id
   instance_type                 = "t4g.medium"
   iam_instance_profile          = aws_iam_instance_profile.meadow_instance_profile.id
-  subnet_id                     = element(tolist(data.aws_subnet_ids.public_subnets.ids), 0)
+  subnet_id                     = element(tolist(data.aws_subnets.public_subnets.ids), 0)
   vpc_security_group_ids        = [aws_security_group.meadow.id, aws_security_group.meadow_ec2.id]
   associate_public_ip_address   = true
   user_data                     = data.template_file.ec2_user_data.rendered

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -160,7 +160,7 @@ resource "aws_lb" "meadow_load_balancer" {
   internal           = false
   load_balancer_type = "application"
 
-  subnets         = data.aws_subnet_ids.public_subnets.ids
+  subnets         = data.aws_subnets.public_subnets.ids
   security_groups = [aws_security_group.meadow_load_balancer.id]
   tags    = var.tags
 }

--- a/terraform/ecs_services.tf
+++ b/terraform/ecs_services.tf
@@ -7,7 +7,7 @@ locals {
     agentless_sso_key          = var.agentless_sso_key
     digital_collections_bucket = var.digital_collections_bucket
     digital_collections_url    = var.digital_collections_url
-    database_url               = "ecto://${module.rds.this_db_instance_username}:${module.rds.this_db_instance_password}@${module.rds.this_db_instance_endpoint}/${module.rds.this_db_instance_username}"
+    database_url               = "ecto://${module.rds.db_instance_username}:${module.rds.db_instance_password}@${module.rds.db_instance_endpoint}/${module.rds.db_instance_username}"
     docker_tag                 = terraform.workspace
     elasticsearch_key          = aws_iam_access_key.meadow_elasticsearch_access_key.id
     elasticsearch_secret       = aws_iam_access_key.meadow_elasticsearch_access_key.secret
@@ -79,7 +79,7 @@ resource "aws_ecs_service" "meadow_all" {
   }
 
   network_configuration {
-    subnets          = data.aws_subnet_ids.private_subnets.ids
+    subnets          = data.aws_subnets.private_subnets.ids
     security_groups  = [aws_security_group.meadow.id]
     assign_public_ip = false
   }


### PR DESCRIPTION
# Summary 
Update AWS provider to 4.2.0

# Specific Changes in this PR
- Update AWS provider to 4.2.0
- Update AWS RDS module to 4.1.2
- Update manifests to use new config resources and arguments in AWS 4.2.0

Terraform-only change. Already applied to both staging and prod.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

