### PR TITLE
Improve seed export/import

### DIFF
--- a/app/lib/meadow/seed/export.ex
+++ b/app/lib/meadow/seed/export.ex
@@ -170,7 +170,7 @@ defmodule Meadow.Seed.Export do
   end
 
   defp param_to_sql(param) when is_list(param) do
-    "ARRAY[" <> (Enum.map_join(param, ", ", &param_to_sql/1)) <> "]"
+    "ARRAY[" <> Enum.map_join(param, ", ", &param_to_sql/1) <> "]"
   end
 
   defp param_to_sql(param) when is_binary(param) do

--- a/app/lib/meadow/seed/import.ex
+++ b/app/lib/meadow/seed/import.ex
@@ -137,15 +137,18 @@ defmodule Meadow.Seed.Import do
     fix_file_set_preservation_locations()
     enable_triggers()
 
-    Repo.transaction(fn ->
-      from(w in Work, select: %{id: w.id})
-      |> Repo.stream()
-      |> Stream.each(fn %{id: work_id} ->
-        Logger.info("Writing manifest for #{work_id}")
-        IIIF.V2.write_manifest(work_id)
-      end)
-      |> Stream.run()
-    end)
+    Repo.transaction(
+      fn ->
+        from(w in Work, select: %{id: w.id})
+        |> Repo.stream()
+        |> Stream.each(fn %{id: work_id} ->
+          Logger.info("Writing manifest for #{work_id}")
+          IIIF.V2.write_manifest(work_id)
+        end)
+        |> Stream.run()
+      end,
+      timeout: :infinity
+    )
 
     Logger.info("Synchronizing index")
     Indexer.synchronize_index()

--- a/app/lib/meadow/seed/queries.ex
+++ b/app/lib/meadow/seed/queries.ex
@@ -20,6 +20,8 @@ defmodule Meadow.Seed.Queries do
     from(a in NUL.Schemas.AuthorityRecord, select: a)
   end
 
+  def ingest_sheet_projects([]), do: from(Project, limit: 0)
+
   def ingest_sheet_projects(ingest_sheet_ids) do
     from(s in Sheet,
       join: p in Project,
@@ -30,6 +32,8 @@ defmodule Meadow.Seed.Queries do
     )
   end
 
+  def ingest_sheets([]), do: from(Sheet, limit: 0)
+
   def ingest_sheets(ingest_sheet_ids) do
     from(s in Sheet,
       where: s.id in ^ingest_sheet_ids,
@@ -38,6 +42,8 @@ defmodule Meadow.Seed.Queries do
     )
   end
 
+  def ingest_sheet_rows([]), do: from(Row, limit: 0)
+
   def ingest_sheet_rows(ingest_sheet_ids) do
     from(r in Row,
       where: r.sheet_id in ^ingest_sheet_ids,
@@ -45,6 +51,8 @@ defmodule Meadow.Seed.Queries do
       select: r
     )
   end
+
+  def ingest_sheet_progress([]), do: from(Progress, limit: 0)
 
   def ingest_sheet_progress(ingest_sheet_ids) do
     from(r in Row,
@@ -56,6 +64,8 @@ defmodule Meadow.Seed.Queries do
     )
   end
 
+  def ingest_sheet_works([]), do: from(Work, limit: 0)
+
   def ingest_sheet_works(ingest_sheet_ids) do
     from(w in Work,
       where: w.ingest_sheet_id in ^ingest_sheet_ids,
@@ -63,6 +73,8 @@ defmodule Meadow.Seed.Queries do
       select: w
     )
   end
+
+  def ingest_sheet_file_sets([]), do: from(FileSet, limit: 0)
 
   def ingest_sheet_file_sets(ingest_sheet_ids) do
     from(w in Work,
@@ -73,6 +85,8 @@ defmodule Meadow.Seed.Queries do
       select: fs
     )
   end
+
+  def ingest_sheet_action_states([]), do: from(ActionState, limit: 0)
 
   def ingest_sheet_action_states(ingest_sheet_ids) do
     from(w in Work,
@@ -86,6 +100,8 @@ defmodule Meadow.Seed.Queries do
     )
   end
 
