### PR TITLE
Index raw EDTF date_created alongside humanized version

### DIFF
--- a/app/lib/meadow/indexing/v2/work.ex
+++ b/app/lib/meadow/indexing/v2/work.ex
@@ -26,6 +26,7 @@ defmodule Meadow.Indexing.V2.Work do
       creator: encode_field(work.descriptive_metadata.creator),
       csv_metadata_update_jobs: work.metadata_update_jobs |> Enum.map(& &1.id),
       cultural_context: work.descriptive_metadata.cultural_context,
+      date_created_edtf: encode_edtf(work.descriptive_metadata.date_created),
       date_created: encode_field(work.descriptive_metadata.date_created),
       description: work.descriptive_metadata.description,
       file_sets: file_sets(work),
@@ -127,6 +128,10 @@ defmodule Meadow.Indexing.V2.Work do
   def encode_field(%{humanized: humanized}), do: humanized
 
   def encode_field(field), do: field
+
+  def encode_edtf(value) when is_list(value), do: Enum.map(value, &encode_edtf/1)
+  def encode_edtf(%{edtf: edtf}), do: edtf
+  def encode_edtf(value), do: value
 
   def encode_project(admin_metadata) do
     %{


### PR DESCRIPTION
# Summary 

Index raw EDTF date_created alongside humanized version

# Specific Changes in this PR
- Add `date_created_edtf` field to v2 Work indexer

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

