### PR TITLE
Fix index version issue, thumbnails and batch works link

### DIFF
--- a/app/assets/js/components/Dashboards/BatchEdit/List.jsx
+++ b/app/assets/js/components/Dashboards/BatchEdit/List.jsx
@@ -1,10 +1,11 @@
-import React from "react";
-import { useQuery } from "@apollo/client";
+import { IconImages, IconView } from "@js/components/Icon";
+
 import { GET_BATCHES } from "@js/components/Dashboards/dashboards.gql";
 import { Link } from "react-router-dom";
-import UIDate from "@js/components/UI/Date";
-import { IconImages, IconView } from "@js/components/Icon";
+import React from "react";
 import { Tag } from "@nulib/design-system";
+import UIDate from "@js/components/UI/Date";
+import { useQuery } from "@apollo/client";
 
 const colHeaders = [
   "Nickname",
@@ -80,7 +81,7 @@ export default function DashboardsBatchEditList() {
                         title="View updated works"
                         to={{
                           pathname: "/search",
-                          state: { passedInSearchTerm: `batches:\"${id}\"` },
+                          state: { passedInSearchTerm: `batch_ids:\"${id}\"` },
                         }}
                       >
                         <IconImages />

--- a/app/assets/js/components/Search/ResultItem.jsx
+++ b/app/assets/js/components/Search/ResultItem.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from "react";
-import PropTypes from "prop-types";
+
 import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
 import { setVisibilityClass } from "../../services/helpers";
 
 const SearchResultItem = ({ res }) => {

--- a/app/assets/js/components/Work/CardItem.jsx
+++ b/app/assets/js/components/Work/CardItem.jsx
@@ -7,7 +7,6 @@ import React from "react";
 import { Tag } from "@nulib/design-system";
 import UIVisibilityTag from "@js/components/UI/VisibilityTag";
 import UIWorkImage from "@js/components/UI/WorkImage";
-import { getIIIFImageUrl } from "@js/services/helpers";
 
 const breakWord = css`
   word-break: break-all;
@@ -29,7 +28,7 @@ const WorkCardItem = ({
         <figure className="image is-3by3">
           <Link to={`/work/${id}`}>
             <UIWorkImage
-              imageUrl={getIIIFImageUrl(representativeImage)}
+              imageUrl={representativeImage}
               size={500}
               workTypeId={workTypeId}
             />

--- a/app/assets/js/components/Work/ListItem.jsx
+++ b/app/assets/js/components/Work/ListItem.jsx
@@ -7,7 +7,6 @@ import PropTypes from "prop-types";
 import { Tag } from "@nulib/design-system";
 import UIVisibilityTag from "@js/components/UI/VisibilityTag";
 import UIWorkImage from "../UI/WorkImage";
-import { getIIIFImageUrl } from "@js/services/helpers";
 
 const breakWord = css`
   word-break: break-all;
@@ -29,7 +28,7 @@ const WorkListItem = ({
           <div className="image is-128x128">
             <Link to={`/work/${id}`} title="View work">
               <UIWorkImage
-                imageUrl={getIIIFImageUrl(representativeImage)}
+                imageUrl={representativeImage}
                 size={500}
                 workTypeId={workTypeId}
               />

--- a/app/assets/js/services/helpers.js
+++ b/app/assets/js/services/helpers.js
@@ -62,12 +62,6 @@ export function getImageUrl(representativeImage) {
   return representativeImage || "";
 }
 
-export function getIIIFImageUrl(representativeImage) {
-  if (!representativeImage || typeof representativeImage !== "string")
-    return "";
-  return `${representativeImage}/square/500,500/0/default.jpg`;
-}
-
 export const TEMP_USER_FRIENDLY_STATUS = {
   UPLOADED: "Validation in progress...",
   ROW_FAIL: "Validation Errors",

--- a/app/config/releases.exs
+++ b/app/config/releases.exs
@@ -68,16 +68,6 @@ config :meadow, Meadow.Search.Cluster,
   json_library: Jason,
   indexes: [
     %{
-      name: "meadow",
-      settings: priv_path.("search/v1/settings/meadow.json"),
-      version: 1,
-      schemas: [
-        Meadow.Data.Schemas.Collection,
-        Meadow.Data.Schemas.FileSet,
-        Meadow.Data.Schemas.Work
-      ]
-    },
-    %{
       name: "dc-v2-work",
       settings: priv_path.("search/v2/settings/work.json"),
       version: 2,

--- a/app/lib/meadow/data/shared_links.ex
+++ b/app/lib/meadow/data/shared_links.ex
@@ -11,7 +11,6 @@ defmodule Meadow.Data.SharedLinks do
 
   @public_expiration "Never"
   @type_name "_doc"
-  @v2_work_index SearchConfig.alias_for(Work, 2)
 
   @enforce_keys [:work_id, :expires]
   defstruct shared_link_id: nil, work_id: nil, expires: nil
@@ -56,7 +55,7 @@ defmodule Meadow.Data.SharedLinks do
   def generate_many(query, ttl) when is_binary(query) do
     docs =
       query
-      |> Scroll.results(@v2_work_index)
+      |> Scroll.results(SearchConfig.alias_for(Work, 2))
       |> Stream.map(fn %{"_source" => work_doc} ->
         case work_doc do
           %{"visibility" => "Public", "published" => true} ->

--- a/app/test/meadow/data/index_worker_test.exs
+++ b/app/test/meadow/data/index_worker_test.exs
@@ -3,7 +3,7 @@ defmodule Meadow.Data.IndexWorkerTest do
   alias Meadow.Data.IndexWorker
 
   setup do
-    worker = start_supervised!({IndexWorker, version: 1})
+    worker = start_supervised!({IndexWorker, version: 2})
     on_exit(fn -> send(worker, :pause) end)
     %{worker: worker}
   end


### PR DESCRIPTION
Fixes #2842 and #2843

# Summary 

- Fix thumbnails on search page. (They had doubled up dimensions, ex: `/square/500,500/0/default.jpg/square/500,500/0/default.jpg`)
- Fix link from batch edit dashboard list to view works affected by a batch
- Remove `@v2_work_index` attributes and get value directly since it is incorrect at build time
- Remove v1 index configuration from `releases.exs`

