### PR TITLE
Clear the CF streaming distribution during file set replace

### DIFF
--- a/app/config/config.exs
+++ b/app/config/config.exs
@@ -121,6 +121,7 @@ config :meadow,
   validation_ping_interval: System.get_env("VALIDATION_PING_INTERVAL", "1000"),
   shared_links_index: prefix("shared_links"),
   pyramid_tiff_working_dir: System.tmp_dir!(),
+  streaming_distribution_id: aws_secret("meadow", dig: ["streaming", "distribution_id"], default: nil),
   work_archiver_endpoint: aws_secret("meadow", dig: ["work_archiver", "endpoint"], default: "")
 
 config :exldap, :settings,

--- a/app/lib/meadow/config.ex
+++ b/app/lib/meadow/config.ex
@@ -60,6 +60,11 @@ defmodule Meadow.Config do
     Application.get_env(:meadow, :streaming_url)
   end
 
+  @doc "Retrieve the environment specific distribution id for streaming"
+  def streaming_cloudfront_distribution_id do
+    Application.get_env(:meadow, :streaming_distribution_id)
+  end
+
   @doc "Retrieve configured lambda scripts"
   def lambda_config(config_key) do
     case Application.get_env(:meadow, :lambda, []) |> Keyword.get(config_key) do

--- a/app/test/pipeline/actions/generate_poster_image_test.exs
+++ b/app/test/pipeline/actions/generate_poster_image_test.exs
@@ -76,7 +76,7 @@ defmodule Meadow.Pipeline.Actions.GeneratePosterImageTest do
 
       assert log
              |> String.contains?(
-               "Skipping poster cache invalidation for: /iiif/2/#{prefix()}/posters/#{file_set_id}/*. No distribution id found."
+               "Skipping cache invalidation for: /iiif/2/#{prefix()}/posters/#{file_set_id}/*. No distribution id found."
              )
     end
   end

--- a/infrastructure/deploy/secrets.tf
+++ b/infrastructure/deploy/secrets.tf
@@ -88,6 +88,7 @@ locals {
 
     streaming = {
       base_url = "https://${aws_route53_record.meadow_streaming_cloudfront.fqdn}/"
+      distribution_id = aws_cloudfront_distribution.meadow_streaming.id
     }
 
     work_archiver = {


### PR DESCRIPTION
# Summary 

When an AV file set is replaced, the streaming Cloudfront distribution needs to be invalidated

# Specific Changes in this PR
- send cache invalidation request when transcode is complete if it's a versioned file set

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Not testable in dev environment (no transcoding or streaming cache)
- On staging (make sure Terraform is applied), replace an AV file set (instructions > in Steps To Test here: https://github.com/nulib/meadow/pull/3466#issue-1830089257)
- In the AWS console validate that an invalidation was received by the streaming distribution
- The new video should play in the player. (Browser refresh may be required)

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [x] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

