### PR TITLE
Adds Meadow.Data.Reindexer to populate separate 'v2' indexes from the 'v1' index

### DIFF
--- a/app/lib/meadow/application/children.ex
+++ b/app/lib/meadow/application/children.ex
@@ -12,6 +12,7 @@ defmodule Meadow.Application.Children do
       "batch_driver" => Meadow.BatchDriver,
       "csv_update_driver" => Meadow.CSVMetadataUpdateDriver,
       "index_worker" => {Meadow.Data.IndexWorker, interval: Config.index_interval()},
+      "reindex_worker" => {Meadow.Data.ReindexWorker, interval: Config.index_interval()},
       "database_listeners" => [
         Meadow.ARKListener,
         Meadow.FilesetDeleteListener,

--- a/app/lib/meadow/data/reindex_worker.ex
+++ b/app/lib/meadow/data/reindex_worker.ex
@@ -1,0 +1,18 @@
+defmodule Meadow.Data.ReindexWorker do
+  @moduledoc """
+  IntervalTask that reindexes from V1 to V2
+  """
+  alias Meadow.Data.Reindexer
+  alias Meadow.IntervalTask
+
+  use IntervalTask, default_interval: 1_000, function: :synchronize
+
+  @impl IntervalTask
+  def initial_state(_args),
+    do: %{override: true, tasks: %{}}
+
+  def synchronize(%{tasks: tasks} = state) do
+    tasks = Reindexer.synchronize(tasks)
+    {:noreply, Map.replace(state, :tasks, tasks)}
+  end
+end

--- a/app/lib/meadow/data/reindexer.ex
+++ b/app/lib/meadow/data/reindexer.ex
@@ -1,0 +1,52 @@
+defmodule Meadow.Data.Reindexer do
+  @moduledoc """
+  Reindexes from v1 to v2 using the OpenSearch Reindex API.
+  """
+  use Meadow.Utils.Logging
+
+  alias Meadow.Config
+  alias Meadow.Data.Schemas.{Collection, FileSet, Work}
+  alias Meadow.Search.Client, as: SearchClient
+
+  require Logger
+
+  def synchronize(tasks) do
+    with_log_metadata module: __MODULE__ do
+      [FileSet, Work, Collection]
+      |> Enum.map(&process_schema(&1, Map.get(tasks, &1, nil)))
+      |> Enum.into(%{})
+    end
+  end
+
+  defp process_schema(schema, task_id) do
+    if SearchClient.task_completed?(task_id) do
+      synchronize_schema(schema)
+    else
+      {schema, task_id}
+    end
+  end
+
+  defp synchronize_schema(schema) do
+    destination = Config.v2_index(schema)
+
+    case SearchClient.latest_v2_indexed_time(schema) do
+      {:ok, indexed_at} ->
+        case SearchClient.reindex(schema, indexed_at) do
+          {:ok, task} ->
+            Logger.info(
+              "Documents newer than #{indexed_at} reindexing into #{destination}, task: #{task}"
+            )
+
+            {schema, task}
+
+          {:error, error} ->
+            Logger.error("Error reindexing into #{destination}: #{inspect(error)}")
+            {schema, nil}
+        end
+
+      {:error, error} ->
+        Logger.error("Error reindexing into #{destination}: #{inspect(error)}")
+        {schema, nil}
+    end
+  end
+end

--- a/app/lib/meadow/indexing/collection.ex
+++ b/app/lib/meadow/indexing/collection.ex
@@ -26,7 +26,8 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Collection do
             }
         end,
       title: collection.title,
-      visibility: format(collection.visibility)
+      visibility: format(collection.visibility),
+      indexed_at: NaiveDateTime.utc_now()
     }
   end
 

--- a/app/lib/meadow/indexing/file_set.ex
+++ b/app/lib/meadow/indexing/file_set.ex
@@ -24,7 +24,8 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.FileSet do
       streamingUrl: FileSets.distribution_streaming_uri_for(file_set),
       visibility: format(file_set.work.visibility),
       webvtt: file_set.structural_metadata.value,
