### PR TITLE
Fix search links for works edited in CSV Update Job

### DIFF
--- a/app/assets/js/components/Dashboards/Csv/Details.jsx
+++ b/app/assets/js/components/Dashboards/Csv/Details.jsx
@@ -1,10 +1,10 @@
-import React from "react";
-import PropTypes from "prop-types";
-import UIDate from "@js/components/UI/Date";
 import DashboardsCsvErrors from "@js/components/Dashboards/Csv/Errors";
 import DashboardsCsvStatus from "@js/components/Dashboards/Csv/Status";
-import { Link } from "react-router-dom";
 import { IconImages } from "@js/components/Icon";
+import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
+import React from "react";
+import UIDate from "@js/components/UI/Date";
 
 function DashboardsCsvDetails({ csvMetadataUpdateJob }) {
   const {
@@ -66,7 +66,7 @@ function DashboardsCsvDetails({ csvMetadataUpdateJob }) {
           to={{
             pathname: "/search",
             state: {
-              passedInSearchTerm: `metadataUpdateJobs:\"${updateId}\"`,
+              passedInSearchTerm: `csv_metadata_update_jobs:\"${updateId}\"`,
             },
           }}
         >

--- a/app/assets/js/components/Dashboards/Csv/List.jsx
+++ b/app/assets/js/components/Dashboards/Csv/List.jsx
@@ -1,13 +1,14 @@
-import React from "react";
-import PropTypes from "prop-types";
-import UISearchBarRow from "@js/components/UI/SearchBarRow";
-import UIFormInput from "@js/components/UI/Form/Input";
-import { useQuery } from "@apollo/client";
-import { GET_CSV_METADATA_UPDATE_JOBS } from "@js/components/Dashboards/dashboards.gql";
-import { formatDate } from "@js/services/helpers";
-import { Link } from "react-router-dom";
 import { IconImages, IconView } from "@js/components/Icon";
+
 import DashboardsCsvStatus from "@js/components/Dashboards/Csv/Status";
+import { GET_CSV_METADATA_UPDATE_JOBS } from "@js/components/Dashboards/dashboards.gql";
+import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
+import React from "react";
+import UIFormInput from "@js/components/UI/Form/Input";
+import UISearchBarRow from "@js/components/UI/SearchBarRow";
+import { formatDate } from "@js/services/helpers";
+import { useQuery } from "@apollo/client";
 
 const displayFields = [
   {
@@ -125,7 +126,7 @@ function DashboardsCsvList(props) {
                           to={{
                             pathname: "/search",
                             state: {
-                              passedInSearchTerm: `metadataUpdateJobs:\"${id}\"`,
+                              passedInSearchTerm: `csv_metadata_update_jobs:\"${id}\"`,
                             },
                           }}
                         >


### PR DESCRIPTION
- Fix links into search for works edited in CSV update job (use v2 index field name)

Relates to [nulib/repodev2843](https://github.com/nulib/repodev_planning_and_docs/issues/2843)