### PR TITLE
Fix most of the modal CSS issues

### DIFF
--- a/app/assets/build.js
+++ b/app/assets/build.js
@@ -29,7 +29,7 @@ const define = {
 
 const loader = {
   ".js": "jsx",
-  ".png": "file"
+  ".png": "file",
 };
 
 const importMapper = (loc) => {
@@ -54,12 +54,12 @@ const plugins = [
   copy({
     assets: {
       from: "./static/**/*",
-      to: ".." // relative to `outdir` below
+      to: "..", // relative to `outdir` below
     },
-    watch: true
+    watch: true,
   }),
-  sassPlugin({ cssImports: true, importMapper }), 
-  svgr()
+  sassPlugin({ cssImports: true, importMapper }),
+  svgr(),
 ];
 
 let opts = {

--- a/app/assets/js/app.jsx
+++ b/app/assets/js/app.jsx
@@ -1,14 +1,14 @@
 import "../styles/app.scss";
-import isUndefined from "lodash.isundefined";
-import React from "react";
-import Root from "./screens/Root";
-import Honeybadger from "@honeybadger-io/js";
-import ErrorBoundary from "@honeybadger-io/react";
-import { createRoot } from 'react-dom/client';
 
 // GraphQL-specific
 import { ApolloProvider } from "@apollo/client";
+import ErrorBoundary from "@honeybadger-io/react";
+import Honeybadger from "@honeybadger-io/js";
+import React from "react";
+import Root from "./screens/Root";
 import client from "./client";
+import { createRoot } from "react-dom/client";
+import isUndefined from "lodash.isundefined";
 
 const ifDefined = (value, fallback) => (isUndefined(value) ? fallback : value);
 
@@ -25,10 +25,10 @@ const honeybadger = Honeybadger.configure(config).setContext({
 
 const container = document.getElementById("react-app");
 const root = createRoot(container);
-root.render(<ErrorBoundary honeybadger={honeybadger}>
-  <ApolloProvider client={client}>
-    <Root />
-  </ApolloProvider>
-</ErrorBoundary>)
-
-
+root.render(
+  <ErrorBoundary honeybadger={honeybadger}>
+    <ApolloProvider client={client}>
+      <Root />
+    </ApolloProvider>
+  </ErrorBoundary>
+);

--- a/app/assets/js/components/Collection/Form.jsx
+++ b/app/assets/js/components/Collection/Form.jsx
@@ -223,7 +223,7 @@ const CollectionForm = ({ collection }) => {
                 id="published"
                 type="checkbox"
                 {...methods.register("published")}
-                className="switch"
+                className="switch is-info"
                 data-testid="checkbox-published"
                 defaultChecked={collection ? collection.published : false}
               />

--- a/app/assets/js/components/UI/Sticky.jsx
+++ b/app/assets/js/components/UI/Sticky.jsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from "react";
+
 import PropTypes from "prop-types";
 
 const UISticky = ({ children, ...restProps }) => {
   const [headerHeight, setHeaderHeight] = useState();
   const styles = {
     headerStyle: {
-      position: "-webkit-sticky",
       position: "sticky",
       top: headerHeight,
       zIndex: 100,

--- a/app/assets/js/components/UI/Tabs/StickyHeader.jsx
+++ b/app/assets/js/components/UI/Tabs/StickyHeader.jsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from "react";
-import PropTypes from "prop-types";
-import AuthDisplayAuthorized from "@js/components/Auth/DisplayAuthorized";
+
 import { ActionHeadline } from "@js/components/UI/UI";
+import AuthDisplayAuthorized from "@js/components/Auth/DisplayAuthorized";
+import PropTypes from "prop-types";
 
 const UITabsStickyHeader = ({ title, children, ...restProps }) => {
   const [headerHeight, setHeaderHeight] = useState();
   const styles = {
     headerStyle: {
-      position: "-webkit-sticky",
       position: "sticky",
       top: headerHeight,
       zIndex: 10,

--- a/app/assets/js/components/Work/Fileset/ListItem.jsx
+++ b/app/assets/js/components/Work/Fileset/ListItem.jsx
@@ -1,16 +1,17 @@
+import { Button, Tag } from "@nulib/design-system";
 import React, { useContext } from "react";
+import { useWorkDispatch, useWorkState } from "@js/context/work-context";
+
+import AuthDisplayAuthorized from "@js/components/Auth/DisplayAuthorized";
+import { IIIFContext } from "@js/components/IIIF/IIIFProvider";
+import { IconPlay } from "@js/components/Icon";
 import PropTypes from "prop-types";
+import UIFormField from "@js/components/UI/Form/Field";
 import UIFormInput from "@js/components/UI/Form/Input";
 import UIFormTextarea from "@js/components/UI/Form/Textarea";
-import UIFormField from "@js/components/UI/Form/Field";
 import WorkFilesetActionButtonsAccess from "@js/components/Work/Fileset/ActionButtons/Access";
 import WorkFilesetActionButtonsAuxillary from "@js/components/Work/Fileset/ActionButtons/Auxillary";
-import { IIIFContext } from "@js/components/IIIF/IIIFProvider";
-import AuthDisplayAuthorized from "@js/components/Auth/DisplayAuthorized";
 import useFileSet from "@js/hooks/useFileSet";
-import { useWorkDispatch, useWorkState } from "@js/context/work-context";
-import { Button, Tag } from "@nulib/design-system";
-import { IconPlay } from "@js/components/Icon";
 
 function WorkFilesetListItem({
   fileSet,
@@ -111,7 +112,7 @@ function WorkFilesetListItem({
                       id={`checkbox-work-switch-${id}`}
                       type="checkbox"
                       name={`checkbox-work-switch-${id}`}
-                      className="switch"
+                      className="switch is-info"
                       checked={workImageFilesetId === id}
                       onChange={() => handleWorkImageChange(id)}
                       data-testid="work-image-selector"

--- a/app/assets/js/components/Work/Tabs/Administrative/Collection.jsx
+++ b/app/assets/js/components/Work/Tabs/Administrative/Collection.jsx
@@ -1,15 +1,16 @@
-import React from "react";
-import PropTypes from "prop-types";
-import UIFormField from "@js/components/UI/Form/Field";
-import UIFormSelect from "@js/components/UI/Form/Select";
-import { toastWrapper, sortItemsArray } from "@js/services/helpers";
-import { useMutation, useQuery, useLazyQuery } from "@apollo/client";
 import {
   GET_COLLECTION,
   GET_COLLECTIONS,
   SET_COLLECTION_IMAGE,
 } from "@js/components/Collection/collection.gql.js";
+import { sortItemsArray, toastWrapper } from "@js/services/helpers";
+import { useLazyQuery, useMutation, useQuery } from "@apollo/client";
+
 import AuthDisplayAuthorized from "@js/components/Auth/DisplayAuthorized";
+import PropTypes from "prop-types";
+import React from "react";
+import UIFormField from "@js/components/UI/Form/Field";
+import UIFormSelect from "@js/components/UI/Form/Select";
 
 function WorkTabsAdministrativeCollection({
   collection,

--- a/app/assets/js/hooks/useRepositoryStats.js
+++ b/app/assets/js/hooks/useRepositoryStats.js
@@ -1,8 +1,9 @@
-import React from "react";
 import {
   elasticsearchDirectCount,
   elasticsearchDirectSearch,
 } from "@js/services/elasticsearch";
+
+import React from "react";
 
 /**
  * Elasticsearch queries

--- a/app/assets/js/screens/Login.jsx
+++ b/app/assets/js/screens/Login.jsx
@@ -1,13 +1,14 @@
 import React, { useContext } from "react";
-import { AuthContext } from "../components/Auth/Auth";
-import { Redirect } from "react-router-dom";
-import Layout from "./Layout";
-import { IconAlert } from "@js/components/Icon";
-import UIIconText from "@js/components/UI/IconText";
-import { Notification } from "@nulib/design-system";
-
 /** @jsx jsx */
 import { css, jsx } from "@emotion/react";
+
+import { AuthContext } from "../components/Auth/Auth";
+import { IconAlert } from "@js/components/Icon";
+import Layout from "./Layout";
+import { Notification } from "@nulib/design-system";
+import { Redirect } from "react-router-dom";
+import UIIconText from "@js/components/UI/IconText";
+
 const wrapper = css`
   height: 75vh;
   display: flex;
@@ -21,7 +22,7 @@ const ScreensLogin = () => {
 
   return (
     <Layout>
-      <div className="section" css={wrapper} className="">
+      <div className="section" css={wrapper}>
         <div className="container has-text-centered">
           <Notification isWarning className="is-size-5">
             <UIIconText icon={<IconAlert />}>

--- a/app/assets/styles/app.scss
+++ b/app/assets/styles/app.scss
@@ -6,7 +6,7 @@
 
 @import "~bulma/bulma";
 @import "~bulma-switch";
-@import "~bulma-checkradio";
+// @import "~bulma-checkradio";
 @import "~bulma-pageloader";
 @import "@creativebulma/bulma-tooltip";
 @import "@creativebulma/bulma-divider";

--- a/app/assets/styles/scss/_base.scss
+++ b/app/assets/styles/scss/_base.scss
@@ -137,3 +137,9 @@ table {
 .content .title {
   font-size: $size-1;
 }
+
+// Bulma switch override
+.switch[type="checkbox"]:checked + label::before,
+.switch[type="checkbox"]:checked + label:before {
+  background: $primary;
+}


### PR DESCRIPTION
@mbklein This fixes most of the CSS issues.  Bulma check radio was the culprit causing the modals to be off.

For the homepage, it's this error I think causing havoc:

<img width="766" alt="image" src="https://github.com/nulib/meadow/assets/3020266/7da143dd-f690-4421-97c6-eae36a7ac462">

The file is `meadow/app/assets/js/services/__mocks__/elasticsearch.js` which is just a mock being used for tests.  We need to tell `esbuild` to ignore this file when not running tests.   