### PR TITLE
Add Meadow.Data.FileSets.aspect_ratio/1 and include in indexed work representative file set data

### DIFF
--- a/app/lib/meadow/data/file_sets.ex
+++ b/app/lib/meadow/data/file_sets.ex
@@ -411,6 +411,13 @@ defmodule Meadow.Data.FileSets do
 
   def width(_), do: nil
 
+  def aspect_ratio(file_set) do
+    width = width(file_set)
+    height = height(file_set)
+
+    if width && height, do: Float.floor(width / height, 5), else: nil
+  end
+
   def access?(%{role: %{id: "A"}}), do: true
   def access?(_), do: false
   def preservation?(%{role: %{id: "P"}}), do: true

--- a/app/lib/meadow/indexing/v2/work.ex
+++ b/app/lib/meadow/indexing/v2/work.ex
@@ -169,8 +169,18 @@ defmodule Meadow.Indexing.V2.Work do
 
   def representative_file_set(work) do
     %{
+      aspect_ratio: aspect_ratio(work.representative_file_set_id),
       id: work.representative_file_set_id,
       url: work.representative_image
     }
+  end
+
+  defp aspect_ratio(nil), do: nil
+
+  defp aspect_ratio(representative_file_set_id) do
+    case FileSets.get_file_set(representative_file_set_id) do
+      nil -> nil
+      file_set -> FileSets.aspect_ratio(file_set)
+    end
   end
 end

--- a/app/test/meadow/data/file_sets_test.exs
+++ b/app/test/meadow/data/file_sets_test.exs
@@ -301,6 +301,31 @@ defmodule Meadow.Data.FileSetsTest do
 
       assert is_nil(FileSets.duration_in_milliseconds(file_set))
     end
+
+    test "aspect_ratio/1 calculated via extracted metadata" do
+      file_set =
+        file_set_fixture(
+          role: %{id: "A", scheme: "FILE_SET_ROLE"},
+          extracted_metadata: %{
+            "exif" => %{"value" => %{"ImageWidth" => 249, "ImageHeight" => 103}}
+          }
+        )
+
+      assert FileSets.aspect_ratio(file_set) == 2.41747
+
+      file_set_without_extracted_metadata = file_set_fixture()
+      assert is_nil(FileSets.aspect_ratio(file_set_without_extracted_metadata))
+
+      file_set_with_only_height =
+        file_set_fixture(
+          role: %{id: "A", scheme: "FILE_SET_ROLE"},
+          extracted_metadata: %{
+            "exif" => %{"value" => %{"ImageWidth" => 249}}
+          }
+        )
+
+      assert is_nil(FileSets.aspect_ratio(file_set_with_only_height))
+    end
   end
 
   describe "distribution_streaming_uri_for/1" do


### PR DESCRIPTION
# Summary 
Adds the ability to calculate aspect ratio data from extracted metadata based on `Meadow.Data.FileSets.height/1` and `Meadow.Data.FileSets.width/1`. Includes this information for use in the front end via the `representative_file_set` data encoded in V2 indexed work documents.

# Specific Changes in this PR
- Add `Meadow.Data.FileSets.aspect_ratio/1`
- Adds to `aspect_ratio` field to `Meadow.Indexing.V2.Work/1`.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Add a representative file set to a work that contains height and width and check the index:

```
POST [V2 Work Index]/_search
{
  "_source": "representative_file_set.aspect_ratio", 
  "query": {
    "match_all": {}
  },
  "size": 3
}
```

```json
{
  "hits" : {
    "hits" : [
      {
        "_index" : "[V2 Work Index]",
        "_type" : "_doc",
        "_id" : "2485d1ee-950d-457b-af1f-7e3662f941f2",
        "_score" : 1.0,
        "_source" : {
          "representative_file_set" : {
            "aspect_ratio" : 1.366666666666666
          }
        }
      },
      {
        "_index" : "[V2 Work Index]",
        "_type" : "_doc",
        "_id" : "d8376039-49cc-4a11-b4d1-becc4ab06061",
        "_score" : 1.0,
        "_source" : {
          "representative_file_set" : {
            "aspect_ratio" : 1.533595113438045
          }
        }
      },
      {
        "_index" : "[V2 Work Index]",
        "_type" : "_doc",
        "_id" : "21991c2b-0e79-4705-9f66-a929d8919329",
        "_score" : 1.0,
        "_source" : {
          "representative_file_set" : {
            "aspect_ratio" : 0.77968719830083
          }
        }
      }
    ]
  }
}
```

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [X] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [X] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

