### PR TITLE
Fix bug causing skipped transcoding during file set replace

### DIFF
--- a/app/lib/meadow/pipeline/actions/initialize_dispatch.ex
+++ b/app/lib/meadow/pipeline/actions/initialize_dispatch.ex
@@ -31,7 +31,7 @@ defmodule Meadow.Pipeline.Actions.InitializeDispatch do
   def process(file_set, attributes) do
     Logger.info("Initializing dispatch for FileSet #{file_set.id}")
 
-    case Dispatcher.dispatcher_actions(file_set) do
+    case Dispatcher.dispatcher_actions(file_set, attributes) do
       nil ->
         err = "Invalid mime-type and file set role combination"
         ActionStates.set_state!(file_set, __MODULE__, "error", err)
@@ -41,7 +41,7 @@ defmodule Meadow.Pipeline.Actions.InitializeDispatch do
         ActionStates.initialize_states({FileSet, file_set.id}, actions, "waiting")
 
         with %{context: "Sheet"} <- attributes do
-          fixup_progress(FileSets.get_file_set_with_work_and_sheet!(file_set.id))
+          fixup_progress(FileSets.get_file_set_with_work_and_sheet!(file_set.id), attributes)
         end
 
         {result, _} =
@@ -52,13 +52,13 @@ defmodule Meadow.Pipeline.Actions.InitializeDispatch do
     end
   end
 
-  defp fixup_progress(%{work: %{ingest_sheet: sheet}}) when is_nil(sheet), do: :noop
-  defp fixup_progress(%{work: work}) when is_nil(work), do: :noop
+  defp fixup_progress(%{work: %{ingest_sheet: sheet}}, _attributes) when is_nil(sheet), do: :noop
+  defp fixup_progress(%{work: work}, _attributes) when is_nil(work), do: :noop
 
-  defp fixup_progress(%{work_id: _work_id, work: %{ingest_sheet_id: ingest_sheet_id}} = file_set) do
+  defp fixup_progress(%{work_id: _work_id, work: %{ingest_sheet_id: ingest_sheet_id}} = file_set, attributes) do
     Rows.get_row_by_file_set_accession_number(ingest_sheet_id, file_set.accession_number)
     |> Progress.update_entries(
-      Dispatcher.not_my_actions(file_set),
+      Dispatcher.not_my_actions(file_set, attributes),
       "ok"
     )
   end

--- a/app/test/pipeline/actions/initialize_dispatch_test.exs
+++ b/app/test/pipeline/actions/initialize_dispatch_test.exs
@@ -54,7 +54,7 @@ defmodule Meadow.Pipeline.Actions.InitializeDispatchTest do
 
       file_set = FileSets.get_file_set(file_set.id)
 
-      Enum.each(Dispatcher.dispatcher_actions(file_set), fn action ->
+      Enum.each(Dispatcher.dispatcher_actions(file_set, %{}), fn action ->
         assert %{outcome: "waiting"} = ActionStates.get_latest_state(file_set.id, action)
       end)
     end

--- a/app/test/pipeline/dispatcher_test.exs
+++ b/app/test/pipeline/dispatcher_test.exs
@@ -88,7 +88,7 @@ defmodule Meadow.Pipeline.DispatcherTest do
           }
         })
 
-      assert Dispatcher.dispatcher_actions(file_set) == [
+      assert Dispatcher.dispatcher_actions(file_set, %{}) == [
                GenerateFileSetDigests,
                ExtractExifMetadata,
                CopyFileToPreservation,
@@ -107,7 +107,7 @@ defmodule Meadow.Pipeline.DispatcherTest do
           }
         })
 
-      assert Dispatcher.dispatcher_actions(file_set) == [
+      assert Dispatcher.dispatcher_actions(file_set, %{}) == [
                GenerateFileSetDigests,
                ExtractExifMetadata,
                CopyFileToPreservation,
@@ -127,7 +127,7 @@ defmodule Meadow.Pipeline.DispatcherTest do
           }
         })
 
-      assert Dispatcher.dispatcher_actions(file_set) == [
+      assert Dispatcher.dispatcher_actions(file_set, %{}) == [
                GenerateFileSetDigests,
                ExtractExifMetadata,
                CopyFileToPreservation,
@@ -147,7 +147,7 @@ defmodule Meadow.Pipeline.DispatcherTest do
           }
         })
 
-      assert Dispatcher.dispatcher_actions(file_set) == [
+      assert Dispatcher.dispatcher_actions(file_set, %{}) == [
                GenerateFileSetDigests,
                CopyFileToPreservation,
                FileSetComplete
@@ -165,9 +165,9 @@ defmodule Meadow.Pipeline.DispatcherTest do
           }
         })
 
-      refute Enum.member?(Dispatcher.dispatcher_actions(file_set), ExtractExifMetadata)
-      assert Enum.member?(Dispatcher.dispatcher_actions(file_set), CreateTranscodeJob)
-      assert Enum.member?(Dispatcher.dispatcher_actions(file_set), TranscodeComplete)
+      refute Enum.member?(Dispatcher.dispatcher_actions(file_set, %{}), ExtractExifMetadata)
+      assert Enum.member?(Dispatcher.dispatcher_actions(file_set, %{}), CreateTranscodeJob)
+      assert Enum.member?(Dispatcher.dispatcher_actions(file_set, %{}), TranscodeComplete)
     end
 
     test "dispatcher_actions for file set role: P, mime_type: audio/*" do
