### PR TITLE
Only wait one second between index runs instead of two minutes

### DIFF
--- a/lib/meadow/data/index_worker.ex
+++ b/lib/meadow/data/index_worker.ex
@@ -4,7 +4,7 @@ defmodule Meadow.Data.IndexWorker do
   """
   alias Meadow.Data.Indexer
   alias Meadow.IntervalTask
-  use IntervalTask, default_interval: 120_000, function: :synchronize
+  use IntervalTask, default_interval: 1_000, function: :synchronize
 
   @impl IntervalTask
   def initial_state(_args), do: %{override: true}


### PR DESCRIPTION
# Summary 
Only wait one second between index runs instead of two minutes

# Specific Changes in this PR
- update `IndexWorker`'s `default_interval` attribute

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Run Meadow. Change something. See the index update within a couple seconds instead of a couple minutes.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

