### PR TITLE
Fix bug in deleting Local Authority

### DIFF
--- a/assets/js/components/Dashboards/LocalAuthorities/List.jsx
+++ b/assets/js/components/Dashboards/LocalAuthorities/List.jsx
@@ -61,28 +61,24 @@ export default function DashboardsLocalAuthoritiesList() {
     { error: deleteAuthorityError, loading: deleteAuthorityLoading },
   ] = useMutation(DELETE_NUL_AUTHORITY_RECORD, {
     update(cache, { data: { deleteNulAuthorityRecord } }) {
-      try {
-        const { nulAuthorityRecords } = client.readQuery({
-          query: GET_NUL_AUTHORITY_RECORDS,
-        });
-        const newData = {
-          nulAuthorityRecords: nulAuthorityRecords.filter(
-            (record) => record.id !== deleteNulAuthorityRecord.id
-          ),
-        };
-        client.writeQuery({
-          query: GET_NUL_AUTHORITY_RECORDS,
-          data: newData,
-        });
-        toastWrapper(
-          "is-success",
-          `${deleteNulAuthorityRecord.label} deleted successfully`
-        );
-        filterValues();
-      } catch (e) {
-        console.error(e);
-        toastWrapper("is-danger", `Error deleting NUL local authority: ${e}`);
-      }
+      cache.modify({
+        fields: {
+          nulAuthorityRecords(existingNulAuthorityRefs = [], { readField }) {
+            const newData = existingNulAuthorityRefs.filter(
+              (ref) => deleteNulAuthorityRecord.id !== readField("id", ref)
+            );
+            return [...newData];
+          },
+        },
+      });
+    },
+    onError({ graphQLErrors, networkError }) {
+      console.error("graphQLErrors", graphQLErrors);
+      console.error("networkError", networkError);
+      toastWrapper(
+        "is-danger",
+        `Error in deleteNulAuthorityRecord GraphQL mutation`
+      );
     },
   });
 


### PR DESCRIPTION
# Summary 
When deleting a local authority, an unhandled error was being displayed in the UI.

# Specific Changes in this PR
- Updated the way we're updating the local GraphQL cache to reflect that a local authority record has been deleted.  

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
1. Add a new local authority
2. Delete the local authority and notice it deletes successfully with no errors.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

