### PR TITLE
Fix license metadata field not being supported in batch updating

### DIFF
--- a/app/assets/js/components/BatchEdit/Confirmation.jsx
+++ b/app/assets/js/components/BatchEdit/Confirmation.jsx
@@ -1,25 +1,26 @@
-import React, { useState } from "react";
-import PropTypes from "prop-types";
-import UIFormInput from "@js/components/UI/Form/Input";
-import UIFormField from "@js/components/UI/Form/Field";
-import { toastWrapper } from "@js/services/helpers";
-import { BATCH_UPDATE } from "@js/components/BatchEdit/batch-edit.gql";
-import { useMutation } from "@apollo/client";
-import BatchEditConfirmationTable from "@js/components/BatchEdit/ConfirmationTable";
-import { removeLabelsFromBatchEditPostData } from "@js/services/metadata";
-import { useHistory } from "react-router-dom";
 import { Button, Notification } from "@nulib/design-system";
 import {
   IconAdd,
-  IconReplace,
   IconAlert,
+  IconReplace,
   IconTrashCan,
 } from "@js/components/Icon";
-import UIIconText from "@js/components/UI/IconText";
-import { useCodeLists } from "@js/context/code-list-context";
-
+import React, { useState } from "react";
 /** @jsx jsx */
 import { css, jsx } from "@emotion/react";
+
+import { BATCH_UPDATE } from "@js/components/BatchEdit/batch-edit.gql";
+import BatchEditConfirmationTable from "@js/components/BatchEdit/ConfirmationTable";
+import PropTypes from "prop-types";
+import UIFormField from "@js/components/UI/Form/Field";
+import UIFormInput from "@js/components/UI/Form/Input";
+import UIIconText from "@js/components/UI/IconText";
+import { removeLabelsFromBatchEditPostData } from "@js/services/metadata";
+import { toastWrapper } from "@js/services/helpers";
+import { useCodeLists } from "@js/context/code-list-context";
+import { useHistory } from "react-router-dom";
+import { useMutation } from "@apollo/client";
+
 const verifyInputWrapper = css`
   width: 100%;
   max-width: 400px;
@@ -210,7 +211,9 @@ const BatchEditConfirmation = ({
                       ? "Publish works"
                       : "Unpublish works",
                   }),
-                  readingRoom: batchReplaces.readingRoom,
+                  ...(batchReplaces.readingRoom && {
+                    readingRoom: batchReplaces.readingRoom,
+                  }),
                 }}
                 type="replace"
               />

--- a/app/assets/js/components/BatchEdit/Tabs.jsx
+++ b/app/assets/js/components/BatchEdit/Tabs.jsx
@@ -1,28 +1,29 @@
-import React, { useState } from "react";
-import BatchEditAbout from "./About/About";
-import BatchEditAdministrative from "./Administrative/Administrative";
-import { CodeListProvider } from "@js/context/code-list-context";
-import BatchEditConfirmation from "@js/components/BatchEdit/Confirmation";
-import BatchEditAboutModalRemove from "@js/components/BatchEdit/ModalRemove";
-import {
-  useBatchDispatch,
-  useBatchState,
-} from "@js/context/batch-edit-context";
-import { useForm, FormProvider } from "react-hook-form";
+import { Button, Notification } from "@nulib/design-system";
 import {
   CONTROLLED_METADATA,
+  PROJECT_METADATA,
   getBatchMultiValueDataFromForm,
   parseMultiValues,
   prepControlledTermInput,
   prepFacetKey,
   prepNotes,
   prepRelatedUrl,
-  PROJECT_METADATA,
 } from "@js/services/metadata";
-import UITabsStickyHeader from "@js/components/UI/Tabs/StickyHeader";
-import { Button, Notification } from "@nulib/design-system";
-import UIIconText from "../UI/IconText";
+import { FormProvider, useForm } from "react-hook-form";
+import React, { useState } from "react";
+import {
+  useBatchDispatch,
+  useBatchState,
+} from "@js/context/batch-edit-context";
+
+import BatchEditAbout from "./About/About";
+import BatchEditAboutModalRemove from "@js/components/BatchEdit/ModalRemove";
+import BatchEditAdministrative from "./Administrative/Administrative";
+import BatchEditConfirmation from "@js/components/BatchEdit/Confirmation";
+import { CodeListProvider } from "@js/context/code-list-context";
 import { IconAlert } from "@js/components/Icon";
+import UIIconText from "../UI/IconText";
+import UITabsStickyHeader from "@js/components/UI/Tabs/StickyHeader";
 
 export default function BatchEditTabs() {
   const [activeTab, setActiveTab] = useState("tab-about");
@@ -110,14 +111,12 @@ export default function BatchEditTabs() {
       }
     });
 
-    console.log(`addItems.descriptive`, addItems.descriptive);
-    console.log(`replaceItems.descriptive`, replaceItems.descriptive);
-
-    if (currentFormValues.rightsStatement) {
-      replaceItems.descriptive.rightsStatement = JSON.parse(
-        currentFormValues.rightsStatement
-      );
-    }
+    /** Handle single-value About metadata dropdown items (whose <select> value is stringified and must be parsed to get the value) */
+    ["license", "rightsStatement"].forEach((item) => {
+      if (currentFormValues[item]) {
+        replaceItems.descriptive[item] = JSON.parse(currentFormValues[item]);
+      }
+    });
 
     ["title"].forEach((item) => {
       if (currentFormValues[item]) {


### PR DESCRIPTION
# Summary 
Supports the `license` field in batch updates.

# Specific Changes in this PR
- Accounts for the `license` form field when prepping Batch replace items.  Previously it wasn't accounted for in the batch update form.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
1. From the Search page, select a few items and do a batch edit.
2. Update the `license` field
3. Notice the `license` field appears in the Batch Edit confirmation modal, and will update successfully on a batch edit.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