-      workId: file_set.work.id
+      workId: file_set.work.id,
+      indexed_at: NaiveDateTime.utc_now()
     }
   end
 

--- a/app/lib/meadow/indexing/work.ex
+++ b/app/lib/meadow/indexing/work.ex
@@ -62,7 +62,8 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Work do
           url -> url <> "/full/!300,300/0/default.jpg"
         end,
       visibility: format(work.visibility),
-      workType: format(work.work_type)
+      workType: format(work.work_type),
+      indexed_at: NaiveDateTime.utc_now()
     }
     |> Map.merge(AdministrativeMetadataDocument.encode(work.administrative_metadata))
     |> Map.merge(DescriptiveMetadataDocument.encode(work.descriptive_metadata))

--- a/app/lib/meadow/release_tasks.ex
+++ b/app/lib/meadow/release_tasks.ex
@@ -11,6 +11,7 @@ defmodule Meadow.ReleaseTasks do
   @modules [
     Meadow.BatchDriver,
     Meadow.Data.IndexWorker,
+    Meadow.Data.ReindexWorker,
     Meadow.Ingest.Progress,
     Meadow.Ingest.WorkCreator,
     Meadow.Ingest.WorkRedriver

--- a/app/lib/meadow/search/client.ex
+++ b/app/lib/meadow/search/client.ex
@@ -1,0 +1,240 @@
+defmodule Meadow.Search.Client do
+  @moduledoc """
+  Defines functions for making Search requests via the OpenSearch HTTP API
+  """
+
+  alias Elastix.HTTP, as: ElastixHTTP
+  alias Meadow.{Config, Error}
+  alias Meadow.ElasticsearchCluster, as: Cluster
+
+  use Retry
+  require Logger
+
+  def delete_by_query(target, query) when is_list(target) do
+    target
+    |> Enum.map_join(",", &to_string/1)
+    |> delete_by_query(query)
+  end
+
+  def delete_by_query(target, query) when is_atom(target),
+    do: target |> to_string() |> delete_by_query(query)
+
+  def delete_by_query(target, query) do
+    with cluster <- Config.elasticsearch_url(),
+         url <- ElastixHTTP.prepare_url(cluster, [target, "_delete_by_query"]),
+         query <- json_encode(query) do
+      case request(:post, url, query) do
+        {:ok, %{body: %{"deleted" => deleted}}} ->
+          Logger.info("Deleting #{deleted} documents from #{target}")
+          {:ok, deleted}
+
+        {:ok, %{body: %{"error" => %{"reason" => reason}}}} ->
+          {:error, reason}
+
+        {:error, reason} ->
+          {:error, inspect(reason)}
+      end
+    end
+  end
+
+  def indexed_doc_count(target) do
+    with cluster <- Config.elasticsearch_url(),
+         url <-
+           ElastixHTTP.prepare_url(cluster, [target, "_count"]) do
+      case request(:get, url) do
+        {:ok, %{body: %{"count" => count}}} -> {:ok, count}
+        {:ok, %{body: %{"error" => %{"reason" => reason}}}} -> {:error, reason}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  def latest_v2_indexed_time(model) do
+    with target <- Config.v2_index(model),
+         query <- %{
+           query: %{
+             match_all: %{}
+           },
+           size: 1,
+           sort: [%{indexed_at: %{order: "desc"}}]
+         } do
+      case search(target, query) do
+        {:ok, []} ->
+          {:ok, "1970-01-01"}
+
+        {:ok, [hit]} ->
+          {:ok, hit["_source"]["indexed_at"]}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  def reindex(model, indexed_at) when is_atom(model) do
+    model = Config.search_model_from_schema(model)
+    reindex(model, indexed_at)
+  end
+
+  def reindex(model, indexed_at) do
+    with cluster <- Config.elasticsearch_url(),
+         url <-
+           ElastixHTTP.prepare_url(cluster, "_reindex")
+           |> ElastixHTTP.append_query_string(wait_for_completion: false),
+         query <- reindex_query(model, indexed_at) do
+      case request(:post, url, query, recv_timeout: 20_000) do
+        {:ok, %{body: %{"task" => task}}} ->
+          {:ok, task}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  defp reindex_query(model, indexed_at) do
+    %{
+      source: %{
+        index: Config.v1_index(),
+        query: %{
+          bool: %{
+            must: [
+              %{
+                term: %{
+                  "model.name.keyword": %{
+                    value: model
+                  }
+                }
+              },
+              %{
+                range: %{
+                  indexed_at: %{
+                    gt: indexed_at
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      dest: %{
+        index: Config.v2_index(model),
+        pipeline: model |> Config.v2_index() |> Config.v2_pipeline()
+      }
+    }
+    |> json_encode()
+  end
+
+  def search(target, query)
+
+  def search(target, query)
+      when is_list(target) do
+    target
+    |> Enum.join(",")
+    |> search(query)
+  end
+
+  def search(target, query) do
+    with cluster <- Config.elasticsearch_url(),
+         url <- ElastixHTTP.prepare_url(cluster, [target, "_search"]),
+         query <- json_encode(query) do
+      case request(:post, url, query) do
+        {:ok, %{body: %{"aggregations" => %{"group_by_id" => %{"buckets" => buckets}}}}} ->
+          {:ok, buckets}
+
+        {:ok, %{body: %{"hits" => %{"hits" => hits}}}} ->
+          {:ok, hits}
+
+        {:ok, %{body: %{"error" => %{"reason" => reason}}}} ->
+          {:error, reason}
+
+        {:error, reason} ->
+          {:error, inspect(reason)}
+      end
+    end
+  end
+
+  def task_completed?(nil), do: true
+
+  def task_completed?(task_id) do
+    with cluster <- Config.elasticsearch_url(),
+         url <-
+           ElastixHTTP.prepare_url(cluster, [
+             "_tasks",
+             task_id
+           ]) do
+      case request(:get, url) do
+        {:ok, %{body: %{"completed" => completed}}} -> completed
+        _ -> true
+      end
+    end
+  end
+
+  def task_created_count(task_id) do
+    with cluster <- Config.elasticsearch_url(),
+         url <-
+           ElastixHTTP.prepare_url(cluster, [
+             "_tasks",
+             task_id
+           ]) do
+      case request(:get, url) do
+        {:ok, %{body: %{"response" => %{"created" => created}}}} -> {:ok, created}
+        _ -> {:error, "No task found for #{task_id}"}
+      end
+    end
+  end
+
+  defp json_encode(val) do
+    with mod <- :meadow |> Application.get_env(Cluster) |> get_in([:json_library]) do
+      mod.encode!(val)
+    end
+  end
+
+  defp request(method, url, body \\ "", options \\ []) do
+    retry with: exponential_backoff() |> randomize() |> cap(1_000) |> Stream.take(10),
+          atoms: [:retry],
+          rescue_only: [] do
+      case ElastixHTTP.request(method, url, body, [], options) do
+        {:ok, %{status_code: status} = response} when status in 200..399 ->
+          {:ok, response}
+
+        {:ok, %{status_code: 404} = response} ->
+          {:ok, response}
+
+        {:ok, %{status_code: 429} = response} ->
+          {:retry, response}
+
+        {:error, error} ->
+          {:error, error}
+
+        response ->
+          "Unexpected response from Elastix.HTTP.request/5: #{inspect(response)}"
+          |> Logger.warn()
+
+          {:error, response}
+      end
+    after
+      result ->
+        result |> maybe_report(%{method: method, url: url, body: body})
+    else
+      error ->
+        error |> maybe_report(%{method: method, url: url, body: body})
+    end
+  end
+
+  defp maybe_report(
+         {:error, {:ok, %HTTPoison.Response{body: %{"error" => %{"reason" => reason}}}}} =
+           response,
+         context
+       ) do
+    Error.report(%HTTPoison.Error{reason: reason}, __MODULE__, [], context)
+    response
+  end
+
+  defp maybe_report({:error, reason} = response, context) do
+    Error.report(inspect(reason), __MODULE__, [], context)
+    response
+  end
+
+  defp maybe_report(response, _), do: response
+end

--- a/app/lib/mix/tasks/elasticsearch.ex
+++ b/app/lib/mix/tasks/elasticsearch.ex
@@ -14,6 +14,7 @@ defmodule Mix.Tasks.Meadow.Elasticsearch.Setup do
   def run(_) do
     RetryAPI.configure()
     Logger.info("Creating Elasticsearch index")
+    System.put_env("MEADOW_PROCESSES", "none")
     Mix.Task.run("app.config")
 
     indexes =
@@ -42,6 +43,7 @@ defmodule Mix.Tasks.Meadow.Elasticsearch.Pipelines do
   def run(_) do
     RetryAPI.configure()
     Logger.info("Creating Elasticsearch ingest pipelines")
+    System.put_env("MEADOW_PROCESSES", "none")
     Mix.Task.run("app.config")
 
     Path.wildcard("priv/elasticsearch/*/pipelines/**/*.*")
@@ -151,6 +153,7 @@ defmodule Mix.Tasks.Meadow.Elasticsearch.Teardown do
 
   @shortdoc @moduledoc
   def run(_) do
+    System.put_env("MEADOW_PROCESSES", "none")
     Mix.Task.run("app.config")
     Logger.info("Tearing down Elasticsearch environment")
 
@@ -253,6 +256,7 @@ defmodule Mix.Tasks.Meadow.Elasticsearch.Clear do
 
   @shortdoc @moduledoc
   def run(_) do
+    System.put_env("MEADOW_PROCESSES", "none")
     Mix.Task.run("app.config")
 
     with url <- Application.get_env(:meadow, Meadow.ElasticsearchCluster) |> Keyword.get(:url),

--- a/app/priv/elasticsearch/v2/pipelines/v1-to-v2/collection.json
+++ b/app/priv/elasticsearch/v2/pipelines/v1-to-v2/collection.json
@@ -1,69 +1,69 @@
 {
-    "description": "Digital Collections API V1-to-V2 Collection Pipeline",
-    "processors": [
-      {
-        "rename": {
-          "field": "adminEmail",
-          "target_field": "admin_email"
-        }
-      },
-      {
-        "set": {
-          "field": "api_link",
-          "value": "[PLACEHOLDER]/{{id}}"
-        }
-      },
-      {
-        "set": {
-          "field": "api_model",
-          "value": "Collection"
-        }
-      },
-      {
-        "rename": {
-          "field": "createDate",
-          "target_field": "create_date"
-        }
-      },
-      {
-        "rename": {
-          "field": "findingAidUrl",
-          "target_field": "finding_aid_url"
-        }
-      },
-      {
-        "rename": {
-          "field": "modifiedDate",
-          "target_field": "modified_date"
-        }
-      },
-      {
-        "rename": {
-          "field": "representativeImage",
-          "target_field": "representative_image"
-        }
-      },
-      {
-        "remove": {
-          "field": "model"
-        }
-      },
-      {
-        "set": {
-          "field": "visibility_copy",
-          "value": "{{visibility.label}}"
-        }
-      },
-      {
-        "remove": {
-          "field": "visibility"
-        }
-      },
-      {
-        "rename": {
-          "field": "visibility_copy",
-          "target_field": "visibility"
-        }
+  "description": "Digital Collections API V1-to-V2 Collection Pipeline",
+  "processors": [
+    {
+      "rename": {
+        "field": "adminEmail",
+        "target_field": "admin_email"
       }
-    ]
-  }
+    },
+    {
+      "set": {
+        "field": "api_link",
+        "value": "[PLACEHOLDER]/{{id}}"
+      }
+    },
+    {
+      "set": {
+        "field": "api_model",
+        "value": "Collection"
+      }
+    },
+    {
+      "rename": {
+        "field": "createDate",
+        "target_field": "create_date"
+      }
+    },
+    {
+      "rename": {
+        "field": "findingAidUrl",
+        "target_field": "finding_aid_url"
+      }
+    },
+    {
+      "rename": {
+        "field": "modifiedDate",
+        "target_field": "modified_date"
+      }
+    },
+    {
+      "rename": {
+        "field": "representativeImage",
+        "target_field": "representative_image"
+      }
+    },
+    {
+      "remove": {
+        "field": "model"
+      }
+    },
+    {
+      "set": {
+        "field": "visibility_copy",
+        "value": "{{visibility.label}}"
+      }
+    },
+    {
+      "remove": {
+        "field": "visibility"
+      }
+    },
+    {
+      "rename": {
+        "field": "visibility_copy",
+        "target_field": "visibility"
+      }
+    }
+  ]
+}

--- a/app/priv/elasticsearch/v2/pipelines/v1-to-v2/work-file-sets.groovy
+++ b/app/priv/elasticsearch/v2/pipelines/v1-to-v2/work-file-sets.groovy
@@ -2,7 +2,7 @@ ctx.file_sets = ctx.original.fileSets
   .stream()
   .map(fs -> {
     def result = [:];
-    result.extracted_metadata = fs.extractedMetadata;
+    // result.extracted_metadata = fs.extractedMetadata;
     result.id = fs.id;
     result.label = fs.label;
     result.mime_type = fs.mime_type;

--- a/app/priv/elasticsearch/v2/pipelines/v1-to-v2/work.json
+++ b/app/priv/elasticsearch/v2/pipelines/v1-to-v2/work.json
@@ -438,6 +438,20 @@
       }
     },
     {
+      "rename": {
+        "field": "original.indexed_at",
+        "target_field": "indexed_at",
+        "on_failure": [
+          {
+            "set": {
+              "field": "indexed_at",
+              "value": "1970-01-01"
+            }
+          }
+        ]
+      }
+    },
+    {
       "remove": {
         "field": "original"
       }

--- a/app/priv/elasticsearch/v2/settings/collection.json
+++ b/app/priv/elasticsearch/v2/settings/collection.json
@@ -3,5 +3,22 @@
     "index": {
       "max_result_window": "50000"
     }
+  },
+  "mappings": {
+    "properties": {
+      "indexed_at": {
+        "type": "date"
+      }
+    },
+    "dynamic_templates": [
+      {
+        "strings": {
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      }
+    ]
   }
 }

--- a/app/priv/elasticsearch/v2/settings/file_set.json
+++ b/app/priv/elasticsearch/v2/settings/file_set.json
@@ -8,25 +8,14 @@
         "full_analyzer": {
           "type": "custom",
           "tokenizer": "standard",
-          "char_filter": [
-            "html_strip"
-          ],
-          "filter": [
-            "lowercase",
-            "asciifolding"
-          ]
+          "char_filter": ["html_strip"],
+          "filter": ["lowercase", "asciifolding"]
         },
         "stopword_analyzer": {
           "type": "custom",
           "tokenizer": "standard",
-          "char_filter": [
-            "html_strip"
-          ],
-          "filter": [
-            "lowercase",
-            "asciifolding",
-            "english_stop"
-          ]
+          "char_filter": ["html_strip"],
+          "filter": ["lowercase", "asciifolding", "english_stop"]
         }
       },
       "filter": {
@@ -38,6 +27,11 @@
     }
   },
   "mappings": {
+    "properties": {
+      "indexed_at": {
+        "type": "date"
+      }
+    },
     "dynamic_templates": [
       {
         "text_fields": {

--- a/app/priv/elasticsearch/v2/settings/work.json
+++ b/app/priv/elasticsearch/v2/settings/work.json
@@ -8,25 +8,14 @@
         "full_analyzer": {
           "type": "custom",
           "tokenizer": "standard",
-          "char_filter": [
-            "html_strip"
-          ],
-          "filter": [
-            "lowercase",
-            "asciifolding"
-          ]
+          "char_filter": ["html_strip"],
+          "filter": ["lowercase", "asciifolding"]
         },
         "stopword_analyzer": {
           "type": "custom",
           "tokenizer": "standard",
-          "char_filter": [
-            "html_strip"
-          ],
-          "filter": [
-            "lowercase",
-            "asciifolding",
-            "english_stop"
-          ]
+          "char_filter": ["html_strip"],
+          "filter": ["lowercase", "asciifolding", "english_stop"]
         }
       },
       "filter": {
@@ -56,21 +45,22 @@
       },
       "all_ids": {
         "type": "keyword"
+      },
+      "indexed_at": {
+        "type": "date"
       }
     },
     "dynamic_templates": [
       {
         "text_fields": {
-          "match": "^abstract$|^alternate_title$|^caption$|^collection.title$|^cultural_context$|^description$|^file_sets.label$|^file_sets.description$|^notes$|^table_of_contents$|^title$",
+          "match": "^abstract$|^alternate_title$|^caption$|^collection.title$|^cultural_context$|^description$|^file_sets.label$|^file_sets.description$|^notes.text$|^table_of_contents$|^title$",
           "match_pattern": "regex",
           "mapping": {
             "type": "text",
             "analyzer": "full_analyzer",
             "search_analyzer": "stopword_analyzer",
             "search_quote_analyzer": "full_analyzer",
-            "copy_to": [
-              "all_text"
-            ]
+            "copy_to": ["all_text"]
           }
         }
       },
@@ -80,9 +70,7 @@
           "match_pattern": "regex",
           "mapping": {
             "type": "keyword",
-            "copy_to": [
-              "all_ids"
-            ]
+            "copy_to": ["all_ids"]
           }
         }
       },
@@ -123,9 +111,7 @@
           "match_mapping_type": "string",
           "mapping": {
             "type": "keyword",
-            "copy_to": [
-              "all_text"
-            ]
+            "copy_to": ["all_text"]
           }
         }
       }

--- a/app/test/meadow/config_test.exs
+++ b/app/test/meadow/config_test.exs
@@ -6,6 +6,17 @@ defmodule Meadow.ConfigTest do
   alias Meadow.Config
   import Assertions
 
+  test "v2_index/1" do
+    assert Config.v2_index(Meadow.Data.Schemas.FileSet) =~ "file-set"
+    assert Config.v2_index(FileSet) =~ "file-set"
+    assert Config.v2_index("FileSet") =~ "file-set"
+  end
+
+  test "search_model_from_schema/1" do
+    assert Config.search_model_from_schema(Meadow.Data.Schemas.FileSet) == "FileSet"
+    assert Config.search_model_from_schema(FileSet) == "FileSet"
+  end
+
   test "index_interval/0" do
     assert Config.index_interval() == 1234
   end

--- a/app/test/meadow/data/reindexer_test.exs
+++ b/app/test/meadow/data/reindexer_test.exs
@@ -1,0 +1,75 @@
+defmodule Meadow.Data.ReindexerTest do
+  use Meadow.DataCase
+  use Meadow.IndexCase
+
+  alias Meadow.Data.{Indexer, Reindexer}
+  alias Meadow.Data.Schemas.{Collection, FileSet, Work}
+  alias Meadow.Repo
+
+  import Assertions
+  import ExUnit.CaptureLog
+
+  @timeout 10_000
+
+  setup do
+    data = indexable_data()
+    Indexer.synchronize_index()
+
+    {:ok, data}
+  end
+
+  describe "synchronize/1" do
+    test "first pass" do
+      log =
+        capture_log(fn ->
+          for {_state, task_id} <-
+                Reindexer.synchronize(%{Collection: nil, FileSet: nil, Work: nil}) do
+            refute is_nil(task_id)
+          end
+        end)
+
+      assert log |> String.contains?("Documents newer than 1970-01-01")
+
+      assert_async timeout: @timeout, sleep_interval: 250 do
+        log =
+          capture_log(fn -> Reindexer.synchronize(%{Collection: nil, FileSet: nil, Work: nil}) end)
+
+        refute log |> String.contains?("Documents newer than 1970-01-01")
+        assert all_synchronized?([Work, FileSet, Collection])
+      end
+    end
+
+    test "add documents", data do
+      reindexer_state = Reindexer.synchronize(%{Collection: nil, FileSet: nil, Work: nil})
+
+      work_with_file_sets_fixture(3, %{collection_id: data.collection.id})
+      log = capture_log(fn -> Indexer.synchronize_index() end)
+      assert log |> String.contains?("Index updates: +3 ~0 -0")
+      assert log |> String.contains?("Index updates: +1 ~0 -0")
+
+      assert_async timeout: @timeout, sleep_interval: 250 do
+        Reindexer.synchronize(reindexer_state)
+        assert all_synchronized?([Work, FileSet, Collection])
+      end
+    end
+
+    test "delete documents", data do
+      Reindexer.synchronize(%{Collection: nil, FileSet: nil, Work: nil})
+
+      assert_async timeout: @timeout, sleep_interval: 150 do
+        assert all_synchronized?([Work, FileSet, Collection])
+      end
+
+      data.works
+      |> Enum.take(2)
+      |> Enum.each(&Repo.delete/1)
+
+      log = capture_log(fn -> Indexer.synchronize_index() end)
+      assert Regex.scan(~r/Index updates: \+0 ~0 -12/, log) |> List.flatten() |> length() == 2
+
+      assert_async timeout: @timeout, sleep_interval: 250 do
+        assert all_synchronized?([Work, FileSet, Collection])
+      end
+    end
+  end
+end

--- a/app/test/meadow/search/client_test.exs
+++ b/app/test/meadow/search/client_test.exs
@@ -1,0 +1,102 @@
+defmodule Meadow.Search.ClientTest do
+  use Meadow.DataCase
+  use Meadow.IndexCase
+
+  import ExUnit.CaptureLog
+  import Meadow.IndexCase
+
+  alias Meadow.Config
+  alias Meadow.Data.Indexer
+  alias Meadow.Data.Schemas.Work
+  alias Meadow.Search.Client
+
+  setup do
+    data = indexable_data()
+    Indexer.synchronize_index()
+
+    {:ok, data}
+  end
+
+  test "delete_by_query/3", %{count: count} do
+    target = Config.v1_index()
+    query = %{query: %{match_all: %{}}}
+
+    assert capture_log(fn ->
+             assert indexed_doc_count(target) == count
+             assert {:ok, ^count} = Client.delete_by_query(target, query)
+           end) =~ "Deleting #{count} documents from #{target}"
+  end
+
+  test "indexed_doc_count/1" do
+    assert {:ok, 16} = Client.indexed_doc_count(Config.v1_index())
+    assert {:ok, 0} = Client.indexed_doc_count(Config.v2_index("Work"))
+    assert {:error, reason} = Client.indexed_doc_count("BAD_INDEX")
+    assert reason =~ "BAD_INDEX"
+  end
+
+  test "latest_v2_indexed_time/1" do
+    assert {:ok, "1970-01-01"} = Client.latest_v2_indexed_time("Collection")
+
+    now = NaiveDateTime.utc_now()
+
+    data =
+      %{
+        adminEmail: "test@example.com",
+        createDate: now,
+        findingAidUrl: "test",
+        modifiedDate: now,
+        representativeImage: "test",
+        model: "test",
+        visibility: %{label: "test"},
+        title: "Test",
+        indexed_at: now
+      }
+      |> Jason.encode!()
+
+    with cluster <- Config.elasticsearch_url(),
+         url <-
+           Elastix.HTTP.prepare_url(cluster, [Config.v2_index("Collection"), "_doc"]) do
+      Elastix.HTTP.post(url, data, [{"Content-Type", "application/json"}])
+    end
+
+    :timer.sleep(1000)
+
+    with {:ok, latest_indexed_time} <- Client.latest_v2_indexed_time("Collection") do
+      assert :eq = NaiveDateTime.compare(now, NaiveDateTime.from_iso8601!(latest_indexed_time))
+    end
+  end
+
+  test "reindex/2" do
+    assert {:ok, 16} = Client.indexed_doc_count(Config.v1_index())
+    assert {:ok, 0} = Client.indexed_doc_count(Config.v2_index("Work"))
+
+    {:ok, task} = Client.reindex("Work", "1970-01-01")
+
+    with {:ok, task_created_count} <- Client.task_created_count(task),
+         {:ok, search_hits} <- Client.search(Config.v2_index("Work"), %{query: %{match_all: %{}}}) do
+      assert task_created_count == length(search_hits)
+    end
+  end
+
+  test "search/3" do
+    with target <- Config.v1_index(),
+         query <- %{query: %{match_all: %{}}} do
+      assert {:ok, _docs} = Client.search(target, query)
+    end
+
+    with target <- [Config.v1_index(), Config.v2_index(Work)],
+         query <- %{query: %{match_all: %{}}} do
+      assert {:ok, _docs} = Client.search(target, query)
+    end
+
+    assert({:error, _reason} = Client.search("BAD_INDEX", %{query: %{}}))
+  end
+
+  test "task_completed?/1" do
+    assert Client.task_completed?(nil)
+    {:ok, task} = Client.reindex("Work", "1970-01-01")
+    refute Client.task_completed?(task)
+    :timer.sleep(1000)
+    assert Client.task_completed?(task)
+  end
+end

--- a/app/test/test_helper.exs
+++ b/app/test/test_helper.exs
@@ -2,11 +2,11 @@ Hush.resolve!()
 Meadow.Repo.wait_for_connection()
 
 Mix.Task.run("ecto.setup")
+Mix.Task.run("meadow.elasticsearch.setup")
 
 unless System.get_env("AWS_DEV_ENVIRONMENT") do
   Mix.Task.run("meadow.pipeline.setup")
   Mix.Task.run("meadow.buckets.create")
-  Mix.Task.run("meadow.elasticsearch.setup")
   Mix.Task.run("meadow.ldap.teardown", ["test/fixtures/ldap_seed.ldif"])
   Mix.Task.run("meadow.ldap.setup", ["test/fixtures/ldap_seed.ldif"])
 end


### PR DESCRIPTION
# Summary 
Adds Meadow.Data.Reindexer, Meadow.Data.ReindexWorker and Meadow.Search.Client modules in order to automatically index documents from `v1` to the three `v2` indexes on an interval.

# Specific Changes in this PR
- Adds Meadow.Data.Reindexer
- Adds Meadow.Data.ReindexWorker
- Adds Meadow.Search.Client

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test
- Reset your dev environment
- Create works/filesets/collections manually or via import
- Spin up your Meadow app and the ReindexWorker will automatically index documents into the correct `v2` index
- Manually clear out your `v1` index
- Documents in your `v2` indexes should automatically be deleted after the next interval comes around

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [x] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

