### PR TITLE
Correct missing slash in poster Cloudfront invalidation path

### DIFF
--- a/app/lib/meadow/utils/aws.ex
+++ b/app/lib/meadow/utils/aws.ex
@@ -84,7 +84,7 @@ defmodule Meadow.Utils.AWS do
   def invalidate_cache(file_set, :pyramid, _), do: perform_invalidation("/iiif/2/#{file_set.id}/*")
   def invalidate_cache(file_set, :poster, :dev), do: perform_invalidation("/iiif/2/#{prefix()}/posters/#{file_set.id}/*")
   def invalidate_cache(file_set, :poster, :test), do: perform_invalidation("/iiif/2/#{prefix()}/posters/#{file_set.id}/*")
-  def invalidate_cache(file_set, :poster, _), do: perform_invalidation("/iiif/2/posters#{file_set.id}/*")
+  def invalidate_cache(file_set, :poster, _), do: perform_invalidation("/iiif/2/posters/#{file_set.id}/*")
 
   defp perform_invalidation(path), do: perform_invalidation(path, Config.iiif_cloudfront_distribution_id())
 


### PR DESCRIPTION
# Summary 

Fix missing slash (`/`)

# Specific Changes in this PR

- (Non-dev) poster cache invalidation path corrected

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

