### PR TITLE
Revert "Use exiftool instead of exifr in EXIF extraction lambda"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,8 +185,6 @@ jobs:
           curl https://s3.amazonaws.com/nul-repo-deploy/ffmpeg-release-64bit-static.tar.xz | tar xJ && \
           sudo cp $(find . -type f -executable) /usr/local/bin/ && \
           echo "FFMPEG VERSION: $(ffmpeg -version | sed -n "s/ffmpeg version \([-0-9.]*\).*/\1/p;")"
-      - name: Install exiftool
-        run: brew install exiftool
       - name: Cache Elixir dependencies
         uses: actions/cache@v2
         with:

--- a/priv/nodejs/exif/exif.js
+++ b/priv/nodejs/exif/exif.js
@@ -1,88 +1,95 @@
 const AWS = require("aws-sdk");
+const exifr = require("exifr");
 const URI = require("uri-js");
 const s3 = new AWS.S3();
-const { spawn } = require('child_process');
-
-const includeTags = [
-  "Artist",
-  "BitsPerSample",
-  "CellLength",
-  "CellWidth",
-  "ColorMap",
-  "Compression",
-  "Copyright",
-  "DateTime",
-  "ExtraSamples",
-  "FillOrder",
-  "FreeByteCounts",
-  "FreeOffsets",
-  "GrayResponseCurve",
-  "GrayResponseUnit",
-  "HostComputer",
-  "ImageDescription",
-  "ImageHeight",
-  "ImageLength",
-  "ImageWidth",
-  "Make",
-  "MaxSampleValue",
-  "MinSampleValue",
-  "Model",
-  "NewSubfileType",
-  "Orientation",
-  "PhotometricInterpretation",
-  "PlanarConfiguration",
-  "ResolutionUnit",
-  "SamplesPerPixel",
-  "Software",
-  "SubfileType",
-  "Threshholding",
-  "XResolution",
-  "YResolution",
-];
-
-const exifToolPath = process.env.EXIFTOOL || 'exiftool';
-const exifToolParams = ['-fast', '-j', '-d', '%Y-%m-%dT%H:%M:%S%z'];
 
 AWS.config.update({httpOptions: {timeout: 600000}});
 
