### PR TITLE
Update front-end and ingest sheet validator to accept any P file

### DIFF
--- a/app/assets/js/hooks/useAcceptedMimeTypes.js
+++ b/app/assets/js/hooks/useAcceptedMimeTypes.js
@@ -73,38 +73,6 @@ export default function useAcceptedMimeTypes() {
         }
         break;
       case "P":
-        switch (workTypeId) {
-          case "IMAGE":
-            if (!isImage) {
-              isValid = false;
-              code = "invalid-image";
-              message =
-                "Image work types Preservation fileset roles must be image mime type";
-            }
-            break;
-          case "AUDIO":
-            if (!isAudio) {
-              isValid = false;
-              code = "invalid-audio";
-              message =
-                "Audio work types Preservation fileset roles must be audio mime type";
-            }
-            break;
-          case "VIDEO":
-            if (!isVideo) {
-              isValid = false;
-              code = "invalid-video";
-              message =
-                "Video work types Preservation fileset roles must be video mime type";
-            }
-            break;
-          default:
-            console.error(`Invalid work type id: ${workTypeId}`);
-            isValid = false;
-            code = "invalid-work-type";
-            message = "Work type is invalid";
-            break;
-        }
         break;
       default:
         console.error(`Invalid file set role: ${fileSetRole}`);

--- a/app/assets/js/hooks/useAcceptedMimeTypes.test.js
+++ b/app/assets/js/hooks/useAcceptedMimeTypes.test.js
@@ -67,28 +67,14 @@ describe("useAcceptedMimeTypes hook", () => {
   describe("Preservation role", () => {
     const { isFileValid } = useAcceptedMimeTypes();
 
-    it("returns the correct mime types for Image work type", () => {
-      const result = isFileValid("P", "IMAGE", "image/tiff");
-      const resultBad = isFileValid("P", "IMAGE", "audio/tiff");
-      expect(result.isValid).toBeTruthy();
-      expect(resultBad.isValid).toBeFalsy();
-      expect(resultBad.code).toEqual("invalid-image");
-    });
+    it("accepts all file types", () => {
+      const results = [
+        isFileValid("P", "VIDEO", "video/x-mts"),
+        isFileValid("P", "IMAGE", "application/octet-stream"),
+        isFileValid("P", "AUDIO", "video/mp4"),
+      ];
 
-    it("returns the correct mime types for Audio work type", () => {
-      const result = isFileValid("P", "AUDIO", "audio/flac");
-      const resultBad = isFileValid("P", "AUDIO", "video/mp4");
-      expect(result.isValid).toBeTruthy();
-      expect(resultBad.isValid).toBeFalsy();
-      expect(resultBad.code).toEqual("invalid-audio");
-    });
-
-    it("returns the correct mime types for Video work type", () => {
-      const result = isFileValid("P", "VIDEO", "video/mp4");
-      const resultBad = isFileValid("P", "VIDEO", "audio/mp4");
-      expect(result.isValid).toBeTruthy();
-      expect(resultBad.isValid).toBeFalsy();
-      expect(resultBad.code).toEqual("invalid-video");
+      expect(results.every((result) => result.isValid)).toBeTruthy();
     });
   });
 });

--- a/app/lib/meadow/ingest/validator.ex
+++ b/app/lib/meadow/ingest/validator.ex
@@ -388,15 +388,17 @@ defmodule Meadow.Ingest.Validator do
 
   defp mime_type_accepted?(_, "X", "image/" <> _rest), do: true
 
+  defp mime_type_accepted?(_, "P", _), do: true
   defp mime_type_accepted?(_, "S", _), do: true
-  defp mime_type_accepted?("IMAGE", role, "image/" <> _rest) when role in ["A", "P"], do: true
+
+  defp mime_type_accepted?("IMAGE", "A", "image/" <> _rest), do: true
   defp mime_type_accepted?("VIDEO", "A", "video/x-matroska"), do: false
   defp mime_type_accepted?("VIDEO", "A", "video/x-vob"), do: false
   defp mime_type_accepted?("VIDEO", "A", "video/x-mts"), do: false
-  defp mime_type_accepted?("VIDEO", role, "video/" <> _rest) when role in ["A", "P"], do: true
+  defp mime_type_accepted?("VIDEO", "A", "video/" <> _rest), do: true
   defp mime_type_accepted?("AUDIO", "A", "audio/x-aiff"), do: false
   defp mime_type_accepted?("AUDIO", "A", "audio/x-flac"), do: false
-  defp mime_type_accepted?("AUDIO", role, "audio/" <> _rest) when role in ["A", "P"], do: true
+  defp mime_type_accepted?("AUDIO", "A", "audio/" <> _rest), do: true
   defp mime_type_accepted?(_, _, _), do: false
 
   defp load_sheet(sheet_id) do


### PR DESCRIPTION
# Summary 

Allow any file to be a preservation file

# Specific Changes in this PR
- Update ingest sheet validator to accept any file type as a `P` file
- Update front end validator to accept any file type as a `P` file
- Update front end tests to reflect the change

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Try to attach files of various types to a work using both ingest sheet and UI ingest. The `P` role should accept anything.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

