### PR TITLE
Migrate from Elasticsearch to OpenSearch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,10 +121,14 @@ jobs:
         ports:
           - 391:389
           - 638:636
-      elasticsearch:
-        image: bitnami/elasticsearch:6
+      opensearch:
+        image: opensearchproject/opensearch:1.3.1
         env:
-          ELASTICSEARCH_HEAP_SIZE: "256m"
+          bootstrap.memory_lock: true
+          OPENSEARCH_JAVA_OPTS: "-Xms256m -Xmx256m"
+          DISABLE_INSTALL_DEMO_CONFIG: true
+          DISABLE_SECURITY_PLUGIN: true
+          discovery.type: single-node
         ports:
           - 9202:9200
       localstack:

--- a/app/lib/meadow/data/shared_links.ex
+++ b/app/lib/meadow/data/shared_links.ex
@@ -162,7 +162,7 @@ defmodule Meadow.Data.SharedLinks do
     case Elastix.Search.count(elasticsearch_url(), @index, [@type_name], %{
            query: %{match_all: %{}}
          }) do
-      {:ok, %{body: %{"error" => %{"reason" => "no such index"}}}} -> 0
+      {:ok, %{body: %{"error" => %{"type" => "index_not_found_exception"}}}} -> 0
       {:ok, %{body: %{"count" => count}}} -> count
       {:ok, %{body: body}} -> {:error, body}
     end

--- a/app/priv/elasticsearch/meadow.json
+++ b/app/priv/elasticsearch/meadow.json
@@ -32,118 +32,116 @@
     }
   },
   "mappings": {
-    "_doc": {
-      "properties": {
-        "full_text": {
-          "type": "text",
-          "analyzer": "full_analyzer",
-          "search_analyzer": "stopword_analyzer",
-          "search_quote_analyzer": "full_analyzer"
-        },
-        "all_titles": {
-          "type": "text",
-          "analyzer": "full_analyzer",
-          "search_analyzer": "stopword_analyzer",
-          "search_quote_analyzer": "full_analyzer"
+    "properties": {
+      "full_text": {
+        "type": "text",
+        "analyzer": "full_analyzer",
+        "search_analyzer": "stopword_analyzer",
+        "search_quote_analyzer": "full_analyzer"
+      },
+      "all_titles": {
+        "type": "text",
+        "analyzer": "full_analyzer",
+        "search_analyzer": "stopword_analyzer",
+        "search_quote_analyzer": "full_analyzer"
+      }
+    },
+    "dynamic_templates": [
+      {
+        "facets": {
+          "match": ".*Facet|^facet",
+          "match_pattern": "regex",
+          "mapping": { "type": "keyword" }
         }
       },
-      "dynamic_templates": [
-        {
-          "facets": {
-            "match": ".*Facet|^facet",
-            "match_pattern": "regex",
-            "mapping": { "type": "keyword" }
-          }
-        },
-        {
-          "latlong": {
-            "match": ".*Geo|^geo",
-            "match_pattern": "regex",
-            "mapping": { "type": "geo_point" }
-          }
-        },
-        {
-          "ids": {
-            "path_match": "*.id",
-            "mapping": {
-              "type": "keyword",
-              "copy_to": ["all_controlled_terms"]
-            }
-          }
-        },
-        {
-          "uris": {
-            "path_match": "*.uri",
-            "mapping": { "type": "keyword" }
-          }
-        },
-        {
-          "titles": {
-            "path_match": "^descriptiveMetadata\\..*[Tt]itle.*$",
-            "match_pattern": "regex",
-            "mapping": {
-              "type": "text",
-              "analyzer": "full_analyzer",
-              "search_analyzer": "stopword_analyzer",
-              "search_quote_analyzer": "full_analyzer",
-              "fields": {
-                "keyword": { "type": "keyword" }
-              },
-              "copy_to": ["full_text", "all_titles"]
-            }
-          }
-        },
-        {
-          "labels": {
-            "path_match": "*.label",
-            "path_unmatch": "descriptiveMetadata.relatedUrl.label",
-            "mapping": {
-              "type": "text",
-              "analyzer": "full_analyzer",
-              "search_analyzer": "stopword_analyzer",
-              "search_quote_analyzer": "full_analyzer",
-              "fields": {
-                "keyword": { "type": "keyword" }
-              },
-              "copy_to": ["full_text", "all_controlled_labels"]
-            }
-          }
-        },
-        {
-          "edtf_strings": {
-            "match": "^edtf",
-            "match_pattern": "regex",
-            "mapping": {
-              "type": "text",
-              "analyzer": "full_analyzer",
-              "search_analyzer": "stopword_analyzer",
-              "search_quote_analyzer": "full_analyzer",
-              "fields": {
-                "keyword": { "type": "keyword" }
-              },
-              "copy_to": ["full_text"]
-            }
-          }
-        },
-        {
-          "strings": {
-            "match_mapping_type": "string",
-            "mapping": {
-              "type": "text",
-              "analyzer": "full_analyzer",
-              "search_analyzer": "stopword_analyzer",
-              "search_quote_analyzer": "full_analyzer",
-              "fields": {
-                "keyword": {
-                  "type": "keyword",
-                  "ignore_above": 512
-                }
-              },
-              "copy_to": ["full_text"]
-            }
+      {
+        "latlong": {
+          "match": ".*Geo|^geo",
+          "match_pattern": "regex",
+          "mapping": { "type": "geo_point" }
+        }
+      },
+      {
+        "ids": {
+          "path_match": "*.id",
+          "mapping": {
+            "type": "keyword",
+            "copy_to": ["all_controlled_terms"]
           }
         }
-      ]
-    }
+      },
+      {
+        "uris": {
+          "path_match": "*.uri",
+          "mapping": { "type": "keyword" }
+        }
+      },
+      {
+        "titles": {
+          "path_match": "^descriptiveMetadata\\..*[Tt]itle.*$",
+          "match_pattern": "regex",
+          "mapping": {
+            "type": "text",
+            "analyzer": "full_analyzer",
+            "search_analyzer": "stopword_analyzer",
+            "search_quote_analyzer": "full_analyzer",
+            "fields": {
+              "keyword": { "type": "keyword" }
+            },
+            "copy_to": ["full_text", "all_titles"]
+          }
+        }
+      },
+      {
+        "labels": {
+          "path_match": "*.label",
+          "path_unmatch": "descriptiveMetadata.relatedUrl.label",
+          "mapping": {
+            "type": "text",
+            "analyzer": "full_analyzer",
+            "search_analyzer": "stopword_analyzer",
+            "search_quote_analyzer": "full_analyzer",
+            "fields": {
+              "keyword": { "type": "keyword" }
+            },
+            "copy_to": ["full_text", "all_controlled_labels"]
+          }
+        }
+      },
+      {
+        "edtf_strings": {
+          "match": "^edtf",
+          "match_pattern": "regex",
+          "mapping": {
+            "type": "text",
+            "analyzer": "full_analyzer",
+            "search_analyzer": "stopword_analyzer",
+            "search_quote_analyzer": "full_analyzer",
+            "fields": {
+              "keyword": { "type": "keyword" }
+            },
+            "copy_to": ["full_text"]
+          }
+        }
+      },
+      {
+        "strings": {
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "text",
+            "analyzer": "full_analyzer",
+            "search_analyzer": "stopword_analyzer",
+            "search_quote_analyzer": "full_analyzer",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 512
+              }
+            },
+            "copy_to": ["full_text"]
+          }
+        }
+      }
+    ]
   }
 }

