### PR TITLE
Order file sets by rank and role in indexed work documents

### DIFF
--- a/app/lib/meadow/indexing/v2/work.ex
+++ b/app/lib/meadow/indexing/v2/work.ex
@@ -138,22 +138,24 @@ defmodule Meadow.Indexing.V2.Work do
   end
 
   def file_sets(work) do
-    Enum.map(work.file_sets, fn file_set ->
-      %{
-        id: file_set.id,
-        duration: FileSets.duration_in_seconds(file_set),
-        height: FileSets.height(file_set),
-        label: file_set.core_metadata.label,
-        mime_type: file_set.core_metadata.mime_type,
-        original_filename: file_set.core_metadata.original_filename,
-        poster_offset: file_set.poster_offset,
-        rank: file_set.rank,
-        representative_image_url: FileSets.representative_image_url_for(file_set),
-        role: file_set.role.label,
-        streaming_url: FileSets.distribution_streaming_uri_for(file_set),
-        webvtt: FileSets.public_vtt_url_for(file_set),
-        width: FileSets.width(file_set)
-      }
+    Enum.flat_map(["A", "P", "S", "X"], fn role ->
+      Enum.map(Meadow.Data.ranked_file_sets_for_work(work.id, role), fn file_set ->
+        %{
+          id: file_set.id,
+          duration: FileSets.duration_in_seconds(file_set),
+          height: FileSets.height(file_set),
+          label: file_set.core_metadata.label,
+          mime_type: file_set.core_metadata.mime_type,
+          original_filename: file_set.core_metadata.original_filename,
+          poster_offset: file_set.poster_offset,
+          rank: file_set.rank,
+          representative_image_url: FileSets.representative_image_url_for(file_set),
+          role: file_set.role.label,
+          streaming_url: FileSets.distribution_streaming_uri_for(file_set),
+          webvtt: FileSets.public_vtt_url_for(file_set),
+          width: FileSets.width(file_set)
+        }
+      end)
     end)
   end
 


### PR DESCRIPTION
# Summary 
Order file sets by rank and role in indexed work documents

# Specific Changes in this PR
- Updates `Meadow.Indexing.V2.Work.file_sets/1`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
- Add multiple file sets of various roles to a work and check the indexed work document for role/rank ordering

`GET dev-dc-v2-work/_doc/c6b8a744-aa8a-4437-b885-175f3816f9cd?_source=file_sets.role,file_sets.rank`
```
{
  "_index" : "dev-dc-v2-work",
  "_source" : {
    "file_sets" : [
      [
        {
          "role" : "Access",
          "rank" : 0
        },
        {
          "role" : "Access",
          "rank" : 1073741824
        },
        {
          "role" : "Access",
          "rank" : 1610612736
        }
      ],
      [
        {
          "role" : "Preservation",
          "rank" : 0
        },
        {
          "role" : "Preservation",
          "rank" : 1073741824
        },
        {
          "role" : "Preservation",
          "rank" : 1610612736
        }
      ],
      [
        {
          "role" : "Supplemental",
          "rank" : 0
        },
        {
          "role" : "Supplemental",
          "rank" : 1073741824
        },
        {
          "role" : "Supplemental",
          "rank" : 1610612736
        }
      ],
      [
        {
          "role" : "Auxiliary",
          "rank" : 0
        },
        {
          "role" : "Auxiliary",
          "rank" : 1073741824
        },
        {
          "role" : "Auxiliary",
          "rank" : 1610612736
        }
      ]
    ]
  }
}
```

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [X] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [X] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

