### PR TITLE
File set mappings for v2 indexing

### DIFF
--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "@absinthe/socket-apollo-link": "^0.2.1",
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",
@@ -106,10 +106,11 @@
       }
     },
     "../deps/phoenix": {
-      "version": "0.0.1"
+      "version": "1.6.10",
+      "license": "MIT"
     },
     "../deps/phoenix_html": {
-      "version": "0.0.1"
+      "version": "3.2.0"
     },
     "node_modules/@absinthe/socket": {
       "version": "0.2.1",

--- a/app/priv/elasticsearch/v2/settings/file_set.json
+++ b/app/priv/elasticsearch/v2/settings/file_set.json
@@ -2,6 +2,63 @@
   "settings": {
     "index": {
       "max_result_window": "50000"
+    },
+    "analysis": {
+      "analyzer": {
+        "full_analyzer": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "char_filter": [
+            "html_strip"
+          ],
+          "filter": [
+            "lowercase",
+            "asciifolding"
+          ]
+        },
+        "stopword_analyzer": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "char_filter": [
+            "html_strip"
+          ],
+          "filter": [
+            "lowercase",
+            "asciifolding",
+            "english_stop"
+          ]
+        }
+      },
+      "filter": {
+        "english_stop": {
+          "type": "stop",
+          "stopwords": "_english_"
+        }
+      }
     }
+  },
+  "mappings": {
+    "dynamic_templates": [
+      {
+        "text_fields": {
+          "match": "^description$|^label$",
+          "match_pattern": "regex",
+          "mapping": {
+            "type": "text",
+            "analyzer": "full_analyzer",
+            "search_analyzer": "stopword_analyzer",
+            "search_quote_analyzer": "full_analyzer"
+          }
+        }
+      },
+      {
+        "strings": {
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
# Summary 

Define file set mappings for v2 index.

# Specific Changes in this PR
- `label` and `description` are `text`, all other strings are `keyword` and everything else defaults.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Reindex some v1 file sets into v2:

```
POST _reindex
{
  "source": {
    "index": "yourdevenv-dev-meadow",
    "query": {
      "term": {
        "model.name.keyword": {
          "value": "FileSet"
        }
      }
    }
  },
  "dest": {
    "index": "yourdevenv-dev-dc-v2-file-set"
  }
}
```


# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

