### PR TITLE
Index MIME type with FileSet

### DIFF
--- a/app/lib/meadow/indexing/v2/file_set.ex
+++ b/app/lib/meadow/indexing/v2/file_set.ex
@@ -18,6 +18,7 @@ defmodule Meadow.Indexing.V2.FileSet do
       id: file_set.id,
       indexed_at: NaiveDateTime.utc_now(),
       label: file_set.core_metadata.label,
+      mime_type: file_set.core_metadata.mime_type,
       modified_date: file_set.updated_at,
       poster_offset: file_set.poster_offset,
       published: file_set.work.published,


### PR DESCRIPTION
# Summary 

Index MIME type with FileSet

# Specific Changes in this PR
- Add `mime_type` field to v2 FileSet indexer

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

After reindex completes, check FileSet documents in both the `works` and `file-sets` API routes to make sure they all have `mime_type` fields.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

