### PR TITLE
Change preservation replication region to us-west-2

### DIFF
--- a/infrastructure/deploy/main.tf
+++ b/infrastructure/deploy/main.tf
@@ -598,7 +598,7 @@ resource "aws_route53_record" "meadow_streaming_cloudfront" {
 
 provider "aws" {
   alias  = "west"
-  region = "us-west-1"
+  region = var.replication_region
 }
 
 resource "aws_iam_role" "replication_role" {
@@ -648,7 +648,7 @@ resource "aws_iam_role" "replication_role" {
 resource "aws_s3_bucket" "meadow_preservation_replica" {
   count    = var.environment == "p" ? 1 : 0
   provider = aws.west
-  bucket   = "${var.stack_name}-${var.environment}-preservation-replica"
+  bucket   = "${var.stack_name}-${var.environment}-preservation-replica-${var.replication_region}"
 
   tags = var.tags
 }

--- a/infrastructure/deploy/variables.tf
+++ b/infrastructure/deploy/variables.tf
@@ -156,6 +156,11 @@ variable "ffmpeg_layer_sha256" {
   type = string
 }
 
+variable "replication_region" {
+  type    = string
+  default = "us-west-2"
+}
+
 variable "shared_bucket" {
   type = string
 }


### PR DESCRIPTION
# Summary 

Change preservation replication region to us-west-2. Terraform-only, production-only change. Already applied.

# Specific Changes in this PR
- Remove existing replication bucket and configuration from Terraform state (so it won't try to delete anything)
- Update manifest to replicate to us-west-2

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

