### PR TITLE
Use exiftool instead of exifr in EXIF extraction lambda

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,6 +185,8 @@ jobs:
           curl https://s3.amazonaws.com/nul-repo-deploy/ffmpeg-release-64bit-static.tar.xz | tar xJ && \
           sudo cp $(find . -type f -executable) /usr/local/bin/ && \
           echo "FFMPEG VERSION: $(ffmpeg -version | sed -n "s/ffmpeg version \([-0-9.]*\).*/\1/p;")"
+      - name: Install exiftool
+        run: brew install exiftool
       - name: Cache Elixir dependencies
         uses: actions/cache@v2
         with:

--- a/priv/nodejs/exif/index.js
+++ b/priv/nodejs/exif/index.js
@@ -1,14 +1,15 @@
 const exif = require("./exif");
 
 const handler = async (event, _context, _callback) => {
-  const result = await exif.extractExif(event.source, event.options)
+  const result = await exif.extract(event.source);
   if (result === null || result === undefined) {
     return null;
   }
+  delete result.SourceFile;
   
   return {
-    tool: "exifr",
-    tool_version: require("exifr/package.json").version,
+    tool: "exiftool",
+    tool_version: await exif.version(),
     value: result
   };
 };

--- a/priv/nodejs/exif/package-lock.json
+++ b/priv/nodejs/exif/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "exifr": "nulib/exifr#external-reader-dist",
         "uri-js": "^4.4.1"
       },
       "devDependencies": {
@@ -75,12 +74,6 @@
       "engines": {
         "node": ">=0.4.x"
       }
-    },
-    "node_modules/exifr": {
-      "version": "6.1.1",
-      "resolved": "git+ssh://git@github.com/nulib/exifr.git#3d926474bc2e629f6352d668c0e5596dc8d3f874",
-      "integrity": "sha512-8lSh/QkNcGdT8qoCwydhE6E2WTVTN6zq4OMuoNlw5a6qxb7B/CaL6qn5e4mlTt3CY/DRN4hlsyrz1MzR37+IRA==",
-      "license": "MIT"
     },
     "node_modules/ieee754": {
       "version": "1.1.13",
@@ -221,11 +214,6 @@
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
-    },
-    "exifr": {
-      "version": "git+ssh://git@github.com/nulib/exifr.git#3d926474bc2e629f6352d668c0e5596dc8d3f874",
-      "integrity": "sha512-8lSh/QkNcGdT8qoCwydhE6E2WTVTN6zq4OMuoNlw5a6qxb7B/CaL6qn5e4mlTt3CY/DRN4hlsyrz1MzR37+IRA==",
-      "from": "exifr@nulib/exifr#external-reader-dist"
     },
     "ieee754": {
       "version": "1.1.13",

--- a/priv/nodejs/exif/package.json
+++ b/priv/nodejs/exif/package.json
@@ -6,7 +6,6 @@
   "author": "bmquinn",
   "license": "Apache-2.0",
   "dependencies": {
-    "exifr": "nulib/exifr#external-reader-dist",
     "uri-js": "^4.4.1"
   },
   "devDependencies": {

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -91,6 +91,14 @@ module "exif_function" {
   stack_name  = var.stack_name
   memory_size = 512
   timeout     = 10
+  layers      = [
+    "arn:aws:lambda:us-east-1:652718333417:layer:perl-5_30-layer:1",
+    aws_lambda_layer_version.exiftool.arn
+  ]
+
+  environment = {
+    EXIFTOOL = "/opt/bin/exiftool"
+  }
 
   tags = merge(
     var.tags,

--- a/terraform/layers.tf
+++ b/terraform/layers.tf
@@ -1,3 +1,11 @@
+resource "aws_lambda_layer_version" "exiftool" {
+  s3_bucket           = "nul-public"
+  s3_key              = "exiftool_lambda_layer.zip"
+  layer_name          = "exiftool"
+  compatible_runtimes = ["nodejs14.x"]
+  description         = "exiftool runtime for nodejs lambdas"
+}
+
 resource "aws_lambda_layer_version" "ffmpeg" {
   s3_bucket           = "nul-public"
   s3_key              = "ffmpeg.zip"

--- a/test/pipeline/actions/extract_exif_metadata_test.exs
+++ b/test/pipeline/actions/extract_exif_metadata_test.exs
@@ -16,10 +16,10 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadataTest do
   @no_exif_fixture %{bucket: @bucket, key: @no_exif_key, content: File.read!(@no_exif_content)}
   @exif %{
     "Artist" => "Artist Name",
-    "BitsPerSample" => %{"0" => 8, "1" => 8, "2" => 8},
-    "Compression" => 1,
+    "BitsPerSample" => "8 8 8",
+    "Compression" => "Uncompressed",
     "Copyright" => "In Copyright",
-    "FillOrder" => 1,
+    "FillOrder" => "Normal",
     "ImageDescription" =>
       "inu-wint-58.6, 8/20/07, 11:16 AM,  8C, 9990x9750 (0+3570), 125%, bent 6 b/w adj,  1/30 s, R43.0, G4.4, B12.6",
     "ImageHeight" => 1024,
@@ -27,11 +27,12 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadataTest do
     "Make" => "Better Light",
     "Model" => "Model Super8K",
     "Orientation" => "Horizontal (normal)",
-    "PhotometricInterpretation" => 2,
-    "PlanarConfiguration" => 1,
+    "PhotometricInterpretation" => "RGB",
+    "PlanarConfiguration" => "Chunky",
     "ResolutionUnit" => "inches",
     "SamplesPerPixel" => 3,
     "Software" => "Adobe Photoshop CC 2015.5 (Windows)",
+    "SourceFile" => "-",
     "XResolution" => 72,
     "YResolution" => 72
   }
@@ -52,7 +53,7 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadataTest do
            Software
            XResolution
            YResolution)
-  @tool_name "exifr"
+  @tool_name "exiftool"
 
   setup do
     exif_file_set =
@@ -123,8 +124,18 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadataTest do
 
       file_set = FileSets.get_file_set!(file_set_id)
 
-      with extracted <- file_set.extracted_metadata do
-        assert is_nil(extracted) || is_nil(Map.get(extracted, "exif"))
+      case file_set.extracted_metadata do
+        nil ->
+          assert true
+
+        %{"exif" => nil} ->
+          assert true
+
+        %{"exif" => %{"value" => map}} ->
+          assert_lists_equal(Map.keys(map), ~w(BitsPerSample ImageHeight ImageWidth))
+
+        _ ->
+          assert false
       end
 
       assert capture_log(fn ->


### PR DESCRIPTION
# Summary 
Use exiftool instead of exifr in EXIF extraction lambda

# Specific Changes in this PR
- update exif lambda to pipe an S3 stream to exiftool and handle its output
- update terraform to create the exiftool layer (and use a public third party perl runtime layer, required by exiftool)

Terraform already applied to staging.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Make sure you have `exiftool` installed locally:
```
$ exiftool -ver
12.26
```
(Version number doesn't need to be exact)

If not, install it with
```
brew install exiftool
```

Run images through the pipeline and make sure they have exif metadata
- `tool` should be `exiftool` (formerly `exifr`)
- `tool_version` should be the same value as running `exiftool -ver`
- `value` should look like EXIF

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [x] Other specific instructions/tasks
  - All devs will need to ensure they have `exiftool` installed


# Tested/Verified
- [ ] End users/stakeholders