-const version = async () => {
-  const exifTool = spawn(exifToolPath, ['-ver'], {stdio: ['ignore', 'pipe', process.stderr]});
-  return await readOutput(exifTool);
-};
+const chunkReader = (input, offset, length) => {
+  return new Promise((resolve, _reject) => {
+    let params = {...input};
 
-const extract = async (source) => {
-  console.log(`Retrieving ${source}`);
+    if (typeof offset === 'number') {
+      let end = length ? offset + length - 1 : undefined;
+      params.Range = `bytes=${[offset, end].join('-')}`;
+    }
 
-  const uri = URI.parse(source);
-  const s3Location = { 
-    Bucket: uri.host, 
-    Key: uri.path.replace(/^\/+/, "")
-  };
-
-  const args = exifToolParams.concat(includeTags.map((tag) => `-${tag}`)).concat(['-']);
-  const inputStream = s3.getObject(s3Location).createReadStream();
-  const exifTool = spawn(exifToolPath, args, {stdio: ['pipe', 'pipe', process.stderr]});
-  inputStream.pipe(exifTool.stdin).on('error', (_error) => undefined);
-  let output = await readOutput(exifTool);
-
-  try {
-    output = JSON.parse(output);
-    if (Array.isArray(output) && output.length == 1) output = output[0];
-  } catch (_err) {
-    console.warn("Output is not JSON. Returning raw data.");
-  }
-  return output;
-};
-
-const readOutput = (child) => {
-  return new Promise((resolve, reject) => {
-    let buffer = '';
-    child.on('error', (error) => reject(error));
-    child.stdout
-      .on('data', (data) => buffer += data)
-      .on('end', () => buffer = buffer.trimEnd())
-      .on('close', () => resolve(buffer));
+    s3.getObject(params, (err, data) => {
+      if (err) {
+        console.error(err);
+        resolve(undefined);
+      } else {
+        resolve(data.Body);
+      }
+    });
   });
-};
+}
 
-module.exports = { extract, version };
+const extractExif = (source, options) => {
+  return new Promise((resolve, reject) => {
+    console.log(`Retrieving ${source}`);
+
+    const defaultOptions = {
+      makerNote: false,
+      pick: [
+        "Artist",
+        "BitsPerSample",
+        "CellLength",
+        "CellWidth",
+        "ColorMap",
+        "Compression",
+        "Copyright",
+        "DateTime",
+        "ExtraSamples",
+        "FillOrder",
+        "FreeByteCounts",
+        "FreeOffsets",
+        "GrayResponseCurve",
+        "GrayResponseUnit",
+        "HostComputer",
+        "ImageDescription",
+        "ImageHeight",
+        "ImageLength",
+        "ImageWidth",
+        "Make",
+        "MaxSampleValue",
+        "MinSampleValue",
+        "Model",
+        "NewSubfileType",
+        "Orientation",
+        "PhotometricInterpretation",
+        "PlanarConfiguration",
+        "ResolutionUnit",
+        "SamplesPerPixel",
+        "Software",
+        "SubfileType",
+        "Threshholding",
+        "XResolution",
+        "YResolution",
+      ],
+    };
+
+    const forcedOptions = {
+      jfif: true,
+      icc: true,
+      iptc: true,
+      xmp: true,
+      interop: true,
+      chunkSize: 1024 * 1024,
+      externalReader: chunkReader
+    };
+    
+    const uri = URI.parse(source);
+    const s3Location = { 
+      Bucket: uri.host, 
+      Key: uri.path.replace(/^\/+/, "")
+    };
+
+    options = Object.assign(options || defaultOptions, forcedOptions);
+    exifr.parse(s3Location, options)
+      .then(exif => resolve(exif))
+      .catch(err => reject(err));
+  });
+}
+
+module.exports = { extractExif };

--- a/priv/nodejs/exif/index.js
+++ b/priv/nodejs/exif/index.js
@@ -1,15 +1,14 @@
 const exif = require("./exif");
 
 const handler = async (event, _context, _callback) => {
-  const result = await exif.extract(event.source);
+  const result = await exif.extractExif(event.source, event.options)
   if (result === null || result === undefined) {
     return null;
   }
-  delete result.SourceFile;
   
   return {
-    tool: "exiftool",
-    tool_version: await exif.version(),
+    tool: "exifr",
+    tool_version: require("exifr/package.json").version,
     value: result
   };
 };

--- a/priv/nodejs/exif/package-lock.json
+++ b/priv/nodejs/exif/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "exifr": "nulib/exifr#external-reader-dist",
         "uri-js": "^4.4.1"
       },
       "devDependencies": {
@@ -74,6 +75,12 @@
       "engines": {
         "node": ">=0.4.x"
       }
+    },
+    "node_modules/exifr": {
+      "version": "6.1.1",
+      "resolved": "git+ssh://git@github.com/nulib/exifr.git#3d926474bc2e629f6352d668c0e5596dc8d3f874",
+      "integrity": "sha512-8lSh/QkNcGdT8qoCwydhE6E2WTVTN6zq4OMuoNlw5a6qxb7B/CaL6qn5e4mlTt3CY/DRN4hlsyrz1MzR37+IRA==",
+      "license": "MIT"
     },
     "node_modules/ieee754": {
       "version": "1.1.13",
@@ -214,6 +221,11 @@
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
+    },
+    "exifr": {
+      "version": "git+ssh://git@github.com/nulib/exifr.git#3d926474bc2e629f6352d668c0e5596dc8d3f874",
+      "integrity": "sha512-8lSh/QkNcGdT8qoCwydhE6E2WTVTN6zq4OMuoNlw5a6qxb7B/CaL6qn5e4mlTt3CY/DRN4hlsyrz1MzR37+IRA==",
+      "from": "exifr@nulib/exifr#external-reader-dist"
     },
     "ieee754": {
       "version": "1.1.13",

--- a/priv/nodejs/exif/package.json
+++ b/priv/nodejs/exif/package.json
@@ -6,6 +6,7 @@
   "author": "bmquinn",
   "license": "Apache-2.0",
   "dependencies": {
+    "exifr": "nulib/exifr#external-reader-dist",
     "uri-js": "^4.4.1"
   },
   "devDependencies": {

--- a/terraform/lambdas.tf
+++ b/terraform/lambdas.tf
@@ -91,14 +91,6 @@ module "exif_function" {
   stack_name  = var.stack_name
   memory_size = 512
   timeout     = 10
-  layers      = [
-    "arn:aws:lambda:us-east-1:652718333417:layer:perl-5_30-layer:1",
-    aws_lambda_layer_version.exiftool.arn
-  ]
-
-  environment = {
-    EXIFTOOL = "/opt/bin/exiftool"
-  }
 
   tags = merge(
     var.tags,

--- a/terraform/layers.tf
+++ b/terraform/layers.tf
@@ -1,11 +1,3 @@
-resource "aws_lambda_layer_version" "exiftool" {
-  s3_bucket           = "nul-public"
-  s3_key              = "exiftool_lambda_layer.zip"
-  layer_name          = "exiftool"
-  compatible_runtimes = ["nodejs14.x"]
-  description         = "exiftool runtime for nodejs lambdas"
-}
-
 resource "aws_lambda_layer_version" "ffmpeg" {
   s3_bucket           = "nul-public"
   s3_key              = "ffmpeg.zip"

--- a/test/pipeline/actions/extract_exif_metadata_test.exs
+++ b/test/pipeline/actions/extract_exif_metadata_test.exs
@@ -16,10 +16,10 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadataTest do
   @no_exif_fixture %{bucket: @bucket, key: @no_exif_key, content: File.read!(@no_exif_content)}
   @exif %{
     "Artist" => "Artist Name",
-    "BitsPerSample" => "8 8 8",
-    "Compression" => "Uncompressed",
+    "BitsPerSample" => %{"0" => 8, "1" => 8, "2" => 8},
+    "Compression" => 1,
     "Copyright" => "In Copyright",
-    "FillOrder" => "Normal",
+    "FillOrder" => 1,
     "ImageDescription" =>
       "inu-wint-58.6, 8/20/07, 11:16 AM,  8C, 9990x9750 (0+3570), 125%, bent 6 b/w adj,  1/30 s, R43.0, G4.4, B12.6",
     "ImageHeight" => 1024,
@@ -27,12 +27,11 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadataTest do
     "Make" => "Better Light",
     "Model" => "Model Super8K",
     "Orientation" => "Horizontal (normal)",
-    "PhotometricInterpretation" => "RGB",
-    "PlanarConfiguration" => "Chunky",
+    "PhotometricInterpretation" => 2,
+    "PlanarConfiguration" => 1,
     "ResolutionUnit" => "inches",
     "SamplesPerPixel" => 3,
     "Software" => "Adobe Photoshop CC 2015.5 (Windows)",
-    "SourceFile" => "-",
     "XResolution" => 72,
     "YResolution" => 72
   }
@@ -53,7 +52,7 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadataTest do
            Software
            XResolution
            YResolution)
-  @tool_name "exiftool"
+  @tool_name "exifr"
 
   setup do
     exif_file_set =
@@ -124,18 +123,8 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadataTest do
 
       file_set = FileSets.get_file_set!(file_set_id)
 
-      case file_set.extracted_metadata do
-        nil ->
-          assert true
-
-        %{"exif" => nil} ->
-          assert true
-
-        %{"exif" => %{"value" => map}} ->
-          assert_lists_equal(Map.keys(map), ~w(BitsPerSample ImageHeight ImageWidth))
-
-        _ ->
-          assert false
+      with extracted <- file_set.extracted_metadata do
+        assert is_nil(extracted) || is_nil(Map.get(extracted, "exif"))
       end
 
       assert capture_log(fn ->


### PR DESCRIPTION
This reverts commit cb058e1cd2a2dda1182b5af37b44ed85017c877b.

# Summary 

Back out the switch from `exifr` to `exiftool`

# Specific Changes in this PR
- Revert commit cb058e1cd2a2dda1182b5af37b44ed85017c877b.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

