### PR TITLE
Add a lifecycle configuration filter to the ingest bucket to retain objects less than 1 byte (empty ingest projects)

### DIFF
--- a/infrastructure/deploy/main.tf
+++ b/infrastructure/deploy/main.tf
@@ -77,6 +77,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "meadow_ingest" {
     id     = "30-day-expiration"
     status = "Enabled"
 
+    filter {
+      object_size_greater_than = 1
+    }
+
     expiration {
       days = 30
     }


### PR DESCRIPTION
# Summary 
We want to prevent lifecycle rules from deleting empty project folders in the ingest bucket.

# Specific Changes in this PR
- Add a lifecycle configuration filter for objects greater than 1 byte (see docs for reference https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration#object_size_greater_than)

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

