### PR TITLE
Update opensearch proxy route

### DIFF
--- a/app/assets/js/services/elasticsearch.js
+++ b/app/assets/js/services/elasticsearch.js
@@ -3,7 +3,7 @@ const slashes = protocol.concat("//");
 const host = slashes.concat(window.location.hostname);
 const port = window.location.port;
 
-export const ELASTICSEARCH_PROXY_ENDPOINT = `${host}:${port}/search`;
+export const ELASTICSEARCH_PROXY_ENDPOINT = `${host}:${port}/_search`;
 export const ELASTICSEARCH_INDEX_NAME = __ELASTICSEARCH_INDEX__;
 
 const Elasticsearch = require("elasticsearch");

--- a/app/lib/meadow_web/plugs/search.ex
+++ b/app/lib/meadow_web/plugs/search.ex
@@ -28,7 +28,7 @@ defmodule MeadowWeb.Plugs.Search do
 
   def process_request(conn, _default) do
     body = extract_body(conn)
-    [_base, path] = String.split(conn.request_path, "/search")
+    [_base, path] = String.split(conn.request_path, "/_search", parts: 2)
     query_string = extract_query_string(conn.query_string) |> URI.encode()
 
     method =

--- a/app/lib/meadow_web/router.ex
+++ b/app/lib/meadow_web/router.ex
@@ -4,82 +4,85 @@ defmodule MeadowWeb.Router do
   import Phoenix.LiveDashboard.Router
 
   pipeline :browser do
-    plug Plug.Logger
-    plug :accepts, ["html"]
-    plug :fetch_session
-    plug :fetch_flash
-    plug :protect_from_forgery
-    plug :put_secure_browser_headers
+    plug(Plug.Logger)
+    plug(:accepts, ["html"])
+    plug(:fetch_session)
+    plug(:fetch_flash)
+    plug(:protect_from_forgery)
+    plug(:put_secure_browser_headers)
   end
 
   pipeline :secure_browser do
-    plug Plug.Logger
-    plug :accepts, ["html"]
-    plug :fetch_session
-    plug :fetch_flash
-    plug :protect_from_forgery
-    plug :put_secure_browser_headers
-    plug MeadowWeb.Plugs.SetCurrentUser
-    plug MeadowWeb.Plugs.RequireLogin
+    plug(Plug.Logger)
+    plug(:accepts, ["html"])
+    plug(:fetch_session)
+    plug(:fetch_flash)
+    plug(:protect_from_forgery)
+    plug(:put_secure_browser_headers)
+    plug(MeadowWeb.Plugs.SetCurrentUser)
+    plug(MeadowWeb.Plugs.RequireLogin)
   end
 
   pipeline :search do
-    plug :accepts, ["json"]
+    plug(:accepts, ["json"])
 
-    plug MeadowWeb.Plugs.SetCurrentUser
-    plug MeadowWeb.Plugs.RequireLogin
+    plug(MeadowWeb.Plugs.SetCurrentUser)
+    plug(MeadowWeb.Plugs.RequireLogin)
   end
 
   scope "/dashboard" do
-    pipe_through :secure_browser
+    pipe_through(:secure_browser)
 
-    live_dashboard "/",
+    live_dashboard("/",
       metrics: Meadow.Telemetry,
       ecto_repos: [Meadow.Repo],
       additional_pages: [broadway: {BroadwayDashboard, pipelines: Meadow.Pipeline.actions()}]
+    )
   end
 
-  scope "/search" do
-    pipe_through :search
+  scope "/_search" do
+    pipe_through(:search)
 
-    forward "/", MeadowWeb.Plugs.Search
+    forward("/", MeadowWeb.Plugs.Search)
   end
 
   pipeline :api do
-    plug :accepts, ["json"]
-    plug MeadowWeb.Plugs.SetCurrentUser
+    plug(:accepts, ["json"])
+    plug(MeadowWeb.Plugs.SetCurrentUser)
   end
 
   # Other scopes may use custom stacks.
   scope "/api" do
-    pipe_through :api
+    pipe_through(:api)
 
-    post "/export/:file", MeadowWeb.ExportController, :export
-    post "/create_shared_links/:file", MeadowWeb.SharedLinksController, :export
+    post("/export/:file", MeadowWeb.ExportController, :export)
+    post("/create_shared_links/:file", MeadowWeb.SharedLinksController, :export)
 
-    forward "/graphql", Absinthe.Plug, schema: MeadowWeb.Schema
+    forward("/graphql", Absinthe.Plug, schema: MeadowWeb.Schema)
 
