### PR TITLE
Add proper CORS headers to streaming CloudFront distribution

### DIFF
--- a/infrastructure/deploy/main.tf
+++ b/infrastructure/deploy/main.tf
@@ -548,6 +548,10 @@ data "aws_cloudfront_origin_request_policy" "cors_s3_origin" {
   name = "Managed-CORS-S3Origin"
 }
 
+data "aws_cloudfront_response_headers_policy" "cors_with_preflight" {
+  name = "Managed-CORS-With-Preflight"
+}
+
 resource "aws_cloudfront_distribution" "meadow_streaming" {
   enabled          = true
   is_ipv6_enabled  = true
@@ -570,8 +574,9 @@ resource "aws_cloudfront_distribution" "meadow_streaming" {
     target_origin_id       = "${var.stack_name}-origin"
     viewer_protocol_policy = "allow-all"
 
-    cache_policy_id          = data.aws_cloudfront_cache_policy.caching_optimized.id
-    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.cors_s3_origin.id
+    cache_policy_id             = data.aws_cloudfront_cache_policy.caching_optimized.id
+    origin_request_policy_id    = data.aws_cloudfront_origin_request_policy.cors_s3_origin.id
+    response_headers_policy_id  = data.aws_cloudfront_response_headers_policy.cors_with_preflight.id
 
     lambda_function_association {
       event_type = "viewer-request"


### PR DESCRIPTION
# Summary 

Add the Managed-CORS-With-Preflight response header cache policy to the streaming CloudFront distribution to prevent cross-origin errors when streaming to Digital Collections (or elsewhere).

Terraform-only change, already applied on Staging

# Specific Changes in this PR
- Update Terraform to include proper response header cache policy

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

