### PR TITLE
Fix bug adding multiple ControlledTerm metadata fields

### DIFF
--- a/app/assets/js/components/UI/Form/ControlledTermArrayItem.jsx
+++ b/app/assets/js/components/UI/Form/ControlledTermArrayItem.jsx
@@ -1,9 +1,10 @@
 import React, { useState } from "react";
-import { useLazyQuery } from "@apollo/client";
+import { useForm, useFormContext } from "react-hook-form";
+
 import { AUTHORITIES_SEARCH } from "../../Work/controlledVocabulary.gql";
 import UIFormSelect from "./Select";
 import { useCombobox } from "downshift";
-import { useFormContext, useForm } from "react-hook-form";
+import { useLazyQuery } from "@apollo/client";
 
 const UIFormControlledTermArrayItem = ({
   authorities,
@@ -29,7 +30,7 @@ const UIFormControlledTermArrayItem = ({
   );
 
   const inputName = `${[name]}[${index}]`;
-  const hasErrors = errors[name] && errors[name][index].label;
+  const hasErrors = errors[name] && errors[name][index]?.label;
 
   const handleAuthorityChange = (e) => {
     setCurrentAuthority(e.target.value);

--- a/app/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/Preservation.jsx
@@ -211,8 +211,6 @@ const WorkTabsPreservation = ({ work }) => {
     setTransferFilesetsModal({ fromWorkId: work.id, isVisible: true });
   };
 
-  console.log("filesetActionStatesModal", filesetActionStatesModal);
-
   return (
     <div data-testid="preservation-tab">
       <UITabsStickyHeader title="Preservation and Access">


### PR DESCRIPTION
# Summary 
Fixes a bug adding multiple ControlledTerm metadata fields.  This was related to handling two types of ControlledTerm fields in the form; those including a `role` and those without.   The `ControlledTermArray` component should now handle this scenario when adding/removing multiple `fieldArray` entries for say, "Subject", "Genre", etc.

![image](https://github.com/nulib/meadow/assets/3020266/af7293c6-77a7-4f33-91df-5d440c1d8f64)


# Specific Changes in this PR
- The `ControlledTermArray` considers `role` in addition to just the `term` value
- Some better error handling built in for `undefined` values

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
1. Go to an existing Work page, and click "Edit" in the About tab.
2. Add a new Subject entry, and pick an Authority and search for a Term, but do not select a Role
3. Add another Subject entry.
4. Click "Save" on the form.  Notice that saving the form is blocked and you get an error message on the missing Role and Term fields.
5. Add 2 new Genre entries, in varying states of incompleteness.  Try to save the form.  If any fields are missing, you should get appropriate error messages on the invalid fields.
 
Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

