### PR TITLE
3737 file version api

### DIFF
--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "@absinthe/socket-apollo-link": "^0.2.1",
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",

--- a/app/config/test.exs
+++ b/app/config/test.exs
@@ -84,7 +84,8 @@ config :meadow,
       "api_token_ttl" => 300,
       "base_url" => "http://dcapi-test.northwestern.edu"
     }
-  ]
+  ],
+  iiif_distribution_id: nil
 
 if System.get_env("AWS_DEV_ENVIRONMENT") |> is_nil() do
   [:mediaconvert, :s3, :secretsmanager, :sns, :sqs]

--- a/app/lib/meadow/config.ex
+++ b/app/lib/meadow/config.ex
@@ -70,7 +70,7 @@ defmodule Meadow.Config do
 
   @doc "Retrieve the IIIF cloudfront distribution id"
   def iiif_cloudfront_distribution_id do
-    Application.get_env(:meadow, :iiif_cloudfront_distribution_id)
+    Application.get_env(:meadow, :iiif_distribution_id)
   end
 
   @doc "Retrieve the IIIF server endpoint"

--- a/app/lib/meadow/data/file_sets.ex
+++ b/app/lib/meadow/data/file_sets.ex
@@ -112,6 +112,24 @@ defmodule Meadow.Data.FileSets do
   end
 
   @doc """
+  Replaces (versions) a FileSet.
+  """
+  def replace_file_set(%FileSet{} = file_set, attrs) do
+    changeset =
+      FileSet.update_changeset(file_set, attrs)
+      |> validate_poster_offset(file_set)
+
+    response = Repo.update(changeset)
+
+    case response do
+      {:ok, _file_set} -> post_process(changeset)
+      other -> other
+    end
+
+    response
+  end
+
+  @doc """
   Updates a FileSet.
   """
   def update_file_set(%FileSet{} = file_set, attrs) do

--- a/app/lib/meadow/data/schemas/file_set.ex
+++ b/app/lib/meadow/data/schemas/file_set.ex
@@ -18,25 +18,26 @@ defmodule Meadow.Data.Schemas.FileSet do
   @foreign_key_type Ecto.UUID
   @timestamps_opts [type: :utc_datetime_usec]
   schema "file_sets" do
-    field :accession_number
-    field :extracted_metadata, :map
-    field :role, Types.CodedTerm
-    field :rank, :integer
-    field :position, :any, virtual: true
-    field :derivatives, :map
-    field :poster_offset, :integer
+    field(:accession_number)
+    field(:extracted_metadata, :map)
+    field(:role, Types.CodedTerm)
+    field(:rank, :integer)
+    field(:position, :any, virtual: true)
+    field(:derivatives, :map)
+    field(:poster_offset, :integer)
     field(:reindex_at, :utc_datetime_usec)
 
-    embeds_one :core_metadata, FileSetCoreMetadata, on_replace: :update
-    embeds_one :structural_metadata, FileSetStructuralMetadata, on_replace: :delete
+    embeds_one(:core_metadata, FileSetCoreMetadata, on_replace: :update)
+    embeds_one(:structural_metadata, FileSetStructuralMetadata, on_replace: :delete)
     timestamps()
 
-    belongs_to :work, Work
+    belongs_to(:work, Work)
 
-    has_many :action_states, ActionState,
+    has_many(:action_states, ActionState,
       references: :id,
       foreign_key: :object_id,
       on_delete: :delete_all
+    )
   end
 
   defp changeset_params do

--- a/app/lib/meadow/pipeline.ex
+++ b/app/lib/meadow/pipeline.ex
@@ -35,6 +35,17 @@ defmodule Meadow.Pipeline do
     end
   end
 
+  def replace_the_file_set(file_set, attrs \\ %{}) do
+    case FileSets.replace_file_set(file_set, attrs) do
+      {:ok, file_set} ->
+        Task.async(fn -> wait_for_checksum_tags(file_set, %{context: "Version"}) end)
+        {:ok, file_set}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
   def kickoff(_, context \\ %{})
 
   def kickoff(%FileSet{} = file_set, context), do: kickoff(file_set.id, context)
@@ -48,14 +59,14 @@ defmodule Meadow.Pipeline do
     end
   end
 
-  defp wait_for_checksum_tags(%{core_metadata: %{location: location}} = file_set) do
+  defp wait_for_checksum_tags(%{core_metadata: %{location: location}} = file_set, context \\ %{}) do
     with %{host: bucket, path: "/" <> key} <- URI.parse(location) do
       case wait(AWS.check_object_tags!(bucket, key, Config.required_checksum_tags()),
              timeout: Config.checksum_wait_timeout(),
              frequency: 1_000
            ) do
         {:ok, true} ->
