### PR TITLE
Update dcapi-types, add login statement.

### DIFF
--- a/app/assets/js/screens/Login.jsx
+++ b/app/assets/js/screens/Login.jsx
@@ -30,6 +30,19 @@ const ScreensLogin = () => {
               Meadow.
             </UIIconText>
           </Notification>
+          <p className="is-size-6 has-text-left p-5">
+            Northwestern University Libraries and its digitized collections in
+            Meadow contain materials that reflect the beliefs and norms of the
+            era and culture in which they were created or collected. As such,
+            staff who log into Meadow may encounter imagery, language, or
+            opinions related to a white supremacist, exploitative, and/or
+            discriminatory culture that they find offensive. Additionally, some
+            collections may contain sexual content or violence that may not be
+            appropriate for all audiences. The Libraries metadata staff are
+            actively working to remediate issues of outdated, inaccurate,
+            objectifying or disrespectful language that describes our
+            collections and welcome suggestions, questions, or comments.
+          </p>
         </div>
       </div>
     </Layout>

--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -68,7 +68,7 @@
         "@creativebulma/bulma-divider": "^1.1.0",
         "@creativebulma/bulma-tooltip": "^1.2.0",
         "@elastic/elasticsearch-mock": "^2.0.0",
-        "@nulib/dcapi-types": "^2.0.0",
+        "@nulib/dcapi-types": "^2.1.0",
         "@nulib/prettier-config": "^1.2.0",
         "@testing-library/dom": "^9.3.0",
         "@testing-library/jest-dom": "^5.16.4",
@@ -4195,9 +4195,9 @@
       }
     },
     "node_modules/@nulib/dcapi-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.0.0.tgz",
-      "integrity": "sha512-noTdZRZE/pEDsA1pRPRgTLhyQpI+QaEqCCwRmKqf7PejuJXeF9bsG3RkNWXXbqZKpw+qx4C6aCf835uE2mx+Hw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.1.0.tgz",
+      "integrity": "sha512-CV0dS65nbjivA/U2Ibgz0kTXzxg4doN96x8YRW7AnzRz0ftDH1DIWsuiTX1xpx3mRQagFFRxiUHp829s2tWT8w==",
       "dev": true
     },
     "node_modules/@nulib/design-system": {
@@ -23273,9 +23273,9 @@
       }
     },
     "@nulib/dcapi-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.0.0.tgz",
-      "integrity": "sha512-noTdZRZE/pEDsA1pRPRgTLhyQpI+QaEqCCwRmKqf7PejuJXeF9bsG3RkNWXXbqZKpw+qx4C6aCf835uE2mx+Hw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.1.0.tgz",
+      "integrity": "sha512-CV0dS65nbjivA/U2Ibgz0kTXzxg4doN96x8YRW7AnzRz0ftDH1DIWsuiTX1xpx3mRQagFFRxiUHp829s2tWT8w==",
       "dev": true
     },
     "@nulib/design-system": {

--- a/app/assets/package.json
+++ b/app/assets/package.json
@@ -76,7 +76,7 @@
     "@creativebulma/bulma-divider": "^1.1.0",
     "@creativebulma/bulma-tooltip": "^1.2.0",
     "@elastic/elasticsearch-mock": "^2.0.0",
-    "@nulib/dcapi-types": "^2.0.0",
+    "@nulib/dcapi-types": "^2.1.0",
     "@nulib/prettier-config": "^1.2.0",
     "@testing-library/dom": "^9.3.0",
     "@testing-library/jest-dom": "^5.16.4",


### PR DESCRIPTION
# Summary 
This handles some minor updates to the Meadow frontend, adding a statement to the login page, and updating @nulib/dcapi-types.

# Specific Changes in this PR
- Adds content statement to login page
- Updates @nulib/dcapi-types to v2.1.0

![image](https://github.com/nulib/meadow/assets/7376450/933f3585-b274-420c-926c-334ccba34e34)

# Version bump required by the PR

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
- Statement looks good!?
- Builds test run post @nulib/dcapi-types update (should not be affected due to lack of use of typescript in Meadow)

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

