### PR TITLE
Make filename-based MIME checks case-insensitive

### DIFF
--- a/app/lib/meadow/utils/mime.ex
+++ b/app/lib/meadow/utils/mime.ex
@@ -39,7 +39,9 @@ defmodule Meadow.Utils.MIME do
   "application/octet-stream"
   """
   def type(ext) do
-    Application.get_env(:meadow, :extra_mime_types)
-    |> Map.get(to_string(ext), MimeTypes.type(ext))
+    with normalized_ext <- ext |> to_string() |> String.downcase() do
+      Application.get_env(:meadow, :extra_mime_types)
+      |> Map.get(normalized_ext, MimeTypes.type(normalized_ext))
+    end
   end
 end

--- a/app/test/meadow/utils/mime_test.exs
+++ b/app/test/meadow/utils/mime_test.exs
@@ -19,4 +19,8 @@ defmodule Meadow.Utils.MIMETest do
     assert MIME.from_path("/path/to/unknown.blorb") == "application/octet-stream"
     assert MIME.type("blorb") == "application/octet-stream"
   end
+
+  test "is case insensitive" do
+    assert MIME.from_path("/path/to/image.jpg") == MIME.from_path("/path/to/image.JPG")
+  end
 end


### PR DESCRIPTION
# Summary 

Make filename-based MIME checks case-insensitive

# Specific Changes in this PR
- `String.downcase()` all extensions passed to `Meadow.Utils.MIME.type/1`
- Add case-sensitivity test

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Ingest a `.JPG` (not `.jpg`) file in a role that only accepts `image/*` types and make sure it validates

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

