### PR TITLE
Adds Meadow.SearchIndex config to releases.exs

### DIFF
--- a/app/config/releases.exs
+++ b/app/config/releases.exs
@@ -54,6 +54,8 @@ config :meadow, MeadowWeb.Endpoint,
   secret_key_base: {:hush, SystemEnvironment, "SECRET_KEY_BASE"},
   live_view: [signing_salt: {:hush, SystemEnvironment, "SECRET_KEY_BASE"}]
 
+config :meadow, Meadow.SearchIndex, primary_index: :meadow
+
 config :meadow, Meadow.ElasticsearchCluster,
   api: Elasticsearch.API.AWS,
   default_options: [


### PR DESCRIPTION
# Summary 
Configure the primary search index in `releases.exs`

# Specific Changes in this PR
- Adds Meadow.SearchIndex config to releases.exs with the value `:meadow`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

