### PR TITLE
Add more fields to v2 work index

### DIFF
--- a/app/lib/meadow/indexing/work.ex
+++ b/app/lib/meadow/indexing/work.ex
@@ -29,6 +29,7 @@ defimpl Elasticsearch.Document, for: Meadow.Data.Schemas.Work do
             extractedMetadata: FileSetDocument.extracted_metadata(file_set.extracted_metadata),
             label: file_set.core_metadata.label,
             mime_type: file_set.core_metadata.mime_type,
+            original_filename: file_set.core_metadata.original_filename,
             posterOffset: file_set.poster_offset,
             rank: file_set.rank,
             representativeImageUrl: FileSets.representative_image_url_for(file_set),

--- a/app/priv/elasticsearch/v2/pipelines/v1-to-v2/work-file-sets.groovy
+++ b/app/priv/elasticsearch/v2/pipelines/v1-to-v2/work-file-sets.groovy
@@ -6,6 +6,7 @@ ctx.file_sets = ctx.original.fileSets
     result.id = fs.id;
     result.label = fs.label;
     result.mime_type = fs.mime_type;
+    result.original_filename = fs.original_filename;
     result.poster_offset = fs.posterOffset;
     result.rank = fs.rank;
     result.representative_image_url = fs.representativeImageUrl;

--- a/app/priv/elasticsearch/v2/pipelines/v1-to-v2/work.json
+++ b/app/priv/elasticsearch/v2/pipelines/v1-to-v2/work.json
@@ -44,6 +44,12 @@
     },
     {
       "rename": {
+        "field": "original.batches",
+        "target_field": "batch_ids"
+      }
+    },
+    {
+      "rename": {
         "field": "original.descriptiveMetadata.boxName",
         "target_field": "box_name"
       }
@@ -82,7 +88,8 @@
               "id": "{{_ingest._value.term.id}}",
               "label": "{{_ingest._value.term.label}}",
               "role": "{{_ingest._value.role.label}}",
-              "label_with_role": "{{_ingest._value.term.label}} ({{_ingest._value.role.label}})"
+              "label_with_role": "{{_ingest._value.term.label}} ({{_ingest._value.role.label}})",
+              "facet": "{{_ingest._value.facet}}"
             }
           }
         }
@@ -102,7 +109,8 @@
             "field": "creator",
             "value": {
               "id": "{{_ingest._value.term.id}}",
-              "label": "{{_ingest._value.term.label}}"
+              "label": "{{_ingest._value.term.label}}",
+              "facet": "{{_ingest._value.facet}}"
             }
           }
         }
@@ -111,6 +119,18 @@
     {
       "script": {
         "id": "v1-to-v2-work-file-sets"
+      }
+    },
+    {
+      "rename": {
+        "field": "original.descriptiveMetadata.dateCreated",
+        "target_field": "date_created"
+      }
+    },
+    {
+      "rename": {
+        "field": "original.descriptiveMetadata.description",
+        "target_field": "description"
       }
     },
     {
@@ -133,7 +153,8 @@
             "field": "genre",
             "value": {
               "id": "{{_ingest._value.term.id}}",
-              "label": "{{_ingest._value.term.label}}"
+              "label": "{{_ingest._value.term.label}}",
+              "facet": "{{_ingest._value.facet}}"
             }
           }
         }
@@ -199,6 +220,12 @@
       "remove": {
         "field": "license.scheme",
         "ignore_failure": true
+      }
+    },
+    {
+      "rename": {
+        "field": "original.metadataUpdateJobs",
+        "target_field": "csv_metadata_update_jobs"
       }
     },
     {
@@ -351,7 +378,8 @@
               "id": "{{_ingest._value.term.id}}",
               "label": "{{_ingest._value.term.label}}",
               "role": "{{_ingest._value.role.label}}",
-              "label_with_role": "{{_ingest._value.term.label}} ({{_ingest._value.role.label}})"
+              "label_with_role": "{{_ingest._value.term.label}} ({{_ingest._value.role.label}})",
+              "facet": "{{_ingest._value.facet}}"
             }
           }
         }
@@ -365,7 +393,8 @@
             "field": "style_period",
             "value": {
               "id": "{{_ingest._value.term.id}}",
-              "label": "{{_ingest._value.term.label}}"
+              "label": "{{_ingest._value.term.label}}",
+              "facet": "{{_ingest._value.facet}}"
             }
           }
         }
@@ -385,7 +414,8 @@
             "field": "technique",
             "value": {
               "id": "{{_ingest._value.term.id}}",
-              "label": "{{_ingest._value.term.label}}"
+              "label": "{{_ingest._value.term.label}}",
+              "facet": "{{_ingest._value.facet}}"
             }
           }
         }

--- a/app/priv/elasticsearch/v2/settings/work.json
+++ b/app/priv/elasticsearch/v2/settings/work.json
@@ -53,7 +53,7 @@
     "dynamic_templates": [
       {
         "text_fields": {
-          "match": "^abstract$|^alternate_title$|^caption$|^collection.title$|^cultural_context$|^description$|^file_sets.label$|^file_sets.description$|^notes.text$|^table_of_contents$|^title$",
+          "match": "^abstract$|^alternate_title$|^caption$|^collection.title$|^cultural_context$|^description$|^file_sets.label$|^file_sets.description$|^file_sets.original_filename$|^notes.text$|^table_of_contents$|^title$",
           "match_pattern": "regex",
           "mapping": {
             "type": "text",

--- a/app/test/meadow/data/indexer_test.exs
+++ b/app/test/meadow/data/indexer_test.exs
@@ -271,7 +271,7 @@ defmodule Meadow.Data.IndexerTest do
       assert doc |> get_in(["model", "application"]) == "Meadow"
       assert doc |> get_in(["model", "name"]) == "Work"
       assert doc |> get_in(["fileSets"]) |> length == 2
-      assert doc |> get_in(["fileSets"]) |> List.first() |> map_size() == 10
+      assert doc |> get_in(["fileSets"]) |> List.first() |> map_size() == 11
 
       with metadata <- subject.descriptive_metadata do
         assert doc |> get_in(["descriptiveMetadata", "title"]) ==


### PR DESCRIPTION
# Summary 
We missed a few fields in the V2 work index, and David requested the addition of `original_filename` for file sets listed in the work document for convenience.

# Specific Changes in this PR
- Fields added to V1 work index:
  - `original_filename` (on the work's file sets)
- Fields added to V2 work index:
  - `description`
  - `date_created`
  - `batch_ids`
  - `csv_metadata_update_jobs`
  - "facet" fields (the ones needed for Meadow batch)
  - `original_filename` (on the work's file sets)
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Add a work to Meadow, and edit it with a csv metadata update and/or batch update.

Check the V2 work index for the fields (truncated for brevity):

```json
{
  "_source": {
    "batch_ids": ["7177160b-20a5-4029-a4fa-526e834b5fb4"],
    "file_sets": [
      {
        "original_filename": "05.tif"
      }
    ],
    "description": ["Here's a description"],
    "csv_metadata_update_jobs": ["670753fc-0e99-47f5-92b2-e6bdeee989c5"],
    "date_created": [
      {
        "edtf": "1983-06-10",
        "humanized": "June 10, 1983"
      }
    ]
  }
}

```

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [x] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

