### PR TITLE
Return application/octet-stream for all unknown file types

### DIFF
--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "@absinthe/socket-apollo-link": "^0.2.1",
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",
@@ -107,10 +107,11 @@
       }
     },
     "../deps/phoenix": {
-      "version": "0.0.1"
+      "version": "1.6.10",
+      "license": "MIT"
     },
     "../deps/phoenix_html": {
-      "version": "0.0.1"
+      "version": "3.2.0"
     },
     "node_modules/@absinthe/socket": {
       "version": "0.2.1",

--- a/app/config/config.exs
+++ b/app/config/config.exs
@@ -236,13 +236,19 @@ config :ex_aws,
 
 config :httpoison_retry, wait: 50
 
-config :mime, :types, %{
-  "video/x-mts" => ["mts"],
-  "video/x-vob" => ["vob"],
-  "video/x-m4v" => ["m4v"],
-  "video/x-matroska" => ["mkv"],
-  "audio/x-aiff" => ["aif", "aiff", "aifc"],
-  "audio/x-flac" => ["flac"]
+config :meadow, :extra_mime_types, %{
+  "aif" => "audio/x-aiff",
+  "aifc" => "audio/x-aiff",
+  "aiff" => "audio/x-aiff",
+  "flac" => "audio/x-flac",
+  "framemd5" => "text/plain",
+  "m4v" => "video/x-m4v",
+  "md5" => "text/plain",
+  "mkv" => "video/x-matroska",
+  "mts" => "video/x-mts",
+  "vob" => "video/x-vob",
+  # package defaults to "text/xml"
+  "xml" => "application/xml"
 }
 
 config :hush,

--- a/app/lib/meadow/ingest/validator.ex
+++ b/app/lib/meadow/ingest/validator.ex
@@ -8,7 +8,7 @@ defmodule Meadow.Ingest.Validator do
   alias Meadow.Ingest.{Rows, Sheets}
   alias Meadow.Ingest.Schemas.{Row, Sheet}
   alias Meadow.Repo
-  alias Meadow.Utils.{AWS, MapList, Truth}
+  alias Meadow.Utils.{AWS, MapList, MIME, Truth}
   alias NimbleCSV.RFC4180, as: CSV
   import Ecto.Query
 

--- a/app/lib/meadow/utils/mime.ex
+++ b/app/lib/meadow/utils/mime.ex
@@ -1,0 +1,45 @@
+defmodule Meadow.Utils.MIME do
+  @moduledoc """
+  MIME type helpers that go slightly beyond the functionality
+  provided by the MIME package
+  """
+
+  alias Elixir.MIME, as: MimeTypes
+
+  @doc """
+  Determine the MIME type from a pathname
+
+  Examples:
+    iex> MIME.from_path("/path/to/image.tiff")
+    "image/tiff"
+
+    iex> MIME.from_path("/path/to/image.framemd5")
+    "text/plain"
+
+    iex> MIME.from_path("/path/to/unknown.blorb")
+    "application/octet-stream"
+  """
+  def from_path(path) do
+    with "." <> ext <- path |> Path.extname() do
+      type(ext)
+    end
+  end
+
+  @doc """
+  Determine the MIME type from a file extension
+
+  Examples:
+  iex> MIME.type("tiff")
+  "image/tiff"
+
+  iex> MIME.type("framemd5")
+  "text/plain"
+
+  iex> MIME.type("blorb")
+  "application/octet-stream"
+  """
+  def type(ext) do
+    Application.get_env(:meadow, :extra_mime_types)
+    |> Map.get(to_string(ext), MimeTypes.type(ext))
+  end
+end

--- a/app/test/meadow/utils/mime_test.exs
+++ b/app/test/meadow/utils/mime_test.exs
@@ -1,0 +1,22 @@
+defmodule Meadow.Utils.MIMETest do
+  use ExUnit.Case
+
+  alias Meadow.Utils.MIME
+
+  # Can't simply doctest because it won't pick up the configured custom types
+
+  test "get a MIME type known to the MIME package" do
+    assert MIME.from_path("/path/to/image.tiff") == "image/tiff"
+    assert MIME.type("tiff") == "image/tiff"
+  end
+
+  test "get a MIME type known to Meadow but not the MIME package" do
+    assert MIME.from_path("/path/to/image.framemd5") == "text/plain"
+    assert MIME.type("framemd5") == "text/plain"
+  end
+
+  test "return application/octet-stream for unknown file type" do
+    assert MIME.from_path("/path/to/unknown.blorb") == "application/octet-stream"
+    assert MIME.type("blorb") == "application/octet-stream"
+  end
+end

--- a/app/test/pipeline/actions/extract_mime_type_test.exs
+++ b/app/test/pipeline/actions/extract_mime_type_test.exs
@@ -64,7 +64,9 @@ defmodule Meadow.Pipeline.Actions.ExtractMimeTypeTest do
         end)
 
       assert log =~ ~r/Received undefined response from lambda/
-      assert log =~ ~r"not_a_tiff.tif appears to be image/tiff but magic number doesn't match."
+
+      assert log =~
+               ~r"not_a_tiff.tif attempting to fall back to image/tiff but magic number doesn't match."
     end
 
     @tag fixture_file: @json_file, file_set_role_id: "P"
@@ -92,7 +94,7 @@ defmodule Meadow.Pipeline.Actions.ExtractMimeTypeTest do
     end
 
     @tag fixture_file: @random_file, file_set_role_id: "S"
-    test "supplemental file falls back to application/octet-stream", %{file_set_id: file_set_id} do
+    test "unknown file type falls back to application/octet-stream", %{file_set_id: file_set_id} do
       send_test_message(ExtractMimeType, %{file_set_id: file_set_id}, %{})
       assert(ActionStates.ok?(file_set_id, ExtractMimeType))
 

--- a/infrastructure/deploy/.terraform.lock.hcl
+++ b/infrastructure/deploy/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/archive" {
   version = "2.2.0"
   hashes = [
     "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
+    "h1:CIWi5G6ob7p2wWoThRQbOB8AbmFlCzp7Ka81hR3cVp0=",
     "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
     "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
     "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 3.62.0, >= 4.0.0, ~> 4.8"
   hashes = [
     "h1:F9BjbxBhuo1A/rP318IUrkW3TAh29i6UC18qwhzCs6c=",
+    "h1:S6xGPRL08YEuBdemiYZyIBf/YwM4OCvzVuaiuU6kLjc=",
     "zh:0a2a7eabfeb7dbb17b7f82aff3fa2ba51e836c15e5be4f5468ea44bd1299b48d",
     "zh:23409c7205d13d2d68b5528e1c49e0a0455d99bbfec61eb0201142beffaa81f7",
     "zh:3adad2245d97816f3919778b52c58fb2de130938a3e9081358bfbb72ec478d9a",
@@ -43,6 +45,7 @@ provider "registry.terraform.io/hashicorp/external" {
   version = "2.2.2"
   hashes = [
     "h1:VUkgcWvCliS0HO4kt7oEQhFD2gcx/59XpwMqxfCU1kE=",
+    "h1:e7RpnZ2PbJEEPnfsg7V0FNwbfSk0/Z3FdrLsXINBmDY=",
     "zh:0b84ab0af2e28606e9c0c1289343949339221c3ab126616b831ddb5aaef5f5ca",
     "zh:10cf5c9b9524ca2e4302bf02368dc6aac29fb50aeaa6f7758cce9aa36ae87a28",
     "zh:56a016ee871c8501acb3f2ee3b51592ad7c3871a1757b098838349b17762ba6b",
@@ -61,6 +64,7 @@ provider "registry.terraform.io/hashicorp/external" {
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.1.1"
   hashes = [
+    "h1:71sNUDvmiJcijsvfXpiLCz0lXIBSsEJjMxljt7hxMhw=",
     "h1:Pctug/s/2Hg5FJqjYcTM0kPyx3AoYK1MpRWO0T9V2ns=",
     "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
     "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
@@ -81,6 +85,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.1.2"
   constraints = ">= 3.1.0"
   hashes = [
+    "h1:5A5VsY5wNmOZlupUcLnIoziMPn8htSZBXbP3lI7lBEM=",
     "h1:9A6Ghjgad0KjJRxa6nPo8i8uFvwj3Vv0wnEgy49u+24=",
     "zh:0daceba867b330d3f8e2c5dc895c4291845a78f31955ce1b91ab2c4d1cd1c10b",
     "zh:104050099efd30a630741f788f9576b19998e7a09347decbec3da0b21d64ba2d",
@@ -101,6 +106,7 @@ provider "registry.terraform.io/hashicorp/template" {
   version = "2.2.0"
   hashes = [
     "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
+    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
     "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
     "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
     "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",

--- a/lambdas/mime-type/index.js
+++ b/lambdas/mime-type/index.js
@@ -1,10 +1,6 @@
 const AWS = require("aws-sdk");
 const FileType = require("file-type");
-const MimeTypes = require("mime-types");
 const path = require("path");
-
-MimeTypes.types['md5'] = 'text/plain';
-MimeTypes.types['framemd5'] = 'text/plain';
 
 AWS.config.update({ httpOptions: { timeout: 600000 } });
 
@@ -22,36 +18,35 @@ const extractMimeType = async (event) => {
     }).createReadStream();
 
     // response: {"ext":"jpg","mime":"image/jpeg"}
-    const fileType =
-      (await FileType.fromStream(s3Stream)) || (await lookupMimeType(event));
-    console.log('identified file as', JSON.stringify(fileType));
-    return fileType;
+    const fileType = await FileType.fromStream(s3Stream) || fallback(event);
+    if (fileType) {
+      console.log('identified file as', JSON.stringify(fileType));
+      return { ...fileType, verified: true };  
+    }
+    return undefined;
   } catch (e) {
     console.error("Error extracting mime-type");
     return Promise.reject(e);
   }
 };
 
-const lookupMimeType = async (event) => {
-  console.warn(
-    "Failed to extract MIME type from content. Falling back to file extension."
-  );
-  const key = event.key;
-  const ext = path.extname(key).replace(/^\./, "");
-  let mime = MimeTypes.lookup(key);
+const fallback = (event) => {
+  const ext = path.extname(event.key).replace(/^\./, "");
+  const mime = event.fallback;
+
+  if (mime === undefined) 
+    return { ext, mime: "application/octet-stream", verified: false }
+
   if (mime && (! mime.match(/xml$/)) && FileType.mimeTypes.has(mime)) {
-    console.warn(
-      `${path.basename(
-        key
-      )} appears to be ${mime} but magic number doesn't match.`
-    );
+    console.warn(`${path.basename(event.key)} attempting to fall back to ${mime} but magic number doesn't match.`);
     return undefined;
-  } else if (mime) {
-    return { ext, mime };
-  } else {
-    console.warn(`Cannot determine MIME type of ${path.basename(key)}.`);
-    return "null";
   }
-};
+
+  return {
+    ext: path.extname(event.key).replace(/^\./, ""),
+    mime: mime,
+    verified: false
+  }
+}
 
 module.exports = { handler };

--- a/lambdas/mime-type/package-lock.json
+++ b/lambdas/mime-type/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "file-type": "^16.0",
-        "mime-types": "^2.1.31"
+        "file-type": "^16.0"
       },
       "devDependencies": {
         "aws-sdk": "^2.0"
@@ -121,25 +120,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.31",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
-      "dependencies": {
-        "mime-db": "1.48.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/peek-readable": {
@@ -405,19 +385,6 @@
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
       "dev": true
-    },
-    "mime-db": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ=="
-    },
-    "mime-types": {
-      "version": "2.1.31",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
-      "requires": {
-        "mime-db": "1.48.0"
-      }
     },
     "peek-readable": {
       "version": "4.1.0",

--- a/lambdas/mime-type/package.json
+++ b/lambdas/mime-type/package.json
@@ -9,8 +9,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "file-type": "^16.0",
-    "mime-types": "^2.1.31"
+    "file-type": "^16.0"
   },
   "devDependencies": {
     "aws-sdk": "^2.0"


### PR DESCRIPTION
# Summary 

Improve MIME type handling as well as the interface/division of responsibility between Meadow and the MIME lambda

# Specific Changes in this PR
- Create `Meadow.Utils.MIME` wrapper for the `MIME` Hex package so that adding custom types no longer requires `mix deps.compile mime --force`.
- Pass the extension-mapped MIME type to the lambda along with the location of the file.
- Update the lambda to fall back to the provided type if the file can't be typed, _unless_ the Lambda knows it _should_ be able to detect files of that type. (This mimics the previous functionality, but the file extension lookup happens on the caller instead of in the lambda.)
- Update wording and log expectations in `ExtractMimeType` test.
- Add a `verified` field (true if detected by magic number, false if resolved via fallback) to the lambda response for possible future use.

Terraform already applied to dev environment.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

1. Run `mix deps.compile --force mime` for the very last time
2. Run `P` and `S` files of various types via an ingest sheet (UI upload doesn't work for all types yet)
3. Make sure they get through the pipeline and end up with sensible MIME types

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

