### PR TITLE
Use a different strategy for determining a fileset id in the stream-authorizer lambda

### DIFF
--- a/priv/nodejs/stream-authorizer/index.js
+++ b/priv/nodejs/stream-authorizer/index.js
@@ -6,7 +6,7 @@ const handler = async (event, _context) => {
   console.log("Initiating stream authorization");
   const request = event.Records[0].cf.request;
   const path = decodeURI(request.uri.replace(/%2f/gi, ""));
-  const id = path.split("/").slice(0, -1).join("");
+  const id = path.split("/").slice(0, 19).join("");
   console.log("Streaming resource ID", id);
   const referer = request?.headers?.referer?.[0]?.value;
   if (referer && new RegExp(allowedReferers).test(referer)) {
@@ -27,7 +27,7 @@ const handler = async (event, _context) => {
     statusDescription: "Forbidden",
     body: "Forbidden",
   };
-  console.log(`Stream unauthorized for $${id}, returning forbidden response`);
+  console.log(`Stream unauthorized for $${id}, returning Forbidden response`);
   return response;
 };
 


### PR DESCRIPTION
# Summary 
Fixes an issue where streaming URIs contain more info than just the `id` in the pairtree (in this case it was `high` following the `id` coming from the encoding preset in content migrated from AVR).

Note: Terraform applied to **BOTH** staging and production environments already.

# Specific Changes in this PR
- Updates `stream-authorizer` lambda code parsing the document id

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

