### PR TITLE
Make keywords multi input on Collection form

### DIFF
--- a/app/assets/js/components/Collection/Form.test.js
+++ b/app/assets/js/components/Collection/Form.test.js
@@ -1,14 +1,15 @@
-import React from "react";
-import CollectionForm from "./Form";
 import {
   renderWithRouterApollo,
   withReactHookForm,
 } from "../../services/testing-helpers";
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
+
+import { CodeListProvider } from "@js/context/code-list-context";
+import CollectionForm from "./Form";
+import React from "react";
+import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
 import { collectionMock } from "./collection.gql.mock";
 import { mockUser } from "@js/components/Auth/auth.gql.mock";
-import { CodeListProvider } from "@js/context/code-list-context";
-import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
 import useIsAuthorized from "@js/hooks/useIsAuthorized";
 
 jest.mock("@js/hooks/useIsAuthorized");
@@ -19,7 +20,9 @@ useIsAuthorized.mockReturnValue({
 
 describe("Collection Form component", () => {
   beforeEach(() => {
-    const Wrapped = withReactHookForm(CollectionForm);
+    const Wrapped = withReactHookForm(CollectionForm, {
+      collection: undefined,
+    });
     renderWithRouterApollo(
       <CodeListProvider>
         <Wrapped />
@@ -51,7 +54,11 @@ describe("Collection Form component", () => {
     expect(await screen.findByTestId("textarea-description")).toHaveValue("");
     expect(await screen.findByTestId("input-finding-aid-url")).toHaveValue("");
     expect(await screen.findByTestId("input-admin-email")).toHaveValue("");
-    expect(await screen.findByTestId("input-keywords")).toHaveValue("");
+
+    const keywordsWrapperEl = screen.getByTestId("input-keywords");
+    const keywordInputEl =
+      within(keywordsWrapperEl).queryAllByTestId("field-array-row");
+    expect(keywordInputEl).toHaveLength(0);
   });
 });
 
@@ -78,13 +85,15 @@ it("renders existing collection values in the form when editing a form", async (
   expect(await screen.findByTestId("input-finding-aid-url")).toHaveValue(
     "https://northwestern.edu"
   );
-
   expect(await screen.findByTestId("input-admin-email")).toHaveValue(
     "admin@nu.com"
   );
-  expect(await screen.findByTestId("input-keywords")).toHaveValue(
-    "yo,foo,bar,work,hey"
-  );
+
+  for (let i = 0; i < collectionMock.keywords.length; i++) {
+    expect(
+      screen.getByDisplayValue(collectionMock.keywords[i])
+    ).toBeInTheDocument();
+  }
 });
 
 //TODO: How to test this form with route changes, using useHistory() hook

--- a/app/assets/js/components/UI/Form/FieldArray.jsx
+++ b/app/assets/js/components/UI/Form/FieldArray.jsx
@@ -1,9 +1,9 @@
-import React from "react";
 import PropTypes from "prop-types";
+import React from "react";
+import UIFormFieldArrayAddButton from "@js/components/UI/Form/FieldArrayAddButton";
+import UIFormFieldArrayRow from "@js/components/UI/Form/FieldArrayRow";
 import { useFieldArray } from "react-hook-form";
 import { useFormContext } from "react-hook-form";
-import UIFormFieldArrayRow from "@js/components/UI/Form/FieldArrayRow";
-import UIFormFieldArrayAddButton from "@js/components/UI/Form/FieldArrayAddButton";
 
 const UIFormFieldArray = ({
   name,
@@ -56,9 +56,9 @@ const UIFormFieldArray = ({
       </ul>
 
       <UIFormFieldArrayAddButton
-          btnLabel={`Add ${fields.length > 0 ? "another" : ""}`}
-          handleAddClick={handleAddClick}
-        />
+        btnLabel={`Add ${fields.length > 0 ? "another" : ""}`}
+        handleAddClick={handleAddClick}
+      />
     </fieldset>
   );
 };

--- a/app/assets/js/components/Work/Tabs/About.jsx
+++ b/app/assets/js/components/Work/Tabs/About.jsx
@@ -1,35 +1,36 @@
-import React, { useEffect, useState } from "react";
-import PropTypes from "prop-types";
-import { toastWrapper } from "../../../services/helpers";
-import { useForm, FormProvider } from "react-hook-form";
-import { useMutation } from "@apollo/client";
-import useIsEditing from "../../../hooks/useIsEditing";
-import { GET_WORK, UPDATE_WORK } from "../work.gql.js";
-import UIAccordion from "../../UI/Accordion";
-import WorkTabsAboutCoreMetadata from "./About/CoreMetadata";
-import WorkTabsAboutControlledMetadata from "./About/ControlledMetadata";
-import WorkTabsAboutIdentifiersMetadata from "./About/IdentifiersMetadata";
-import WorkTabsAboutPhysicalMetadata from "./About/PhysicalMetadata";
-import WorkTabsAboutRightsMetadata from "./About/RightsMetadata";
-import WorkTabsAboutUncontrolledMetadata from "./About/UncontrolledMetadata";
 import {
-  convertFieldArrayValToHookFormVal,
-  prepControlledTermInput,
-  prepFieldArrayItemsForPost,
-  prepEDTFforPost,
-  prepNotes,
-  prepRelatedUrl,
   CONTROLLED_METADATA,
   IDENTIFIER_METADATA,
   PHYSICAL_METADATA,
   RIGHTS_METADATA,
   UNCONTROLLED_METADATA,
+  convertFieldArrayValToHookFormVal,
   deleteKeyFromObject,
+  prepControlledTermInput,
+  prepEDTFforPost,
+  prepFieldArrayItemsForPost,
+  prepNotes,
+  prepRelatedUrl,
 } from "@js/services/metadata";
-import UIError from "../../UI/Error";
-import { IconEdit } from "@js/components/Icon";
-import { Button } from "@nulib/design-system";
+import { FormProvider, useForm } from "react-hook-form";
+import { GET_WORK, UPDATE_WORK } from "../work.gql.js";
+import React, { useEffect, useState } from "react";
 import { Skeleton, TabsStickyHeader } from "@js/components/UI/UI";
+
+import { Button } from "@nulib/design-system";
+import { IconEdit } from "@js/components/Icon";
+import PropTypes from "prop-types";
+import UIAccordion from "../../UI/Accordion";
+import UIError from "../../UI/Error";
+import WorkTabsAboutControlledMetadata from "./About/ControlledMetadata";
+import WorkTabsAboutCoreMetadata from "./About/CoreMetadata";
+import WorkTabsAboutIdentifiersMetadata from "./About/IdentifiersMetadata";
+import WorkTabsAboutPhysicalMetadata from "./About/PhysicalMetadata";
+import WorkTabsAboutRightsMetadata from "./About/RightsMetadata";
+import WorkTabsAboutUncontrolledMetadata from "./About/UncontrolledMetadata";
+import { toastWrapper } from "../../../services/helpers";
+import useIsEditing from "../../../hooks/useIsEditing";
+import { useMutation } from "@apollo/client";
 
 function prepFormData(work) {
   const { descriptiveMetadata } = work;

--- a/app/assets/js/components/Work/Tabs/About/UncontrolledMetadata.test.js
+++ b/app/assets/js/components/Work/Tabs/About/UncontrolledMetadata.test.js
@@ -1,15 +1,15 @@
-import React from "react";
 import {
   renderWithRouterApollo,
   withReactHookForm,
 } from "@js/services/testing-helpers";
+
+import { CodeListProvider } from "@js/context/code-list-context";
+import React from "react";
+import { UNCONTROLLED_METADATA } from "@js/services/metadata";
+import WorkTabsAboutUncontrolledMetadata from "./UncontrolledMetadata";
+import { allCodeListMocks } from "../../controlledVocabulary.gql.mock";
 import { mockWork } from "@js/components/Work/work.gql.mock";
 import { screen } from "@testing-library/react";
-import WorkTabsAboutUncontrolledMetadata from "./UncontrolledMetadata";
-import { waitFor } from "@testing-library/react";
-import { UNCONTROLLED_METADATA } from "@js/services/metadata";
-import { allCodeListMocks } from "../../controlledVocabulary.gql.mock";
-import { CodeListProvider } from "@js/context/code-list-context";
 
 describe("Work About tab Uncontrolled Metadata component", () => {
   beforeEach(() => {

--- a/app/assets/js/screens/Collection/Form.test.js
+++ b/app/assets/js/screens/Collection/Form.test.js
@@ -1,12 +1,12 @@
 import React from "react";
-import ScreensCollectionForm from "./Form";
-import { renderWithRouterApollo } from "../../services/testing-helpers";
 import { Route } from "react-router-dom";
-import { waitFor } from "@testing-library/react";
+import ScreensCollectionForm from "./Form";
+import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
 import { getCollectionMock } from "../../components/Collection/collection.gql.mock";
 import { mockUser } from "@js/components/Auth/auth.gql.mock";
-import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
+import { renderWithRouterApollo } from "../../services/testing-helpers";
 import useIsAuthorized from "@js/hooks/useIsAuthorized";
+import { waitFor } from "@testing-library/react";
 
 jest.mock("@js/hooks/useIsAuthorized");
 useIsAuthorized.mockReturnValue({
@@ -46,40 +46,4 @@ it("renders add collection title", async () => {
 it("renders breadcrumbs", async () => {
   const { findByTestId } = setupTests();
   expect(await findByTestId("breadcrumbs"));
-});
-
-it("renders no initial form values when creating a collection", async () => {
-  const { getByTestId } = renderWithRouterApollo(
-    <Route path="/collection/form/" component={ScreensCollectionForm} />,
-    {
-      mocks: [...allCodeListMocks],
-      route: "/collection/form/",
-    }
-  );
-
-  await waitFor(() => {
-    expect(getByTestId("input-collection-title")).toHaveValue("");
-    expect(getByTestId("textarea-description")).toHaveValue("");
-    expect(getByTestId("input-finding-aid-url")).toHaveValue("");
-    expect(getByTestId("input-admin-email")).toHaveValue("");
-    expect(getByTestId("input-keywords")).toHaveValue("");
-  });
-});
-
-it("renders existing collection values in the form when editing a form", async () => {
-  const { getByTestId } = setupTests();
-
-  await waitFor(() => {
-    expect(getByTestId("input-collection-title")).toHaveValue(
-      "Great collection"
-    );
-    expect(getByTestId("textarea-description")).toHaveValue(
-      "Collection description lorem ipsum"
-    );
-    expect(getByTestId("input-finding-aid-url")).toHaveValue(
-      "https://northwestern.edu"
-    );
-    expect(getByTestId("input-admin-email")).toHaveValue("admin@nu.com");
-    expect(getByTestId("input-keywords")).toHaveValue("yo,foo,bar,work,hey");
-  });
 });

--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -20,7 +20,7 @@
         "@honeybadger-io/react": "^1.0.1",
         "@nulib/design-system": "^1.5.1",
         "@radix-ui/react-dialog": "^0.1.7",
-        "@samvera/clover-iiif": "^1.10.2",
+        "@samvera/clover-iiif": "1.10.2",
         "@samvera/image-downloader": "^1.1.1",
         "bulma": "^0.9.4",
         "bulma-checkradio": "^2.1.3",


### PR DESCRIPTION
# Summary 
Previously users entered `keywords` for a Collection form via a single text input, with keywords separated by commas.  Now it uses the Field Array component, which lets users input keywords one by one, same as we do on the Work form.

**Before**

![image](https://user-images.githubusercontent.com/3020266/226732360-3df83d86-d064-414b-bdc3-252b58983683.png)


**After**

![image](https://user-images.githubusercontent.com/3020266/226731953-5644a8ae-895f-4c6c-9252-deea8c711142.png)


# Specific Changes in this PR
- Collection form `keywords` form input updated

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Add a new Collection, or edit an existing Collection on Meadow Staging.

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