--- a/app/test/meadow/utils/elasticsearch/retry_api_test.exs
+++ b/app/test/meadow/utils/elasticsearch/retry_api_test.exs
@@ -9,7 +9,7 @@ defmodule Meadow.Utils.Elasticsearch.RetryAPITest do
 
   import ExUnit.CaptureLog
 
-  @too_many_fields_error ~r/Limit of total fields \[1500\] in index \[meadow-\d+\] has been exceeded/
+  @too_many_fields_error ~r/Limit of total fields \[1500\] has been exceeded/
 
   def current_api do
     Application.get_env(:meadow, Cluster) |> Keyword.get(:api)

--- a/app/test/meadow_web/plugs/elasticsearch_test.exs
+++ b/app/test/meadow_web/plugs/elasticsearch_test.exs
@@ -29,7 +29,7 @@ defmodule ElasticsearchTest do
           Jason.encode!(%{"query" => %{"match_all" => %{}}})
         )
 
-      assert Jason.decode!(conn.resp_body)["hits"]["total"] == indexed_doc_count()
+      assert Jason.decode!(conn.resp_body)["hits"]["total"]["value"] == indexed_doc_count()
     end
 
     test "returns results for _msearch reqeusts" do


### PR DESCRIPTION
# Summary 
The migration includes updates to indexing functions, mapping configuration and tests

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [ ] Minor
- [x] Major

# Steps to Test
- Check out the devstack branch `2812-opensearch-upgrade` in https://github.com/nulib/devstack/pull/12
- Run `devstack up meadow opensearch-dashboard` and the usual mix setup tasks.
- Tests should pass and app should run as expected.

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [x] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [x] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

