### PR TITLE
Add LastModified property to IIIF manifests

### DIFF
--- a/app/lib/meadow/data/schemas/iiif/V2/collection.ex
+++ b/app/lib/meadow/data/schemas/iiif/V2/collection.ex
@@ -7,6 +7,9 @@ defimpl Meadow.IIIF.V2.Resource, for: Meadow.Data.Schemas.Collection do
     %Collection{
       id: collection.id,
       label: collection.description,
+      metadata: [
+        IIIF.V2.property("LastModified", DateTime.utc_now() |> DateTime.to_iso8601())
+      ],
       manifests:
         Enum.map(collection.works, fn work ->
           %Manifest{

--- a/app/lib/meadow/data/schemas/iiif/V2/work.ex
+++ b/app/lib/meadow/data/schemas/iiif/V2/work.ex
@@ -7,6 +7,9 @@ defimpl Meadow.IIIF.V2.Resource, for: Meadow.Data.Schemas.Work do
       id: IIIF.V2.manifest_id(work.id),
       label: work.descriptive_metadata.title,
       description: work.descriptive_metadata.description,
+      metadata: [
+        IIIF.V2.property("LastModified", DateTime.utc_now() |> DateTime.to_iso8601())
+      ],
       sequences: [
         %Sequence{
           canvases:

--- a/app/lib/meadow/data/schemas/iiif/V3/work.ex
+++ b/app/lib/meadow/data/schemas/iiif/V3/work.ex
@@ -19,6 +19,9 @@ defimpl Meadow.IIIF.V3.Resource, for: Meadow.Data.Schemas.Work do
       id: IIIF.V3.manifest_id(work.id),
       label: manifest_label(work),
       summary: summary(work.descriptive_metadata.description),
+      metadata: [
+        IIIF.V3.property("LastModified", DateTime.utc_now() |> DateTime.to_iso8601())
+      ],
       rights: rights_statement(work.descriptive_metadata.rights_statement),
       requiredStatement: %LabelValue{
         label: %Label{en: ["Attribution"]},

--- a/app/lib/meadow/iiif/v2/generator.ex
+++ b/app/lib/meadow/iiif/v2/generator.ex
@@ -28,9 +28,11 @@ defmodule Meadow.IIIF.V2.Generator do
     |> Jason.encode!(pretty: true)
   end
 
+  defp to_json(manifest) when is_struct(manifest),
+    do: manifest |> Map.from_struct() |> to_json()
+
   defp to_json(manifest) do
     manifest
-    |> Map.from_struct()
     |> Enum.map(&set_property/1)
     |> Enum.filter(&filter_property/1)
     |> Enum.into(%{})

--- a/app/lib/meadow/iiif/v2/iiif.ex
+++ b/app/lib/meadow/iiif/v2/iiif.ex
@@ -54,6 +54,18 @@ defmodule Meadow.IIIF.V2 do
     end
   end
 
+  @doc """
+  Generate property
+
+  Examples:
+    iex> property("LastModified", ~U[2022-08-17 15:10:38.486346Z])
+    %{label: %{en: ["LastModified"]}, value: %{en: [~U[2022-08-17 15:10:38.486346Z]]}}
+  """
+  def property(label, value) do
+    value = if is_list(value), do: value, else: [value]
+    %{label: %{en: [label]}, value: %{en: value}}
+  end
+
   def resource_type("AUDIO"), do: "Sound"
   def resource_type(work_type), do: work_type
 

--- a/app/lib/meadow/iiif/v2/presentation/collection.ex
+++ b/app/lib/meadow/iiif/v2/presentation/collection.ex
@@ -8,6 +8,7 @@ defmodule IIIF.V2.Presentation.Collection do
   @descriptive_and_rights context: @default_context,
                           label: nil,
                           description: nil,
+                          metadata: [],
                           thumbnail: nil,
                           attribution: nil,
                           license: nil,

--- a/app/lib/meadow/iiif/v3/generator.ex
+++ b/app/lib/meadow/iiif/v3/generator.ex
@@ -28,9 +28,11 @@ defmodule Meadow.IIIF.V3.Generator do
     |> Jason.encode!(pretty: true)
   end
 
+  defp to_json(manifest) when is_struct(manifest),
+    do: manifest |> Map.from_struct() |> to_json()
+
   defp to_json(manifest) do
     manifest
-    |> Map.from_struct()
     |> Enum.map(&set_property/1)
     |> Enum.filter(&filter_property/1)
     |> Enum.into(%{})

--- a/app/lib/meadow/iiif/v3/iiif.ex
+++ b/app/lib/meadow/iiif/v3/iiif.ex
@@ -97,6 +97,18 @@ defmodule Meadow.IIIF.V3 do
     "#{manifest_id(work_id)}/canvas/#{file_set_id}"
   end
 
+  @doc """
+  Generate property
+
+  Examples:
+    iex> property("LastModified", ~U[2022-08-17 15:10:38.486346Z])
+    %{label: %{en: ["LastModified"]}, value: %{en: [~U[2022-08-17 15:10:38.486346Z]]}}
+  """
+  def property(label, value) do
+    value = if is_list(value), do: value, else: [value]
+    %{label: %{en: [label]}, value: %{en: value}}
+  end
+
   defp write_to_s3(manifest, key) do
     ExAws.S3.put_object(
       Meadow.Config.pyramid_bucket(),

--- a/app/test/meadow/iiif/generator_v3_test.exs
+++ b/app/test/meadow/iiif/generator_v3_test.exs
@@ -32,99 +32,94 @@ defmodule Meadow.IIIF.V3.GeneratorTest do
           }
         })
 
-      json = """
-      {
-        \"id\": \"#{IIIF.V3.manifest_id(work.id)}\",
-        \"items\": [
-          {
-            \"height\": 480,
-            \"id\": \"#{IIIF.V3.canvas_id(work.id, file_set.id)}\",
-            \"items\": [
-              {
-                \"id\": \"#{IIIF.V3.annotation_page_id(work.id, file_set.id, 1)}\",
-                \"items\": [
-                  {
-                    \"body\": {
-                      \"id\": \"https://test-streaming-url/bar.m3u8\",
-                      \"type\": \"Video\"
-                    },
-                    \"id\": \"#{IIIF.V3.annotation_id(work.id, file_set.id, 1, 1)}\",
-                    \"motivation\": \"painting\",
-                    \"target\": \"#{IIIF.V3.canvas_id(work.id, file_set.id)}\",
-                    \"type\": \"Annotation\"
-                  }
-                ],
-                \"type\": \"AnnotationPage\"
-              }
-            ],
-            \"label\": {
-              \"en\": [
-                \"This is the label\"
-              ]
-            },
-            \"type\": \"Canvas\",
-            \"width\": 640
-          },
-          {
-            \"height\": 480,
-            \"id\": \"#{IIIF.V3.canvas_id(work.id, file_set2.id)}\",
-            \"items\": [
-              {
-                \"id\": \"#{IIIF.V3.annotation_page_id(work.id, file_set2.id, 1)}\",
-                \"items\": [
-                  {
-                    \"body\": {
-                      \"id\": \"http://localhost:8184/iiif/2/#{file_set2.id}/full/max/0/default.jpg\",
-                      \"service\": [
-                        {
-                          \"id\": \"http://localhost:8184/iiif/2/#{file_set2.id}\",
-                          \"profile\": \"http://iiif.io/api/image/2/level2.json\",
-                          \"type\": \"ImageService2\"
-                        }
-                      ],
-                      \"type\": \"Image\"
-                    },
-                    \"id\": \"#{IIIF.V3.annotation_id(work.id, file_set2.id, 1, 1)}\",
-                    \"motivation\": \"painting\",
-                    \"target\": \"#{IIIF.V3.canvas_id(work.id, file_set2.id)}\",
-                    \"type\": \"Annotation\"
-                  }
-                ],
-                \"type\": \"AnnotationPage\"
-              }
-            ],
-            \"label\": {
-              \"en\": [
-                \"This should not be in the manifest\"
-              ]
-            },
-            \"type\": \"Canvas\",
-            \"width\": 640
-          }
-        ],
-        \"label\": {
-          \"en\": [
-            \"Test title\"
-          ]
-        },
-        \"requiredStatement\": {
-          \"label\": {
-            \"en\": [
-              \"Attribution\"
-            ]
-          },
-          \"value\": {
-            \"en\": [
-              \"Courtesy of Northwestern University Libraries\"
-            ]
-          }
-        },
-        \"type\": \"Manifest\",
-        \"@context\": \"http://iiif.io/api/presentation/3/context.json\"
-      }\
-      """
+      manifest = Generator.create_manifest(work)
+      assert {:ok, subject} = Jason.decode(manifest, keys: :atoms)
 
-      assert Generator.create_manifest(work) == json
+      manifest_id = IIIF.V3.manifest_id(work.id)
+      canvas1_id = IIIF.V3.canvas_id(work.id, file_set.id)
+      annotation_page1_id = IIIF.V3.annotation_page_id(work.id, file_set.id, 1)
+      annotation1_id = IIIF.V3.annotation_id(work.id, file_set.id, 1, 1)
+      canvas2_id = IIIF.V3.canvas_id(work.id, file_set2.id)
+      annotation_page2_id = IIIF.V3.annotation_page_id(work.id, file_set2.id, 1)
+      annotation2_id = IIIF.V3.annotation_id(work.id, file_set2.id, 1, 1)
+      item2_body_id = "http://localhost:8184/iiif/2/#{file_set2.id}/full/max/0/default.jpg"
+      item2_service_id = "http://localhost:8184/iiif/2/#{file_set2.id}"
+
+      assert %{
+               "@context": "http://iiif.io/api/presentation/3/context.json",
+               id: ^manifest_id,
+               items: [
+                 %{
+                   height: 480,
+                   id: ^canvas1_id,
+                   items: [
+                     %{
+                       id: ^annotation_page1_id,
+                       items: [
+                         %{
+                           body: %{id: "https://test-streaming-url/bar.m3u8", type: "Video"},
+                           id: ^annotation1_id,
+                           motivation: "painting",
+                           target: ^canvas1_id,
+                           type: "Annotation"
+                         }
+                       ],
+                       type: "AnnotationPage"
+                     }
+                   ],
+                   label: %{en: ["This is the label"]},
+                   type: "Canvas",
+                   width: 640
+                 },
+                 %{
+                   height: 480,
+                   id: ^canvas2_id,
+                   items: [
+                     %{
+                       id: ^annotation_page2_id,
+                       items: [
+                         %{
+                           body: %{
+                             id: ^item2_body_id,
+                             service: [
+                               %{
+                                 id: ^item2_service_id,
+                                 profile: "http://iiif.io/api/image/2/level2.json",
+                                 type: "ImageService2"
+                               }
+                             ],
+                             type: "Image"
+                           },
+                           id: ^annotation2_id,
+                           motivation: "painting",
+                           target: ^canvas2_id,
+                           type: "Annotation"
+                         }
+                       ],
+                       type: "AnnotationPage"
+                     }
+                   ],
+                   label: %{en: ["This should not be in the manifest"]},
+                   type: "Canvas",
+                   width: 640
+                 }
+               ],
+               label: %{en: ["Test title"]},
+               metadata: [
+                 %{
+                   label: %{en: ["LastModified"]},
+                   value: %{en: [manifest_last_modified]}
+                 }
+               ],
+               requiredStatement: %{
+                 label: %{en: ["Attribution"]},
+                 value: %{en: ["Courtesy of Northwestern University Libraries"]}
+               },
+               type: "Manifest"
+             } = subject
+
+      assert {:ok, timestamp, _} = manifest_last_modified |> DateTime.from_iso8601()
+      assert timestamp |> DateTime.diff(DateTime.utc_now(), :second) < 2
     end
   end
 end


### PR DESCRIPTION
# Summary 
Add `LastModified` metadata property to IIIF manifests

# Specific Changes in this PR

- Add property function to IIIF modules
- Add metadata to IIIF v2 and v3 manifests

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Generate a manifest and check the top-level `metadata` section

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

