### PR TITLE
Write sitemap.xml if necessary

### DIFF
--- a/app/config/releases.exs
+++ b/app/config/releases.exs
@@ -111,7 +111,8 @@ config :meadow,
     gzip: true,
     store: Sitemapper.S3Store,
     store_config: [
-      bucket: aws_secret("meadow", dig: ["buckets", "sitemap"])
+      bucket: aws_secret("meadow", dig: ["buckets", "sitemap"]),
+      path: "/"
     ],
     sitemap_url: aws_secret("meadow", dig: ["dc", "base_url"])
   ],


### PR DESCRIPTION
# Summary 
Include sitemap.xml alongsize sitemap.xml.gz

# Specific Changes in this PR
- Update Sitemap module to include sitemap.xml when gzip option is set

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
- Run `mix sitemap.generate` on a dev machine and check the sitemap files in `priv/static/`
- Add `config :meadow, sitemaps: [ gzip: true ]` to `dev.local.exs` and repeat the above step

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

