### PR TITLE
Add published to file set v2 index

### DIFF
--- a/app/lib/meadow/indexing/v2/file_set.ex
+++ b/app/lib/meadow/indexing/v2/file_set.ex
@@ -20,6 +20,7 @@ defmodule Meadow.Indexing.V2.FileSet do
       label: file_set.core_metadata.label,
       modified_date: file_set.updated_at,
       poster_offset: file_set.poster_offset,
+      published: file_set.work.published,
       rank: file_set.rank,
       representative_image_url: FileSets.representative_image_url_for(file_set),
       role: file_set.role.label,


### PR DESCRIPTION
# Summary 

File sets that are not published should not be accessible so we need to index the Work's published flag in the file set doc (V2)

# Specific Changes in this PR
- index `work.published` into file set v2 index


Trigger looks OK already: 

<img width="1098" alt="Screen Shot 2022-10-31 at 8 25 43 AM" src="https://user-images.githubusercontent.com/6372022/199032529-421253cb-59b9-41ac-83ce-8b8f35da064b.png">


- # Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test


- Start up dev environment and reindex works
- Adjust published value on work, see that it cascades to file set in index

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