-          kickoff(file_set, %{role: file_set.role.id})
+          kickoff(file_set, Map.merge(context, %{role: file_set.role.id}))
 
         {:timeout, timeout} ->
           Logger.error(

--- a/app/lib/meadow/utils/aws.ex
+++ b/app/lib/meadow/utils/aws.ex
@@ -4,10 +4,14 @@ defmodule Meadow.Utils.AWS do
   @moduledoc """
   Utility functions for AWS requests and object management
   """
+  alias Meadow.Config
   alias Meadow.Error
   alias Meadow.Utils.AWS.MultipartCopy
 
+  import Env
   import SweetXml, only: [sigil_x: 2]
+
+  require Logger
 
   @doc """
   Drop-in replacement for ExAws.request/2 that reports errors to Honeybadger
@@ -73,6 +77,60 @@ defmodule Meadow.Utils.AWS do
 
   def copy_object(dest_bucket, dest_object, src_bucket, src_object, opts \\ []),
     do: MultipartCopy.copy_object(dest_bucket, dest_object, src_bucket, src_object, opts)
+
+  def invalidate_cache(file_set, invalidation_type), do: invalidate_cache(file_set, invalidation_type, Config.environment())
+  def invalidate_cache(file_set, :pyramid, :dev), do: perform_invalidation("/iiif/2/#{prefix()}/#{file_set.id}/*")
+  def invalidate_cache(file_set, :pyramid, :test), do: perform_invalidation("/iiif/2/#{prefix()}/#{file_set.id}/*")
+  def invalidate_cache(file_set, :pyramid, _), do: perform_invalidation("/iiif/2/#{file_set.id}/*")
+  def invalidate_cache(file_set, :poster, :dev), do: perform_invalidation("/iiif/2/#{prefix()}/posters/#{file_set.id}/*")
+  def invalidate_cache(file_set, :poster, :test), do: perform_invalidation("/iiif/2/#{prefix()}/posters/#{file_set.id}/*")
+  def invalidate_cache(file_set, :poster, _), do: perform_invalidation("/iiif/2/posters#{file_set.id}/*")
+
+  defp perform_invalidation(path), do: perform_invalidation(path, Config.iiif_cloudfront_distribution_id())
+
+  defp perform_invalidation(path, nil) do
+    Logger.info(
+      "Skipping poster cache invalidation for: #{path}. No distribution id found."
+
+      )
+
+    :ok
+  end
+
+  defp perform_invalidation(path, distribution_id) do
+    version = "2020-05-31"
+    caller_reference = "meadow-app-#{Ecto.UUID.generate()}"
+
+    data = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <InvalidationBatch xmlns="http://cloudfront.amazonaws.com/doc/#{version}/">
+        <CallerReference>#{caller_reference}</CallerReference>
+        <Paths>
+          <Items>
+              <Path>#{path}</Path>
+          </Items>
+          <Quantity>1</Quantity>
+        </Paths>
+    </InvalidationBatch>
+    """
+
+    operation = %ExAws.Operation.RestQuery{
+      action: :create_invalidation,
+      body: data,
+      http_method: :post,
+      path: "/#{version}/distribution/#{distribution_id}/invalidation",
+      service: :cloudfront
+    }
+
+    case operation |> ExAws.request() do
+      {:ok, %{status_code: status_code}} when status_code in 200..299 ->
+        :ok
+
+      _ ->
+        Logger.error("Unable to clear poster cache for #{path}")
+        :ok
+    end
+  end
 
   defp generate_aws_signature(request, region, access_key, secret) do
     now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)

--- a/app/lib/meadow_web/resolvers/data.ex
+++ b/app/lib/meadow_web/resolvers/data.ex
@@ -140,6 +140,20 @@ defmodule MeadowWeb.Resolvers.Data do
     end
   end
 
+  def replace_file_set(_, %{id: id} = params, _) do
+    file_set = FileSets.get_file_set!(id)
+
+    case Pipeline.replace_the_file_set(file_set, Map.delete(params, :id)) do
+      {:error, changeset} ->
+        {:error,
+         message: "Could not replace file set",
+         details: ChangesetErrors.humanize_errors(changeset)}
+
+      {:ok, file_set} ->
+        {:ok, file_set}
+    end
+  end
+
   def update_file_set(_, %{id: id} = params, _) do
     file_set = FileSets.get_file_set!(id)
 

