### PR TITLE
Clean EXIF lambda temp files at start instead of end

### DIFF
--- a/lambdas/exif/index.js
+++ b/lambdas/exif/index.js
@@ -1,7 +1,20 @@
 const exif = require("./exif");
+const fs = require('fs');
+
+const cleanTmpFiles = () => {
+  fs.readdirSync('/tmp')
+    .filter(fn => fn.startsWith('exif-'))
+    .map(fn => {
+      const path = `/tmp/${fn}`;
+      console.log(`Cleaning up ${path}`);
+      fs.unlinkSync(path);
+    });
+}
 
 const handler = async (event, _context, _callback) => {
-  const result = await exif.extract(event.source);
+  cleanTmpFiles();
+  const source = event.source || event.headers['x-source-location'];
+  const result = await exif.extract(source);
   if (result === null || result === undefined) {
     return null;
   }


### PR DESCRIPTION
# Summary 
Fix EXIF lambda timeout

# Specific Changes in this PR
- Update EXIF lambda so that it cleans up temp files at the beginning rather than the end of the function call

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

