### PR TITLE
Include mediainfo tech metadata in FileSet GraphQL response

### DIFF
--- a/app/lib/meadow/indexing/file_set.ex
+++ b/app/lib/meadow/indexing/file_set.ex
@@ -11,7 +11,7 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.FileSet do
       createDate: file_set.inserted_at,
       description: file_set.core_metadata.description,
       digests: file_set.core_metadata.digests,
-      extractedMetadata: ExtractedMetadata.transform(file_set.extracted_metadata),
+      extractedMetadata: extracted_metadata(file_set.extracted_metadata),
       id: file_set.id,
       label: file_set.core_metadata.label,
       mime_type: file_set.core_metadata.mime_type,
@@ -24,9 +24,13 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.FileSet do
       streamingUrl: FileSets.distribution_streaming_uri_for(file_set),
       visibility: format(file_set.work.visibility),
       webvtt: file_set.structural_metadata.value,
-      workId: file_set.work.id,
+      workId: file_set.work.id
     }
   end
+
+  def extracted_metadata(%{"exif" => _} = value), do: ExtractedMetadata.transform(value)
+  def extracted_metadata(%{"mediainfo" => _}), do: nil
+  def extracted_metadata(value), do: value
 
   defp format(%{id: id, name: name}), do: %{id: id, name: name}
   defp format(%{id: id, title: title}), do: %{id: id, title: title}

--- a/app/lib/meadow/indexing/work.ex
+++ b/app/lib/meadow/indexing/work.ex
@@ -1,5 +1,8 @@
 defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Work do
   alias Meadow.Data.FileSets
+
+  alias Elasticsearch.Document.Meadow.Data.Schemas.FileSet, as: FileSetDocument
+
   alias Elasticsearch.Document.Meadow.Data.Schemas.WorkAdministrativeMetadata,
     as: AdministrativeMetadataDocument
 
@@ -7,7 +10,6 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Work do
     as: DescriptiveMetadataDocument
 
   alias Meadow.IIIF
-  alias Meadow.Utils.ExtractedMetadata
 
   def id(work), do: work.id
   def routing(_), do: false
@@ -24,7 +26,7 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Work do
         |> Enum.map(fn file_set ->
           %{
             id: file_set.id,
-            extractedMetadata: ExtractedMetadata.transform(file_set.extracted_metadata),
+            extractedMetadata: FileSetDocument.extracted_metadata(file_set.extracted_metadata),
             label: file_set.core_metadata.label,
             mime_type: file_set.core_metadata.mime_type,
             posterOffset: file_set.poster_offset,

--- a/app/lib/meadow/utils/extracted_metadata.ex
+++ b/app/lib/meadow/utils/extracted_metadata.ex
@@ -10,7 +10,6 @@ defmodule Meadow.Utils.ExtractedMetadata do
     |> Enum.map(fn {key, data} ->
       case key do
         "exif" -> {key, transform_data(data, &Exif.transform/1)}
-        "mediainfo" -> nil
         _ -> {key, data}
       end
     end)


### PR DESCRIPTION
# Summary 

Include mediainfo tech metadata in FileSet GraphQL response

# Specific Changes in this PR

- Allow mediainfo tech metadata to pass through to the GraphQL extractedMetadata field
- Continue to suppress indexing of mediainfo metadata

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

1. Ingest an audio or video file
2. Retrieve the work with fileSets -> extractedMetadata in graphiql
3. Make sure extractedMetadata is present
4. Check the same FileSet in the index and make sure extractedMetadata is not present

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

