### PR TITLE
Adds more granular "reindex all" functionality

### DIFF
--- a/app/lib/meadow/data/indexer.ex
+++ b/app/lib/meadow/data/indexer.ex
@@ -32,11 +32,18 @@ defmodule Meadow.Data.Indexer do
   end
 
   def reindex_all(version) do
-    [FileSet, Work, Collection]
-    |> Enum.each(fn schema ->
-      SearchClient.hot_swap(schema, version, fn index ->
-        synchronize_schema(schema, version, index, :all)
-      end)
+    reindex_all(version, [FileSet, Work, Collection])
+  end
+
+  def reindex_all(version, schemas) when is_list(schemas) do
+    schemas
+    |> Enum.uniq()
+    |> Enum.each(&reindex_all(version, &1))
+  end
+
+  def reindex_all(version, schema) do
+    SearchClient.hot_swap(schema, version, fn index ->
+      synchronize_schema(schema, version, index, :all)
     end)
   end
 

--- a/app/test/meadow/data/indexer_test.exs
+++ b/app/test/meadow/data/indexer_test.exs
@@ -21,10 +21,16 @@ defmodule Meadow.Data.IndexerTest do
       assert_doc_counts_match(context)
     end
 
-    test "reindex_all/0", context do
+    test "reindex_all", context do
       Indexer.synchronize_index()
       assert_doc_counts_match(context)
       Indexer.reindex_all()
+      assert_doc_counts_match(context)
+      Indexer.reindex_all(2)
+      assert_doc_counts_match(context)
+      Indexer.reindex_all(2, Work)
+      assert_doc_counts_match(context)
+      Indexer.reindex_all(2, [FileSet, Collection])
       assert_doc_counts_match(context)
     end
   end


### PR DESCRIPTION
# Summary 
You can now pass in any combination of versions and schemas to the `reindex_all/1` function. See test for examples.

# Specific Changes in this PR
- indexer and indexer_test updates

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [x] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

