### PR TITLE
Index api_link correctly

### DIFF
--- a/app/config/config.exs
+++ b/app/config/config.exs
@@ -251,6 +251,13 @@ config :meadow, :extra_mime_types, %{
   "xml" => "application/xml"
 }
 
+config :meadow,
+  dc_api: [
+    v2: [
+      base_url: aws_secret("meadow", dig: ["dc_api", "v2"], default: "http://localhost:3000")
+    ]
+  ]
+
 config :hush,
   transformers_override: true,
   transformers: [

--- a/app/priv/elasticsearch/v2/pipelines/v1-to-v2/collection.json
+++ b/app/priv/elasticsearch/v2/pipelines/v1-to-v2/collection.json
@@ -10,7 +10,7 @@
     {
       "set": {
         "field": "api_link",
-        "value": "[PLACEHOLDER]/{{id}}"
+        "value": "$base_url$/collections/{{id}}"
       }
     },
     {

--- a/app/priv/elasticsearch/v2/pipelines/v1-to-v2/file_set.json
+++ b/app/priv/elasticsearch/v2/pipelines/v1-to-v2/file_set.json
@@ -8,6 +8,12 @@
       }
     },
     {
+      "set": {
+        "field": "api_link",
+        "value": "$base_url$/file-sets/{{id}}"
+      }
+    },
+    {
       "rename": {
         "field": "accessionNumber",
         "target_field": "accession_number"

--- a/app/priv/elasticsearch/v2/pipelines/v1-to-v2/work.json
+++ b/app/priv/elasticsearch/v2/pipelines/v1-to-v2/work.json
@@ -33,7 +33,7 @@
     {
       "set": {
         "field": "api_link",
-        "value": "[PLACEHOLDER]/{{original.id}}"
+        "value": "$base_url$/works/{{original.id}}"
       }
     },
     {

--- a/infrastructure/deploy/secrets.tf
+++ b/infrastructure/deploy/secrets.tf
@@ -22,6 +22,12 @@ locals {
       base_url = var.digital_collections_url
     }
 
+    dc_api = {
+      v2 = {
+        base_url = var.dc_api_v2_base
+      }
+    }
+
     ezid  = {
       password        = var.ezid_password
       shoulder        = var.ezid_shoulder

--- a/infrastructure/deploy/variables.tf
+++ b/infrastructure/deploy/variables.tf
@@ -163,3 +163,7 @@ variable "shared_bucket" {
 variable "work_archiver_endpoint" {
   type = string
 }
+
+variable "dc_api_v2_base" {
+  type = string
+}


### PR DESCRIPTION
# Summary 

Index `api_link` field correctly

# Specific Changes in this PR
- Add variable substitution code to Elasticsearch pipeline task
- Update pipeline files with `base_url` variable in `api_link`
- Update Meadow configuration with variable values for the above
- Update Terraform to store the correct variable values in AWS Secrets Manager

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

1. Run `mix meadow.elasticsearch.pipelines` in dev environment
2. Either do a manual `_reindex` in OpenSearch Dashboards or do `Indexer.reindex_all!()` in Meadow and wait for the Reindexer to run
3. Check resulting v2 index records for the correct `api_link` URLs

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [x] Other specific instructions/tasks
  - Run `mix meadow.elasticsearch.pipelines` on Meadow console after deploy


# Tested/Verified
- [ ] End users/stakeholders