--- a/app/lib/meadow_web/schema/types/data/file_set_types.ex
+++ b/app/lib/meadow_web/schema/types/data/file_set_types.ex
@@ -45,6 +45,15 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
       resolve(&Resolvers.Data.update_file_set/3)
     end
 
+    @desc "Replace file set (create new version)"
+    field :replace_file_set, :file_set do
+      arg(:id, non_null(:id))
+      arg(:core_metadata, non_null(:file_set_core_metadata_input))
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Resolvers.Data.replace_file_set/3)
+    end
+
     @desc "Update metadata for a list of fileSets"
     field :update_file_sets, list_of(:file_set) do
       arg(:file_sets, non_null(list_of(:file_set_update)))
@@ -153,9 +162,10 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
 
   @desc "`digests` represents the possible digest hashes for a file set."
   object :digests do
-    field :md5, :string, do: resolve(fn digests, _, _ -> {:ok, Map.get(digests, "md5")} end)
-    field :sha1, :string, do: resolve(fn digests, _, _ -> {:ok, Map.get(digests, "sha1")} end)
-    field :sha256, :string, do: resolve(fn digests, _, _ -> {:ok, Map.get(digests, "sha256")} end)
+    field(:md5, :string, do: resolve(fn digests, _, _ -> {:ok, Map.get(digests, "md5")} end))
+    field(:sha1, :string, do: resolve(fn digests, _, _ -> {:ok, Map.get(digests, "sha1")} end))
+
+    field(:sha256, :string, do: resolve(fn digests, _, _ -> {:ok, Map.get(digests, "sha256")} end))
   end
 
   @desc "`file_set_structural_metadata` represents the structural metadata within a file set object."

--- a/app/test/gql/ReplaceFileSet.gql
+++ b/app/test/gql/ReplaceFileSet.gql
@@ -1,0 +1,13 @@
+#import "./FileSetFields.frag.gql"
+
+mutation(
+  $id: ID!
+  $coreMetadata: FileSetCoreMetadataInput!
+) {
+  replaceFileSet(
+    id: $id
+    coreMetadata: $coreMetadata
+  ) {
+    ...FileSetFields
+  }
+}

--- a/app/test/meadow/data/file_sets_test.exs
+++ b/app/test/meadow/data/file_sets_test.exs
@@ -128,6 +128,21 @@ defmodule Meadow.Data.FileSetsTest do
              }
     end
 
+    test "replace_file_set/1 with new location updates file_set" do
+      file_set = file_set_fixture()
+
+      replace_attrs = %{
+        id: file_set.id,
+        core_metadata: %{
+          location: "https://example.com",
+          original_filename: "test.tiff"
+        }
+      }
+
+      assert {:ok, %FileSet{} = file_set} = FileSets.replace_file_set(file_set, replace_attrs)
+      assert file_set.core_metadata.location == "https://example.com"
+    end
+
     test "get_file_set!/1 returns a file set by id" do
       file_set = file_set_fixture()
       assert FileSets.get_file_set!(file_set.id) == file_set

--- a/app/test/meadow/pipeline_test.exs
+++ b/app/test/meadow/pipeline_test.exs
@@ -71,6 +71,27 @@ defmodule Meadow.Data.PipelineTest do
     end
   end
 
+  describe "replacing a file set" do
+    @describetag s3: [@s3_fixture]
+
+    test "replace_the_file_set/1 updates a file_set location" do
+      file_set = file_set_fixture(%{
+        accession_number: "12345",
+        role: %{id: "A", scheme: "FILE_SET_ROLE"},
+        mime_type: "image/png",
+        core_metadata: %{
+          description: "yes",
+          location: "s3://old-location",
+          original_filename: "test.png"
+        }
+      })
+
+      attrs = %{core_metadata: %{location: @tiff_location}}
+      assert {:ok, %FileSet{} = updated_file_set} = Pipeline.replace_the_file_set(file_set, attrs)
+      assert updated_file_set.core_metadata.location == @tiff_location
+    end
+  end
+
   describe "checksum timeout" do
     @describetag s3: [@s3_fixture]
 

