### PR TITLE
Revert shared-links index name to shared_links

### DIFF
--- a/app/config/config.exs
+++ b/app/config/config.exs
@@ -138,7 +138,7 @@ config :meadow,
     ),
   progress_ping_interval: System.get_env("PROGRESS_PING_INTERVAL", "1000"),
   validation_ping_interval: System.get_env("VALIDATION_PING_INTERVAL", "1000"),
-  shared_links_index: prefix("shared-links"),
+  shared_links_index: prefix("shared_links"),
   pyramid_tiff_working_dir: System.tmp_dir!(),
   work_archiver_endpoint: aws_secret("meadow", dig: ["work_archiver", "endpoint"], default: "")
 

--- a/app/config/releases.exs
+++ b/app/config/releases.exs
@@ -113,7 +113,7 @@ config :meadow,
   multipart_upload_concurrency: environment_secret("MULTIPART_UPLOAD_CONCURRENCY", default: "50"),
   pipeline_delay: environment_secret("PIPELINE_DELAY", default: "120000"),
   progress_ping_interval: environment_secret("PROGRESS_PING_INTERVAL", default: "1000"),
-  shared_links_index: "shared-links",
+  shared_links_index: "shared_links",
   sitemaps: [
     gzip: true,
     store: Sitemapper.S3Store,


### PR DESCRIPTION
# Summary 

Shared links are broken because they are currently writing to an index with the wrong name. 

fixes [#3020 ](https://github.com/nulib/repodev_planning_and_docs/issues/3020)

# Specific Changes in this PR
- Revert shared-links index name to shared_links

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Create a shared link. Check that it is written to an index named `shared_links` (may have dev env prefix)

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

