### PR TITLE
Send bucket size for agg terms in batch edit query

### DIFF
--- a/app/assets/js/services/elasticsearch.js
+++ b/app/assets/js/services/elasticsearch.js
@@ -16,41 +16,49 @@ export const ELASTICSEARCH_AGGREGATION_FIELDS = {
   contributor: {
     terms: {
       field: "descriptiveMetadata.contributor.facet",
+      size: 1000,
     },
   },
   creator: {
     terms: {
       field: "descriptiveMetadata.creator.facet",
+      size: 1000,
     },
   },
   genre: {
     terms: {
       field: "descriptiveMetadata.genre.facet",
+      size: 1000,
     },
   },
   language: {
     terms: {
       field: "descriptiveMetadata.language.facet",
+      size: 1000,
     },
   },
   location: {
     terms: {
       field: "descriptiveMetadata.location.facet",
+      size: 1000,
     },
   },
   stylePeriod: {
     terms: {
       field: "descriptiveMetadata.stylePeriod.facet",
+      size: 1000,
     },
   },
   subject: {
     terms: {
       field: "descriptiveMetadata.subject.facet",
+      size: 1000,
     },
   },
   technique: {
     terms: {
       field: "descriptiveMetadata.technique.facet",
+      size: 1000,
     },
   },
 };


### PR DESCRIPTION
# Summary 

Recent changes to our backend Elasticsearch client were causing the default agg term size (10) to be respected (which seems like a correct behavior).  This was causing only 10 controlled terms to be shown in the batch edit/view and remove modal. Sending the size with the agg/term request allows for all to show. (1000 seemed sufficient?)

Docs: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-size

# Specific Changes in this PR

- Add `size` to `terms` `aggregations` query in batch edit

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Perform a batch edit and view or remove a controlled term that has more than 10 values, observe that all are shown as options

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

