### PR TITLE
Index file set info in work doc

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "@absinthe/socket-apollo-link": "^0.2.1",
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",
@@ -106,10 +106,11 @@
       }
     },
     "../deps/phoenix": {
-      "version": "0.0.1"
+      "version": "1.6.6",
+      "license": "MIT"
     },
     "../deps/phoenix_html": {
-      "version": "0.0.1"
+      "version": "3.2.0"
     },
     "node_modules/@absinthe/socket": {
       "version": "0.2.1",

--- a/lib/meadow/indexing/work.ex
+++ b/lib/meadow/indexing/work.ex
@@ -1,4 +1,5 @@
 defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Work do
+  alias Meadow.Data.FileSets
   alias Elasticsearch.Document.Meadow.Data.Schemas.WorkAdministrativeMetadata,
     as: AdministrativeMetadataDocument
 
@@ -23,10 +24,15 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Work do
         |> Enum.map(fn file_set ->
           %{
             id: file_set.id,
-            accessionNumber: file_set.accession_number,
-            description: file_set.core_metadata.description,
+            extractedMetadata: ExtractedMetadata.transform(file_set.extracted_metadata),
             label: file_set.core_metadata.label,
-            extractedMetadata: ExtractedMetadata.transform(file_set.extracted_metadata)
+            mime_type: file_set.core_metadata.mime_type,
+            posterOffset: file_set.poster_offset,
+            rank: file_set.rank,
+            representativeImageUrl: FileSets.representative_image_url_for(file_set),
+            role: format(file_set.role),
+            streamingUrl: FileSets.distribution_streaming_uri_for(file_set),
+            webvtt: file_set.structural_metadata.value
           }
         end),
       id: work.id,

--- a/test/meadow/data/indexer_test.exs
+++ b/test/meadow/data/indexer_test.exs
@@ -271,7 +271,7 @@ defmodule Meadow.Data.IndexerTest do
       assert doc |> get_in(["model", "application"]) == "Meadow"
       assert doc |> get_in(["model", "name"]) == "Work"
       assert doc |> get_in(["fileSets"]) |> length == 2
-      assert doc |> get_in(["fileSets"]) |> List.first() |> map_size() == 5
+      assert doc |> get_in(["fileSets"]) |> List.first() |> map_size() == 10
 
       with metadata <- subject.descriptive_metadata do
         assert doc |> get_in(["descriptiveMetadata", "title"]) ==


### PR DESCRIPTION
# Summary 

We need more file set fields indexed at the work level in order to build a manifest from Elasticsearch/OpenSearch

# Specific Changes in this PR

- Index rank, role, vtt, streamingUrl, rep image url and poster info at work level


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test

- reindex and check work doc in Kibana

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [x] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

