### PR TITLE
Include controlled term variants in v2 index

### DIFF
--- a/app/lib/meadow/indexing/v2/work.ex
+++ b/app/lib/meadow/indexing/v2/work.ex
@@ -80,7 +80,8 @@ defmodule Meadow.Indexing.V2.Work do
     %{
       id: field.term.id,
       label: field.term.label,
-      facet: "#{field.term.id}||#{field.term.label}"
+      facet: "#{field.term.id}||#{field.term.label}",
+      variants: field.term.variants
     }
   end
 
@@ -90,7 +91,8 @@ defmodule Meadow.Indexing.V2.Work do
       label: field.term.label,
       role: field.role.label,
       label_with_role: "#{field.term.label} (#{field.role.label})",
-      facet: "#{field.term.id}|#{field.role.id}|#{field.term.label} (#{field.role.label})"
+      facet: "#{field.term.id}|#{field.role.id}|#{field.term.label} (#{field.role.label})",
+      variants: field.term.variants
     }
   end
 

--- a/app/test/meadow/indexing/v1/encoding_test.exs
+++ b/app/test/meadow/indexing/v1/encoding_test.exs
@@ -108,6 +108,28 @@ defmodule Meadow.Indexing.V1.EncodingTest do
       assert doc |> get_in([:dateCreated]) == dates
     end
 
+    test "work encodes controlled term variants", %{work: subject} do
+      {:ok, subject} =
+        subject
+        |> Works.update_work(%{
+          descriptive_metadata: %{
+            subject: [
+              %{
+                role: %{id: "TOPICAL", scheme: "subject_role"},
+                term: %{id: "http://id.loc.gov/authorities/names/nb2015010626"}
+              }
+            ]
+          }
+        })
+
+      Indexer.synchronize_index()
+      doc = subject |> Document.encode(1)
+
+      assert doc
+             |> get_in([:descriptiveMetadata, :subject, Access.at(0), :term, :variants])
+             |> Enum.member?("BCT G.B. (Border Collie Trust G.B.)")
+    end
+
     test "file set encoding", %{file_set: subject} do
       derivatives = FileSets.add_derivative(subject, :poster, FileSets.poster_uri_for(subject))
 

--- a/app/test/meadow/indexing/v2/encoding_test.exs
+++ b/app/test/meadow/indexing/v2/encoding_test.exs
@@ -94,6 +94,28 @@ defmodule Meadow.Indexing.V2.EncodingTest do
       assert doc |> get_in([:date_created]) == dates
     end
 
+    test "work encodes controlled term variants", %{work: subject} do
+      {:ok, subject} =
+        subject
+        |> Works.update_work(%{
+          descriptive_metadata: %{
+            subject: [
+              %{
+                role: %{id: "TOPICAL", scheme: "subject_role"},
+                term: %{id: "http://id.loc.gov/authorities/names/nb2015010626"}
+              }
+            ]
+          }
+        })
+
+      Indexer.synchronize_index()
+      doc = subject |> Document.encode(2)
+
+      assert doc
+             |> get_in([:subject, Access.at(0), :variants])
+             |> Enum.member?("BCT G.B. (Border Collie Trust G.B.)")
+    end
+
     test "file set encoding", %{file_set: subject} do
       derivatives = FileSets.add_derivative(subject, :poster, FileSets.poster_uri_for(subject))
 


### PR DESCRIPTION
# Summary 
Include controlled term variants in v2 index

# Specific Changes in this PR
- Add variants to controlled terms in v2 document encoding
- Add tests for variants in v1
- Add tests for variants in v2

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- `ControlledTerms.clear!()` to make sure updates pull live data from LOC
- Create a work with a controlled term that has variants (e.g., `http://id.loc.gov/authorities/subjects/sh85148273`)
- Wait for the index to update
- Make sure both v1 and v2 indexes include the variants on that term within the work

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [x] Other specific instructions/tasks
  - Might want to clear the controlled term cache before reindexing

# Tested/Verified
- [ ] End users/stakeholders

