### PR TITLE
Handle single Work editing of License field

### DIFF
--- a/app/assets/js/components/UI/Form/Select.jsx
+++ b/app/assets/js/components/UI/Form/Select.jsx
@@ -1,5 +1,5 @@
-import React from "react";
 import PropTypes from "prop-types";
+import React from "react";
 import { useFormContext } from "react-hook-form";
 
 const UIFormSelect = ({

--- a/app/assets/js/components/Work/Tabs/About.jsx
+++ b/app/assets/js/components/Work/Tabs/About.jsx
@@ -71,7 +71,6 @@ function prepFormData(work) {
     })),
     notes: descriptiveMetadata.notes,
     relatedUrl: descriptiveMetadata.relatedUrl,
-    license: descriptiveMetadata.license,
     ...resetValues,
     ...controlledTermResetValues,
   };
@@ -117,6 +116,7 @@ const WorkTabsAbout = ({ work }) => {
     let currentFormValues = methods.getValues();
 
     const { title = "" } = currentFormValues;
+
     let workUpdateInput = {
       descriptiveMetadata: {
         alternateTitle: prepFieldArrayItemsForPost(
@@ -125,7 +125,10 @@ const WorkTabsAbout = ({ work }) => {
         dateCreated: prepEDTFforPost(currentFormValues.dateCreated),
         description: prepFieldArrayItemsForPost(currentFormValues.description),
         license: data.license
-          ? deleteKeyFromObject(JSON.parse(data.license))
+          ? {
+              id: data.license,
+              scheme: "LICENSE",
+            }
           : {},
         notes: prepNotes(currentFormValues.notes),
         relatedUrl: prepRelatedUrl(currentFormValues.relatedUrl),

--- a/app/assets/js/components/Work/Tabs/About/RightsMetadata.jsx
+++ b/app/assets/js/components/Work/Tabs/About/RightsMetadata.jsx
@@ -1,15 +1,12 @@
-import React from "react";
 import PropTypes from "prop-types";
+import { RIGHTS_METADATA } from "@js/services/metadata";
+import React from "react";
+import UICodedTermItem from "@js/components/UI/CodedTerm/Item";
+import UIFormField from "@js/components/UI/Form/Field";
 import UIFormFieldArray from "@js/components/UI/Form/FieldArray";
 import UIFormFieldArrayDisplay from "@js/components/UI/Form/FieldArrayDisplay";
-import {
-  RIGHTS_METADATA,
-  getCodedTermSelectOptions,
-} from "@js/services/metadata";
-import UIFormField from "@js/components/UI/Form/Field";
 import UIFormInput from "@js/components/UI/Form/Input";
 import UIFormSelect from "@js/components/UI/Form/Select";
-import UICodedTermItem from "@js/components/UI/CodedTerm/Item";
 import { useCodeLists } from "@js/context/code-list-context";
 
 const WorkTabsAboutRightsMetadata = ({ descriptiveMetadata, isEditing }) => {
@@ -20,12 +17,12 @@ const WorkTabsAboutRightsMetadata = ({ descriptiveMetadata, isEditing }) => {
       {RIGHTS_METADATA.map((item) => (
         <div className="column is-half" key={item.name} data-testid={item.name}>
           {isEditing ? (
-            <UIFormFieldArray 
-              required 
-              name={item.name} 
+            <UIFormFieldArray
+              required
+              name={item.name}
               label={item.label}
-              isTextarea={item.inputEl && item.inputEl === 'textarea'} 
-              />
+              isTextarea={item.inputEl && item.inputEl === "textarea"}
+            />
           ) : (
             <UIFormFieldArrayDisplay
               values={descriptiveMetadata[item.name]}
@@ -35,22 +32,18 @@ const WorkTabsAboutRightsMetadata = ({ descriptiveMetadata, isEditing }) => {
         </div>
       ))}
 
-      <div className="column is-half" data-testid="license">
+      <div className="column is-half">
         {/* License */}
         <UIFormField label="License">
           {isEditing ? (
             <UIFormSelect
-              name="license"
               isReactHookForm
-              showHelper={true}
+              name="license"
               label="License"
+              showHelper={true}
+              data-testid="license"
               options={
-                codeLists.licenseData
-                  ? getCodedTermSelectOptions(
-                      codeLists.licenseData.codeList,
-                      "LICENSE"
-                    )
-                  : []
+                codeLists.licenseData ? codeLists.licenseData.codeList : []
               }
               defaultValue={
                 descriptiveMetadata.license

--- a/app/assets/js/components/Work/Tabs/About/RightsMetadata.test.js
+++ b/app/assets/js/components/Work/Tabs/About/RightsMetadata.test.js
@@ -1,16 +1,17 @@
-import React from "react";
 import {
   renderWithRouterApollo,
   withReactHookForm,
 } from "@js/services/testing-helpers";
-import { mockWork } from "@js/components/Work/work.gql.mock";
-import WorkTabsAboutRightsMetadata from "./RightsMetadata";
-import { RIGHTS_METADATA } from "@js/services/metadata";
-import { screen } from "@testing-library/react";
-import { CodeListProvider } from "@js/context/code-list-context";
-import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
 
-describe("Work About tab Idenfiers Metadata component", () => {
+import { CodeListProvider } from "@js/context/code-list-context";
+import { RIGHTS_METADATA } from "@js/services/metadata";
+import React from "react";
+import WorkTabsAboutRightsMetadata from "./RightsMetadata";
+import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
+import { mockWork } from "@js/components/Work/work.gql.mock";
+import { screen } from "@testing-library/react";
+
+describe.only("Work About tab Idenfiers Metadata component", () => {
   beforeEach(() => {
     const Wrapped = withReactHookForm(WorkTabsAboutRightsMetadata, {
       isEditing: true,
@@ -28,18 +29,18 @@ describe("Work About tab Idenfiers Metadata component", () => {
 
   it("renders expected rights metadata fields", async () => {
     for (let item of RIGHTS_METADATA) {
-      expect(await screen.findByTestId(item.name));
+      expect(await screen.findByTestId(item.name)).toBeInTheDocument();
     }
   });
 
   it("renders rights metadata component", async () => {
-    expect(await screen.findByTestId("rights-metadata"));
+    expect(await screen.findByTestId("rights-metadata")).toBeInTheDocument();
   });
 
   it("renders license field", async () => {
-    expect(await screen.findByTestId("license"));
+    expect(await screen.findByTestId("license")).toBeInTheDocument();
   });
   it("renders terms of use field", async () => {
-    expect(await screen.findByTestId("input-terms-of-use"));
+    expect(await screen.findByTestId("input-terms-of-use")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Handle single Work editing of License field, which was impacting updating Rights Statement

# Summary 
There was an issue with the `License` field being handled in a single Work edit page.  This possibly was a red herring of why updating `Rights Statement` didn't work.  Now both can be updated, and removed (by selecting "--Select") for a single Work.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Go to a single work.  Update the Work to set and unset the "License" and "Rights Statement" fields, in any order and it should update as expected.

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

