### PR TITLE
Use an S3 readable stream instead of a tokenizer in the MIME lambda

### DIFF
--- a/infrastructure/deploy/lambdas.tf
+++ b/infrastructure/deploy/lambdas.tf
@@ -139,7 +139,7 @@ module "mime_type_function" {
   description = "Function to extract the mime-type from an S3 object"
   role        = aws_iam_role.lambda_role.arn
   stack_name  = var.stack_name
-  memory_size = 512
+  memory_size = 256
   timeout     = 120
 
   tags = merge(

--- a/lambdas/mime-type/index.js
+++ b/lambdas/mime-type/index.js
@@ -1,7 +1,6 @@
 const AWS = require("aws-sdk");
 const FileType = require("file-type");
 const MimeTypes = require("mime-types");
-const { makeTokenizer } = require("@tokenizer/s3");
 const path = require("path");
 
 MimeTypes.types['md5'] = 'text/plain';
@@ -17,15 +16,15 @@ const extractMimeType = async (event) => {
   try {
     const s3 = new AWS.S3();
 
-    const s3Tokenizer = await makeTokenizer(s3, {
+    const s3Stream = s3.getObject({
       Bucket: event.bucket,
       Key: event.key,
-    });
+    }).createReadStream();
 
     // response: {"ext":"jpg","mime":"image/jpeg"}
     const fileType =
-      (await FileType.fromTokenizer(s3Tokenizer)) || (await lookupMimeType(event));
-    console.log(JSON.stringify(fileType));
+      (await FileType.fromStream(s3Stream)) || (await lookupMimeType(event));
+    console.log('identified file as', JSON.stringify(fileType));
     return fileType;
   } catch (e) {
     console.error("Error extracting mime-type");

--- a/lambdas/mime-type/package-lock.json
+++ b/lambdas/mime-type/package-lock.json
@@ -9,38 +9,17 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tokenizer/s3": "^0.1.3",
-        "file-type": "^16.5.4",
-        "install": "^0.13.0",
-        "mime-types": "^2.1.31",
-        "strtok3": "~6.1.0"
+        "file-type": "^16.0",
+        "mime-types": "^2.1.31"
       },
       "devDependencies": {
-        "aws-sdk": "^2.833.0"
-      }
-    },
-    "node_modules/@tokenizer/range": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@tokenizer/range/-/range-0.3.3.tgz",
-      "integrity": "sha512-kEIGyLK31/woTYkdJLAVXTcZ6d55J/Ir2y/2S9PnA4MjJPRqlZBssDwKSkEwnuLEZEhQPscKkIC1husW1UC08A==",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "strtok3": "^6.0.4"
-      }
-    },
-    "node_modules/@tokenizer/s3": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@tokenizer/s3/-/s3-0.1.3.tgz",
-      "integrity": "sha512-RMoT960jkGlj/Pu3DrKbIaVN9I1OKnsj80YO5tsIBHX8B/QyEIxBfaIX9115mhyv+OEBY0Staf+0i6dxDnNiLQ==",
-      "dependencies": {
-        "@tokenizer/range": "^0.3.0",
-        "strtok3": "^6.0.0"
+        "aws-sdk": "^2.0"
       }
     },
     "node_modules/@tokenizer/token": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
-      "integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "node_modules/aws-sdk": {
       "version": "2.833.0",
@@ -93,22 +72,6 @@
         "isarray": "^1.0.0"
       }
     },
-    "node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -134,39 +97,6 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
-    "node_modules/file-type/node_modules/@tokenizer/token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
-    },
-    "node_modules/file-type/node_modules/peek-readable": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
-      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/file-type/node_modules/strtok3": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
-      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -177,14 +107,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/install": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/install/-/install-0.13.0.tgz",
-      "integrity": "sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==",
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -220,15 +142,10 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
     "node_modules/peek-readable": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.4.tgz",
-      "integrity": "sha512-DX7ec7frSMtCWw+zMd27f66hcxIz/w9LQTY2RflB4WNHCVPAye1pJiP2t3gvaaOhu7IOhtPbHw8MemMj+F5lrg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
       "engines": {
         "node": ">=8"
       },
@@ -315,12 +232,12 @@
       }
     },
     "node_modules/strtok3": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.1.3.tgz",
-      "integrity": "sha512-ssWSKFOeUTurMSucgyUf+a6Z9mVTYrsYiyEK5RLnh8BM6sFrKSljVlnjZXIDxMguYfdQI+mUPFHo88FYTxq1XA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
       "dependencies": {
-        "@tokenizer/token": "^0.1.1",
-        "peek-readable": "^3.1.4"
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
       },
       "engines": {
         "node": ">=10"
@@ -331,9 +248,9 @@
       }
     },
     "node_modules/token-types": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.0.tgz",
