### PR TITLE
Use delimited string instead of JSON array in custom_actions attribute

### DIFF
--- a/app/lib/meadow/pipeline/dispatcher.ex
+++ b/app/lib/meadow/pipeline/dispatcher.ex
@@ -104,6 +104,7 @@ defmodule Meadow.Pipeline.Dispatcher do
     case attributes do
       %{custom_actions: custom_actions} ->
         custom_actions
+        |> String.split(~r/\s*\|\s*/)
         |> Enum.map(&Module.safe_concat(Meadow.Pipeline.Actions, &1))
 
       _ ->

--- a/app/test/pipeline/dispatcher_test.exs
+++ b/app/test/pipeline/dispatcher_test.exs
@@ -243,7 +243,7 @@ defmodule Meadow.Pipeline.DispatcherTest do
           }
         })
 
-      actions = ["ExtractExifMetadata", "CopyFileToPreservation"]
+      actions = "ExtractExifMetadata | CopyFileToPreservation"
       queue = [ExtractExifMetadata, CopyFileToPreservation]
 
       assert Dispatcher.dispatcher_actions(file_set, %{custom_actions: actions}) == queue


### PR DESCRIPTION
# Summary 

This updates the functionality introduced in #3338.

It turns out that SQS Message Attributes don't support string lists even though their documentation includes examples of them:

```
An error occurred (AWS.SimpleQueueService.UnsupportedOperation) when calling the SendMessage operation: Message attribute list values in SendMessage operation are not supported.
```

So instead of using a JSON array of actions (`["ExtractExifMetadata", "CopyFileToPreservation"]`), this PR has Meadow use a pipe-delimited list with optional whitespace (`"ExtractExifMetadata | CopyFileToPreservation"`).

# Specific Changes in this PR
- Change dispatcher to use delimited string list of custom actions instead of native list
- Update dispatcher test to reflect the change

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Similar to the test in #3338:

From iex, load an existing FileSet and
```
Meadow.Pipeline.Actions.ExtractExifMetadata.send_message(%{file_set_id: file_set.id}, %{force: "true"})
```
and watch the logs for the series of actions it goes through.

Then when it's done, do
```
Meadow.Pipeline.Actions.ExtractExifMetadata.send_message(%{file_set_id: file_set.id}, %{custom_actions: "ExtractExifMetadata | FileSetComplete", force: "true"})
```
and watch how it only does those two.

Play with other combinations if you want.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

