### PR TITLE
Set a placeholder image on collections without a representative work

### DIFF
--- a/app/lib/meadow/data/collections.ex
+++ b/app/lib/meadow/data/collections.ex
@@ -5,8 +5,8 @@ defmodule Meadow.Data.Collections do
 
   import Ecto.Changeset
   import Ecto.Query, warn: false
-  alias Meadow.Data.Schemas.{Collection, Work}
-  alias Meadow.Data.Works
+  alias Meadow.Data.Schemas.{Collection, FileSet, Work}
+  alias Meadow.Data.{FileSets, Works}
   alias Meadow.Repo
 
   require Logger
@@ -108,7 +108,14 @@ defmodule Meadow.Data.Collections do
 
     case collection.representative_work do
       nil ->
-        Map.put(collection, :representative_image, nil)
+        Map.put(
+          collection,
+          :representative_image,
+          FileSets.representative_image_url_for(%FileSet{
+            derivatives: %{"pyramid_tiff" => nil},
+            id: "00000000-0000-0000-0000-000000000001"
+          })
+        )
 
       work ->
         with updated_work <- work |> Works.add_representative_image() do

--- a/app/lib/meadow/indexing/v2/collection.ex
+++ b/app/lib/meadow/indexing/v2/collection.ex
@@ -18,7 +18,7 @@ defmodule Meadow.Indexing.V2.Collection do
       keywords: collection.keywords,
       modified_date: collection.updated_at,
       published: collection.published,
-      representative_image: representative_image(collection.representative_work),
+      representative_image: representative_image(collection),
       thumbnail: thumbnail_url(collection),
       title: collection.title,
       visibility: encode_label(collection.visibility)
@@ -31,12 +31,10 @@ defmodule Meadow.Indexing.V2.Collection do
 
   def thumbnail_url(collection), do: "#{api_url()}/collections/#{collection.id}/thumbnail"
 
-  def representative_image(nil), do: %{}
-
-  def representative_image(work) do
+  def representative_image(collection) do
     %{
-      work_id: work.id,
-      url: work.representative_image
+      work_id: collection.representative_work_id,
+      url: collection.representative_image
     }
   end
 

--- a/app/test/meadow/data/collections_test.exs
+++ b/app/test/meadow/data/collections_test.exs
@@ -104,9 +104,11 @@ defmodule Meadow.Data.CollectionsTest do
       {:ok, collection: collection, work: work, image_url: work.representative_image}
     end
 
-    test "no representative image assigned", %{collection: collection} do
+    test "a placeholder image is assigned without a representative work", %{
+      collection: collection
+    } do
       {:ok, collection} = Collections.set_representative_image(collection, nil)
-      assert(is_nil(collection.representative_image))
+      assert(collection.representative_image)
     end
 
     test "list_works/0", %{image_url: image_url} do
@@ -156,7 +158,7 @@ defmodule Meadow.Data.CollectionsTest do
       assert "Not a collection" |> Collections.add_representative_image() == "Not a collection"
     end
 
-    test "deleting a work nilifies the representative image", %{
+    test "deleting a work sets the placeholder representative image", %{
       collection: collection,
       image_url: image_url,
       work: work
@@ -167,7 +169,7 @@ defmodule Meadow.Data.CollectionsTest do
 
       work |> Works.delete_work()
 
-      assert(is_nil(Collections.get_collection!(collection.id) |> Map.get(:representative_image)))
+      assert(Collections.get_collection!(collection.id) |> Map.get(:representative_image))
     end
   end
 end


### PR DESCRIPTION
# Summary 
This PR sets a placeholder image on collections without a representative work:
![SCR-20230202-miw](https://user-images.githubusercontent.com/1395707/216462181-55144bd9-7a61-44c7-851b-ffb8a20e6f35.png)


# Specific Changes in this PR
- Placeholder images set in the same way as the works implementation

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

