### PR TITLE
Eliminate superfluous config/env.exs

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -6,7 +6,7 @@ LABEL edu.northwestern.library.app=meadow \
 ENV MIX_ENV=prod
 COPY ./mix.exs /app/mix.exs
 COPY ./mix.lock /app/mix.lock
-COPY ./config/config.exs ./config/prod.exs ./config/pipeline.exs ./config/env.exs /app/config/
+COPY ./config/config.exs ./config/prod.exs ./config/pipeline.exs /app/config/
 COPY ./lib/env.ex /app/lib/
 WORKDIR /app
 RUN mix deps.get --only prod \

--- a/app/config/env.exs
+++ b/app/config/env.exs
@@ -1,2 +1,0 @@
-if !function_exported?(:Env, :prefix, 0),
-  do: File.read!("lib/env.ex") |> Code.eval_string()

--- a/app/config/releases.exs
+++ b/app/config/releases.exs
@@ -8,8 +8,7 @@ import Env
 
 alias Meadow.Pipeline.Actions
 
-if function_exported?(:Hush, :release_mode?, 0) and Hush.release_mode?(),
-  do: [:hackney, :ex_aws] |> Enum.each(&Application.ensure_all_started/1)
+[:hackney, :ex_aws] |> Enum.each(&Application.ensure_all_started/1)
 
 priv_path = fn path ->
   case :code.priv_dir(:meadow) do

--- a/app/lib/env.ex
+++ b/app/lib/env.ex
@@ -1,4 +1,4 @@
-if !function_exported?(:Env, :prefix, 0) do
+if !function_exported?(:Env, :__info__, 1) do
   defmodule Env do
     @moduledoc """
     Configuration helpers for Meadow Dev, Staging, and Prod

--- a/app/mix.exs
+++ b/app/mix.exs
@@ -1,4 +1,4 @@
-Code.require_file("config/env.exs")
+Code.require_file("lib/env.ex")
 
 defmodule Meadow.MixProject do
   use Mix.Project


### PR DESCRIPTION
# Summary 

Eliminate a superfluous file involved in the environment config

# Specific Changes in this PR
- Require `lib/env.ex` from `mix.exs` instead of `config/env.exs`
- Delete `config/env.exs`
- Update build

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Make sure the app compiles and loads in dev environment

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

