### PR TITLE
Make sure ARKs update properly

### DIFF
--- a/app/lib/meadow/application/children.ex
+++ b/app/lib/meadow/application/children.ex
@@ -16,7 +16,7 @@ defmodule Meadow.Application.Children do
          interval: Config.index_interval(), version: 2, name: Meadow.Data.IndexWorker.V2}
       ],
       "database_listeners" => [
-        Meadow.ARKListener,
+        Meadow.ArkListener,
         Meadow.FilesetDeleteListener,
         Meadow.IIIF.ManifestListener,
         Meadow.IndexDeleteListener,

--- a/app/lib/meadow/ark.ex
+++ b/app/lib/meadow/ark.ex
@@ -5,6 +5,12 @@ defmodule Meadow.Ark do
 
   alias Meadow.Ark.{Client, Serializer}
   alias Meadow.Config
+  alias Meadow.Data.Schemas.ArkCache
+  alias Meadow.Repo
+
+  import Ecto.Query
+
+  require Logger
 
   defstruct ark: nil,
             creator: nil,
@@ -13,7 +19,10 @@ defmodule Meadow.Ark do
             publication_year: nil,
             resource_type: nil,
             status: nil,
-            target: nil
+            target: nil,
+            work_id: nil
+
+  def from_attrs(attributes), do: struct!(__MODULE__, Enum.into(attributes, []))
 
   @doc """
   Mint a new ARK identifier
@@ -66,7 +75,9 @@ defmodule Meadow.Ark do
       case Client.post("/shoulder/#{shoulder}", Serializer.serialize(ark)) do
         {:ok, %{status_code: status, body: body}} when status in 200..201 ->
           new_id = Serializer.deserialize(body) |> Map.get(:ark)
-          {:ok, Map.put(ark, :ark, new_id)}
+          ark = Map.put(ark, :ark, new_id)
+          put_in_cache(ark)
+          {:ok, ark}
 
         {:ok, %{body: body}} ->
           {:error, body}
@@ -103,6 +114,25 @@ defmodule Meadow.Ark do
    {:error, "error: bad request - no such identifier"}
   """
   def get(id) do
+    case get_from_cache(id) do
+      nil ->
+        case get_from_source(id) do
+          {:ok, ark} ->
+            put_in_cache(ark)
+            {:ok, ark}
+
+          other ->
+            other
+        end
+
+      ark ->
+        {:ok, ark}
+    end
+  end
+
+  def get_from_source(id) do
+    Logger.debug("Retrieving ark #{id} from source")
+
     case Client.get("/id/#{id}") do
       {:ok, %{status_code: 200, body: body}} -> {:ok, Serializer.deserialize(body)}
       {:ok, %{body: body}} -> {:error, body}
@@ -135,15 +165,19 @@ defmodule Meadow.Ark do
 
   def put(%__MODULE__{} = ark) do
     case Client.put("/id/#{ark.ark}?update_if_exists=yes", Serializer.serialize(ark)) do
-      {:ok, %{status_code: status}} when status in 200..201 -> {:ok, ark}
-      {:ok, %{body: body}} -> {:error, body}
-      {:error, error} -> {:error, error}
+      {:ok, %{status_code: status}} when status in 200..201 ->
+        put_in_cache(ark)
+        {:ok, ark}
+
+      {:ok, %{body: body}} ->
+        {:error, body}
+
+      {:error, error} ->
+        {:error, error}
     end
   end
 
-  def put(attributes) do
-    put(struct!(__MODULE__, Enum.into(attributes, [])))
-  end
+  def put(attributes), do: from_attrs(attributes) |> put()
 
   @doc """
   Remove the ARK identifier
@@ -158,7 +192,46 @@ defmodule Meadow.Ark do
   """
   def delete(id) do
     case Client.delete("/id/#{id}") do
-      {:ok, %{status_code: 200, body: body}} -> {:ok, Serializer.deserialize(body)}
+      {:ok, %{status_code: 200, body: body}} ->
+        delete_from_cache(id)
+        {:ok, Serializer.deserialize(body)}
+
+      other ->
+        other
     end
+  end
+
+  def digest(%__MODULE__{} = ark), do: :crypto.hash(:md5, Serializer.serialize(ark))
+  def digest(attributes), do: from_attrs(attributes) |> digest()
+
+  def clear_cache, do: ArkCache |> Repo.delete_all()
+
+  def delete_from_cache(id) do
+    from(c in ArkCache, where: c.ark == ^id)
+    |> Repo.delete_all()
+  end
+
+  def get_from_cache(id) do
+    Logger.debug("Retrieving ark #{id} from cache")
+
+    from(c in ArkCache, where: c.ark == ^id)
+    |> Repo.one()
+    |> from_cache()
+  end
+
+  def put_in_cache(ark) do
+    from(c in ArkCache, where: c.ark == ^ark.ark)
+    |> Repo.one()
+    |> ArkCache.changeset(Map.from_struct(ark))
+    |> Repo.insert_or_update()
+  end
+
+  def from_cache(nil), do: nil
+
+  def from_cache(%ArkCache{} = cache) do
+    cache
+    |> Map.from_struct()
+    |> Enum.reject(fn {_, v} -> not is_binary(v) end)
+    |> from_attrs()
   end
 end

--- a/app/lib/meadow/ark/serializer.ex
+++ b/app/lib/meadow/ark/serializer.ex
@@ -39,11 +39,13 @@ defmodule Meadow.Ark.Serializer do
     Enum.reduce(ark, ["_profile: datacite"], fn
       {_, nil}, acc -> acc
       {:ark, _}, acc -> acc
+      {:work_id, _}, acc -> acc
       entry, acc -> [serialize(entry) | acc]
     end)
     |> Enum.reverse()
     |> Enum.join("\n")
   end
 
-  def serialize({key, value}) when is_atom(key), do: Map.get(@datacite_map, key) <> ": " <> String.replace(value, "%", "%25")
+  def serialize({key, value}) when is_atom(key),
+    do: Map.get(@datacite_map, key) <> ": " <> String.replace(value, "%", "%25")
 end

--- a/app/lib/meadow/data/schemas/ark_cache.ex
+++ b/app/lib/meadow/data/schemas/ark_cache.ex
@@ -1,0 +1,36 @@
+defmodule Meadow.Data.Schemas.ArkCache do
+  @moduledoc """
+  Schema for caching ARKs
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:ark, :string, autogenerate: false, read_after_writes: true}
+  schema "ark_cache" do
+    field(:creator, :string)
+    field(:title, :string)
+    field(:publisher, :string)
+    field(:publication_year, :string)
+    field(:resource_type, :string)
+    field(:status, :string)
+    field(:target, :string)
+    field(:work_id, Ecto.UUID)
+  end
+
+  def changeset(ark \\ %__MODULE__{}, params)
+  def changeset(nil, params), do: changeset(params)
+
+  def changeset(ark, params) do
+    cast(ark, params, [
+      :ark,
+      :creator,
+      :title,
+      :publisher,
+      :publication_year,
+      :resource_type,
+      :status,
+      :target,
+      :work_id
+    ])
+  end
+end

--- a/app/lib/meadow/data/schemas/work_descriptive_metadata.ex
+++ b/app/lib/meadow/data/schemas/work_descriptive_metadata.ex
@@ -5,7 +5,7 @@ defmodule Meadow.Data.Schemas.WorkDescriptiveMetadata do
 
   import Ecto.Changeset
   use Ecto.Schema
-  alias Meadow.Data.Schemas.{ControlledMetadataEntry, NoteEntry, RelatedURLEntry}
+  alias Meadow.Data.Schemas.{ArkCache, ControlledMetadataEntry, NoteEntry, RelatedURLEntry}
   alias Meadow.Data.Types
 
   # {field_name, repeating}
@@ -84,6 +84,8 @@ defmodule Meadow.Data.Schemas.WorkDescriptiveMetadata do
 
     embeds_many(:notes, NoteEntry, on_replace: :delete)
     embeds_many(:related_url, RelatedURLEntry, on_replace: :delete)
+
+    belongs_to(:cached_ark, ArkCache, foreign_key: :ark, references: :ark, define_field: false)
 
     timestamps()
   end

--- a/app/lib/meadow/utils/arks.ex
+++ b/app/lib/meadow/utils/arks.ex
@@ -1,0 +1,184 @@
+defmodule Meadow.Arks do
+  @moduledoc """
+  High-level context wrapper for Meadow.Ark
+  """
+
+  alias Meadow.{Ark, Config}
+  alias Meadow.Data.Works
+  alias Meadow.Data.Schemas.{ArkCache, ControlledMetadataEntry, Work}
+  alias Meadow.Repo
+
+  import Ecto.Query
+
+  require Logger
+
+  @work_type_resource_type_mapping %{
+    "AUDIO" => "Sound",
+    "VIDEO" => "Audiovisual"
+  }
+
+  @doc """
+  Retrieves the ARK Target URL for a work
+  iex> ark_target_url("f352eb30-ae2f-4b49-81f9-6eb4659a3f47")
+  "https://dc.library.northwestern.edu/items/f352eb30-ae2f-4b49-81f9-6eb4659a3f47"
+
+  iex> ark_target_url(%Work{id:"f352eb30-ae2f-4b49-81f9-6eb4659a3f47"})
+  "https://dc.library.northwestern.edu/items/f352eb30-ae2f-4b49-81f9-6eb4659a3f47"
+
+  """
+  def ark_target_url(%Work{id: id}) do
+    ark_target_url(id)
+  end
+
+  def ark_target_url(work_id) do
+    Map.get(Config.ark_config(), :target_url) <> work_id
+  end
+
+  @doc """
+  Mints an ARK for a work
+  iex> mint_ark(work)
+  {:ok,
+   %Work{
+     ...
+     descriptive_metadata: %WorkDescriptiveMetadata{
+       ...
+       ark: "ark:/99999/fk4newark"
+     }
+   }}
+
+  iex> mint_ark(work_with_existing_ark)
+  {:noop,
+   %Work{...}}
+  """
+  def mint_ark(%Work{descriptive_metadata: %{ark: ark}} = work, _)
+      when not is_nil(ark) do
+    {:noop, work}
+  end
+
+  def mint_ark(nil), do: {:noop, nil}
+
+  def mint_ark(%Work{} = work) do
+    case work |> initial_ark() |> Ark.mint() do
+      {:ok, result} ->
+        Works.update_work(work, %{descriptive_metadata: %{ark: result.ark}})
+
+      {:error, error_message} ->
+        Meadow.Error.report(error_message, __MODULE__, [], %{work_id: work.id})
+        {:error, error_message}
+    end
+  end
+
+  def initial_ark(work) do
+    work |> initial_ark_attributes() |> Ark.from_attrs()
+  end
+
+  def update_ark_metatdata(%Work{} = work) do
+    case existing_ark(work) do
+      {:error, message} ->
+        {:error, message}
+
+      {:ok, %{status: current_status} = existing} ->
+        with new_status <- ark_update_status(current_status, work),
+             ark <- ark(work, status: new_status) do
+          work |> update_existing_ark(existing, ark)
+        end
+    end
+  end
+
+  defp update_existing_ark(_work, ark, ark) do
+    Logger.debug("Metadata for #{ark.ark} didn't change. Not sending update.")
+    :noop
+  end
+
+  defp update_existing_ark(work, _, ark) do
+    case Ark.put(ark) do
+      {:ok, result} ->
+        Logger.info("Ark successfully updated. #{inspect(result)}")
+        {:ok, result}
+
+      {:error, error_message} ->
+        Meadow.Error.report(error_message, __MODULE__, [], %{work_id: work.id})
+        {:error, error_message}
+    end
+  end
+
+  def existing_ark(work) do
+    case work.descriptive_metadata.cached_ark do
+      %ArkCache{} = cached -> {:ok, Ark.from_cache(cached)}
+      _ -> Ark.get(work.descriptive_metadata.ark)
+    end
+  end
+
+  def ark(work, attrs \\ []) do
+    work |> ark_attributes(attrs) |> Ark.from_attrs()
+  end
+
+  def ark_attributes(work, attrs) do
+    Keyword.merge(
+      [
+        ark: work.descriptive_metadata.ark,
+        creator: scalar_value(work.descriptive_metadata.creator),
+        title: work.descriptive_metadata.title,
+        publisher: scalar_value(work.descriptive_metadata.publisher),
+        publication_year: nil,
+        resource_type: resource_type(work),
+        target: ark_target_url(work),
+        work_id: work.id
+      ],
+      attrs
+    )
+  end
+
+  defp initial_ark_attributes(work) do
+    status =
+      case work do
+        %{published: true, visibility: %{id: "RESTRICTED"}} -> "unavailable | restricted"
+        %{published: true} -> "public"
+        _ -> "reserved"
+      end
+
+    ark_attributes(work, status: status)
+  end
+
+  defp resource_type(%{work_type: nil}), do: nil
+
+  defp resource_type(%{work_type: %{id: work_type}}) do
+    case Map.get(@work_type_resource_type_mapping, work_type) do
+      nil -> work_type |> String.downcase() |> Inflex.Camelize.camelize()
+      value -> value
+    end
+  end
+
+  defp scalar_value([%ControlledMetadataEntry{term: %{label: value}} | _]), do: value
+  defp scalar_value([value | _]), do: value
+  defp scalar_value(%{label: value}), do: value
+  defp scalar_value([]), do: nil
+  defp scalar_value(value), do: value
+
+  def mint_ark!(work) do
+    case mint_ark(work) do
+      {:noop, work} -> work
+      {:ok, work} -> work
+      {_, other} -> raise other
+    end
+  end
+
+  defp ark_update_status("reserved", %{published: false}), do: "reserved"
+  defp ark_update_status(_, %{published: false}), do: "unavailable | unpublished"
+  defp ark_update_status(_, %{visibility: %{id: "RESTRICTED"}}), do: "unavailable | restricted"
+  defp ark_update_status(_, _), do: "public"
+
+  def delete_ark(ark) do
+    Ark.delete(ark.ark)
+  end
+
+  def work_deleted(work_id) do
+    case from(c in ArkCache, where: c.work_id == ^work_id)
+         |> Repo.one()
+         |> Ark.from_cache() do
+      nil -> :noop
+      %{status: "reserved"} = ark -> delete_ark(ark)
+      ark -> Ark.put(%Ark{ark | status: "unavailable | withdrawn", work_id: nil})
+    end
+  end
+end

--- a/app/priv/repo/migrations/20230809205037_add_ark_cache.exs
+++ b/app/priv/repo/migrations/20230809205037_add_ark_cache.exs
@@ -1,0 +1,18 @@
+defmodule Meadow.Repo.Migrations.AddArkCache do
+  use Ecto.Migration
+
+  def change do
+    create table(:ark_cache, primary_key: [name: :ark, type: :string]) do
+      add(:creator, :string)
+      add(:title, :string)
+      add(:publisher, :string)
+      add(:publication_year, :string)
+      add(:resource_type, :string)
+      add(:status, :string)
+      add(:target, :string)
+      add(:work_id, :binary_id)
+    end
+
+    create index(:ark_cache, [:work_id], concurrently: false)
+  end
+end

--- a/app/test/meadow/ark_listener_test.exs
+++ b/app/test/meadow/ark_listener_test.exs
@@ -1,0 +1,72 @@
+defmodule Meadow.ArkListenerTest do
+  use Meadow.DataCase
+
+  alias Meadow.{Ark, ArkListener}
+  alias Meadow.Data.Works
+
+  import Meadow.TestHelpers
+
+  def update_work(work, attrs) do
+    {:ok, work} = Works.update_work(work, attrs)
+    mock_database_notification(ArkListener, :works, :update, [work.id])
+    work
+  end
+
+  describe "ArkListener" do
+    setup do
+      work =
+        work_fixture(%{published: false, visibility: %{id: "RESTRICTED", scheme: "visibility"}})
+
+      mock_database_notification(ArkListener, :works, :insert, [work.id])
+
+      with work <- Works.get_work(work.id) do
+        {:ok, %{work: work, ark: work.descriptive_metadata.ark}}
+      end
+    end
+
+    test "ark minted on insert", %{ark: ark} do
+      assert {:ok, %{status: _}} = Ark.get(ark)
+    end
+
+    test "never published / reserved", %{ark: ark} do
+      assert {:ok, %Ark{status: "reserved"}} = Ark.get(ark)
+    end
+
+    test "published to unpublished / unavailable | unpublished", %{work: work, ark: ark} do
+      work |> update_work(%{published: true}) |> update_work(%{published: false})
+      assert {:ok, %Ark{status: "unavailable | unpublished"}} = Ark.get(ark)
+    end
+
+    test "private / unavilable | restricted", %{work: work, ark: ark} do
+      work |> update_work(%{published: true})
+      assert {:ok, %Ark{status: "unavailable | restricted"}} = Ark.get(ark)
+    end
+
+    test "public / public", %{work: work, ark: ark} do
+      work |> update_work(%{published: true, visibility: %{id: "OPEN", scheme: "visibility"}})
+      assert {:ok, %Ark{status: "public"}} = Ark.get(ark)
+    end
+
+    test "institution / public", %{work: work, ark: ark} do
+      work
+      |> update_work(%{published: true, visibility: %{id: "AUTHENTICATED", scheme: "visibility"}})
+
+      assert {:ok, %Ark{status: "public"}} = Ark.get(ark)
+    end
+
+    test "delete never-published work", %{work: work, ark: ark} do
+      work |> Works.delete_work()
+      mock_database_notification(ArkListener, "works", :delete, [work.id])
+      assert {:error, "error: bad request - no such identifier"} = Ark.get(ark)
+    end
+
+    test "delete published work", %{work: work, ark: ark} do
+      work
+      |> update_work(%{published: true})
+      |> Works.delete_work()
+
+      mock_database_notification(ArkListener, "works", :delete, [work.id])
+      assert {:ok, %{status: "unavailable | withdrawn"}} = Ark.get(ark)
+    end
+  end
+end

--- a/app/test/meadow/ark_test.exs
+++ b/app/test/meadow/ark_test.exs
@@ -1,5 +1,5 @@
 defmodule Meadow.ArkTest do
-  use ExUnit.Case, async: false
+  use Meadow.DataCase, async: false
 
   alias Meadow.Ark
   alias Meadow.Utils.ArkClient.MockServer

--- a/app/test/meadow/arks_test.exs
+++ b/app/test/meadow/arks_test.exs
@@ -1,0 +1,25 @@
+defmodule Meadow.ArksTest do
+  use Meadow.DataCase
+
+  alias Meadow.Arks
+
+  describe "mint_ark/1" do
+    setup %{work_type: work_type} do
+      {:ok, work: work_fixture(%{work_type: %{id: work_type, scheme: "work_type"}})}
+    end
+
+    seed_values("coded_terms/work_type")
+    |> Enum.each(fn %{id: work_type} ->
+      @tag work_type: work_type
+      test "mint_ark/1 mints an ark for #{work_type} work type", %{work: work} do
+        assert {:ok, %{descriptive_metadata: %{ark: ark}}} = Arks.mint_ark(work)
+        assert is_binary(ark)
+      end
+
+      @tag work_type: work_type
+      test "mint_ark!/1 mints an ark for #{work_type} work type", %{work: work} do
+        assert Arks.mint_ark!(work)
+      end
+    end)
+  end
+end

--- a/app/test/meadow/data/csv/export_test.exs
+++ b/app/test/meadow/data/csv/export_test.exs
@@ -3,6 +3,7 @@ defmodule Meadow.Data.CSV.ExportTest do
   use Meadow.IndexCase
 
   alias NimbleCSV.RFC4180, as: CSV
+  alias Meadow.Arks
   alias Meadow.Data.{CSV.Export, Indexer, Works}
 
   import Assertions
@@ -16,7 +17,10 @@ defmodule Meadow.Data.CSV.ExportTest do
 
     exs_fixture("test/fixtures/csv/work_fixtures.exs")
     |> Enum.each(fn work_data ->
-      work_data |> Map.put(:collection_id, collection.id) |> Works.create_work!()
+      work_data
+      |> Map.put(:collection_id, collection.id)
+      |> Works.create_work!()
+      |> Arks.mint_ark()
     end)
 
     Indexer.synchronize_index()

--- a/app/test/meadow/data/works_test.exs
+++ b/app/test/meadow/data/works_test.exs
@@ -46,18 +46,6 @@ defmodule Meadow.Data.WorksTest do
       assert_raise(Ecto.InvalidChangesetError, fn -> Works.create_work!(@invalid_attrs) end)
     end
 
-    test "create_work/1 creates a work with an ark" do
-      with {:ok, work} <- Works.create_work(@valid_attrs) do
-        assert work.descriptive_metadata.ark |> String.match?(~r'^ark:/12345/nu2\d{8}$')
-      end
-    end
-
-    test "create_work!/1 creates a work with an ark" do
-      with work <- Works.create_work!(@valid_attrs) do
-        assert work.descriptive_metadata.ark |> String.match?(~r'^ark:/12345/nu2\d{8}$')
-      end
-    end
-
     test "update_work/2 updates a work" do
       work = work_fixture()
 
@@ -125,10 +113,16 @@ defmodule Meadow.Data.WorksTest do
   describe "representative images for image type works" do
     setup do
       work =
-        work_with_file_sets_fixture(3, %{work_type: %{id: "IMAGE", scheme: "work_type"}}, %{
-          role: %{id: "A", scheme: "FILE_SET_ROLE"},
-          derivatives: %{"pyramid_tiff" => "s3://fo/ob/ar/1-pyramid.tif"}
-        })
+        work_with_file_sets_fixture(
+          3,
+          %{
+            work_type: %{id: "IMAGE", scheme: "work_type"}
+          },
+          %{
+            role: %{id: "A", scheme: "FILE_SET_ROLE"},
+            derivatives: %{"pyramid_tiff" => "s3://fo/ob/ar/1-pyramid.tif"}
+          }
+        )
 
       file_set = work.file_sets |> Enum.at(1)
 
@@ -164,6 +158,16 @@ defmodule Meadow.Data.WorksTest do
         Works.get_work_by_accession_number!(work.accession_number)
         |> Map.get(:representative_image) == image_url
       )
+    end
+
+    test "get_work_by_ark!/1", %{work: work, image_url: image_url} do
+      with {:ok, work} <-
+             work |> Works.update_work(%{descriptive_metadata: %{ark: "ark:/12345/nu209876543"}}) do
+        assert(
+          Works.get_work_by_ark!(work.descriptive_metadata.ark)
+          |> Map.get(:representative_image) == image_url
+        )
+      end
     end
 
     test "get_works_by_title/1", %{work: work, image_url: image_url} do
@@ -555,25 +559,5 @@ defmodule Meadow.Data.WorksTest do
         assert result.verified == false
       end)
     end
-  end
-
-  describe "mint_ark/1" do
-    setup %{work_type: work_type} do
-      {:ok, work: work_fixture(%{work_type: %{id: work_type, scheme: "work_type"}})}
-    end
-
-    seed_values("coded_terms/work_type")
-    |> Enum.each(fn %{id: work_type} ->
-      @tag work_type: work_type
-      test "mint_ark/1 mints an ark for #{work_type} work type", %{work: work} do
-        assert {:ok, %{descriptive_metadata: %{ark: ark}}} = Works.mint_ark(work)
-        assert is_binary(ark)
-      end
-
-      @tag work_type: work_type
-      test "mint_ark!/1 mints an ark for #{work_type} work type", %{work: work} do
-        assert Works.mint_ark!(work)
-      end
-    end)
   end
 end

--- a/app/test/support/test_helpers.ex
+++ b/app/test/support/test_helpers.ex
@@ -266,6 +266,14 @@ defmodule Meadow.TestHelpers do
     end
   end
 
+  def mock_database_notification(listener, table, operation, ids, state \\ %{}) do
+    listener.handle_info(
+      {:notification, self(), self(), "#{table}_changed",
+       Jason.encode!(%{source: "#{table}", operation: operation, ids: ids})},
+      state
+    )
+  end
+
   defp uniqify_ingest_sheet_rows(csv) do
     with prefix <- test_id() do
       [headers | rows] = CSV.parse_string(csv, skip_headers: false)


### PR DESCRIPTION
# Summary 
Make sure ARKs update properly (especially status) when works change

# Specific Changes in this PR
- Create `Arks` context to declutter `Works` context
- Create database cache for ARK metadata
- Fix `ArkListener` to update ARK content when work changes
- Add `ArkListener` tests
- Make `ArkListener` responsible for minting ARKs when works are inserted instead of having `Works.create_work` do it

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Setup:
```
mix ecto.migrate
iex -S mix phx.server
```

The rest of the steps all have to be done without shutting down Meadow, because the mock ARK server that runs in development mode only retains its data as long as the process is running.

- Open TablePlus and refresh the `ark_cache` table after each of the following steps
- Create an unpublished work (`ark_cache.status` should be `reserved`)
- Change `published`/`visibility` in various combinations, and compare the `ark_cache` contents to the [Done Looks Like criteria](https://github.com/nulib/repodev_planning_and_docs/issues/4095)
- Change other ARK-related metadata fields (title, creator, etc.) and make sure `ark_cache` changes accordingly
- Change some _non_-ARK-related metadata and watch Meadow's log for the message `Metadata for #{ark} didn't change. Not sending update.`
- Make a direct change to the `works` table in TablePlus and make sure `ark_cache` changes accordingly
- Delete a row from the `ark_cache` and make sure it gets re-populated the next time its work changes.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [x] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

