### PR TITLE
Fix indexing error if EXIF is empty string

### DIFF
--- a/app/lib/meadow/utils/extracted_metadata.ex
+++ b/app/lib/meadow/utils/extracted_metadata.ex
@@ -20,6 +20,8 @@ defmodule Meadow.Utils.ExtractedMetadata do
 
   def transform(other), do: other
 
+  defp transform_data("", _), do: %{}
+
   defp transform_data(data, transformer) do
     with value <- Map.get(data, "value") do
       Map.put(data, "value", transformer.(value))

--- a/app/test/meadow/data/indexer_test.exs
+++ b/app/test/meadow/data/indexer_test.exs
@@ -386,6 +386,20 @@ defmodule Meadow.Data.IndexerTest do
 
       assert doc |> get_in(["representativeImageUrl"]) == poster_url
     end
+
+    test "file set encoding with bad EXIF data (empty string)", %{file_set: subject} do
+      {:ok, subject} =
+        subject
+        |> FileSets.update_file_set(%{
+          extracted_metadata: %{exif: ""}
+        })
+
+      subject = FileSets.get_file_set_with_work_and_sheet!(subject.id)
+
+      [header, doc] = subject |> Indexer.encode!(:index) |> decode_njson()
+      assert header |> get_in(["index", "_id"]) == subject.id
+      assert doc |> get_in(["extractedMetadata"]) == %{"exif" => %{}}
+    end
   end
 
   describe "mix task" do


### PR DESCRIPTION
# Summary 

Indexer should be able to handle an empty string for EXIF value

# Specific Changes in this PR

- Set empty string for `exif` to empty map when indexing

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- One way would be to edit a file set in Meadow to have an empty string for EXIF. `FileSets.updateFileSet(file_set, %{extracted_metadata: %{exif: ""}}`
- Then reindex


# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

