### PR TITLE
Disable NUSSO extended attribute fetching

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -164,7 +164,7 @@ config :ueberauth, Ueberauth,
          base_url: System.get_env("SETTINGS__NUSSO__BASE_URL"),
          callback_path: "/auth/nusso/callback",
          consumer_key: System.get_env("SETTINGS__NUSSO__CONSUMER_KEY"),
-         include_attributes: true,
+         include_attributes: false,
          ssl_port: 3001
        ]}
   ]

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -146,7 +146,7 @@ config :ueberauth, Ueberauth,
          base_url: "https://northwestern-prod.apigee.net/agentless-websso/",
          callback_path: "/auth/nusso/callback",
          consumer_key: get_required_var.("AGENTLESS_SSO_KEY"),
-         include_attributes: true
+         include_attributes: false
        ]}
   ]
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -80,7 +80,7 @@ config :ueberauth, Ueberauth,
          base_url: "https://northwestern-dev.apigee.net/agentless-websso/",
          callback_path: "/auth/nusso/callback",
          consumer_key: "test-sso-key",
-         include_attributes: true
+         include_attributes: false
        ]}
   ]
 


### PR DESCRIPTION
# Summary 
Disable NUSSO extended attribute fetching

# Specific Changes in this PR
- Update config files to set `include_attributes: false` on NUSSO provider

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Log in.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

