### PR TITLE
Add placeholder download video button 

### DIFF
--- a/app/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
+++ b/app/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
@@ -1,21 +1,38 @@
 import React, { useContext } from "react";
-import PropTypes from "prop-types";
+
 import { Button } from "@nulib/design-system";
 import { IIIFContext } from "@js/components/IIIF/IIIFProvider";
 import { IIIF_SIZES } from "@js/services/global-vars";
 import { IconDownload } from "@js/components/Icon";
 import { ImageDownloader } from "@samvera/image-downloader";
-import { useWorkDispatch } from "@js/context/work-context";
+import PropTypes from "prop-types";
+import { toastWrapper } from "@js/services/helpers";
 import useFileSet from "@js/hooks/useFileSet";
 import useIsAuthorized from "@js/hooks/useIsAuthorized";
+import { useWorkDispatch } from "@js/context/work-context";
 
-function MediaButtons({ fileSet }) {
+export function MediaButtons({ fileSet }) {
   const { getWebVttString } = useFileSet();
   const { isAuthorized } = useIsAuthorized();
-
   const dispatch = useWorkDispatch();
+  const [downloadStarted, setDownloadStarted] = React.useState(false);
+
+  const handleDownloadMedia = () => {
+    console.log("handleDownloadMedia", handleDownloadMedia);
+    // TODO: Call the download media endpoint here
+
+    toastWrapper(
+      "is-success",
+      `Your media download is being prepared. You will receive an email when it is ready.`
+    );
+
+    setDownloadStarted(true);
+  };
+
+  if (!fileSet) return null;
+
   return (
-    <div className="buttons is-flex is-justify-content-flex-end">
+    <div className="buttons is-grouped is-right">
       {isAuthorized() && (
         <Button
           onClick={() =>
@@ -29,11 +46,15 @@ function MediaButtons({ fileSet }) {
           Edit structure (vtt)
         </Button>
       )}
+      <Button onClick={handleDownloadMedia} disabled={downloadStarted}>
+        <IconDownload />
+        Download
+      </Button>
     </div>
   );
 }
 
-function ImageButtons({ iiifServerUrl, fileSet }) {
+export function ImageButtons({ iiifServerUrl, fileSet }) {
   return (
     <div className="field has-addons is-flex is-justify-content-flex-end">
       <p className="control">

--- a/app/assets/js/components/Work/Fileset/ActionButtons/MediaButtons.test.jsx
+++ b/app/assets/js/components/Work/Fileset/ActionButtons/MediaButtons.test.jsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+
+import { MediaButtons } from "./Access";
+import React from "react";
+import { WorkProvider } from "@js/context/work-context";
+import { mockUser } from "@js/components/Auth/auth.gql.mock";
+import useIsAuthorized from "@js/hooks/useIsAuthorized";
+
+jest.mock("@js/hooks/useIsAuthorized");
+useIsAuthorized.mockReturnValue({
+  user: mockUser,
+  isAuthorized: () => true,
+});
+
+const mockFileSet = {
+  __typename: "FileSet",
+  id: "120da9c2-abb3-4492-a62c-e4f0beb2bb6f",
+  accessionNumber: "Donohue_002_01",
+  coreMetadata: {
+    __typename: "FileSetCoreMetadata",
+    description: "Photo, man with two children",
+    label: "The label",
+    location: "s3://testing",
+    mimeType: "video/x-m4v",
+    originalFilename: "small.m4v",
+    digests: {
+      __typename: "Digests",
+      md5: "a036e18dad7b0deab383454ec1d32f87",
+      sha1: null,
+      sha256: null,
+    },
+  },
+  extractedMetadata: "",
+  insertedAt: "2023-05-04T20:31:27.097298Z",
+  role: {
+    __typename: "CodedTerm",
+    id: "A",
+    label: "Access",
+  },
+  representativeImageUrl: null,
+  streamingUrl: "https://testings/120da9c2-abb3-4492-a62c-e4f0beb2bb6f.m4v",
+  structuralMetadata: {
+    __typename: "FileSetStructuralMetadata",
+    type: "WEBVTT",
+    value:
+      "WEBVTT - Translation of that film I like\n\nNOTE\nThis translation was done by Kyle so that\nsome friends can watch it with their parents.\n\n1\n00:02:15.000 --> 00:02:20.000\n- Ta en kopp varmt te.\n- Det är inte varmt.\n\n2\n00:02:20.000 --> 00:02:25.000\n- Har en kopp te.\n- Det smakar som te.\n\nNOTE This last line may not translate well.\n\n3\n00:02:25.000 --> 00:02:30.000\n- Ta en kopp",
+  },
+  updatedAt: "2023-05-04T20:32:03.571707Z",
+};
+
+const initialState = {
+  activeMediaFileSet: mockFileSet,
+  webVttModal: {
+    fileSetId: null,
+    isOpen: false,
+    webVttString: "",
+  },
+  workType: "VIDEO",
+};
+
+describe("MediaButtons", () => {
+  it("renders the Edit VTT button and Download Video button for a video mime/type Fileset", () => {
+    render(
+      <WorkProvider initialState={initialState}>
+        <MediaButtons fileSet={mockFileSet} />
+      </WorkProvider>
+    );
+
+    expect(screen.getByText("Edit structure (vtt)")).toBeInTheDocument();
+    expect(screen.getByText("Download")).toBeInTheDocument();
+  });
+});

--- a/app/assets/js/hooks/useFileSet.js
+++ b/app/assets/js/hooks/useFileSet.js
@@ -35,11 +35,18 @@ export default function useFileSet() {
     return mimeType.includes("video") || mimeType.includes("audio");
   }
 
+  function isVideo(fileSet = {}) {
+    const mimeType = fileSet.coreMetadata?.mimeType?.toLowerCase();
+    if (!mimeType) return;
+    return mimeType.includes("video");
+  }
+
   return {
     filterFileSets,
     getWebVttString,
     isEmpty,
     isImage,
     isMedia,
+    isVideo,
   };
 }


### PR DESCRIPTION
# Summary 
This PR wires up the download video button for a Filetset on the Structure tab. This is not fully complete until we get the download url (coming soon in another issue)

<img width="1176" alt="image" src="https://github.com/nulib/meadow/assets/3020266/74de2dca-cba3-4255-b4f9-7b9d6eb7be8a">


# Specific Changes in this PR
- Add download button to the Work > Structure tab for `video` mime type files

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
1. Go to a Video Work page, click on the "Structure" tab and notice "Download video" button for an "Access" Fileset video.
2. Go to an Audio Work page and notice the "Download video" button doesn't appear in the same spot as above.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

