### PR TITLE
Add primary index configuration so indexing works

### DIFF
--- a/app/config/config.exs
+++ b/app/config/config.exs
@@ -47,6 +47,9 @@ config :meadow, MeadowWeb.Endpoint,
   pubsub_server: Meadow.PubSub,
   live_view: [signing_salt: "C7BC/yBsTCe/PaJ9g0krwlQrNZZV2r3jSjeuGCeIu9mfNE+4bPcNPHiINQtIQk/B"]
 
+# Search index configuration
+config :meadow, Meadow.SearchIndex, primary_index: :"#{prefix}-meadow"
+
 # Configures the ElasticsearchCluster
 config :meadow, Meadow.ElasticsearchCluster,
   url:

--- a/app/lib/meadow/config.ex
+++ b/app/lib/meadow/config.ex
@@ -11,12 +11,10 @@ defmodule Meadow.Config do
     |> ensure_trailing_slash()
   end
 
-  @doc "Retrieve Elasticsearch index name"
+  @doc "Retrieve primary (meadow) Elasticsearch index name"
   def elasticsearch_index do
-    Application.get_env(:meadow, Meadow.ElasticsearchCluster)
-    |> Keyword.get(:indexes)
-    |> Map.keys()
-    |> List.first()
+    Application.get_env(:meadow, Meadow.SearchIndex)
+    |> Keyword.get(:primary_index)
   end
 
   @doc "Retrieve shared links index name"


### PR DESCRIPTION
# Summary 

Fix bug with v2 indexing/pipeline work which retrieved the wrong index name for the meadow index

# Specific Changes in this PR
- Add `primary_index` configuration
-
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Saving objects in Meadow should index to the `meadow` index

# :rocket: Deployment Notes

- [x] Other specific instructions/tasks 
  - [ ] Need to recreate the v2 collection index as it now has the wrong mappings




# Tested/Verified
- [ ] End users/stakeholders