-    forward "/graphiql", Absinthe.Plug.GraphiQL,
+    forward("/graphiql", Absinthe.Plug.GraphiQL,
       schema: MeadowWeb.Schema,
       interface: :playground,
       socket: MeadowWeb.UserSocket
+    )
 
-    forward "/", Plug.Static,
+    forward("/", Plug.Static,
       at: "/",
       from: {:meadow, "priv/static"},
       only: ["voyager"],
       headers: %{"content-type" => "text/html"}
+    )
   end
 
   scope "/" do
-    pipe_through :browser
+    pipe_through(:browser)
 
-    get "/auth/logout", MeadowWeb.AuthController, :logout
-    get "/auth/:provider", MeadowWeb.AuthController, :login
-    post "/auth/:provider", MeadowWeb.AuthController, :login
-    get "/auth/:provider/callback", MeadowWeb.AuthController, :callback
-    post "/auth/:provider/callback", MeadowWeb.AuthController, :callback
+    get("/auth/logout", MeadowWeb.AuthController, :logout)
+    get("/auth/:provider", MeadowWeb.AuthController, :login)
+    post("/auth/:provider", MeadowWeb.AuthController, :login)
+    get("/auth/:provider/callback", MeadowWeb.AuthController, :callback)
+    post("/auth/:provider/callback", MeadowWeb.AuthController, :callback)
 
-    get "/*path", MeadowWeb.PageController, :index
+    get("/*path", MeadowWeb.PageController, :index)
   end
 end

--- a/app/test/meadow_web/plugs/search_test.exs
+++ b/app/test/meadow_web/plugs/search_test.exs
@@ -18,7 +18,7 @@ defmodule SearchTest do
       conn =
         build_conn()
         |> auth_user(user_fixture())
-        |> delete("/search/#{@v1_index}/_doc/#{work.id}")
+        |> delete("/_search/#{@v1_index}/_doc/#{work.id}")
 
       assert conn.status == 400
     end
@@ -29,7 +29,7 @@ defmodule SearchTest do
         |> auth_user(user_fixture())
         |> put_req_header("content-type", "application/json")
         |> post(
-          "/search/#{@v1_index}/_search",
+          "/_search/#{@v1_index}/_search",
           Jason.encode!(%{"query" => %{"match_all" => %{}}})
         )
 
@@ -49,7 +49,7 @@ defmodule SearchTest do
         build_conn()
         |> auth_user(user_fixture())
         |> put_req_header("content-type", "application/x-ndjson")
-        |> post("/search/#{@v1_index}/_msearch", mquery)
+        |> post("/_search/#{@v1_index}/_msearch", mquery)
 
       assert Jason.decode!(conn.resp_body) |> get_in(@total_hits_path) > 1
     end
@@ -62,7 +62,7 @@ defmodule SearchTest do
         build_conn()
         |> auth_user(user_fixture())
         |> put_req_header("content-type", "application/json")
-        |> get("/search/#{@v1_index}/_search?q=#{work.descriptive_metadata.title}")
+        |> get("/_search/#{@v1_index}/_search?q=#{work.descriptive_metadata.title}")
 
       assert Jason.decode!(conn.resp_body) |> get_in(@total_hits_path) > 0
     end

--- a/lambdas/mime-type/package-lock.json
+++ b/lambdas/mime-type/package-lock.json
@@ -1,8 +1,312 @@
 {
   "name": "mime-type",
   "version": "0.1.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "mime-type",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "file-type": "^16.0"
+      },
+      "devDependencies": {
+        "aws-sdk": "^2.0"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.833.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.833.0.tgz",
+      "integrity": "sha512-s0xzhRhaycNBetfLWU5E5GTdWKwT/Fb8UIdMI1G7Jf/xscivpGvakVWUYwhQLn2xWpPcdQQwsVsvkG3KS4bmCA==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dev": true,
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+      "dev": true
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "dependencies": {
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+      "dev": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/token-types/node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dev": true,
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "node_modules/uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dev": true,
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    }
+  },
   "dependencies": {
     "@tokenizer/token": {
       "version": "0.3.0",


### PR DESCRIPTION
# Summary 

The Opensearch proxy route is conflicting with Meadow's search route which can cause the user to occasionally see an Opensearch response rather than the Meadow website. 

# Specific Changes in this PR
- change Opensearch proxy route from `/search` to `/_search` and update front end's endpoint variable. 

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch (technically this is probably major but since we only use the route internally in same app, that seemed extreme)
- [ ] Minor
- [ ] Major

# Steps to Test

Fire up Meadow and make sure searching works. Including requests on homepage. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

