### PR TITLE
Add file sets line to chart.

### DIFF
--- a/app/assets/js/components/Charts/RepositoryGrowth.jsx
+++ b/app/assets/js/components/Charts/RepositoryGrowth.jsx
@@ -15,7 +15,37 @@ function formatDate(tickItem) {
   return moment(tickItem).format("MMM Do YY");
 }
 
-export default function ChartsRepositoryGrowth({ worksCreatedByWeek = [] }) {
+function mergeChartData(works, fileSets) {
+  let worksIndex = 0;
+  let fileSetsIndex = 0;
+  let result = [];
+
+  while (worksIndex < works.length && fileSetsIndex < fileSets.length) {
+    if (works[worksIndex].timestamp < fileSets[fileSetsIndex].timestamp) {
+      worksIndex++;
+    } else if (
+      works[worksIndex].timestamp > fileSets[fileSetsIndex].timestamp
+    ) {
+      fileSetsIndex++;
+    } else {
+      result.push({
+        ...works[worksIndex],
+        ...fileSets[fileSetsIndex],
+      });
+      worksIndex++;
+      fileSetsIndex++;
+    }
+  }
+
+  return result;
+}
+
+export default function ChartsRepositoryGrowth({
+  worksCreatedByWeek = [],
+  fileSetsCreatedByWeek = [],
+}) {
+  const data = mergeChartData(worksCreatedByWeek, fileSetsCreatedByWeek);
+
   return (
     <div className="box">
       <h3 className="subtitle is-3">Repository Growth</h3>
@@ -24,7 +54,7 @@ export default function ChartsRepositoryGrowth({ worksCreatedByWeek = [] }) {
           <LineChart
             width={500}
             height={300}
-            data={worksCreatedByWeek}
+            data={data}
             margin={{
               top: 5,
               right: 30,
@@ -36,11 +66,19 @@ export default function ChartsRepositoryGrowth({ worksCreatedByWeek = [] }) {
             <XAxis dataKey="timestamp" tickFormatter={formatDate} />
             <YAxis />
             <Tooltip labelFormatter={formatDate} />
-            <Legend formatter={(value) => "Works"} />
+            <Legend />
             <Line
               type="monotone"
               dataKey="works"
+              name="Works"
               stroke="#5091cd"
+              activeDot={{ r: 8 }}
+            />
+            <Line
+              type="monotone"
+              dataKey="fileSets"
+              name="File Sets"
+              stroke="#EF553F"
               activeDot={{ r: 8 }}
             />
           </LineChart>

--- a/app/assets/js/screens/Home/Home.jsx
+++ b/app/assets/js/screens/Home/Home.jsx
@@ -55,6 +55,7 @@ const ScreensHome = () => {
             <div className="column is-two-thirds">
               <ChartsRepositoryGrowth
                 worksCreatedByWeek={stats.worksCreatedByWeek}
+                fileSetsCreatedByWeek={stats.fileSetsCreatedByWeek}
               />
             </div>
 


### PR DESCRIPTION
# Summary 
This adds a _File Sets created by week_ line the chart (shown in red) on the Meadow homepage. To accomplish this, some stat generation queries were created.

![image](https://github.com/nulib/meadow/assets/7376450/db8bd858-6221-4a39-81b4-da88042d882c)


# Specific Changes in this PR
- Adds new _filetSets_ `<Line />`to the homepage chart
- Adds functionality to the `useRepositoryStats` hook including querying for and returning weekly data for file sets
- Adds a function to merge fileSets and work weekly data into a single array by timestamp for use by `recharts`


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Chart should render accurately to Works/FileSets count in your env
- The `useRepositoryStats` hook is a little messy, I could have spent some time cleaning that up but decided against it for now and just added to the mess a bit more, thoughts?
- The `mergeChartData()` function added to `app/assets/js/components/Charts/RepositoryGrowth.jsx` could be handled by some lodash functions but I went ahead and just wrote it out myself. I don't love it and am open to thoughts there.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

