### PR TITLE
Bump max_header_value_length configuration

### DIFF
--- a/app/config/releases.exs
+++ b/app/config/releases.exs
@@ -44,7 +44,8 @@ config :meadow, MeadowWeb.Endpoint,
     :inet6,
     port: port,
     protocol_options: [
-      idle_timeout: :infinity
+      idle_timeout: :infinity,
+      max_header_value_length: 8192
     ]
   ],
   check_origin: environment_secret("ALLOWED_ORIGINS", split: ~r/,\s*/, default: ""),


### PR DESCRIPTION
# Summary 
Bugfix for users reporting `431 Request Header Fields Too Large` errors in Meadow.

# Specific Changes in this PR
- Bump max_header_value_length configuration to 2x above the default value

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Make an HTTP request with a header above 4096 bytes in size

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

