### PR TITLE
Feed empty array for batch item candidateList.

### DIFF
--- a/app/assets/js/components/BatchEdit/ModalRemove.js
+++ b/app/assets/js/components/BatchEdit/ModalRemove.js
@@ -16,6 +16,8 @@ const modalContent = css`
 `;
 
 function setupCandidateList(items) {
+  if (items.length == 0) return [];
+
   const newList = items.map((item) => {
     const { label, role, term } = splitFacetKey(item.key);
     return {
@@ -48,7 +50,7 @@ export default function BatchEditAboutModalRemove({
       : [];
 
   useEffect(() => {
-    setCandidateList(items.length > 0 ? setupCandidateList(items) : []);
+    setCandidateList(setupCandidateList(items));
   }, [items]);
 
   function handleCheckboxChange({ key }) {

--- a/app/assets/js/components/BatchEdit/ModalRemove.js
+++ b/app/assets/js/components/BatchEdit/ModalRemove.js
@@ -50,6 +50,8 @@ export default function BatchEditAboutModalRemove({
   useEffect(() => {
     if (items.length > 0) {
       setCandidateList(setupCandidateList(items));
+    } else {
+      setCandidateList([]);
     }
   }, [items]);
 
@@ -74,7 +76,9 @@ export default function BatchEditAboutModalRemove({
               {currentRemoveField.label}
             </h3>
             <h4 className="subtitle">
-              Select values to remove from all batch Works
+              {items.length > 0
+                ? `Select values to remove from all batch Works`
+                : `Selected batch Works do not have ${currentRemoveField.label} values`}
             </h4>
           </header>
           <div className="my-4">
@@ -102,7 +106,7 @@ export default function BatchEditAboutModalRemove({
           <footer>
             <div className="buttons is-right">
               <Button isLight onClick={closeModal} data-testid="close-button">
-                Save &amp; close
+                {items.length > 0 && <>Save &amp; </>} Close
               </Button>
             </div>
           </footer>

--- a/app/assets/js/components/BatchEdit/ModalRemove.js
+++ b/app/assets/js/components/BatchEdit/ModalRemove.js
@@ -48,11 +48,7 @@ export default function BatchEditAboutModalRemove({
       : [];
 
   useEffect(() => {
-    if (items.length > 0) {
-      setCandidateList(setupCandidateList(items));
-    } else {
-      setCandidateList([]);
-    }
+    setCandidateList(items.length > 0 ? setupCandidateList(items) : []);
   }, [items]);
 
   function handleCheckboxChange({ key }) {
@@ -106,7 +102,7 @@ export default function BatchEditAboutModalRemove({
           <footer>
             <div className="buttons is-right">
               <Button isLight onClick={closeModal} data-testid="close-button">
-                {items.length > 0 && `Save &amp; `} Close
+                {items.length > 0 && `Save & `} Close
               </Button>
             </div>
           </footer>

--- a/app/assets/js/components/BatchEdit/ModalRemove.js
+++ b/app/assets/js/components/BatchEdit/ModalRemove.js
@@ -106,7 +106,7 @@ export default function BatchEditAboutModalRemove({
           <footer>
             <div className="buttons is-right">
               <Button isLight onClick={closeModal} data-testid="close-button">
-                {items.length > 0 && <>Save &amp; </>} Close
+                {items.length > 0 && `Save &amp; `} Close
               </Button>
             </div>
           </footer>


### PR DESCRIPTION
# Summary 
This should fix the issue where a user was seeing previously selected Metadata field values on the batch edit remove modal. If a remove modal was rendered and it did not have items associated, the **candidateList** that rendered in the modal did not update. I swapped out the dangling `if` there with a ternary to set an empty array if the `items` array is empty, flushing out previous values.

**Updated fix.**
https://github.com/nulib/meadow/blob/5e65e7419291509d1234c8219d37ff1a69b2fa2a/app/assets/js/components/BatchEdit/ModalRemove.js#L50-L52

**Previous state.**
https://github.com/nulib/meadow/blob/301021011f8e2cf25948e2d55a5fda79f811dfcf/app/assets/js/components/BatchEdit/ModalRemove.js#L50-L54

# Specific Changes in this PR
- Fixes bug allowing user to see and attempt to remove values on Batch Edit remove modal
- Adds language telling the user that no values exist if that is the case

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Search works in Meadow
- Select multiple works with a variance in metadata fields and values, making sure to select a batch of them that do not have values for a metadata field 
- Click **View Bulk Actions (Selected Works)** 
- Click **Batch Edit [#] Works**
- Click **View and Remove [Metadata Field Label]** for a metadata field that you know to have values
- Acknowledge that you are seeing accurate values, Close it
- Click **View and Remove [Metadata Field Label]** for a metadata field that you know to NOT have values 
- Acknowledge that you are seeing message _Selected batch Works do not have [Metadata Field Label] values_

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

