### PR TITLE
Allow well-formed XML files to pass MIME type extraction without declaration

### DIFF
--- a/priv/nodejs/mime-type/index.js
+++ b/priv/nodejs/mime-type/index.js
@@ -3,6 +3,7 @@ const FileType = require("file-type");
 const MimeTypes = require("mime-types");
 const { makeTokenizer } = require("@tokenizer/s3");
 const path = require("path");
+const { XMLValidator } = require("fast-xml-parser");
 
 if (process.env.LOCALSTACK_HOSTNAME) {
   AWS.config.update({
@@ -14,21 +15,21 @@ if (process.env.LOCALSTACK_HOSTNAME) {
 AWS.config.update({ httpOptions: { timeout: 600000 } });
 
 const handler = async (event, _context, _callback) => {
-  return await extractMimeType(event.bucket, event.key);
+  return await extractMimeType(event);
 };
 
-const extractMimeType = async (bucket, key) => {
+const extractMimeType = async (event) => {
   try {
     const s3 = new AWS.S3();
 
     const s3Tokenizer = await makeTokenizer(s3, {
-      Bucket: bucket,
-      Key: key,
+      Bucket: event.bucket,
+      Key: event.key,
     });
 
     // response: {"ext":"jpg","mime":"image/jpeg"}
     const fileType =
-      (await FileType.fromTokenizer(s3Tokenizer)) || lookupMimeType(key);
+      (await FileType.fromTokenizer(s3Tokenizer)) || (await lookupMimeType(event));
     console.log(JSON.stringify(fileType));
     return fileType;
   } catch (e) {
@@ -37,23 +38,57 @@ const extractMimeType = async (bucket, key) => {
   }
 };
 
-const lookupMimeType = (key) => {
+const lookupMimeType = async (event) => {
   console.warn(
     "Failed to extract MIME type from content. Falling back to file extension."
   );
-  const mimeType = MimeTypes.lookup(key);
-  if (FileType.mimeTypes.has(mimeType)) {
-    console.warn(
-      `${path.basename(
-        key
-      )} appears to be ${mimeType} but magic number doesn't match.`
-    );
-    return undefined;
-  } else if (mimeType) {
-    return { ext: path.extname(key).replace(/^\./, ""), mime: mimeType };
+  const key = event.key;
+  const ext = path.extname(key).replace(/^\./, "");
+  const mime = MimeTypes.lookup(event.key);
+  if (FileType.mimeTypes.has(mime)) {
+    if (await validateKnownType(mime, event)) {
+      return { ext, mime }
+    } else {
+      return undefined;
+    }
+  } else if (mime) {
+    return { ext, mime };
   } else {
     console.warn(`Cannot determine MIME type of ${path.basename(key)}.`);
     return "null";
+  }
+};
+
+const validateKnownType = async (mimeType, event) => {
+  const filename = path.basename(event.key);
+
+  if (thinksItsXml(mimeType)) {
+    const result = await validateXml(event);
+    if (! result) {
+      console.warn(`${filename} appears to be ${mimeType} but is not valid XML`);
+    }
+    return result;
+  } else {
+    console.warn(
+      `${filename} appears to be ${mimeType} but magic number doesn't match.`
+    );
+    return undefined;  
+  }
+};
+
+const thinksItsXml = (mimeType) => !!mimeType.match(/[/+]xml$/);
+
+const validateXml = async (event) => {
+  console.warn(`Confirming ${event.key} is well-formed XML`);
+  const s3 = new AWS.S3();
+  const response = await s3.getObject({Bucket: event.bucket, Key: event.key}).promise();
+  const xml = response.Body.toString();
+  const result = XMLValidator.validate(response.Body.toString());
+  if (result.err) {
+    console.warn(`${result.err.code}: ${result.err.msg}`);
+    return false;
+  } else {
+    return true;
   }
 };
 

--- a/priv/nodejs/mime-type/package-lock.json
+++ b/priv/nodejs/mime-type/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@tokenizer/s3": "^0.1.3",
         "aws-sdk": "^2.833.0",
+        "fast-xml-parser": "^4.0.3",
         "file-type": "^16.2.0",
         "install": "^0.13.0",
         "mime-types": "^2.1.31"
@@ -109,6 +110,21 @@
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "engines": {
         "node": ">=0.4.x"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.3.tgz",
+      "integrity": "sha512-xhQbg3a/EYNHwK0cxIG1nZmVkHX/0tWihamn5pU4Mhd9KEVE2ga8ZJiqEUgB2sApElvAATOdMTLjgqIpvYDUkQ==",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/file-type": {
@@ -273,6 +289,11 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/strtok3": {
       "version": "6.2.4",
@@ -447,6 +468,14 @@
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
+    "fast-xml-parser": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.3.tgz",
+      "integrity": "sha512-xhQbg3a/EYNHwK0cxIG1nZmVkHX/0tWihamn5pU4Mhd9KEVE2ga8ZJiqEUgB2sApElvAATOdMTLjgqIpvYDUkQ==",
+      "requires": {
+        "strnum": "^1.0.5"
+      }
+    },
     "file-type": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.2.0.tgz",
@@ -556,6 +585,11 @@
       "requires": {
         "safe-buffer": "~5.2.0"
       }
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "strtok3": {
       "version": "6.2.4",

--- a/priv/nodejs/mime-type/package.json
+++ b/priv/nodejs/mime-type/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@tokenizer/s3": "^0.1.3",
     "aws-sdk": "^2.833.0",
+    "fast-xml-parser": "^4.0.3",
     "file-type": "^16.2.0",
     "install": "^0.13.0",
     "mime-types": "^2.1.31"

--- a/test/fixtures/bad_xml.xml
+++ b/test/fixtures/bad_xml.xml
@@ -1,0 +1,9 @@
+<catalog>
+   <book id="bk101">
+      <author>Gambardella, Matthew</author>
+      <title>XML Developer's Guide</title>
+      <genre>Computer</genre>
+      <price>44.95</price>
+      <publish_date>2000-10-01</publish_date>
+      <description>An in-depth look at creating applications 
+      with XML.</description>

--- a/test/fixtures/good_xml.xml
+++ b/test/fixtures/good_xml.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0"?>
+<catalog>
+   <book id="bk101">
+      <author>Gambardella, Matthew</author>
+      <title>XML Developer's Guide</title>
+      <genre>Computer</genre>
+      <price>44.95</price>
+      <publish_date>2000-10-01</publish_date>
+      <description>An in-depth look at creating applications 
+      with XML.</description>
+   </book>
+   <book id="bk102">
+      <author>Ralls, Kim</author>
+      <title>Midnight Rain</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2000-12-16</publish_date>
+      <description>A former architect battles corporate zombies, 
+      an evil sorceress, and her own childhood to become queen 
+      of the world.</description>
+   </book>
+   <book id="bk103">
+      <author>Corets, Eva</author>
+      <title>Maeve Ascendant</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2000-11-17</publish_date>
+      <description>After the collapse of a nanotechnology 
+      society in England, the young survivors lay the 
+      foundation for a new society.</description>
+   </book>
+   <book id="bk104">
+      <author>Corets, Eva</author>
+      <title>Oberon's Legacy</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2001-03-10</publish_date>
+      <description>In post-apocalypse England, the mysterious 
+      agent known only as Oberon helps to create a new life 
+      for the inhabitants of London. Sequel to Maeve 
+      Ascendant.</description>
+   </book>
+   <book id="bk105">
+      <author>Corets, Eva</author>
+      <title>The Sundered Grail</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2001-09-10</publish_date>
+      <description>The two daughters of Maeve, half-sisters, 
+      battle one another for control of England. Sequel to 
+      Oberon's Legacy.</description>
+   </book>
+   <book id="bk106">
+      <author>Randall, Cynthia</author>
+      <title>Lover Birds</title>
+      <genre>Romance</genre>
+      <price>4.95</price>
+      <publish_date>2000-09-02</publish_date>
+      <description>When Carla meets Paul at an ornithology 
+      conference, tempers fly as feathers get ruffled.</description>
+   </book>
+   <book id="bk107">
+      <author>Thurman, Paula</author>
+      <title>Splish Splash</title>
+      <genre>Romance</genre>
+      <price>4.95</price>
+      <publish_date>2000-11-02</publish_date>
+      <description>A deep sea diver finds true love twenty 
+      thousand leagues beneath the sea.</description>
+   </book>
+   <book id="bk108">
+      <author>Knorr, Stefan</author>
+      <title>Creepy Crawlies</title>
+      <genre>Horror</genre>
+      <price>4.95</price>
+      <publish_date>2000-12-06</publish_date>
+      <description>An anthology of horror stories about roaches,
+      centipedes, scorpions  and other insects.</description>
+   </book>
+   <book id="bk109">
+      <author>Kress, Peter</author>
+      <title>Paradox Lost</title>
+      <genre>Science Fiction</genre>
+      <price>6.95</price>
+      <publish_date>2000-11-02</publish_date>
+      <description>After an inadvertant trip through a Heisenberg
+      Uncertainty Device, James Salway discovers the problems 
+      of being quantum.</description>
+   </book>
+   <book id="bk110">
+      <author>O'Brien, Tim</author>
+      <title>Microsoft .NET: The Programming Bible</title>
+      <genre>Computer</genre>
+      <price>36.95</price>
+      <publish_date>2000-12-09</publish_date>
+      <description>Microsoft's .NET initiative is explored in 
+      detail in this deep programmer's reference.</description>
+   </book>
+   <book id="bk111">
+      <author>O'Brien, Tim</author>
+      <title>MSXML3: A Comprehensive Guide</title>
+      <genre>Computer</genre>
+      <price>36.95</price>
+      <publish_date>2000-12-01</publish_date>
+      <description>The Microsoft MSXML3 parser is covered in 
+      detail, with attention to XML DOM interfaces, XSLT processing, 
+      SAX and more.</description>
+   </book>
+   <book id="bk112">
+      <author>Galos, Mike</author>
+      <title>Visual Studio 7: A Comprehensive Guide</title>
+      <genre>Computer</genre>
+      <price>49.95</price>
+      <publish_date>2001-04-16</publish_date>
+      <description>Microsoft Visual Studio 7 is explored in depth,
+      looking at how Visual Basic, Visual C++, C#, and ASP+ are 
+      integrated into a comprehensive development 
+      environment.</description>
+   </book>
+</catalog>

--- a/test/fixtures/no_declaration.xml
+++ b/test/fixtures/no_declaration.xml
@@ -1,0 +1,119 @@
+<catalog>
+   <book id="bk101">
+      <author>Gambardella, Matthew</author>
+      <title>XML Developer's Guide</title>
+      <genre>Computer</genre>
+      <price>44.95</price>
+      <publish_date>2000-10-01</publish_date>
+      <description>An in-depth look at creating applications 
+      with XML.</description>
+   </book>
+   <book id="bk102">
+      <author>Ralls, Kim</author>
+      <title>Midnight Rain</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2000-12-16</publish_date>
+      <description>A former architect battles corporate zombies, 
+      an evil sorceress, and her own childhood to become queen 
+      of the world.</description>
+   </book>
+   <book id="bk103">
+      <author>Corets, Eva</author>
+      <title>Maeve Ascendant</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2000-11-17</publish_date>
+      <description>After the collapse of a nanotechnology 
+      society in England, the young survivors lay the 
+      foundation for a new society.</description>
+   </book>
+   <book id="bk104">
+      <author>Corets, Eva</author>
+      <title>Oberon's Legacy</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2001-03-10</publish_date>
+      <description>In post-apocalypse England, the mysterious 
+      agent known only as Oberon helps to create a new life 
+      for the inhabitants of London. Sequel to Maeve 
+      Ascendant.</description>
+   </book>
+   <book id="bk105">
+      <author>Corets, Eva</author>
+      <title>The Sundered Grail</title>
+      <genre>Fantasy</genre>
+      <price>5.95</price>
+      <publish_date>2001-09-10</publish_date>
+      <description>The two daughters of Maeve, half-sisters, 
+      battle one another for control of England. Sequel to 
+      Oberon's Legacy.</description>
+   </book>
+   <book id="bk106">
+      <author>Randall, Cynthia</author>
+      <title>Lover Birds</title>
+      <genre>Romance</genre>
+      <price>4.95</price>
+      <publish_date>2000-09-02</publish_date>
+      <description>When Carla meets Paul at an ornithology 
+      conference, tempers fly as feathers get ruffled.</description>
+   </book>
+   <book id="bk107">
+      <author>Thurman, Paula</author>
+      <title>Splish Splash</title>
+      <genre>Romance</genre>
+      <price>4.95</price>
+      <publish_date>2000-11-02</publish_date>
+      <description>A deep sea diver finds true love twenty 
+      thousand leagues beneath the sea.</description>
+   </book>
+   <book id="bk108">
+      <author>Knorr, Stefan</author>
+      <title>Creepy Crawlies</title>
+      <genre>Horror</genre>
+      <price>4.95</price>
+      <publish_date>2000-12-06</publish_date>
+      <description>An anthology of horror stories about roaches,
+      centipedes, scorpions  and other insects.</description>
+   </book>
+   <book id="bk109">
+      <author>Kress, Peter</author>
+      <title>Paradox Lost</title>
+      <genre>Science Fiction</genre>
+      <price>6.95</price>
+      <publish_date>2000-11-02</publish_date>
+      <description>After an inadvertant trip through a Heisenberg
+      Uncertainty Device, James Salway discovers the problems 
+      of being quantum.</description>
+   </book>
+   <book id="bk110">
+      <author>O'Brien, Tim</author>
+      <title>Microsoft .NET: The Programming Bible</title>
+      <genre>Computer</genre>
+      <price>36.95</price>
+      <publish_date>2000-12-09</publish_date>
+      <description>Microsoft's .NET initiative is explored in 
+      detail in this deep programmer's reference.</description>
+   </book>
+   <book id="bk111">
+      <author>O'Brien, Tim</author>
+      <title>MSXML3: A Comprehensive Guide</title>
+      <genre>Computer</genre>
+      <price>36.95</price>
+      <publish_date>2000-12-01</publish_date>
+      <description>The Microsoft MSXML3 parser is covered in 
+      detail, with attention to XML DOM interfaces, XSLT processing, 
+      SAX and more.</description>
+   </book>
+   <book id="bk112">
+      <author>Galos, Mike</author>
+      <title>Visual Studio 7: A Comprehensive Guide</title>
+      <genre>Computer</genre>
+      <price>49.95</price>
+      <publish_date>2001-04-16</publish_date>
+      <description>Microsoft Visual Studio 7 is explored in depth,
+      looking at how Visual Basic, Visual C++, C#, and ASP+ are 
+      integrated into a comprehensive development 
+      environment.</description>
+   </book>
+</catalog>


### PR DESCRIPTION
# Summary 
Allow well-formed XML files to pass MIME type extraction without declaration

# Specific Changes in this PR
- Add XML validation code to MIME type extraction lambda
- Add tests for XML with declaration, XML without declaration, and corrupt/poorly-formed XML

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Run good and bad XML files through the ingest pipeline, some with and without XML declarations. See `good_xml.xml`, `bad_xml.xml`, and `no_declaration.xml` in the `test/fixtures` directory for examples.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

