### PR TITLE
Adjust regex to ensure a starts with on URL pattern protocol.

### DIFF
--- a/assets/js/services/global-vars.js
+++ b/assets/js/services/global-vars.js
@@ -45,3 +45,5 @@ export const VISIBILITY_OPTIONS = [
 
 export const URL_PATTERN_MATCH =
   /(((http|https):\/\/)|www\.)(\S+)\.([a-z]{2,}?)(.*?)( |,|$|\.)/gim;
+
+export const URL_PATTERN_START = ["http", "https", "www"];

--- a/assets/js/services/helpers.js
+++ b/assets/js/services/helpers.js
@@ -1,6 +1,6 @@
 import moment from "moment";
 import { toast } from "bulma-toast";
-import { URL_PATTERN_MATCH } from "./global-vars";
+import { URL_PATTERN_MATCH, URL_PATTERN_START } from "./global-vars";
 import edtf from "edtf";
 
 /**
@@ -24,7 +24,10 @@ export function formatSimpleISODate(date) {
 }
 
 export function isUrlValid(url) {
-  return url.match(URL_PATTERN_MATCH) ? true : false;
+  return url.match(URL_PATTERN_MATCH) &&
+    URL_PATTERN_START.some((validStart) => url.startsWith(validStart))
+    ? true
+    : false;
 }
 
 export function isEDTFValid(edtfString) {

--- a/assets/js/services/helpers.js
+++ b/assets/js/services/helpers.js
@@ -24,10 +24,10 @@ export function formatSimpleISODate(date) {
 }
 
 export function isUrlValid(url) {
-  return url.match(URL_PATTERN_MATCH) &&
+  return (
+    url.match(URL_PATTERN_MATCH) &&
     URL_PATTERN_START.some((validStart) => url.startsWith(validStart))
-    ? true
-    : false;
+  );
 }
 
 export function isEDTFValid(edtfString) {

--- a/assets/js/services/helpers.test.js
+++ b/assets/js/services/helpers.test.js
@@ -17,6 +17,7 @@ it("should validate URL pattern", () => {
   expect(isUrlValid("htttp://northwestern.edu")).toBe(false);
   expect(isUrlValid("ww.northwestern.edu")).toBe(false);
   expect(isUrlValid("northwestern.edu")).toBe(false);
+  expect(isUrlValid("northwestern https://www.northwestern.edu")).toBe(false);
 
   expect(isUrlValid("www.google.cc")).toBe(true);
   expect(isUrlValid("www.google.co.uk")).toBe(true);


### PR DESCRIPTION
# Summary 
URL Pattern matching was checking for any part of the string input into the URL field to start with `http://` or `https://`. In that case an input value of `foo https://bar.baz` would validate TRUE. This now validates false and will require a url to match a pattern `https://foo.bar` with only valid starts:

- `http://foo.bar`
- `https://foo.bar`
- `www.foo.bar`

_My solution here probably could be done completely with RegEx but I'm not sure how considering we are seeking to allow **www** as well as the protocols to be valid._

# Specific Changes in this PR
- Adjusts URL validation to make sure URL strings start with either `http://`, `https://`, or `www`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

1. Edit any work
2. Add a Related URL of `foo https://bar.baz`
3. This should fail validation ❌ 
2. Add a Related URL of `https://foo.bar`
3. This should pass validation ✅ 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

