### PR TITLE
Replace @batch_index module attribute with runtime lookup

### DIFF
--- a/app/lib/meadow/batches.ex
+++ b/app/lib/meadow/batches.ex
@@ -12,7 +12,6 @@ defmodule Meadow.Batches do
 
   require Logger
 
-  @batch_index SearchConfig.alias_for(Work, 1)
   @controlled_fields ~w(contributor creator genre language location style_period subject technique)a
 
   @doc """
@@ -492,7 +491,7 @@ defmodule Meadow.Batches do
     Logger.debug("Starting Elasticsearch scroll for batch update")
     Logger.debug("query #{inspect(query)}")
 
-    HTTP.post!([@batch_index, "_search?scroll=10m"], query)
+    HTTP.post!([SearchConfig.alias_for(Work, 1), "_search?scroll=10m"], query)
     |> Map.get(:body)
     |> process_updates(delete, add, replace, batch_id)
   end
@@ -528,7 +527,7 @@ defmodule Meadow.Batches do
     Logger.debug("Starting Elasticsearch scroll for batch delete")
     Logger.debug("query #{inspect(query)}")
 
-    HTTP.post!([@batch_index, "_search?scroll=10m"], query)
+    HTTP.post!([SearchConfig.alias_for(Work, 1), "_search?scroll=10m"], query)
     |> Map.get(:body)
     |> process_deletes(batch_id)
   end


### PR DESCRIPTION
# Summary 

The indexing refactor introduced a bug with batch editing:

```
:erlang.iolist_to_binary(%{"error" => %{"index" => "prod-meadow", "index_uuid" => "_na_", "reason" => "no such index [prod-meadow]", "resource.id" => "prod-meadow", "resource.type" => "index_or_alias", "root_cause" => [%{"index" => "prod-meadow", "index_uuid" => "_na_", "reason" => "no such index [prod-meadow]", "resource.id" => "prod-meadow", "resource.type" => "index_or_alias", "type" => "index_not_found_exception"}], "type" => "index_not_found_exception"}, "status" => 404})
@timestamp	
1665687852606
```

This is a compile-time vs. runtime problem:

- `config.exs` (compile-time) defines the v1 index as `prefix("meadow")`, where `prefix/1` adds the `dev-` or `test-` or - `mbk-dev`- or whatever.
- `releases.exs` (runtime) just uses `meadow`, as it should.
- But because the batch code uses a module attribute – `@batch_index SearchConfig.alias_for(Work, 1)`, it gets defined at compile-time, where `Mix.env() `is prod.



# Specific Changes in this PR

- get rid of the module attribute `@batch_index`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

