### PR TITLE
Change preservation lifecycle config to use intelligent tiering for deep archive

### DIFF
--- a/infrastructure/deploy/main.tf
+++ b/infrastructure/deploy/main.tf
@@ -130,6 +130,17 @@ resource "aws_s3_bucket_lifecycle_configuration" "meadow_preservation_staging" {
   }
 }
 
+resource "aws_s3_bucket_intelligent_tiering_configuration" "meadow_preservation_production" {
+  count  = var.environment == "p" ? 1 : 0
+  bucket = aws_s3_bucket.meadow_preservation.id
+  name   = "intelligent-archive"
+
+  tiering {
+    access_tier = "DEEP_ARCHIVE_ACCESS"
+    days        = 180
+  }
+}
+
 # Production Preservation Bucket
 resource "aws_s3_bucket_lifecycle_configuration" "meadow_preservation_production" {
   count  = var.environment == "p" ? 1 : 0
@@ -147,21 +158,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "meadow_preservation_production
     transition {
       days          = 0
       storage_class = "INTELLIGENT_TIERING"
-    }
-  }
-
-  rule {
-    id = "deep-glacier"
-
-    status = "Enabled"
-
-    filter {
-      prefix = ""
-    }
-
-    transition {
-      days          = 180
-      storage_class = "DEEP_ARCHIVE"
     }
   }
 


### PR DESCRIPTION
# Summary 

Change preservation lifecycle config to use intelligent tiering for deep archive

Production-only, terraform-only change

# Specific Changes in this PR
- Update `main.tf` with correct lifecycle/intelligent tiering rules

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

