### PR TITLE
Avoid atom/string key collision when updating exif metadata

### DIFF
--- a/app/lib/meadow/pipeline/actions/extract_exif_metadata.ex
+++ b/app/lib/meadow/pipeline/actions/extract_exif_metadata.ex
@@ -55,7 +55,7 @@ defmodule Meadow.Pipeline.Actions.ExtractExifMetadata do
     extracted_metadata =
       case file_set.extracted_metadata do
         nil -> %{exif: exif_metadata}
-        map -> Map.put(map, :exif, exif_metadata)
+        map -> map |> Map.delete("exif") |> Map.put(:exif, exif_metadata)
       end
 
     FileSets.update_file_set(file_set, %{extracted_metadata: extracted_metadata})


### PR DESCRIPTION
# Summary 

Small bug fix to allow updating EXIF metadata when the existing value has string keys

# Specific Changes in this PR

- Update ExtractExifMetadata.handle_result/2
- Add test

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Create an image FileSet and let it run through the pipeline
- `Meadow.Data.FileSets.update_file_set(file_set, %{extracted_metadata: %{"exif" => [whatever you want]})`
- Check the database to make sure the value is NOT the file's actual EXIF
- `Meadow.Pipeline.Actions.ExtractExifMetadata.process(file_set, %{})`
- Check the database to make sure the value IS the file's actual EXIF

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

