### PR TITLE
Reveal Action State log info on a Fileset in the UI

### DIFF
--- a/app/assets/js/components/Work/Tabs/Preservation/ActionsCol.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/ActionsCol.jsx
@@ -12,6 +12,7 @@ import {
   IconBinaryFile,
   IconBucket,
   IconCopyToClipboard,
+  IconList,
   IconReplace,
   IconTrashCan,
   IconView,
@@ -20,7 +21,6 @@ import React, { useState } from "react";
 
 import AuthDisplayAuthorized from "@js/components/Auth/DisplayAuthorized";
 import { Icon } from "@nulib/design-system";
-import WorkTabsPreservationReplaceFileSet from "@js/components/Work/Tabs/Preservation/ReplaceFileSet";
 import WorkTabsPreservationTechnical from "@js/components/Work/Tabs/Preservation/Technical";
 import classNames from "classnames";
 import { toastWrapper } from "@js/services/helpers";
@@ -33,6 +33,7 @@ const PreservationActionsCol = ({
   handleDeleteFilesetClick,
   handleTechnicalMetaClick,
   handleReplaceFilesetClick,
+  handleViewFilesetActionStates,
   technicalMetadata,
   work,
 }) => {
@@ -157,6 +158,20 @@ const PreservationActionsCol = ({
                 />
               </DialogContent>
             </Dialog.Root>
+          </div>
+          <div>
+            <a
+              className={actionItemClasses}
+              onClick={() => {
+                handleViewFilesetActionStates(fileset.id);
+                setIsActionsOpen(false);
+              }}
+            >
+              <IconList />
+              <span style={{ marginLeft: "0.5rem" }}>
+                View fileset action states
+              </span>
+            </a>
           </div>
           <AuthDisplayAuthorized>
             <a

--- a/app/assets/js/components/Work/Tabs/Preservation/FilesetActionStatesModal.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/FilesetActionStatesModal.jsx
@@ -1,0 +1,97 @@
+import * as Dialog from "@radix-ui/react-dialog";
+
+import {
+  DialogClose,
+  DialogContent,
+  DialogOverlay,
+  DialogTitle,
+  DialogTrigger,
+} from "@js/components/UI/Dialog/Dialog.styled";
+import { Icon, Tag } from "@nulib/design-system";
+import React, { useEffect } from "react";
+import { useLazyQuery, useQuery } from "@apollo/client";
+
+import { ACTION_STATES } from "@js/components/Work/work.gql";
+import UIDate from "@js/components/UI/Date";
+
+const FilesetActionsStatesModal = ({ closeModal, id, isVisible }) => {
+  const [getActionStates, { data, error, loading }] =
+    useLazyQuery(ACTION_STATES);
+
+  useEffect(() => {
+    if (id) {
+      getActionStates({
+        variables: {
+          objectId: id,
+        },
+      });
+    }
+  }, [id]);
+
+  if (loading) return <p>Loading ...</p>;
+  if (error) return `Error! ${error}`;
+
+  const columns = ["action", "outcome", "notes", "inserted at", "updated at"];
+  const getTagProps = (actionState) => {
+    return {
+      isSuccess: actionState.outcome === "OK",
+      isDanger: actionState?.outcome === "ERROR",
+    };
+  };
+
+  return (
+    <Dialog.Root open={isVisible} onOpenChange={closeModal}>
+      <Dialog.Portal>
+        <DialogOverlay />
+        <DialogContent data-testid="fileset-action-states">
+          <DialogClose>
+            <Icon isSmall aria-label="Close">
+              <Icon.Close />
+            </Icon>
+          </DialogClose>
+          <DialogTitle css={{ textAlign: "left" }}>
+            Fileset Action States
+          </DialogTitle>
+          {id && (
+            <>
+              <p className="mt-3 mb-3">Fileset Id: {id}</p>
+              <table className="table" data-testid="action-states">
+                <thead>
+                  <tr>
+                    {columns.map((column) => (
+                      <th key={column} style={{ textTransform: "capitalize" }}>
+                        {column}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {data &&
+                    data.actionStates.map((actionState, idx) => (
+                      <tr key={idx} data-testid="action-state-row">
+                        <td>{actionState.action}</td>
+                        <td>
+                          <Tag {...getTagProps(actionState)}>
+                            {actionState.outcome}
+                          </Tag>
+                        </td>
+                        <td>{actionState.notes}</td>
+                        <td>
+                          <UIDate dateString={actionState.insertedAt} />
+                        </td>
+                        <td>
+                          <UIDate dateString={actionState.updatedAt} />
+                        </td>
+                      </tr>
+                    ))}
+                </tbody>
+              </table>
+            </>
+          )}
+        </DialogContent>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};
+
+export default FilesetActionsStatesModal;

--- a/app/assets/js/components/Work/Tabs/Preservation/FilesetActionStatesModal.test.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/FilesetActionStatesModal.test.jsx
@@ -1,0 +1,73 @@
+import { screen, within } from "@testing-library/react";
+
+import FilesetActionsStatesModal from "@js/components/Work/Tabs/Preservation/FilesetActionStatesModal";
+import React from "react";
+import { actionStatesMock } from "@js/components/Work/work.gql.mock";
+import { renderWithRouterApollo } from "@js/services/testing-helpers";
+
+const defaultProps = {
+  closeModal: jest.fn(),
+  isVisible: true,
+  id: "abc123",
+};
+
+describe("FilesetActionsStatesModal", () => {
+  it("renders the modal with expected modal title fileset id", async () => {
+    renderWithRouterApollo(<FilesetActionsStatesModal {...defaultProps} />, {
+      mocks: [actionStatesMock],
+    });
+    expect(
+      await screen.findByTestId("fileset-action-states")
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("action-states")).toBeInTheDocument();
+
+    expect(
+      await screen.findByText("Fileset Action States")
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Fileset Id: abc123")).toBeInTheDocument();
+  });
+
+  it("renders the expected action state rows", async () => {
+    renderWithRouterApollo(<FilesetActionsStatesModal {...defaultProps} />, {
+      mocks: [actionStatesMock],
+    });
+
+    const rows = await screen.findAllByTestId("action-state-row");
+
+    // Action row 1
+    within(rows[0]).getByText("Completed Processing FileSet");
+    expect(within(rows[0]).getAllByText("Mar 16, 2021 4:22 PM")).toHaveLength(
+      2
+    );
+    within(rows[0]).getByText("OK");
+
+    // Action row 2
+    within(rows[1]).getByText("Create pyramid TIFF from source image");
+    within(rows[1]).getByText("ERROR");
+    within(rows[1]).getByText("I am some notes");
+    within(rows[1]).getByText("Mar 16, 2021 4:22 PM");
+    within(rows[1]).getByText("Mar 16, 2021 4:23 PM");
+  });
+
+  it("does not render the modal when isVisible is false", async () => {
+    renderWithRouterApollo(
+      <FilesetActionsStatesModal {...defaultProps} isVisible={false} />,
+      {
+        mocks: [actionStatesMock],
+      }
+    );
+    expect(
+      await screen.queryByTestId("fileset-action-states")
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render the modal when there is no fileset id", async () => {
+    renderWithRouterApollo(
+      <FilesetActionsStatesModal {...defaultProps} id={null} />,
+      {
+        mocks: [actionStatesMock],
+      }
+    );
+    expect(await screen.queryByTestId("action-states")).not.toBeInTheDocument();
+  });
+});

--- a/app/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
@@ -26,6 +26,7 @@ import { sortFileSets, toastWrapper } from "@js/services/helpers";
 import { useMutation, useQuery } from "@apollo/client";
 
 import AuthDisplayAuthorized from "@js/components/Auth/DisplayAuthorized";
+import FilesetActionStatesModal from "./FilesetActionStatesModal";
 import PreservationActionsCol from "@js/components/Work/Tabs/Preservation/ActionsCol";
 import PropTypes from "prop-types";
 import UISkeleton from "@js/components/UI/Skeleton";
@@ -64,6 +65,11 @@ const WorkTabsPreservation = ({ work }) => {
     fileset: {},
     isVisible: false,
   });
+  const [filesetActionStatesModal, setFilesetActionStatesModal] =
+    React.useState({
+      filesetId: "",
+      isVisible: false,
+    });
 
   const {
     data: verifyFileSetsData,
@@ -197,9 +203,15 @@ const WorkTabsPreservation = ({ work }) => {
     setTechnicalMetadata({ fileSet: { ...fileSet } });
   };
 
+  const handleViewFilesetActionStates = (filesetId) => {
+    setFilesetActionStatesModal({ filesetId, isVisible: true });
+  };
+
   const handleTransferFileSetsClick = () => {
     setTransferFilesetsModal({ fromWorkId: work.id, isVisible: true });
   };
+
+  console.log("filesetActionStatesModal", filesetActionStatesModal);
 
   return (
     <div data-testid="preservation-tab">
@@ -271,6 +283,9 @@ const WorkTabsPreservation = ({ work }) => {
                           handleDeleteFilesetClick={handleDeleteFilesetClick}
                           handleReplaceFilesetClick={handleReplaceFilesetClick}
                           handleTechnicalMetaClick={handleTechnicalMetaClick}
+                          handleViewFilesetActionStates={
+                            handleViewFilesetActionStates
+                          }
                           technicalMetadata={technicalMetadata}
                           work={work}
                         />
@@ -363,6 +378,14 @@ const WorkTabsPreservation = ({ work }) => {
         isVisible={replaceFilesetModal.isVisible}
         workId={work.id}
         workTypeId={work.workType?.id}
+      />
+
+      <FilesetActionStatesModal
+        closeModal={() =>
+          setFilesetActionStatesModal({ filesetId: "", isVisible: false })
+        }
+        id={filesetActionStatesModal.filesetId}
+        isVisible={filesetActionStatesModal.isVisible}
       />
     </div>
   );

--- a/app/assets/js/components/Work/work.gql.js
+++ b/app/assets/js/components/Work/work.gql.js
@@ -1,5 +1,18 @@
 import gql from "graphql-tag";
 
+export const ACTION_STATES = gql`
+  query ActionStates($objectId: ID!) {
+    actionStates(objectId: $objectId) {
+      action
+      insertedAt
+      notes
+      objectId
+      outcome
+      updatedAt
+    }
+  }
+`;
+
 export const ADD_WORK_TO_COLLECTION = gql`
   mutation addWorkToCollection($workId: ID!, $collectionId: ID!) {
     addWorkToCollection(workId: $workId, collectionId: $collectionId) {

--- a/app/assets/js/components/Work/work.gql.mock.js
+++ b/app/assets/js/components/Work/work.gql.mock.js
@@ -4,11 +4,13 @@ import {
   GET_DC_API_TOKEN,
   GET_WORK,
   GET_WORK_TYPES,
-  VERIFY_FILE_SETS,
   TRANSFER_FILE_SETS,
+  VERIFY_FILE_SETS,
   WORK_ARCHIVER_ENDPOINT,
 } from "@js/components/Work/work.gql.js";
 import { mockVisibility, mockWorkType } from "@js/client-local";
+
+import { ACTION_STATES } from "./work.gql";
 
 export const MOCK_WORK_ID = "ABC123";
 export const MOCK_WORK_ID_2 = "DEF456";
@@ -573,6 +575,37 @@ export const dcApiTokenMock = {
         expires: "2033-08-29T16:50:56.785203Z",
         token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
       },
+    },
+  },
+};
+
+export const actionStatesMock = {
+  request: {
+    query: ACTION_STATES,
+    variables: {
+      objectId: "abc123",
+    },
+  },
+  result: {
+    data: {
+      actionStates: [
+        {
+          action: "Completed Processing FileSet",
+          insertedAt: "2021-03-16T16:22:09.862625Z",
+          notes: null,
+          objectId: "a04e4a28-340f-46cb-aca2-9e7f5713ae84",
+          outcome: "OK",
+          updatedAt: "2021-03-16T16:22:19.644696Z",
+        },
+        {
+          action: "Create pyramid TIFF from source image",
+          insertedAt: "2021-03-16T16:22:09.861998Z",
+          notes: "I am some notes",
+          objectId: "a04e4a28-340f-46cb-aca2-9e7f5713ae84",
+          outcome: "ERROR",
+          updatedAt: "2021-03-16T16:23:17.652523Z",
+        },
+      ],
     },
   },
 };


### PR DESCRIPTION
# Summary 
On a Work page, Preservation tab, there is now an option in the action columns dropdown which will display a modal listing Action States for a given Fileset.  

<img width="1200" alt="image" src="https://github.com/nulib/meadow/assets/3020266/9c26c9b3-bfb6-4d92-aa16-ecb2147020dd">

<img width="821" alt="image" src="https://github.com/nulib/meadow/assets/3020266/e8276cbf-26e1-40c7-b28c-8e23ce5f47e3">


# Specific Changes in this PR
- Add a new action in the Action Column dropdown (see above)
- Open and close a modal which hits the GraphQL `actionStates` query using Fileset `id` as the param.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
1. Go to any Work on Staging and test out clicking the action state item "View fileset action states"

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

