### PR TITLE
Toggle Collection representative image on/off from Work page

### DIFF
--- a/assets/js/components/Work/Tabs/Administrative/Collection.jsx
+++ b/assets/js/components/Work/Tabs/Administrative/Collection.jsx
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import UIFormField from "@js/components/UI/Form/Field";
 import UIFormSelect from "@js/components/UI/Form/Select";
 import { toastWrapper, sortItemsArray } from "@js/services/helpers";
-import { Notification } from "@nulib/design-system";
 import { useMutation, useQuery, useLazyQuery } from "@apollo/client";
 import {
   GET_COLLECTION,
@@ -11,7 +10,6 @@ import {
   SET_COLLECTION_IMAGE,
 } from "@js/components/Collection/collection.gql.js";
 import AuthDisplayAuthorized from "@js/components/Auth/DisplayAuthorized";
-import { IconAlert } from "@js/components/Icon";
 
 function WorkTabsAdministrativeCollection({
   collection,
@@ -19,8 +17,6 @@ function WorkTabsAdministrativeCollection({
   isEditing,
   workId,
 }) {
-  const [isHelperMessageVisible, setIsHelperMessageVisible] =
-    React.useState(false);
   const [isCollectionImage, setIsCollectionImage] = React.useState(false);
   const { data: collectionsData, loading, error } = useQuery(GET_COLLECTIONS);
 
@@ -30,7 +26,6 @@ function WorkTabsAdministrativeCollection({
   const [setCollectionImage] = useMutation(SET_COLLECTION_IMAGE, {
     onCompleted({ setCollectionImage }) {
       toastWrapper("is-success", "Collection image has been updated");
-      setIsCollectionImage(true);
     },
     onError({ graphQLErrors, networkError }) {
       let errorStrings = [];
@@ -58,9 +53,7 @@ function WorkTabsAdministrativeCollection({
     fetchPolicy: "network-only",
     variables: { id: collection ? collection.id : "" },
     onCompleted({ collection: { representativeWork } }) {
-      setIsCollectionImage(
-        representativeWork && representativeWork.id === workId ? true : false
-      );
+      setIsCollectionImage(representativeWork?.id === workId ? true : false);
     },
     onError({ graphQLErrors, networkError }) {
       console.error("graphQLErrors", graphQLErrors);
@@ -86,17 +79,15 @@ function WorkTabsAdministrativeCollection({
     }
   }, [collection]);
 
-  /**
-   * Handle toggle Featured Collection Image on/off
-   */
-  const handleToggleCollectionImage = () => {
-    if (!isCollectionImage) {
-      setCollectionImage({
-        variables: { collectionId: collection.id, workId },
-      });
-    } else {
-      setIsHelperMessageVisible(true);
-    }
+  const handleCollectionImageToggleChange = () => {
+    // NOTE we update the state value of the toggle after we fire the mutation
+    setCollectionImage({
+      variables: {
+        collectionId: collection.id,
+        workId: isCollectionImage ? null : workId,
+      },
+    });
+    setIsCollectionImage(!isCollectionImage);
   };
 
   if (loading) return null;
@@ -156,20 +147,11 @@ function WorkTabsAdministrativeCollection({
               name={`featured-image-toggle`}
               className="switch"
               checked={isCollectionImage}
-              onChange={handleToggleCollectionImage}
+              onChange={handleCollectionImageToggleChange}
               data-testid="featured-image-toggle"
             />
             <label htmlFor={`featured-image-toggle`}>Collection image</label>
           </div>
-          {isHelperMessageVisible && (
-            <Notification isWarning className="is-flex is-align-items-center">
-              <IconAlert />
-              <span className="ml-3">
-                To select a new featured image for the Collection, please
-                navigate to the new Work.
-              </span>
-            </Notification>
-          )}
         </AuthDisplayAuthorized>
       )}
     </div>


### PR DESCRIPTION
# Summary 
On a Work page, the Collection Image toggle switch can now toggle on/off.  Previously it blocked removing a Collection image via the toggle.

# Specific Changes in this PR
- Updated `WorkTabsAdministrativeCollection` component to handle toggling Collection image switch on/off
- Cleaned up tests for this component

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
1. Go to a Work page, Administrative tab
2. Toggle on/off the Collection image tab

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

