### PR TITLE
Add thumbnail property to v2 collection index

### DIFF
--- a/app/lib/meadow/indexing/v2/collection.ex
+++ b/app/lib/meadow/indexing/v2/collection.ex
@@ -18,12 +18,15 @@ defmodule Meadow.Indexing.V2.Collection do
       modified_date: collection.updated_at,
       published: collection.published,
       representative_image: representative_image(collection.representative_work),
+      thumbnail: thumbnail_url(collection),
       title: collection.title,
       visibility: encode_label(collection.visibility)
     }
   end
 
   def api_url, do: Application.get_env(:meadow, :dc_api) |> get_in([:v2, "base_url"])
+
+  def thumbnail_url(collection), do: "#{api_url}/collections/#{collection.id}/thumbnail"
 
   def representative_image(nil), do: %{}
 


### PR DESCRIPTION
# Summary 

We need to be able to have a thumbnail property in the API v2 `collection` and `collection/id` results. 

# Specific Changes in this PR

- Add `thumbnail` property to v2 collection index

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [x] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

