### PR TITLE
Upload file sets using their native content type as determined by the browser

### DIFF
--- a/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
+++ b/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
@@ -172,7 +172,7 @@ function WorkTabsPreservationFileSetModal({
     });
 
     request.open("put", presignedUrl);
-    request.setRequestHeader("Content-Type", "multipart/form-data");
+    request.setRequestHeader("Content-Type", "application/octet-stream");
     request.send(currentFile);
     setStateXhr(request);
   };

--- a/lib/meadow/utils/aws.ex
+++ b/lib/meadow/utils/aws.ex
@@ -38,7 +38,7 @@ defmodule Meadow.Utils.AWS do
   end
 
   def presigned_url(bucket, %{upload_type: "file_set", filename: filename}) do
-    generate_presigned_url(bucket, "file_sets/#{Ecto.UUID.generate()}.#{Path.extname(filename)}")
+    generate_presigned_url(bucket, "file_sets/#{Ecto.UUID.generate()}#{Path.extname(filename)}")
   end
 
   def presigned_url(bucket, %{upload_type: "ingest_sheet"}) do


### PR DESCRIPTION
# Summary 
Fix zero-byte browser uploads to Localstack

# Specific Changes in this PR
- Use a `Content-Type` of `currentFile.type` instead of `"multipart/form-data"` when uploading FileSet through the UI
- Remove double-dot from presigned file set URLs
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Attach an audio, video, or image preservation file to a work using the UI and make sure it passes the `ExtractMimeType` action.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

