### PR TITLE
FileSetDeleteListener: Retain un-ingested files

### DIFF
--- a/app/test/support/unsandboxed_data_case.ex
+++ b/app/test/support/unsandboxed_data_case.ex
@@ -14,6 +14,8 @@ defmodule Meadow.UnsandboxedDataCase do
   defmodule Repo do
     @moduledoc false
     use Ecto.Repo, adapter: Ecto.Adapters.Postgres, otp_app: :meadow
+
+    def listen(event_name), do: Meadow.Repo.listen(event_name)
   end
 
   setup_all do


### PR DESCRIPTION
# Summary 

Have `FileSetDeleteListener` only delete derivatives and things in preservation, leaving un-ingested files behind.

# Specific Changes in this PR
- `FileSetDeleteListener` makes sure the file is in the preservation bucket before deleting
- Add test to make sure non-preservation files are left behind

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

1. Preservation file is deleted
  - Submit an ingest sheet and let the pipeline run
  - Delete a FileSet
  - Make sure the preservation file is gone
2. Ingest file is not deleted
  - Submit an ingest sheet and let it create works but don't let the pipeline run
  - Delete a FileSet
  - Make sure the file is still in the ingest bucket

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

