### PR TITLE
Adds title.keyword to work v2 index

### DIFF
--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -107,7 +107,7 @@
       }
     },
     "../deps/phoenix": {
-      "version": "1.6.10",
+      "version": "1.6.12",
       "license": "MIT"
     },
     "../deps/phoenix_html": {

--- a/app/priv/search/v2/settings/work.json
+++ b/app/priv/search/v2/settings/work.json
@@ -8,14 +8,25 @@
         "full_analyzer": {
           "type": "custom",
           "tokenizer": "standard",
-          "char_filter": ["html_strip"],
-          "filter": ["lowercase", "asciifolding"]
+          "char_filter": [
+            "html_strip"
+          ],
+          "filter": [
+            "lowercase",
+            "asciifolding"
+          ]
         },
         "stopword_analyzer": {
           "type": "custom",
           "tokenizer": "standard",
-          "char_filter": ["html_strip"],
-          "filter": ["lowercase", "asciifolding", "english_stop"]
+          "char_filter": [
+            "html_strip"
+          ],
+          "filter": [
+            "lowercase",
+            "asciifolding",
+            "english_stop"
+          ]
         }
       },
       "filter": {
@@ -46,19 +57,6 @@
       "all_ids": {
         "type": "keyword"
       },
-      "collection.title": {
-        "type": "text",
-        "analyzer": "full_analyzer",
-        "search_analyzer": "stopword_analyzer",
-        "search_quote_analyzer": "full_analyzer",
-        "fields" : {
-          "keyword" : {
-            "type" : "keyword",
-            "ignore_above" : 256
-          }
-        },
-        "copy_to": ["all_text"]
-      },
       "indexed_at": {
         "type": "date_nanos"
       }
@@ -66,14 +64,16 @@
     "dynamic_templates": [
       {
         "text_fields": {
-          "match": "^abstract$|^alternate_title$|^caption$|^cultural_context$|^description$|^file_sets.label$|^file_sets.description$|^file_sets.original_filename$|^notes.text$|^table_of_contents$|^title$",
+          "match": "^abstract$|^alternate_title$|^caption$|^cultural_context$|^description$|^file_sets.label$|^file_sets.description$|^file_sets.original_filename$|^notes.text$|^table_of_contents$",
           "match_pattern": "regex",
           "mapping": {
             "type": "text",
             "analyzer": "full_analyzer",
             "search_analyzer": "stopword_analyzer",
             "search_quote_analyzer": "full_analyzer",
-            "copy_to": ["all_text"]
+            "copy_to": [
+              "all_text"
+            ]
           }
         }
       },
@@ -83,7 +83,9 @@
           "match_pattern": "regex",
           "mapping": {
             "type": "keyword",
-            "copy_to": ["all_ids"]
+            "copy_to": [
+              "all_ids"
+            ]
           }
         }
       },
@@ -98,7 +100,7 @@
       },
       {
         "labels": {
-          "path_match": "^contributor.label$|^creator.label$|^language.label$|^location.label$|^genre.label$|^style_period.label$|^technique.label$,",
+          "path_match": "^contributor.label$|^creator.label$|^language.label$|^location.label$|^genre.label$|^style_period.label$|^technique.label$",
           "match_pattern": "regex",
           "mapping": {
             "type": "keyword",
@@ -106,6 +108,24 @@
               "all_text",
               "all_controlled_terms",
               "all_controlled_labels"
+            ]
+          }
+        }
+      },
+      {
+        "text_plus_keyword": {
+          "path_match": "^title$|^collection.title$",
+          "match_pattern": "regex",
+          "mapping": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            },
+            "copy_to": [
+              "all_text"
             ]
           }
         }
@@ -124,7 +144,9 @@
           "match_mapping_type": "string",
           "mapping": {
             "type": "keyword",
-            "copy_to": ["all_text"]
+            "copy_to": [
+              "all_text"
+            ]
           }
         }
       }


### PR DESCRIPTION
# Summary 

Work titles need to be able to be aggregated

# Specific Changes in this PR
- Add `title.keyword` to `work.json` for V2 work mappings
- Combines with `collection.title` to start to group mappings that require text + keyword
<img width="376" alt="Screen Shot 2022-10-13 at 10 07 15 AM" src="https://user-images.githubusercontent.com/6372022/195649535-ff3cc0b1-c331-4441-9abe-62534902d564.png">


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Do a `Meadow.Data.Indexer.reindex_all()
- Check your mappings for both `work.title` (text) and `work.title.keyword`

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

