### PR TITLE
Update dispatcher with non-image/audio/video P file actions

### DIFF
--- a/app/lib/meadow/pipeline/dispatcher.ex
+++ b/app/lib/meadow/pipeline/dispatcher.ex
@@ -139,6 +139,9 @@ defmodule Meadow.Pipeline.Dispatcher do
   def dispatcher_actions(%{role: %{id: "P"}, core_metadata: %{mime_type: "video/" <> _}}),
     do: @preservation_video_actions
 
+  def dispatcher_actions(%{role: %{id: "P"}}),
+    do: @preservation_actions
+
   def dispatcher_actions(%{role: %{id: "S"}}),
     do: @preservation_actions
 

--- a/app/test/pipeline/actions/initialize_dispatch_test.exs
+++ b/app/test/pipeline/actions/initialize_dispatch_test.exs
@@ -132,7 +132,7 @@ defmodule Meadow.Pipeline.Actions.InitializeDispatchTest do
       file_set =
         file_set_fixture(%{
           accession_number: row.file_set_accession_number,
-          role: %{id: "P", scheme: "FILE_SET_ROLE"},
+          role: %{id: "A", scheme: "FILE_SET_ROLE"},
           core_metadata: %{
             location: "s3://#{@bucket}/#{@key}",
             original_filename: "test.tif"


### PR DESCRIPTION
# Summary 

Preservation files with non image/AV mime types were passing ingest sheet validation but failing `InitializeDispatch`

# Specific Changes in this PR
- Update Dispatcher to return the same actions for non-image/AV `P` files as it does for `S` files
- Update `InitializeDispatch` test with an invalid role/type combo since the old one is now valid

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Run an ingest sheet with a bunch of P files of random types

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

