### PR TITLE
Allow audio works auxiliary images to be representative work image

### DIFF
--- a/app/assets/js/components/Work/Fileset/ListItem.jsx
+++ b/app/assets/js/components/Work/Fileset/ListItem.jsx
@@ -101,7 +101,10 @@ function WorkFilesetListItem({
         <div className="column is-5 has-text-right is-clearfix">
           {!isEditing && (
             <>
-              {workContextState.workTypeId !== "AUDIO" && (
+              {!(
+                workContextState.workTypeId === "AUDIO" &&
+                fileSet.role.id === "A"
+              ) && (
                 <AuthDisplayAuthorized>
                   <div className="field">
                     <input


### PR DESCRIPTION
# Summary 

Allow audio works auxiliary images to be representative work image


# Specific Changes in this PR
- Allow audio works auxiliary images to be representative work image

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Viewing the structure tab for Audio works, you should see the "Work Image" toggle by "X" file sets and not "A" file sets
- All other work types should still have the toggle for file sets of both roles

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

