### PR TITLE
Hide media download button

### DIFF
--- a/app/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
+++ b/app/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
@@ -46,10 +46,11 @@ export function MediaButtons({ fileSet }) {
           Edit structure (vtt)
         </Button>
       )}
-      <Button onClick={handleDownloadMedia} disabled={downloadStarted}>
+      {/* //TODO: Re-enable once backend is ready to support the link *}
+      {/* <Button onClick={handleDownloadMedia} disabled={downloadStarted}>
         <IconDownload />
         Download
-      </Button>
+      </Button> */}
     </div>
   );
 }

--- a/app/assets/js/components/Work/Fileset/ActionButtons/MediaButtons.test.jsx
+++ b/app/assets/js/components/Work/Fileset/ActionButtons/MediaButtons.test.jsx
@@ -67,6 +67,6 @@ describe("MediaButtons", () => {
     );
 
     expect(screen.getByText("Edit structure (vtt)")).toBeInTheDocument();
-    expect(screen.getByText("Download")).toBeInTheDocument();
+    //expect(screen.getByText("Download")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Summary 
Temporarily hide download media button for a Fileset until back-end is ready to support it.

<img width="1390" alt="image" src="https://github.com/nulib/meadow/assets/3020266/46aa4be9-9336-4b22-bb88-20b35deaccea">


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

