### PR TITLE
Add track_total_hits flag to all msearch requests

### DIFF
--- a/app/test/meadow_web/plugs/search_test.exs
+++ b/app/test/meadow_web/plugs/search_test.exs
@@ -51,6 +51,7 @@ defmodule SearchTest do
         |> put_req_header("content-type", "application/x-ndjson")
         |> post("/_search/#{@v2_work_index}/_msearch", mquery)
 
+      assert String.contains?(conn.assigns |> Map.get(:updated_req_body), "track_total_hits")
       assert Jason.decode!(conn.resp_body) |> get_in(@total_hits_path) > 1
     end
 


### PR DESCRIPTION
# Summary 

Works around sorting bug in UI/Reactivesearch https://github.com/nulib/repodev_planning_and_docs/issues/4007


# Specific Changes in this PR
- Adds `track_total_hits=true` to all `_msearch` requests if not present.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Make sure all searches in Meadow UI work and result count is preserved even after sorting results

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

