### PR TITLE
Fix manifest url route

### DIFF
--- a/app/lib/meadow/indexing/v2/work.ex
+++ b/app/lib/meadow/indexing/v2/work.ex
@@ -161,7 +161,7 @@ defmodule Meadow.Indexing.V2.Work do
   defp format(%{id: _id, label: _label, scheme: _scheme} = field), do: Map.delete(field, :scheme)
   defp format(_), do: %{}
 
-  defp manifest_id(work), do: "#{api_url()}/#{work.id}?as=iiif"
+  defp manifest_id(work), do: "#{api_url()}/works/#{work.id}?as=iiif"
 
   def representative_file_set(nil), do: %{}
 


### PR DESCRIPTION
# Summary 

- Mistake on previous PR, omitted the `/works/` in manifest url for v2 Index
- 
# Specific Changes in this PR
- fix manifest url path in v2 index
- 
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test


Start Meadow and reindex works.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

