### PR TITLE
Allow pipeline attributes to override default dispatch queue

### DIFF
--- a/app/lib/meadow/pipeline/dispatcher.ex
+++ b/app/lib/meadow/pipeline/dispatcher.ex
@@ -100,6 +100,17 @@ defmodule Meadow.Pipeline.Dispatcher do
 
   def all_progress_actions, do: @all_actions
 
+  def dispatcher_actions(file_set, attributes) do
+    case attributes do
+      %{custom_actions: custom_actions} ->
+        custom_actions
+        |> Enum.map(&Module.safe_concat(Meadow.Pipeline.Actions, &1))
+
+      _ ->
+        dispatcher_actions(file_set)
+    end
+  end
+
   def dispatcher_actions(%{role: %{id: "A"}, core_metadata: %{mime_type: "image/" <> _}}),
     do: @access_image_actions
 
@@ -179,7 +190,7 @@ defmodule Meadow.Pipeline.Dispatcher do
   def dispatch_next_action(file_set, last_action, attributes) do
     last = Module.safe_concat(Meadow.Pipeline.Actions, last_action)
 
-    case next_action(last, dispatcher_actions(file_set)) do
+    case next_action(last, dispatcher_actions(file_set, attributes)) do
       nil ->
         :noop
 

--- a/app/test/pipeline/dispatcher_test.exs
+++ b/app/test/pipeline/dispatcher_test.exs
@@ -231,6 +231,25 @@ defmodule Meadow.Pipeline.DispatcherTest do
 
       assert Dispatcher.dispatcher_actions(file_set) == nil
     end
+
+    test "custom list of actions" do
+      file_set =
+        file_set_fixture(%{
+          role: %{id: "A", scheme: "FILE_SET_ROLE"},
+          core_metadata: %{
+            mime_type: "image/tiff",
+            location: "s3://blahblah",
+            original_filename: "test.tif"
+          }
+        })
+
+      actions = ["ExtractExifMetadata", "CopyFileToPreservation"]
+      queue = [ExtractExifMetadata, CopyFileToPreservation]
+
+      assert Dispatcher.dispatcher_actions(file_set, %{custom_actions: actions}) == queue
+      assert Dispatcher.next_action(ExtractExifMetadata, queue) == CopyFileToPreservation
+      assert Dispatcher.next_action(CopyFileToPreservation, queue) |> is_nil()
+    end
   end
 
   describe "playlist exists" do


### PR DESCRIPTION
# Summary 

Accept list of actions as part of the initial dispatch to override the default queue

# Specific Changes in this PR
- Update dispatcher to take custom actions into account
- Add tests for custom actions
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

From iex, load an existing FileSet and
```
Meadow.Pipeline.Actions.ExtractExifMetadata.send_message(%{file_set_id: file_set.id}, %{force: "true"})
```
and watch the logs for the series of actions it goes through.

Then when it's done, do
```
Meadow.Pipeline.Actions.ExtractExifMetadata.send_message(%{file_set_id: file_set.id}, %{custom_actions: ["ExtractExifMetadata", "FileSetComplete"], force: "true"})
```
and watch how it only does those two.

Play with other combinations if you want.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

