### PR TITLE
Use MediaConvert for transcoding in dev environment

### DIFF
--- a/app/.iex.exs
+++ b/app/.iex.exs
@@ -1,3 +1,5 @@
+Code.put_compiler_option(:ignore_module_conflict, true)
+
 alias Meadow.Repo
 
 alias Meadow.{

--- a/app/config/config.exs
+++ b/app/config/config.exs
@@ -99,7 +99,7 @@ config :meadow,
       dig: ["streaming", "base_url"],
       default: "https://#{prefix()}-streaming.s3.amazonaws.com/"
     ),
-  mediaconvert_client: MediaConvert.Mock,
+  mediaconvert_client: MediaConvert,
   multipart_upload_concurrency: System.get_env("MULTIPART_UPLOAD_CONCURRENCY", "10"),
   iiif_server_url:
     aws_secret("meadow",
@@ -121,7 +121,8 @@ config :meadow,
   validation_ping_interval: System.get_env("VALIDATION_PING_INTERVAL", "1000"),
   shared_links_index: prefix("shared_links"),
   pyramid_tiff_working_dir: System.tmp_dir!(),
-  streaming_distribution_id: aws_secret("meadow", dig: ["streaming", "distribution_id"], default: nil),
+  streaming_distribution_id:
+    aws_secret("meadow", dig: ["streaming", "distribution_id"], default: nil),
   work_archiver_endpoint: aws_secret("meadow", dig: ["work_archiver", "endpoint"], default: "")
 
 config :exldap, :settings,

--- a/app/config/dev.exs
+++ b/app/config/dev.exs
@@ -57,7 +57,8 @@ if System.get_env("AWS_DEV_ENVIRONMENT") |> is_nil() do
     checksum_notification: %{
       arn: "arn:aws:lambda:us-east-1:000000000000:function:digest-tag",
       buckets: ["dev-ingest", "dev-uploads"]
-    }
+    },
+    mediaconvert_client: MediaConvert.Mock
 
   [:mediaconvert, :s3, :secretsmanager, :sns, :sqs]
   |> Enum.each(fn service ->
@@ -72,7 +73,9 @@ if System.get_env("AWS_DEV_ENVIRONMENT") |> is_nil() do
 end
 
 config :meadow,
-  index_interval: 30_000
+  index_interval: 30_000,
+  mediaconvert_queue: prefix("transcode"),
+  mediaconvert_role: aws_secret("meadow", dig: ["transcode", "role_arn"])
 
 config :meadow, Meadow.Scheduler,
   overlap: false,


### PR DESCRIPTION
# Summary 
Use MediaConvert for transcoding in dev environment

# Specific Changes in this PR
- Update dev configuration to use MediaCovert
- Retrieve MediaConvert queue/role info from shared Meadow config

Required changes to `aws-developer-environment` have already been applied to common and all dev profiles

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

1. Start meadow in dev environment
2. Create or navigate to an audio or video work
3. Add an audio or video fileset
4. Watch the log for the `CreateTranscodeJob` and `TranscodeJobComplete` actions
5. Using TablePlus or GraphQL, check the FileSets's streaming URL to make sure it's an `.m3u8`.
6. Try to play the file in the browser.

*Note:* I had to make another change to the work after adding the fileset to force Meadow to generate a manifest. This is a preexisting issue and outside the scope of this ticket.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

