### PR TITLE
Add API-based thumbnail to v2 work index

### DIFF
--- a/app/config/config.exs
+++ b/app/config/config.exs
@@ -253,9 +253,7 @@ config :meadow, :extra_mime_types, %{
 
 config :meadow,
   dc_api: [
-    v2: [
-      base_url: aws_secret("meadow", dig: ["dc_api", "v2"], default: "http://localhost:3000")
-    ]
+    v2: aws_secret("meadow", dig: ["dc_api", "v2"], default: "http://localhost:3000")
   ]
 
 config :hush,

--- a/app/config/test.exs
+++ b/app/config/test.exs
@@ -107,6 +107,13 @@ config :meadow, Meadow.Repo,
   queue_target: 5000,
   pool_size: 50
 
+config :meadow,
+  dc_api: [
+    v2: %{
+      "base_url" => "http://dcapi-test.northwestern.edu"
+    }
+  ]
+
 if System.get_env("AWS_DEV_ENVIRONMENT") |> is_nil() do
   [:mediaconvert, :s3, :secretsmanager, :sns, :sqs]
   |> Enum.each(fn service ->

--- a/app/priv/elasticsearch/v2/pipelines/v1-to-v2/work.json
+++ b/app/priv/elasticsearch/v2/pipelines/v1-to-v2/work.json
@@ -37,6 +37,12 @@
       }
     },
     {
+      "set": {
+        "field": "thumbnail",
+        "value": "$base_url$/works/{{original.id}}/thumbnail"
+      }
+    },
+    {
       "rename": {
         "field": "original.descriptiveMetadata.ark",
         "target_field": "ark"
@@ -425,12 +431,6 @@
       "rename": {
         "field": "original.descriptiveMetadata.termsOfUse",
         "target_field": "terms_of_use"
-      }
-    },
-    {
-      "rename": {
-        "field": "original.thumbnail",
-        "target_field": "thumbnail"
       }
     },
     {


### PR DESCRIPTION
# Summary 

Change the `thumbnail` field of the v2 work index to point to the `/works/{id}/thumbnail` API route

# Specific Changes in this PR
- fix a bug in the pipeline task config
- update the `v1-to-v2-work` pipeline with the new thumbnail route

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

- `mix meadow.elasticsearch.pipelines`
- Reindex into v2
- Check the work index thumbnails

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex (v2)
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

