### PR TITLE
Update Project Description field in UI

### DIFF
--- a/app/assets/js/components/Work/Tabs/Administrative/Administrative.jsx
+++ b/app/assets/js/components/Work/Tabs/Administrative/Administrative.jsx
@@ -45,6 +45,7 @@ const WorkTabsAdministrative = ({ work }) => {
       refetchQueries: [{ query: GET_WORK, variables: { id: work.id } }],
       awaitRefetchQueries: true,
     });
+
   const {
     projectCycle,
     projectDesc,
@@ -56,6 +57,7 @@ const WorkTabsAdministrative = ({ work }) => {
 
   const onSubmit = (data) => {
     const currentFormValues = methods.getValues();
+
     const workUpdateInput = {
       administrativeMetadata: {
         libraryUnit: currentFormValues.libraryUnit
@@ -245,23 +247,12 @@ const WorkTabsAdministrative = ({ work }) => {
                     data-testid="project-description"
                     isReactHookForm
                     placeholder="Project Description"
-                    name="projectDescription"
+                    name="projectDesc"
                     label="Project Description"
                     defaultValue={projectDesc}
                   />
                 ) : projectDesc.length > 0 ? (
-                  <a
-                    data-testid="project-description-link"
-                    className="break-word"
-                    onClick={() =>
-                      handlePassedInSearchTerm(
-                        "administrativeMetadata.projectDesc",
-                        projectDesc || null
-                      )
-                    }
-                  >
-                    {projectDesc}
-                  </a>
+                  projectDesc[0]
                 ) : null}
               </UIFormField>
 

--- a/app/assets/js/components/Work/Tabs/Administrative/Administrative.test.jsx
+++ b/app/assets/js/components/Work/Tabs/Administrative/Administrative.test.jsx
@@ -1,19 +1,20 @@
-import React from "react";
-import { renderWithRouterApollo } from "@js/services/testing-helpers";
-import { mockWork } from "../../work.gql.mock";
-import WorkTabsAdministrative from "./Administrative";
-import { waitFor, screen } from "@testing-library/react";
 import {
   MOCK_COLLECTION_ID,
   getCollectionMock,
   getCollectionsMock,
 } from "@js/components/Collection/collection.gql.mock";
-import { mockUser } from "@js/components/Auth/auth.gql.mock";
-import userEvent from "@testing-library/user-event";
-import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
+import { screen, waitFor } from "@testing-library/react";
+
 import { CodeListProvider } from "@js/context/code-list-context";
-import useIsAuthorized from "@js/hooks/useIsAuthorized";
+import React from "react";
+import WorkTabsAdministrative from "./Administrative";
+import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
 import { formatDate } from "@js/services/helpers";
+import { mockUser } from "@js/components/Auth/auth.gql.mock";
+import { mockWork } from "../../work.gql.mock";
+import { renderWithRouterApollo } from "@js/services/testing-helpers";
+import useIsAuthorized from "@js/hooks/useIsAuthorized";
+import userEvent from "@testing-library/user-event";
 
 jest.mock("@js/hooks/useIsAuthorized");
 useIsAuthorized.mockReturnValue({
@@ -69,6 +70,8 @@ describe("Work Administrative tab component", () => {
     const description = /New Project Description/i;
     const cycleName = /Project Cycle Name/i;
     await waitFor(() => {
+      const descriptionEl = screen.getByText(description);
+      expect(descriptionEl.tagName).not.toEqual(/a/i);
       expect(screen.getByText(description));
       expect(screen.getByText(cycleName));
       expect(screen.getByText(/Started/i));

--- a/app/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
@@ -211,8 +211,6 @@ const WorkTabsPreservation = ({ work }) => {
     setTransferFilesetsModal({ fromWorkId: work.id, isVisible: true });
   };
 
-  console.log("filesetActionStatesModal", filesetActionStatesModal);
-
   return (
     <div data-testid="preservation-tab">
       <UITabsStickyHeader title="Preservation and Access">


### PR DESCRIPTION
# Summary 
Update Project Description in both form submit (this was not working) and in non-edit mode for display (removes the facet link).

<img width="974" alt="image" src="https://github.com/nulib/meadow/assets/3020266/6a6ba194-5a86-4122-aeb5-2081104491fb">


# Specific Changes in this PR
- Fix metadata field name in the `form` which handles Project Description field updates.  It was not updating in the UI.  Now fixed.
- Remove the facet link on a Project Description field.  It just displays as plain text.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

