### PR TITLE
Work model mappings for v2 index

### DIFF
--- a/app/priv/elasticsearch/v2/settings/work.json
+++ b/app/priv/elasticsearch/v2/settings/work.json
@@ -2,6 +2,133 @@
   "settings": {
     "index": {
       "max_result_window": "50000"
+    },
+    "analysis": {
+      "analyzer": {
+        "full_analyzer": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "char_filter": [
+            "html_strip"
+          ],
+          "filter": [
+            "lowercase",
+            "asciifolding"
+          ]
+        },
+        "stopword_analyzer": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "char_filter": [
+            "html_strip"
+          ],
+          "filter": [
+            "lowercase",
+            "asciifolding",
+            "english_stop"
+          ]
+        }
+      },
+      "filter": {
+        "english_stop": {
+          "type": "stop",
+          "stopwords": "_english_"
+        }
+      }
     }
+  },
+  "mappings": {
+    "properties": {
+      "all_text": {
+        "type": "text",
+        "analyzer": "full_analyzer",
+        "search_analyzer": "stopword_analyzer",
+        "search_quote_analyzer": "full_analyzer"
+      },
+      "all_controlled_labels": {
+        "type": "text",
+        "analyzer": "full_analyzer",
+        "search_analyzer": "stopword_analyzer",
+        "search_quote_analyzer": "full_analyzer"
+      },
+      "all_controlled_terms": {
+        "type": "keyword"
+      },
+      "all_ids": {
+        "type": "keyword"
+      }
+    },
+    "dynamic_templates": [
+      {
+        "text_fields": {
+          "match": "^abstract$|^alternate_title$|^caption$|^collection.title$|^cultural_context$|^description$|^file_sets.label$|^file_sets.description$|^notes$|^table_of_contents$|^title$",
+          "match_pattern": "regex",
+          "mapping": {
+            "type": "text",
+            "analyzer": "full_analyzer",
+            "search_analyzer": "stopword_analyzer",
+            "search_quote_analyzer": "full_analyzer",
+            "copy_to": [
+              "all_text"
+            ]
+          }
+        }
+      },
+      {
+        "ids": {
+          "match": "^accession_number$|^batch_ids$|^csv_metadata_update_job_ids$|^collection.id$|^id$|^identifier$|^legacy_identifier$|^ark$|catalog_key",
+          "match_pattern": "regex",
+          "mapping": {
+            "type": "keyword",
+            "copy_to": [
+              "all_ids"
+            ]
+          }
+        }
+      },
+      {
+        "latlong": {
+          "match": ".*Geo|^geo",
+          "match_pattern": "regex",
+          "mapping": {
+            "type": "geo_point"
+          }
+        }
+      },
+      {
+        "labels": {
+          "path_match": "^contributor.label$|^creator.label$|^language.label$|^location.label$|^genre.label$|^style_period.label$|^technique.label$,",
+          "match_pattern": "regex",
+          "mapping": {
+            "type": "keyword",
+            "copy_to": [
+              "all_text",
+              "all_controlled_terms",
+              "all_controlled_labels"
+            ]
+          }
+        }
+      },
+      {
+        "extracted_metadata_strings": {
+          "path_match": "file_sets.extracted_metadata.*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      },
+      {
+        "strings": {
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword",
+            "copy_to": [
+              "all_text"
+            ]
+          }
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
# Summary 

Provide mappings for our v2 works index.

<details><summary>@davidschober - these are how the fields are looking (EXPAND ME). Can you make sure this matches what you want?</summary>


``` 
{
    "abstract": {
        "type": "text",
        "copy_to": [
            "all_text"
        ],
        "analyzer": "full_analyzer",
        "search_analyzer": "stopword_analyzer",
        "search_quote_analyzer": "full_analyzer"
    },
    "accession_number": {
        "type": "keyword",
        "copy_to": [
            "all_ids"
        ]
    },
    "all_controlled_labels": {
        "type": "text",
        "analyzer": "full_analyzer",
        "search_analyzer": "stopword_analyzer",
        "search_quote_analyzer": "full_analyzer"
    },
    "all_controlled_terms": {
        "type": "keyword"
    },
    "all_ids": {
        "type": "keyword"
    },
    "all_text": {
        "type": "text",
        "analyzer": "full_analyzer",
        "search_analyzer": "stopword_analyzer",
        "search_quote_analyzer": "full_analyzer"
    },
    "api_link": {
        "type": "keyword",
        "copy_to": [
            "all_text"
        ]
    },
    "api_model": {
        "type": "keyword",
        "copy_to": [
            "all_text"
        ]
    },
    "ark": {
        "type": "keyword",
        "copy_to": [
            "all_ids"
        ]
    },
    "caption": {
        "type": "text",
        "copy_to": [
            "all_text"
        ],
        "analyzer": "full_analyzer",
        "search_analyzer": "stopword_analyzer",
        "search_quote_analyzer": "full_analyzer"
    },
    "collection": {
        "properties": {
            "id": {
                "type": "keyword",
                "copy_to": [
                    "all_ids"
                ]
            },
            "title": {
                "type": "text",
                "copy_to": [
                    "all_text"
                ],
                "analyzer": "full_analyzer",
                "search_analyzer": "stopword_analyzer",
                "search_quote_analyzer": "full_analyzer"
            }
        }
    },
    "contributor": {
        "properties": {
            "id": {
                "type": "keyword",
                "copy_to": [
                    "all_ids"
                ]
            },
            "label": {
                "type": "keyword",
                "copy_to": [
                    "all_text",
                    "all_controlled_terms",
                    "all_controlled_labels"
                ]
            },
            "label_with_role": {
                "type": "keyword",
                "copy_to": [
                    "all_text"
                ]
            },
            "role": {
                "type": "keyword",
                "copy_to": [
                    "all_text"
                ]
            }
        }
    },
    "create_date": {
        "type": "date"
    },
    "file_sets": {
        "properties": {
            "extracted_metadata": {
                "properties": {
                    "exif": {
                        "properties": {
                            "tool": {
                                "type": "keyword"
                            },
                            "tool_version": {
                                "type": "keyword"
                            },
                            "value": {
                                "properties": {
                                    "bitsPerSample": {
                                        "type": "keyword"
                                    },
                                    "compression": {
                                        "type": "keyword"
                                    },
                                    "imageDescription": {
                                        "type": "keyword"
                                    },
                                    "imageHeight": {
                                        "type": "long"
                                    },
                                    "imageWidth": {
                                        "type": "long"
                                    },
                                    "make": {
                                        "type": "keyword"
                                    },
                                    "model": {
                                        "type": "keyword"
                                    },
                                    "orientation": {
                                        "type": "keyword"
                                    },
                                    "photometricInterpretation": {
                                        "type": "keyword"
                                    },
                                    "planarConfiguration": {
                                        "type": "keyword"
                                    },
                                    "resolutionUnit": {
                                        "type": "keyword"
                                    },
                                    "samplesPerPixel": {
                                        "type": "long"
                                    },
                                    "software": {
                                        "type": "keyword"
                                    },
                                    "subfileType": {
                                        "type": "keyword"
                                    },
                                    "xResolution": {
                                        "type": "long"
                                    },
                                    "yResolution": {
                                        "type": "long"
                                    }
                                }
                            }
                        }
                    }
                }
            },
            "id": {
                "type": "keyword",
                "copy_to": [
                    "all_ids"
                ]
            },
            "label": {
                "type": "keyword",
                "copy_to": [
                    "all_text"
                ]
            },
            "mime_type": {
                "type": "keyword",
                "copy_to": [
                    "all_text"
                ]
            },
            "rank": {
                "type": "long"
            },
            "representative_image_url": {
                "type": "keyword",
                "copy_to": [
                    "all_text"
                ]
            },
            "role": {
                "type": "keyword",
                "copy_to": [
                    "all_text"
                ]
            }
        }
    },
    "genre": {
        "properties": {
            "id": {
                "type": "keyword",
                "copy_to": [
                    "all_ids"
                ]
            },
            "label": {
                "type": "keyword",
                "copy_to": [
                    "all_text",
                    "all_controlled_terms",
                    "all_controlled_labels"
                ]
            }
        }
    },
    "id": {
        "type": "keyword",
        "copy_to": [
            "all_ids"
        ]
    },
    "identifier": {
        "type": "keyword",
        "copy_to": [
            "all_ids"
        ]
    },
    "iiif_manifest": {
        "type": "keyword",
        "copy_to": [
            "all_text"
        ]
    },
    "legacy_identifier": {
        "type": "keyword",
        "copy_to": [
            "all_ids"
        ]
    },
    "library_unit": {
        "type": "keyword",
        "copy_to": [
            "all_text"
        ]
    },
    "modified_date": {
        "type": "date"
    },
    "physical_description_material": {
        "type": "keyword",
        "copy_to": [
            "all_text"
        ]
    },
    "physical_description_size": {
        "type": "keyword",
        "copy_to": [
            "all_text"
        ]
    },
    "preservation_level": {
        "type": "keyword",
        "copy_to": [
            "all_text"
        ]
    },
    "published": {
        "type": "boolean"
    },
    "related_url": {
        "properties": {
            "label": {
                "type": "keyword",
                "copy_to": [
                    "all_text"
                ]
            },
            "url": {
                "type": "keyword",
                "copy_to": [
                    "all_text"
                ]
            }
        }
    },
    "representative_file_set": {
        "properties": {
            "fileSetId": {
                "type": "keyword",
                "copy_to": [
                    "all_text"
                ]
            },
            "url": {
                "type": "keyword",
                "copy_to": [
                    "all_text"
                ]
            }
        }
    },
    "rights_statement": {
        "properties": {
            "id": {
                "type": "keyword",
                "copy_to": [
                    "all_ids"
                ]
            },
            "label": {
                "type": "keyword",
                "copy_to": [
                    "all_text"
                ]
            }
        }
    },
    "scope_and_contents": {
        "type": "keyword",
        "copy_to": [
            "all_text"
        ]
    },
    "series": {
        "type": "keyword",
        "copy_to": [
            "all_text"
        ]
    },
    "status": {
        "type": "keyword",
        "copy_to": [
            "all_text"
        ]
    },
    "subject": {
        "properties": {
            "id": {
                "type": "keyword",
                "copy_to": [
                    "all_ids"
                ]
            },
            "label": {
                "type": "keyword",
                "copy_to": [
                    "all_text"
                ]
            },
            "label_with_role": {
                "type": "keyword",
                "copy_to": [
                    "all_text"
                ]
            },
            "role": {
                "type": "keyword",
                "copy_to": [
                    "all_text"
                ]
            }
        }
    },
    "technique": {
        "properties": {
            "id": {
                "type": "keyword",
                "copy_to": [
                    "all_ids"
                ]
            },
            "label": {
                "type": "keyword",
                "copy_to": [
                    "all_text"
                ]
            }
        }
    },
    "terms_of_use": {
        "type": "keyword",
        "copy_to": [
            "all_text"
        ]
    },
    "thumbnail": {
        "type": "keyword",
        "copy_to": [
            "all_text"
        ]
    },
    "title": {
        "type": "text",
        "copy_to": [
            "all_text"
        ],
        "analyzer": "full_analyzer",
        "search_analyzer": "stopword_analyzer",
        "search_quote_analyzer": "full_analyzer"
    },
    "visibility": {
        "type": "keyword",
        "copy_to": [
            "all_text"
        ]
    },
    "work_type": {
        "type": "keyword",
        "copy_to": [
            "all_text"
        ]
    }
}
```
</details>

# Specific Changes in this PR

- Added v2 works mappings to the placeholder `app/priv/elasticsearch/v2/settings/work.json` file

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch (because this only effects our unpublished API)
- [ ] Minor
- [ ] Major

# Steps to Test

- Delete your dev v2 works alias and index
- Reindex v1 works into v2
```
POST _reindex
{
  "source": {
    "index": "kdid-dev-meadow",
    "query": {
      "term": {
        "model.name.keyword": {
          "value": "Work"
        }
      }
    }
  },
  "dest": {
    "index": "kdid-dev-dc-v2-work"
  }
}
```

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