--- a/app/test/meadow_web/schema/mutation/replace_file_set_test.exs
+++ b/app/test/meadow_web/schema/mutation/replace_file_set_test.exs
@@ -1,0 +1,55 @@
+defmodule MeadowWeb.Schema.Mutation.ReplaceFileSetTest do
+  use Meadow.DataCase
+  use MeadowWeb.ConnCase, async: true
+  use Meadow.S3Case
+  use Wormwood.GQLCase
+
+  load_gql(MeadowWeb.Schema, "test/gql/ReplaceFileSet.gql")
+
+  @bucket @ingest_bucket
+  @key "create_file_set_test/file.tif"
+  @content "test/fixtures/coffee.tif"
+  @fixture %{bucket: @bucket, key: @key, content: File.read!(@content)}
+
+  @tag s3: [@fixture]
+  test "replaceFileSet mutation updates a FileSet's metadata", _context do
+    file_set = file_set_fixture()
+
+    {:ok, result} =
+        query_gql(
+          variables: %{
+            "id" => file_set.id,
+            "coreMetadata" =>  %{
+              "original_filename" => "file.tif",
+              "location" => "s3://#{@bucket}/#{@key}"
+            }
+          },
+          context: gql_context()
+        )
+
+    assert result.data["replaceFileSet"]
+    location = get_in(result, [:data, "replaceFileSet", "coreMetadata", "location"])
+    assert location == "s3://#{@bucket}/#{@key}"
+  end
+
+  describe "authorization" do
+    @tag s3: [@fixture]
+    test "viewers are not authorized to replace file sets" do
+      file_set = file_set_fixture()
+
+      {:ok, result} =
+        query_gql(
+          variables: %{
+            "id" => file_set.id,
+            "coreMetadata" =>  %{
+              "original_filename" => "file.tif",
+              "location" => "s3://#{@bucket}/#{@key}"
+            }
+          },
+          context: %{current_user: %{role: "User"}}
+        )
+
+      assert %{errors: [%{message: "Forbidden", status: 403}]} = result
+    end
+  end
+end

--- a/app/test/pipeline/actions/generate_poster_image_test.exs
+++ b/app/test/pipeline/actions/generate_poster_image_test.exs
@@ -7,6 +7,7 @@ defmodule Meadow.Pipeline.Actions.GeneratePosterImageTest do
   alias Meadow.Pipeline.Actions.GeneratePosterImage
   alias Meadow.Utils.Pairtree
 
+  import Env
   import ExUnit.CaptureLog
 
   @mediainfo %{
@@ -75,7 +76,7 @@ defmodule Meadow.Pipeline.Actions.GeneratePosterImageTest do
 
       assert log
              |> String.contains?(
-               "Skipping poster cache invalidation for file set: #{file_set_id}. No distribution id found."
+               "Skipping poster cache invalidation for: /iiif/2/#{prefix()}/posters/#{file_set_id}/*. No distribution id found."
              )
     end
   end


### PR DESCRIPTION
# Summary 

Creates GraphQL for replacing file set - which will create a new version in the preservation bucket.
Also fixes configuration problem with invalidating the CloudFront cache after updating a poster image. (fixes https://github.com/nulib/repodev_planning_and_docs/issues/3211)

# Specific Changes in this PR

- Adds GraphQL `replaceFileSet` mutation
  -  mutation updates the file set's `location` and kicks off the ingest pipeline
- Updates config to use `iiif_distribution_id`
- Extracts cache invalidation code to `/app/utils/aws.ex` so it can be used by multiple modules

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test

PREREQUISITE
- Make sure these changes are Terraformed to your dev environment: https://github.com/nulib/aws-developer-environment/pull/3/files

POSTER REGENERATION:

- Make sure your dev environment is updated with changes ☝️ 
- Confirm video does not error on the transcoding step during ingest
- Update a poster image (on file set that already has poster image), UI thumbnail should update (you may need to refresh your browser)
- Any IIIF poster image URL that has been previously requested (exact dimensions, etc) will show the new image rather than the old)

FILE SET VERSION/REPLACE
- Make sure these changes are Terraformed to your dev environment:  ☝️ 
- Generate a presigned url to upload a file (ex: coffee.tif) to the uploads bucket. Ex: 
```
query {
  presignedUrl(
    filename: "coffee.tif", 
    uploadType: FILE_SET){
    url
  }
}
```
- Upload the file to the url returned. Ex: 
```
curl -v -T coffee.tif 'PUT THE PRESIGNED URL HERE'
```
- Call the `replaceFileSet` mutation using the id from the presigned url. Ex: 
```
mutation {
  replaceFileSet(
    id: "0d8838ea-dcc1-4a4a-9070-b6946a5512f4",
    coreMetadata: {
      label: "New label",
      location: "s3://kdid-dev-uploads/file_sets/5af60f79-04c1-4e8b-b8f8-542744b70c60.tif"
			
    }
  ){
    id
    coreMetadata{
      location
      label
      description
      digests {
        sha1
        sha256
        md5
      }
    }
  }
}
```
- Check that the file (preservation location) has created a new version
- Check that pipeline steps have completed appropriately (new pres location, mime type, pyramid, extracted metadata, etc....)

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