-      "integrity": "sha512-P0rrp4wUpefLncNamWIef62J0v0kQR/GfDVji9WKY7GDCWy5YbVSrKUTam07iWPZQGy0zWNOfstYTykMmPNR7w==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
@@ -345,11 +262,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
-    },
-    "node_modules/token-types/node_modules/@tokenizer/token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "node_modules/token-types/node_modules/ieee754": {
       "version": "1.2.1",
@@ -416,28 +328,10 @@
     }
   },
   "dependencies": {
-    "@tokenizer/range": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@tokenizer/range/-/range-0.3.3.tgz",
-      "integrity": "sha512-kEIGyLK31/woTYkdJLAVXTcZ6d55J/Ir2y/2S9PnA4MjJPRqlZBssDwKSkEwnuLEZEhQPscKkIC1husW1UC08A==",
-      "requires": {
-        "debug": "^4.1.1",
-        "strtok3": "^6.0.4"
-      }
-    },
-    "@tokenizer/s3": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@tokenizer/s3/-/s3-0.1.3.tgz",
-      "integrity": "sha512-RMoT960jkGlj/Pu3DrKbIaVN9I1OKnsj80YO5tsIBHX8B/QyEIxBfaIX9115mhyv+OEBY0Staf+0i6dxDnNiLQ==",
-      "requires": {
-        "@tokenizer/range": "^0.3.0",
-        "strtok3": "^6.0.0"
-      }
-    },
     "@tokenizer/token": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
-      "integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "aws-sdk": {
       "version": "2.833.0",
@@ -473,14 +367,6 @@
         "isarray": "^1.0.0"
       }
     },
-    "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "requires": {
-        "ms": "2.1.2"
-      }
-    },
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -495,27 +381,6 @@
         "readable-web-to-node-stream": "^3.0.0",
         "strtok3": "^6.2.4",
         "token-types": "^4.1.1"
-      },
-      "dependencies": {
-        "@tokenizer/token": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-          "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
-        },
-        "peek-readable": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
-          "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="
-        },
-        "strtok3": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
-          "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
-          "requires": {
-            "@tokenizer/token": "^0.3.0",
-            "peek-readable": "^4.1.0"
-          }
-        }
       }
     },
     "ieee754": {
@@ -528,11 +393,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "install": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/install/-/install-0.13.0.tgz",
-      "integrity": "sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA=="
     },
     "isarray": {
       "version": "1.0.0",
@@ -559,15 +419,10 @@
         "mime-db": "1.48.0"
       }
     },
-    "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
     "peek-readable": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.4.tgz",
-      "integrity": "sha512-DX7ec7frSMtCWw+zMd27f66hcxIz/w9LQTY2RflB4WNHCVPAye1pJiP2t3gvaaOhu7IOhtPbHw8MemMj+F5lrg=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="
     },
     "punycode": {
       "version": "1.3.2",
@@ -619,28 +474,23 @@
       }
     },
     "strtok3": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.1.3.tgz",
-      "integrity": "sha512-ssWSKFOeUTurMSucgyUf+a6Z9mVTYrsYiyEK5RLnh8BM6sFrKSljVlnjZXIDxMguYfdQI+mUPFHo88FYTxq1XA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
       "requires": {
-        "@tokenizer/token": "^0.1.1",
-        "peek-readable": "^3.1.4"
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
       }
     },
     "token-types": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.0.tgz",
-      "integrity": "sha512-P0rrp4wUpefLncNamWIef62J0v0kQR/GfDVji9WKY7GDCWy5YbVSrKUTam07iWPZQGy0zWNOfstYTykMmPNR7w==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
       "requires": {
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
       },
       "dependencies": {
-        "@tokenizer/token": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-          "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
-        },
         "ieee754": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",

--- a/lambdas/mime-type/package.json
+++ b/lambdas/mime-type/package.json
@@ -9,13 +9,10 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@tokenizer/s3": "^0.1.3",
-    "strtok3": "~6.1.0",
-    "file-type": "^16.5.4",
-    "install": "^0.13.0",
+    "file-type": "^16.0",
     "mime-types": "^2.1.31"
   },
   "devDependencies": {
-    "aws-sdk": "^2.833.0"
+    "aws-sdk": "^2.0"
   }
 }


### PR DESCRIPTION
# Summary 

The S3 tokenizer wasn't correctly reading one particular ZIP file, but the readable stream worked fine.

# Specific Changes in this PR
- Change `FileType.fromTokenizer()` to `FileType.fromStream()`
- Remove tokenizer dependencies

Already deployed to staging via Terraform

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Try to ingest `s3://meadow-s-ingest/vrtestingproject-1646238635/Photos-001.zip` and make sure it passes MIME type extraction.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

