### PR TITLE
Ensure ARK transition from reserved to unavailable goes through public

### DIFF
--- a/app/lib/meadow/ark_listener.ex
+++ b/app/lib/meadow/ark_listener.ex
@@ -41,7 +41,7 @@ defmodule Meadow.ArkListener do
       "Updating ARK metadata for work: #{work.id}, with ark: #{work.descriptive_metadata.ark}"
     )
 
-    case Arks.update_ark_metatdata(work) do
+    case Arks.update_ark_metadata(work) do
       :noop ->
         :noop
 

--- a/app/lib/meadow/utils/ark_client/mock_server.ex
+++ b/app/lib/meadow/utils/ark_client/mock_server.ex
@@ -207,7 +207,7 @@ defmodule Meadow.Utils.ArkClient.MockServer do
   defp send_message(message) do
     case Cachex.get!(@cache, :send_to) do
       nil -> :noop
-      process -> send(process, message)
+      process -> send(process, %{message: message, at: NaiveDateTime.utc_now()})
     end
   end
 

--- a/app/test/meadow/ark_test.exs
+++ b/app/test/meadow/ark_test.exs
@@ -61,8 +61,8 @@ defmodule Meadow.ArkTest do
         Enum.each(@fields, &assert(result |> Map.get(&1) |> is_nil()))
       end
 
-      assert_received({:post, :credentials, {"mockuser", "mockpassword"}})
-      assert_received({:post, :body, "_profile: datacite\n_status: reserved"})
+      assert_received(%{message: {:post, :credentials, {"mockuser", "mockpassword"}}})
+      assert_received(%{message: {:post, :body, "_profile: datacite\n_status: reserved"}})
     end
 
     test "attribute list argument" do
@@ -73,7 +73,7 @@ defmodule Meadow.ArkTest do
         Enum.each(@fields, &assert(Map.get(result, &1) == Keyword.get(source, &1)))
       end
 
-      assert_received({:post, :credentials, {"mockuser", "mockpassword"}})
+      assert_received(%{message: {:post, :credentials, {"mockuser", "mockpassword"}}})
 
       expected =
         [
@@ -83,7 +83,7 @@ defmodule Meadow.ArkTest do
         ]
         |> Enum.join("\n")
 
-      assert_received({:post, :body, ^expected})
+      assert_received(%{message: {:post, :body, ^expected}})
     end
 
     test "map argument" do
@@ -94,7 +94,7 @@ defmodule Meadow.ArkTest do
         Enum.each(@fields, &assert(Map.get(result, &1) == Map.get(source, &1)))
       end
 
-      assert_received({:post, :credentials, {"mockuser", "mockpassword"}})
+      assert_received(%{message: {:post, :credentials, {"mockuser", "mockpassword"}}})
 
       expected =
         [
@@ -104,7 +104,7 @@ defmodule Meadow.ArkTest do
         ]
         |> Enum.join("\n")
 
-      assert_received({:post, :body, ^expected})
+      assert_received(%{message: {:post, :body, ^expected}})
     end
 
     test "Meadow.Ark argument" do
@@ -115,7 +115,7 @@ defmodule Meadow.ArkTest do
         Enum.each(@fields, &assert(Map.get(result, &1) == Map.get(source, &1)))
       end
 
-      assert_received({:post, :credentials, {"mockuser", "mockpassword"}})
+      assert_received(%{message: {:post, :credentials, {"mockuser", "mockpassword"}}})
 
       expected =
         [
@@ -125,7 +125,7 @@ defmodule Meadow.ArkTest do
         ]
         |> Enum.join("\n")
 
-      assert_received({:post, :body, ^expected})
+      assert_received(%{message: {:post, :body, ^expected}})
     end
   end
 
@@ -169,7 +169,7 @@ defmodule Meadow.ArkTest do
       update = Map.put(fixture, :title, "A 100% New Title for This ARK!")
       assert {:ok, update} == Ark.put(update)
       assert {:ok, update} == Ark.get(fixture.ark)
-      assert_received({:post, :credentials, {"mockuser", "mockpassword"}})
+      assert_received(%{message: {:post, :credentials, {"mockuser", "mockpassword"}}})
 
       expected =
         [
@@ -181,7 +181,7 @@ defmodule Meadow.ArkTest do
         ]
         |> Enum.join("\n")
 
-      assert_received({:post, :body, ^expected})
+      assert_received(%{message: {:post, :body, ^expected}})
     end
 
     test "invalid ARK" do

--- a/app/test/meadow/arks_test.exs
+++ b/app/test/meadow/arks_test.exs
@@ -1,7 +1,9 @@
 defmodule Meadow.ArksTest do
   use Meadow.DataCase
 
-  alias Meadow.Arks
+  alias Meadow.{Ark, Arks}
+  alias Meadow.Data.Works
+  alias Meadow.Utils.ArkClient.MockServer
 
   describe "mint_ark/1" do
     setup %{work_type: work_type} do
@@ -21,5 +23,55 @@ defmodule Meadow.ArksTest do
         assert Arks.mint_ark!(work)
       end
     end)
+  end
+
+  describe "update_ark_metadata/1" do
+    setup do
+      MockServer.send_to(self())
+    end
+
+    setup %{visibility: visibility} do
+      with work <-
+             work_fixture(%{
+               published: false,
+               visibility: %{id: visibility, scheme: "visibility"}
+             })
+             |> Arks.mint_ark!() do
+        {:ok, work: work}
+      end
+    end
+
+    @tag visibility: "OPEN"
+    test "correctly transitions from reserved to public when published", %{work: work} do
+      assert {:ok, %Ark{status: "reserved"}} = Arks.existing_ark(work)
+
+      work
+      |> Works.update_work!(%{published: true})
+      |> Arks.update_ark_metadata()
+
+      assert {:ok, %Ark{status: "public"}} = Arks.existing_ark(work)
+    end
+
+    @tag visibility: "RESTRICTED"
+    test "correctly transitions from reserved to unavailable when published", %{work: work} do
+      assert_received(%{message: {:post, :body, anvl}, at: reserved_time})
+      assert String.contains?(anvl, "_status: reserved")
+      assert {:ok, %Ark{status: "reserved"}} = Arks.existing_ark(work)
+
+      work
+      |> Works.update_work!(%{published: true})
+      |> Arks.update_ark_metadata()
+
+      assert_received(%{message: {:post, :body, anvl}, at: public_time})
+      assert String.contains?(anvl, "_status: public")
+
+      assert_received(%{message: {:post, :body, anvl}, at: unavailable_time})
+      assert String.contains?(anvl, "_status: unavailable | restricted")
+
+      assert reserved_time < public_time
+      assert public_time < unavailable_time
+
+      assert {:ok, %Ark{status: "unavailable | restricted"}} = Arks.existing_ark(work)
+    end
   end
 end


### PR DESCRIPTION
# Summary 
ARKs cannot transition directly from `reserved` to `unavailable` without becoming `public` first. This PR makes sure that transition happens correctly.

# Specific Changes in this PR
- Add special case to transition `reserved` to `unavailable`
- Add tests to make sure the double transition happens in the right order

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Create a private, unpublished work
- Check its ARK on ezid.cdlib.org and make sure its status is `reserved`
- Publish the work
- Check that the ARK's status is now `unavailable | restricted`

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

