### PR TITLE
Poster image bug

### DIFF
--- a/app/assets/js/components/UI/MediaPlayer/PosterSelector.jsx
+++ b/app/assets/js/components/UI/MediaPlayer/PosterSelector.jsx
@@ -52,6 +52,7 @@ function MediaPlayerPosterSelector() {
     }
 
     const posterOffset = parseInt(el.currentTime * 1000);
+
     updateFileSet({
       variables: {
         id: workState.activeMediaFileSet.id,

--- a/app/assets/js/components/Work/Work.jsx
+++ b/app/assets/js/components/Work/Work.jsx
@@ -19,7 +19,6 @@ const osdOptions = {
 
 const Work = ({ work }) => {
   const [manifestObj, setManifestObj] = React.useState();
-  const [manifestKey, setManifestKey] = React.useState("abc");
   const workContextState = useWorkState();
   const workDispatch = useWorkDispatch();
 
@@ -28,14 +27,17 @@ const Work = ({ work }) => {
     ["AUDIO", "VIDEO"].indexOf(work.workType?.id) === -1;
   const { filterFileSets } = useFileSet();
 
-  useQuery(GET_IIIF_MANIFEST_HEADERS, {
+  const {
+    data: dataManifestHeaders,
+    error: errorManifestHeaders,
+    loading: loadingManifestHeaders,
+  } = useQuery(GET_IIIF_MANIFEST_HEADERS, {
     variables: { workId: work.id },
-    pollInterval: 1000,
-    onCompleted: (data) => {
-      if (data.iiifManifestHeaders.etag)
-        setManifestKey(data.iiifManifestHeaders.etag);
-    },
+    pollInterval: 2000,
+    notifyOnNetworkStatusChange: true,
   });
+
+  const etag = dataManifestHeaders?.iiifManifestHeaders?.etag;
 
   React.useEffect(() => {
     workDispatch({ type: "updateWorkType", workTypeId: work.workType.id });
@@ -77,7 +79,7 @@ const Work = ({ work }) => {
               <OpenSeadragonViewer
                 manifest={manifestObj}
                 options={osdOptions}
-                key={manifestKey}
+                key={etag}
               />
             )}
           </div>
@@ -89,7 +91,7 @@ const Work = ({ work }) => {
           fileSet={workContextState?.activeMediaFileSet}
           fileSets={[...filterFileSets(work.fileSets).access]}
           manifestId={work.manifestUrl}
-          manifestKey={manifestKey}
+          manifestKey={etag}
           workTypeId={work.workType?.id}
         />
       )}


### PR DESCRIPTION


# Summary 
Diagnose issues with Poster image not updating properly in the UI

# Specific Changes in this PR
- Update to how the UI is handling a changing `etag` value, which is supposed to update from a GraphQL Query when a manifest is updated.
- list changes

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

