### PR TITLE
Index the new IIIF manifest url in the DC V2 work index

### DIFF
--- a/app/lib/meadow/indexing/v2/work.ex
+++ b/app/lib/meadow/indexing/v2/work.ex
@@ -161,8 +161,7 @@ defmodule Meadow.Indexing.V2.Work do
   defp format(%{id: _id, label: _label, scheme: _scheme} = field), do: Map.delete(field, :scheme)
   defp format(_), do: %{}
 
-  defp manifest_id(%{work_type: %{id: "IMAGE"}} = work), do: IIIF.V2.manifest_id(work.id)
-  defp manifest_id(work), do: IIIF.V3.manifest_id(work.id)
+  defp manifest_id(work), do: "#{api_url()}/#{work.id}?as=iiif"
 
   def representative_file_set(nil), do: %{}
 


### PR DESCRIPTION
# Summary 

The V2 work index needs to contain the IIIF manifest url that is for the newer manifests produced by DC API V2.


# Specific Changes in this PR

- index `iiif_manifest` as `{dc-api-url-base}/works/{id}?as=iiif` in V2 work index


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

