### PR TITLE
Fix streaming cache invalidation path

### DIFF
--- a/app/lib/meadow/utils/aws.ex
+++ b/app/lib/meadow/utils/aws.ex
@@ -88,7 +88,7 @@ defmodule Meadow.Utils.AWS do
   def invalidate_cache(file_set, :poster, _), do: perform_iiif_invalidation("/iiif/2/posters/#{file_set.id}/*")
   def invalidate_cache(_file_set, :streaming, :dev), do: :ok
   def invalidate_cache(_file_set, :streaming, :test), do: :ok
-  def invalidate_cache(file_set, :streaming, _), do: perform_streaming_invalidation(Pairtree.generate(file_set.id))
+  def invalidate_cache(file_set, :streaming, _), do: perform_streaming_invalidation("/#{Pairtree.generate(file_set.id)}/*")
 
   defp perform_iiif_invalidation(path), do: perform_invalidation(path, Config.iiif_cloudfront_distribution_id())
   defp perform_streaming_invalidation(path), do: perform_invalidation(path, Config.streaming_cloudfront_distribution_id())
@@ -96,9 +96,7 @@ defmodule Meadow.Utils.AWS do
   defp perform_invalidation(path, nil) do
     Logger.info(
       "Skipping cache invalidation for: #{path}. No distribution id found."
-
       )
-
     :ok
   end
 


### PR DESCRIPTION
# Summary 

Correct path for streaming cache invalidation in previous PR: https://github.com/nulib/meadow/pull/3508

# Specific Changes in this PR
- Correct path for streaming cache invalidation in previous PR
- 
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

