### PR TITLE
Fix bug in uploading a file set w/ duplicate accession number

### DIFF
--- a/assets/js/components/Work/Tabs/Preservation/FileSetDropzone.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/FileSetDropzone.jsx
@@ -98,24 +98,17 @@ function WorkTabsPreservationFileSetDropzone({
       )}
 
       {currentFile && uploadProgress === 100 && (
-        <Notification isSuccess>
-          <h4>
-            <strong>File uploaded successfully</strong>
-          </h4>
-          <ul className="block">{acceptedFileItems}</ul>
-          <Button
-            css={{
-              padding: "5px",
-              textDecoration: "underline",
-              textTransform: "unset",
-              color: "White",
-            }}
-            isText
-            onClick={handleRemoveFile}
-          >
-            Remove file
-          </Button>
-        </Notification>
+        <>
+          <Notification isSuccess>
+            <h4>
+              <strong>File uploaded successfully</strong>
+            </h4>
+            <ul className="block">{acceptedFileItems}</ul>
+          </Notification>
+          <p className="has-text-right">
+            <a onClick={handleRemoveFile}>Remove file</a>
+          </p>
+        </>
       )}
 
       {currentFile && uploadProgress < 100 && (

--- a/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
@@ -60,18 +60,18 @@ function WorkTabsPreservationFileSetModal({
     setAcceptedFileTypes(mimeTypes);
   }, [watchRole]);
 
-  const [getPresignedUrl, { urlError, urlLoading, urlData }] = useLazyQuery(
-    GET_PRESIGNED_URL,
-    {
-      fetchPolicy: "no-cache",
-      onCompleted: (data) => {
-        uploadFile(data.presignedUrl.url);
-      },
-      onError(error) {
-        console.error(`error`, error);
-      },
-    }
-  );
+  const [
+    getPresignedUrl,
+    { error: urlError, loading: urlLoading, data: urlData },
+  ] = useLazyQuery(GET_PRESIGNED_URL, {
+    fetchPolicy: "no-cache",
+    onCompleted: (data) => {
+      uploadFile(data.presignedUrl.url);
+    },
+    onError(error) {
+      console.error(`error`, error);
+    },
+  });
 
   const [ingestFileSet, { loading, error, data }] = useMutation(
     INGEST_FILE_SET,
@@ -86,6 +86,7 @@ function WorkTabsPreservationFileSetModal({
       },
       onError(error) {
         console.error(`error:`, error);
+        resetForm();
         // bug with this error not clearing/resetting
         // https://github.com/apollographql/apollo-feature-requests/issues/170
       },
@@ -226,7 +227,7 @@ function WorkTabsPreservationFileSetModal({
                 </UIFormField>
 
                 {watchRole && (
-                  <div className="block">
+                  <div className="block mt-5">
                     <WorkTabsPreservationFileSetDropzone
                       currentFile={currentFile}
                       acceptedFileTypes={acceptedFileTypes}


### PR DESCRIPTION
Fix bug in uploading a file set which initially throws a GraphQL validation error (for example a duplicate accession number).  The entire fileset upload form now resets.

# Summary 
Previously any GraphQL mutation errors were just being communicated to the browser console, but now we're calling a reset form helper function from the GraphQL mutation error conditional callback function.

*Note: this is a hard reset of the form and requires a re-upload of the file set.  Trying to save the previous upload and pre-signed URL would require a pretty significant refactor.*

# Specific Changes in this PR
- Handling error in `ingestFileSet` mutation
- Minor UI updates in the form

<img width="748" alt="image" src="https://user-images.githubusercontent.com/3020266/156052553-222df577-3259-4b1f-a300-20f8e34eab08.png">


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
-[ ] Go to a Work Preservation tab and attempt to upload a new file set using an existing accession number.  Notice the form resets and you can continue in the process.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

