### PR TITLE
Update search query to use all_ids and search all_text

### DIFF
--- a/app/assets/js/components/UI/SearchBar.jsx
+++ b/app/assets/js/components/UI/SearchBar.jsx
@@ -30,6 +30,10 @@ const UISearchBar = () => {
       weight: 3,
     },
     {
+      field: "all_ids",
+      weight: 2,
+    },
+    {
       field: "collection.title",
       weight: 2,
     },
@@ -42,7 +46,7 @@ const UISearchBar = () => {
       weight: 2,
     },
     {
-      field: "full_text",
+      field: "all_text",
       weight: 1,
     },
     {


### PR DESCRIPTION
# Summary 
See https://github.com/nulib/repodev_planning_and_docs/issues/3956

# Specific Changes in this PR
- Update search query to use `all_ids` and `all_text`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
1. Navigate to a Work, and copy the `ark` value
2. Navigate to the Search page, and search by this value: ie `"ark: [YOUR VALUE]"`
3. The Work should appear in search results

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

