### PR TITLE
Use SQL `COPY ... WITH FORMAT CSV` for bulk updates

### DIFF
--- a/app/lib/meadow/data/csv/bulk_import.ex
+++ b/app/lib/meadow/data/csv/bulk_import.ex
@@ -1,0 +1,114 @@
+defmodule Meadow.Data.CSV.BulkImport do
+  @moduledoc """
+  Functions to bulk import CSV Metadata Updates using PostgreSQL
+  COPY/UPDATE
+  """
+
+  alias Ecto.Adapters.SQL
+  alias Meadow.Data.CSV.Import
+  alias Meadow.Utils.Stream, as: StreamUtil
+  alias NimbleCSV.RFC4180, as: CSV
+
+  @chunk_size 500
+
+  def import_stream(stream, job_id, repo \\ Meadow.Repo) do
+    with temp_table <- "works_" <> String.replace(job_id, "-", "") do
+      repo.transaction(
+        fn ->
+          repo.query("CREATE TEMP TABLE #{temp_table} (LIKE works)")
+
+          try do
+            stream
+            |> stream_rows()
+            |> Stream.map(fn chunk ->
+              update_chunk(temp_table, job_id, chunk, repo)
+            end)
+            |> Stream.run()
+          after
+            repo.query("DROP TABLE #{temp_table}")
+          end
+        end,
+        timeout: :infinity
+      )
+    end
+  end
+
+  def import_job(job) do
+    job.source
+    |> StreamUtil.stream_from()
+    |> Import.read_csv()
+    |> Import.stream()
+    |> import_stream(job.id)
+  end
+
+  defp update_chunk(temp_table, job_id, stream, repo) do
+    with [header_row] <- stream |> Enum.take(1),
+         rows <- stream |> Stream.drop(1),
+         set_clause <-
+           header_row
+           |> String.split(~r/\s*,\s*/)
+           |> Enum.map_join(", ", &"#{&1} = #{temp_table}.#{&1}"),
+         sql <-
+           "COPY #{temp_table} (#{header_row}) FROM STDIN WITH (FORMAT CSV, NULL '')" do
+      rows |> Enum.into(SQL.stream(repo, sql))
+      # credo:disable-for-previous-line Credo.Check.Warning.UnusedEnumOperation
+
+      repo.query(
+        "UPDATE works SET #{set_clause} FROM #{temp_table} WHERE works.id = #{temp_table}.id"
+      )
+
+      repo.query(
+        "INSERT INTO works_metadata_update_jobs (metadata_update_job_id, work_id) SELECT '#{job_id}', id FROM #{temp_table}"
+      )
+
+      repo.query("TRUNCATE TABLE #{temp_table}")
+    end
+  end
+
+  defp stream_rows(stream) do
+    with timestamp <- NaiveDateTime.utc_now() do
+      stream
+      |> Stream.map(fn entry ->
+        entry
+        |> Map.put(:inserted_at, timestamp)
+        |> Map.put(:updated_at, timestamp)
+      end)
+      |> Stream.chunk_every(@chunk_size)
+      |> Stream.map(&stream_chunk_of_rows/1)
+    end
+  end
+
+  defp stream_chunk_of_rows(chunk) do
+    Stream.resource(
+      fn -> :header end,
+      fn
+        nil ->
+          {:halt, nil}
+
+        :header ->
+          {
+            [chunk |> List.first() |> Map.keys() |> Enum.map(&to_string/1)]
+            |> CSV.dump_to_stream(),
+            :rows
+          }
+
+        :rows ->
+          {
+            chunk
+            |> Enum.map(fn entry ->
+              entry
+              |> Enum.map(fn
+                {_, %NaiveDateTime{} = v} -> NaiveDateTime.to_iso8601(v)
+                {_, v} when is_list(v) or is_map(v) -> Jason.encode!(v)
+                {_, v} -> to_string(v)
+              end)
+            end)
+            |> CSV.dump_to_stream(),
+            nil
+          }
+      end,
+      fn _ -> :ok end
+    )
+    |> Stream.map(&IO.iodata_to_binary/1)
+  end
+end

--- a/app/lib/meadow/data/schemas/types/edtf_date.ex
+++ b/app/lib/meadow/data/schemas/types/edtf_date.ex
@@ -33,6 +33,8 @@ defmodule Meadow.Data.Types.EDTFDate do
   defp humanize(%{"edtf" => edtf, "humanized" => humanized}),
     do: {:ok, %{edtf: edtf, humanized: humanized}}
 
+  defp humanize(%{"edtf" => edtf}), do: humanize(edtf)
+
   defp humanize(%{edtf: edtf}), do: humanize(edtf)
 
   defp humanize(edtf) when is_binary(edtf) do


### PR DESCRIPTION
# Summary 

Use the bulk load / update from temp table strategy for CSV metadata updates. I'm giving it a minor bump instead of patch because it seems like a pretty big change in functionality even though it's the same from the end user perspective.

# Specific Changes in this PR
- Add `CSV.BulkImport` context
- Update `CSV.MetadataUpdateJobs` module to use bulk import
- Add one case to the EDTF type that was previously overlooked

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test

Do a round trip (export/import) of CSV metadata with some changes to the CSV file. Check the results.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

