### PR TITLE
Configure correct shared links index on staging/prod

### DIFF
--- a/app/config/releases.exs
+++ b/app/config/releases.exs
@@ -91,6 +91,7 @@ config :meadow,
     {:hush, SystemEnvironment, "MULTIPART_UPLOAD_CONCURRENCY", default: "50"},
   pipeline_delay: {:hush, SystemEnvironment, "PIPELINE_DELAY", default: "120000"},
   progress_ping_interval: {:hush, SystemEnvironment, "PROGRESS_PING_INTERVAL", default: "1000"},
+  shared_links_index: "shared-links",
   sitemaps: [
     gzip: true,
     store: Sitemapper.S3Store,


### PR DESCRIPTION
# Summary 
Fix sharing on staging

# Specific Changes in this PR
- Add the correct shared links index name to `releases.exs`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