+  def standalone_works([]), do: from(Work, limit: 0)
+
   def standalone_works(work_ids) do
     from(w in Work,
       where: w.id in ^work_ids,
@@ -94,6 +110,8 @@ defmodule Meadow.Seed.Queries do
     )
   end
 
+  def standalone_file_sets([]), do: from(FileSet, limit: 0)
+
   def standalone_file_sets(work_ids) do
     from(fs in FileSet,
       where: fs.work_id in ^work_ids,
@@ -101,6 +119,8 @@ defmodule Meadow.Seed.Queries do
       select: fs
     )
   end
+
+  def standalone_action_states([]), do: from(ActionState, limit: 0)
 
   def standalone_action_states(work_ids) do
     from(w in Work,

--- a/app/lib/mix/tasks/seed/export.ex
+++ b/app/lib/mix/tasks/seed/export.ex
@@ -40,7 +40,7 @@ defmodule Mix.Tasks.Meadow.Seed.Export do
         |> Enum.into(%{
           ingest_sheets: 0,
           works: 0,
-          bucket: Meadow.Config.upload_bucket(),
+          bucket: System.get_env("SHARED_BUCKET"),
           prefix: nil,
           skip_assets: false,
           threads: 1
@@ -80,7 +80,7 @@ defmodule Mix.Tasks.Meadow.Seed.Export do
       |> Export.export_assets(parsed_opts.bucket, parsed_opts.prefix, parsed_opts.threads)
     end
   rescue
-    exception -> Logger.error(exception.message)
+    exception -> Logger.error(exception)
   end
 
   def missing?(value), do: is_nil(value) or value == ""

--- a/infrastructure/deploy/ec2.tf
+++ b/infrastructure/deploy/ec2.tf
@@ -121,7 +121,8 @@ data "template_file" "ec2_meadow_config" {
     {
       environment               = var.environment == "s" ? "staging" : "production"
       meadow_ec2_hostname       = "${var.stack_name}-console.${data.aws_route53_zone.app_zone.name}",
-      meadow_hostname           = aws_route53_record.app_hostname.fqdn
+      meadow_hostname           = aws_route53_record.app_hostname.fqdn,
+      shared_bucket             = var.shared_bucket
     }
   )
 }

--- a/infrastructure/deploy/ec2_files/meadowrc
+++ b/infrastructure/deploy/ec2_files/meadowrc
@@ -10,6 +10,7 @@ export MEADOW_HOSTNAME="${host_name}"
 export MEADOW_PROCESSES="none"
 export REAL_AWS_CONFIG="true"
 export HONEYBADGER_ENVIRONMENT="${environment}-ec2"
+export SHARED_BUCKET="${shared_bucket}"
 
 cd ~/meadow
 git fetch -pa origin

--- a/infrastructure/deploy/variables.tf
+++ b/infrastructure/deploy/variables.tf
@@ -156,6 +156,10 @@ variable "ffmpeg_layer_sha256" {
   type = string
 }
 
+variable "shared_bucket" {
+  type = string
+}
+
 variable "work_archiver_endpoint" {
   type = string
 }


### PR DESCRIPTION
# Summary 

Make seed export and import more robust

# Specific Changes in this PR
- ~Remove import asset sync (use AWS CLI instead)~ Leave asset sync alone now that Localstack can handle it
- Don't timeout on import
- Use shared bucket by default on seed export

Terraform updates included but changes applied by hand to avoid replacing the Meadow console instance.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

With an empty dev environment, follow the new steps in the [documentation update PR](https://github.com/nulib/repodev_planning_and_docs/blob/f890166c4dabda30509f6aa2321fd97a972aa88f/docs/2._Developer_Guides/Meadow/Seed-Data.md#importing-into-your-aws-development-environment) to import the seed at `s3://nul-shared-prod-staging/dev-seed/`

You can then try to export the same data (or any other data you may have in your dev environment), replacing `PREFIX` with your dev environment user prefix:
```
mix meadow.seed.export --bucket PREFIX-dev-uploads --prefix path/to/my/export --ingest-sheets 0 --works 10
```

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [x] Other specific instructions/tasks
  - Manually add `SHARED_BUCKET` variable to `/home/ec2-user/.meadowrc` on production console instance


# Tested/Verified
- [ ] End users/stakeholders

