### PR TITLE
Increase EXIF action timeout to match lambda timeout (see 5c814673)

### DIFF
--- a/app/lib/meadow/pipeline/actions/extract_exif_metadata.ex
+++ b/app/lib/meadow/pipeline/actions/extract_exif_metadata.ex
@@ -14,7 +14,7 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadata do
 
   require Logger
 
-  @timeout 10_000
+  @timeout 120_000
 
   def actiondoc, do: "Extract EXIF metadata from FileSet"
 


### PR DESCRIPTION
# Summary 

The timeout for the EXIF extraction lambda was changed to 2 minutes (5c814673) but the timeout of the lambda invocation from the action was never increased to match.

# Specific Changes in this PR
- Increase `ExAws.request` timeout for exif lambda invocation

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

