### PR TITLE
Separate staging/prod preservation lifecycle rules

### DIFF
--- a/infrastructure/deploy/variables.tf
+++ b/infrastructure/deploy/variables.tf
@@ -35,11 +35,6 @@ variable "digital_collections_url" {
   type = string
 }
 
-variable "deleted_object_expiration" {
-  type    = number
-  default = 180
-}
-
 variable "fixity_function" {
   type = string
 }


### PR DESCRIPTION
# Summary 

Create separate preservation lifecycle rules for staging and prod

Terraform only – changes applied to both staging and prod

# Specific Changes in this PR
- Separate `aws_s3_bucket_lifecycle_configuration.meadow_preservation` resource into `staging` and `production` varieties, controlled by `var.environment`
- Set preservation rule to `INTELLIGENT_TIERING` on Day 0 and `DEEP_ARCHIVE` on Day 180

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