@@ -181,9 +181,9 @@ defmodule Meadow.Pipeline.DispatcherTest do
           }
         })
 
-      refute Enum.member?(Dispatcher.dispatcher_actions(file_set), ExtractExifMetadata)
-      refute Enum.member?(Dispatcher.dispatcher_actions(file_set), CreateTranscodeJob)
-      refute Enum.member?(Dispatcher.dispatcher_actions(file_set), TranscodeComplete)
+      refute Enum.member?(Dispatcher.dispatcher_actions(file_set, %{}), ExtractExifMetadata)
+      refute Enum.member?(Dispatcher.dispatcher_actions(file_set, %{}), CreateTranscodeJob)
+      refute Enum.member?(Dispatcher.dispatcher_actions(file_set, %{}), TranscodeComplete)
     end
 
     test "dispatcher_actions for file set role: A, mime_type: video/*" do
@@ -197,9 +197,24 @@ defmodule Meadow.Pipeline.DispatcherTest do
           }
         })
 
-      refute Enum.member?(Dispatcher.dispatcher_actions(file_set), ExtractExifMetadata)
-      assert Enum.member?(Dispatcher.dispatcher_actions(file_set), CreateTranscodeJob)
-      assert Enum.member?(Dispatcher.dispatcher_actions(file_set), TranscodeComplete)
+      refute Enum.member?(Dispatcher.dispatcher_actions(file_set, %{}), ExtractExifMetadata)
+      assert Enum.member?(Dispatcher.dispatcher_actions(file_set, %{}), CreateTranscodeJob)
+      assert Enum.member?(Dispatcher.dispatcher_actions(file_set, %{}), TranscodeComplete)
+    end
+
+    test "dispatcher_actions does not skip transcode for file set versioning (role: A, mime_type: video/*)" do
+      file_set =
+        file_set_fixture(%{
+          role: %{id: "A", scheme: "FILE_SET_ROLE"},
+          core_metadata: %{
+            mime_type: "video/mp4",
+            location: "s3://blahblah",
+            original_filename: "test.m4v"
+          }
+        })
+
+      assert Enum.member?(Dispatcher.dispatcher_actions(file_set, %{context: "Version"}), CreateTranscodeJob)
+      assert Enum.member?(Dispatcher.dispatcher_actions(file_set, %{context: "Version"}), TranscodeComplete)
     end
 
     test "dispatcher_actions for file set role: P, mime_type: video/*" do
@@ -213,9 +228,9 @@ defmodule Meadow.Pipeline.DispatcherTest do
           }
         })
 
-      refute Enum.member?(Dispatcher.dispatcher_actions(file_set), ExtractExifMetadata)
-      refute Enum.member?(Dispatcher.dispatcher_actions(file_set), CreateTranscodeJob)
-      refute Enum.member?(Dispatcher.dispatcher_actions(file_set), TranscodeComplete)
+      refute Enum.member?(Dispatcher.dispatcher_actions(file_set, %{}), ExtractExifMetadata)
+      refute Enum.member?(Dispatcher.dispatcher_actions(file_set, %{}), CreateTranscodeJob)
+      refute Enum.member?(Dispatcher.dispatcher_actions(file_set, %{}), TranscodeComplete)
     end
 
     test "dispatcher_actions for unknown mime type" do
@@ -229,7 +244,7 @@ defmodule Meadow.Pipeline.DispatcherTest do
           }
         })
 
-      assert Dispatcher.dispatcher_actions(file_set) == nil
+      assert Dispatcher.dispatcher_actions(file_set, %{}) == nil
     end
 
     test "custom list of actions" do
@@ -280,9 +295,9 @@ defmodule Meadow.Pipeline.DispatcherTest do
     test "dispatcher_actions for A/V file set where playlist exists skips trancoding steps", %{
       file_set: file_set
     } do
-      assert Enum.member?(Dispatcher.dispatcher_actions(file_set), CopyFileToPreservation)
-      refute Enum.member?(Dispatcher.dispatcher_actions(file_set), CreateTranscodeJob)
-      refute Enum.member?(Dispatcher.dispatcher_actions(file_set), TranscodeComplete)
+      assert Enum.member?(Dispatcher.dispatcher_actions(file_set, %{}), CopyFileToPreservation)
+      refute Enum.member?(Dispatcher.dispatcher_actions(file_set, %{}), CreateTranscodeJob)
+      refute Enum.member?(Dispatcher.dispatcher_actions(file_set, %{}), TranscodeComplete)
     end
 
     test "dispatches to FileSetComplete after TranscodeComplete even if skip_transcode? is true",


### PR DESCRIPTION
# Summary 

https://github.com/nulib/meadow/blob/deploy/staging/app/lib/meadow/pipeline/dispatcher.ex#L166

☝️ This line was causing the transcoding to be skipped on a file set replace. 


# Specific Changes in this PR

- Don't skip transcoding in file set replace.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

