### PR TITLE
Add clicks external of actions dropdowm to close

### DIFF
--- a/app/assets/js/components/Work/Tabs/Preservation/ActionsCol.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/ActionsCol.jsx
@@ -32,11 +32,26 @@ const PreservationActionsCol = ({
   work,
 }) => {
   const [isActionsOpen, setIsActionsOpen] = React.useState(false);
+  const dropdownRef = React.useRef(null);
   const actionItemClasses = `dropdown-item is-flex is-align-items-center`;
 
   const handleActionsToggle = () => {
     setIsActionsOpen(!isActionsOpen);
   };
+
+  React.useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (
+        isActionsOpen &&
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target)
+      )
+        setIsActionsOpen(false);
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isActionsOpen, dropdownRef]);
 
   const clipboard = useClipboard({
     onSuccess() {
@@ -66,7 +81,12 @@ const PreservationActionsCol = ({
           <IconArrowDown className="icon" />
         </button>
       </div>
-      <div className="dropdown-menu" id="dropdown-menu" role="menu">
+      <div
+        className="dropdown-menu"
+        id="dropdown-menu"
+        role="menu"
+        ref={dropdownRef}
+      >
         <div className="dropdown-content">
           <a
             className={actionItemClasses}


### PR DESCRIPTION
# Summary 
This adds functionality that watches a dropdown ref for clicks external to it. If it is in an open state and a click occurs external to the element, the `isActionsOpen` state value will be set to **false**.

# Specific Changes in this PR
- Adds functionality to close dropdowns on clicks external to div

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
 - Go to any Work in meadow that has more than one fileset
 - Go to preservation tab and click actions
 - Click actions on another fileset
 - The previous actions dropdown should close

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

