### PR TITLE
Quick fix for adding a Controlled Term item to a Work

### DIFF
--- a/app/assets/js/components/UI/Form/ControlledTermArrayItem.jsx
+++ b/app/assets/js/components/UI/Form/ControlledTermArrayItem.jsx
@@ -26,7 +26,7 @@ const UIFormControlledTermArrayItem = ({
       onCompleted: (data) => {
         setIsLoading(false);
       },
-    }
+    },
   );
 
   const inputName = `${[name]}[${index}]`;
@@ -126,7 +126,6 @@ function DropDownComboBox({
     getLabelProps,
     getMenuProps,
     getInputProps,
-    getComboboxProps,
     getItemProps,
     highlightedIndex,
     isOpen,
@@ -151,7 +150,7 @@ function DropDownComboBox({
   return (
     <>
       <label {...getLabelProps({ className: "label" })}>Choose an item:</label>
-      <div {...getComboboxProps()}>
+      <div>
         <input
           {...getInputProps({
             className: `input ${hasErrors ? "is-danger" : ""}`,


### PR DESCRIPTION
# Summary 
Removes a downshift helper function no longer provided in v8, which was causing an error adding a Controlled Term field to a Work.

# Specific Changes in this PR
- Remove the bad function 

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

