### PR TITLE
Fix EZID update errors

### DIFF
--- a/app/lib/meadow/ark.ex
+++ b/app/lib/meadow/ark.ex
@@ -164,7 +164,7 @@ defmodule Meadow.Ark do
   end
 
   def put(%__MODULE__{} = ark) do
-    case Client.put("/id/#{ark.ark}?update_if_exists=yes", Serializer.serialize(ark)) do
+    case Client.post("/id/#{ark.ark}", Serializer.serialize(ark)) do
       {:ok, %{status_code: status}} when status in 200..201 ->
         put_in_cache(ark)
         {:ok, ark}

--- a/app/test/meadow/ark_test.exs
+++ b/app/test/meadow/ark_test.exs
@@ -169,7 +169,7 @@ defmodule Meadow.ArkTest do
       update = Map.put(fixture, :title, "A 100% New Title for This ARK!")
       assert {:ok, update} == Ark.put(update)
       assert {:ok, update} == Ark.get(fixture.ark)
-      assert_received({:put, :credentials, {"mockuser", "mockpassword"}})
+      assert_received({:post, :credentials, {"mockuser", "mockpassword"}})
 
       expected =
         [
@@ -181,7 +181,7 @@ defmodule Meadow.ArkTest do
         ]
         |> Enum.join("\n")
 
-      assert_received({:put, :body, ^expected})
+      assert_received({:post, :body, ^expected})
     end
 
     test "invalid ARK" do


### PR DESCRIPTION
# Summary 

Fix EZID update errors

# Specific Changes in this PR

- Use `POST` instead of `PUT` for ezid updates

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

1. Add the following to `config/meadow.dev.exs` to point your local Meadow at the actual CDLIB ARK test account:
    ```elixir
    config :meadow,
      ark: %{
        default_shoulder: "ark:/99999/fk4",
        user: "apitest",
        password: "apitest",
        target_url: "https://devbox.library.northwestern.edu:3333/items/",
        url: "https://ezid.cdlib.org/"
      }
    ```    
3. Follow the steps to test in nulib/meadow#3498, but also check each status change against the metadata displayed at `https://ezid.cdlib.org/id/ark:/99999/fk4.....`:
    ![image](https://github.com/nulib/meadow/assets/196872/f02f6dca-c8cb-4ad9-9a02-ac604fd05e25)


# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

