### PR TITLE
Adds infinite timeouts to a few long-running transactions using the default

### DIFF
--- a/app/lib/meadow/application.ex
+++ b/app/lib/meadow/application.ex
@@ -36,6 +36,13 @@ defmodule Meadow.Application do
     children
     |> Enum.each(&DynamicSupervisor.start_child(Meadow.Supervisor, &1))
 
+    :telemetry.attach(
+      "reorder-file-sets-stop-handler",
+      [:meadow, :data, :works, :reorder_file_sets, :stop],
+      &Meadow.Telemetry.handle_reorder_file_sets_stop_event/4,
+      nil
+    )
+
     result
   end
 

--- a/app/lib/meadow/data/works/transfer_file_sets.ex
+++ b/app/lib/meadow/data/works/transfer_file_sets.ex
@@ -39,7 +39,7 @@ defmodule Meadow.Data.Works.TransferFileSets do
       |> Multi.run(:delete_empty_work, fn _repo, _changes -> delete_empty_work(from_work_id) end)
       |> Multi.run(:refetch_to_work, fn _repo, _changes -> fetch_work(to_work_id) end)
 
-    case Repo.transaction(multi) do
+    case Repo.transaction(multi, timeout: :infinity) do
       {:ok, %{refetch_to_work: work}} ->
         {:ok, work}
 

--- a/app/lib/meadow/telemetry.ex
+++ b/app/lib/meadow/telemetry.ex
@@ -61,4 +61,19 @@ defmodule Meadow.Telemetry do
       Map.put(metadata, :action, action)
     end
   end
+
+  require Logger
+
+  def handle_reorder_file_sets_stop_event(
+        [:meadow, :data, :works, :reorder_file_sets, :stop],
+        %{work_id: work_id, duration: duration, file_set_count: file_set_count},
+        _metadata,
+        _config
+      ) do
+    duration_in_seconds = :erlang.convert_time_unit(3_024_815_045, :native, :second)
+
+    Logger.info(
+      "reorder_file_sets operation for #{work_id} with #{file_set_count} file sets took #{duration_in_seconds} seconds (#{duration} monotonic time units)"
+    )
+  end
 end


### PR DESCRIPTION
# Summary 
- Adds infinite timeouts to a few long-running transactions using the default
- Adds telemetry event logging the time it takes to reorder file sets

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Add some file sets and reorder them in the UI. The logs should contain telemetry events like `module=Meadow.Telemetry [info] reorder_file_sets operation for be86ed67-2a48-4b33-936c-05d542339b43 with 200 file sets took 8045709849 monotonic time units.`

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

