### PR TITLE
Fix bug in sticky header obscuring top nav dropdown links

### DIFF
--- a/assets/js/components/UI/Sticky.jsx
+++ b/assets/js/components/UI/Sticky.jsx
@@ -8,7 +8,7 @@ const UISticky = ({ children, ...restProps }) => {
       position: "-webkit-sticky",
       position: "sticky",
       top: headerHeight,
-      zIndex: 1000,
+      zIndex: 100,
     },
   };
 


### PR DESCRIPTION
# Summary 
Make top nav always overlay the sticky header, in batch edit.

# Specific Changes in this PR
- Update sticky header z-index to lowest possible value

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
1. Select a few search results on the search page
2. Select "Batch Edit" x number of works
3. On Batch Edit page, activate any of the top bar nav links and notice the links display over the sticky header.

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

