### PR TITLE
Additional file set properties that trigger work reindex

### DIFF
--- a/app/priv/repo/migrations/20221031181525_update_work_file_set_parent_dependency_trigger.exs
+++ b/app/priv/repo/migrations/20221031181525_update_work_file_set_parent_dependency_trigger.exs
@@ -1,0 +1,24 @@
+defmodule Meadow.Repo.Migrations.UpdateWorkFileSetParentDependencyTrigger do
+  use Ecto.Migration
+
+  import Meadow.Utils.DependencyTriggers
+
+  def up do
+    drop_parent_trigger(:works, :file_sets)
+
+    create_parent_trigger(:works, :file_sets, [
+      :core_metadata,
+      :derivatives,
+      :extracted_metadata,
+      :poster_offset,
+      :rank,
+      :role,
+      :structural_metadata
+    ])
+  end
+
+  def down do
+    drop_parent_trigger(:works, :file_sets)
+    create_parent_trigger(:works, :file_sets, [:core_metadata, :derivatives, :rank])
+  end
+end


### PR DESCRIPTION
# Summary 

V2 index has more file set properties on the indexed work document than v1 so we need to update the parent trigger so that the work is reindex when any file set field that is in the work index is updated. 

# Specific Changes in this PR

- Adds `:extracted_metadata, :poster_offset, :role, :structural_metadata` to Work/File set parent trigger
- 
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- In dev environment, run `mix ecto.migrate`
- Check that an update to  any of the following: `:extracted_metadata, :poster_offset, :role, :structural_metadata` on the file set triggers a reindex of the work. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

