### PR TITLE
Add wrapping logic to batch edit notes.

### DIFF
--- a/assets/js/components/BatchEdit/About/IdentifiersMetadata.jsx
+++ b/assets/js/components/BatchEdit/About/IdentifiersMetadata.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import UIFormField from "../../UI/Form/Field";
+import UIFormSelect from "@js/components/UI/Form/Select";
 import UIFormBatchFieldArray from "../../UI/Form/BatchFieldArray";
 import { IDENTIFIER_METADATA } from "../../../services/metadata";
 import UIFormRelatedURL from "../../UI/Form/RelatedURL";
@@ -21,15 +22,30 @@ const BatchEditAboutIdentifiersMetadata = ({ ...restProps }) => {
         </div>
       ))}
       <div className="column is-full" data-testid="relatedUrl">
-        <UIFormField label="Related URL">
-          <UIFormRelatedURL
-            codeLists={
-              codeLists.relatedUrlData ? codeLists.relatedUrlData.codeList : []
-            }
-            label="Related URL"
-            name="relatedUrl"
-          />
-        </UIFormField>
+        <fieldset data-testid="batch-field-array">
+          <legend data-testid="legend">Related URL</legend>
+          <UIFormField label="Related URL">
+            <UIFormRelatedURL
+              codeLists={
+                codeLists.relatedUrlData
+                  ? codeLists.relatedUrlData.codeList
+                  : []
+              }
+              label="Related URL"
+              name="relatedUrl"
+            />
+            <UIFormSelect
+              isReactHookForm
+              name="relatedUrl--editType"
+              data-testid="select-edit-type"
+              options={[
+                { id: "append", label: "Append values" },
+                { id: "replace", label: "Replace existing values" },
+                { id: "delete", label: "Delete all values" },
+              ]}
+            ></UIFormSelect>
+          </UIFormField>
+        </fieldset>
       </div>
     </div>
   );

--- a/assets/js/components/BatchEdit/About/UncontrolledMetadata.jsx
+++ b/assets/js/components/BatchEdit/About/UncontrolledMetadata.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import UIFormField from "@js/components/UI/Form/Field";
+import UIFormSelect from "@js/components/UI/Form/Select";
 import UIFormBatchFieldArray from "@js/components/UI/Form/BatchFieldArray";
 import { UNCONTROLLED_METADATA } from "@js/services/metadata";
 import UIFormNote from "@js/components/UI/Form/Note";
@@ -21,15 +22,28 @@ const BatchEditAboutUncontrolledMetadata = ({ ...restProps }) => {
         </div>
       ))}
       <div className="column is-full" data-testid="notes">
-        <UIFormField label="Notes">
-          <UIFormNote
-            codeLists={
-              codeLists.notesData ? codeLists.notesData.codeList : []
-            }
-            label="Notes"
-            name="notes"
-          />
-        </UIFormField>
+        <fieldset data-testid="batch-field-array">
+          <legend data-testid="legend">Notes</legend>
+          <UIFormField label="Notes">
+            <UIFormNote
+              codeLists={
+                codeLists.notesData ? codeLists.notesData.codeList : []
+              }
+              label="Notes"
+              name="notes"
+            />
+            <UIFormSelect
+              isReactHookForm
+              name="notes--editType"
+              data-testid="select-edit-type"
+              options={[
+                { id: "append", label: "Append values" },
+                { id: "replace", label: "Replace existing values" },
+                { id: "delete", label: "Delete all values" },
+              ]}
+            ></UIFormSelect>
+          </UIFormField>
+        </fieldset>
       </div>
     </div>
   );

--- a/assets/js/components/BatchEdit/Tabs.jsx
+++ b/assets/js/components/BatchEdit/Tabs.jsx
@@ -72,26 +72,53 @@ export default function BatchEditTabs() {
     // updated.
 
     let currentFormValues = methods.getValues();
-    console.log(`currentFormValues`, currentFormValues);
     let addItems = { administrative: {}, descriptive: {} };
     let deleteReadyItems = {};
     let replaceItems = { administrative: {}, descriptive: {} };
     let multiValues = {};
 
-    // Process Descriptive metadata items
-    if (currentFormValues.notes?.length > 0) {
-      replaceItems.descriptive.notes = prepNotes(currentFormValues.notes);
-    }
-    if (currentFormValues.relatedUrl?.length > 0) {
-      replaceItems.descriptive.relatedUrl = prepRelatedUrl(
-        currentFormValues.relatedUrl
-      );
-    }
+    /**
+     * Array of data for `notes` and `relatedUrl`
+     */
+    const preppedDataFields = [
+      { name: "notes", data: prepNotes(currentFormValues.notes) },
+      {
+        name: "relatedUrl",
+        data: prepRelatedUrl(currentFormValues.relatedUrl),
+      },
+    ];
+
+    /**
+     * Process each prepped data field,
+     */
+    preppedDataFields.forEach((field) => {
+      const { name, data } = field;
+      const editType = currentFormValues[`${name}--editType`];
+
+      switch (editType) {
+        case "append":
+          addItems.descriptive[name] = data;
+          break;
+        case "delete":
+          replaceItems.descriptive[name] = [];
+          break;
+        case "replace":
+          if (data?.length > 0) replaceItems.descriptive[name] = data;
+          break;
+        default:
+          console.error(`No known editType of: ${editType}.`);
+      }
+    });
+
+    console.log(`addItems.descriptive`, addItems.descriptive);
+    console.log(`replaceItems.descriptive`, replaceItems.descriptive);
+
     if (currentFormValues.rightsStatement) {
       replaceItems.descriptive.rightsStatement = JSON.parse(
         currentFormValues.rightsStatement
       );
     }
+
     ["title"].forEach((item) => {
       if (currentFormValues[item]) {
         replaceItems.descriptive[item] = currentFormValues[item];

--- a/assets/js/services/metadata.js
+++ b/assets/js/services/metadata.js
@@ -623,7 +623,11 @@ export function prepRelatedUrl(items = []) {
  * @returns {Object}
  */
 export function deleteKeyFromObject(item) {
-  if (typeof item !== "object" || Array.isArray(item)) {
+  if (
+    typeof item !== "object" ||
+    Array.isArray(item) ||
+    item.hasOwnProperty("url")
+  ) {
     return item;
   }
   let itemObj = { ...item };


### PR DESCRIPTION
# Summary 
This adds wrapping UI logic and processing to Notes and Related URL fields in the batch edit workflow. As `replace` was already working for these fields, I don't believe an back end work is required here to make this work as expected.

# Specific Changes in this PR
- Adds Replace, Append, and Delete options to Notes and Related URL fields
- Adds functionality to process editType options for Notes and Related URL fields

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Test batch edit process for:

### Notes
- [x] Append
- [x] Delete
- [x] Replace

### Related URL
- [x] Append
- [x] Delete
- [x] Replace

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

