### PR TITLE
Add download AV mechanism for Video filesets.

### DIFF
--- a/app/assets/js/components/UI/IIIF/Viewer.test.js
+++ b/app/assets/js/components/UI/IIIF/Viewer.test.js
@@ -23,11 +23,13 @@ const initialState = {
     webVttString: "",
   },
   workType: "VIDEO",
+  dcApiToken: "asd8967asd89asc78234891289nkldsnn89123",
 };
 
 const mocks = [dcApiTokenMock];
 
 jest.mock("@js/services/get-api-response-headers");
+
 jest.mock("@samvera/clover-iiif/viewer", () => {
   return {
     __esModule: true,
@@ -35,7 +37,7 @@ jest.mock("@samvera/clover-iiif/viewer", () => {
       // Call the canvasCallback with a string when the component is rendered
       if (props.canvasCallback) {
         props.canvasCallback(
-          "https://mat.dev.rdc.library.northwestern.edu:3002/works/a1239c42-6e26-4a95-8cde-0fa4dbf0af6a?as=iiif/canvas/access/0"
+          "https://mat.dev.rdc.library.northwestern.edu:3002/works/a1239c42-6e26-4a95-8cde-0fa4dbf0af6a?as=iiif/canvas/access/0",
         );
       }
       return <div></div>;
@@ -54,7 +56,7 @@ describe("IIIFViewer component", () => {
           workTypeId="IMAGE"
         />
       </WorkProvider>,
-      { mocks }
+      { mocks },
     );
     expect(await screen.findByTestId("iiif-viewer"));
   });
@@ -69,7 +71,7 @@ describe("IIIFViewer component", () => {
           workTypeId="VIDEO"
         />
       </WorkProvider>,
-      { mocks }
+      { mocks },
     );
     expect(await screen.findByTestId("set-poster-image-button"));
   });
@@ -83,11 +85,11 @@ describe("IIIFViewer component", () => {
           iiifContent="ABC123"
           workTypeId="AUDIO"
         />
-      </WorkProvider>
+      </WorkProvider>,
     );
     await waitFor(() => {
       expect(
-        screen.queryByTestId("set-poster-image-button")
+        screen.queryByTestId("set-poster-image-button"),
       ).not.toBeInTheDocument();
     });
   });

--- a/app/assets/js/components/UI/ui.gql.js
+++ b/app/assets/js/components/UI/ui.gql.js
@@ -7,3 +7,11 @@ export const DIGITAL_COLLECTIONS_URL = gql`
     }
   }
 `;
+
+export const GET_DCAPI_ENDPOINT = gql`
+  query {
+    dcapiEndpoint {
+      url
+    }
+  }
+`;

--- a/app/assets/js/components/UI/ui.gql.mock.js
+++ b/app/assets/js/components/UI/ui.gql.mock.js
@@ -1,6 +1,8 @@
-import { DIGITAL_COLLECTIONS_URL } from "./ui.gql";
+import { GET_DCAPI_ENDPOINT, DIGITAL_COLLECTIONS_URL } from "./ui.gql";
 
 export const mockDCUrl = "https://imamockurl.io/";
+export const dcapiEndpointUrl =
+  "https://prefix.dev.rdc.library.northwestern.edu/";
 
 export const digitalCollectionsUrlMock = {
   request: {
@@ -10,6 +12,19 @@ export const digitalCollectionsUrlMock = {
     data: {
       digitalCollectionsUrl: {
         url: mockDCUrl,
+      },
+    },
+  },
+};
+
+export const dcApiEndpointMock = {
+  request: {
+    query: GET_DCAPI_ENDPOINT,
+  },
+  result: {
+    data: {
+      dcapiEndpoint: {
+        url: dcapiEndpointUrl,
       },
     },
   },

--- a/app/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
+++ b/app/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
@@ -9,24 +9,41 @@ import PropTypes from "prop-types";
 import { toastWrapper } from "@js/services/helpers";
 import useFileSet from "@js/hooks/useFileSet";
 import useIsAuthorized from "@js/hooks/useIsAuthorized";
-import { useWorkDispatch } from "@js/context/work-context";
+import { useWorkDispatch, useWorkState } from "@js/context/work-context";
+import { getApiResponse } from "@js/services/get-api-response";
+import { useQuery } from "@apollo/client";
+import { AuthContext } from "@js/components/Auth/Auth";
+import { GET_DCAPI_ENDPOINT } from "@js/components/UI/ui.gql";
 
 export function MediaButtons({ fileSet }) {
-  const { getWebVttString } = useFileSet();
-  const { isAuthorized } = useIsAuthorized();
-  const dispatch = useWorkDispatch();
   const [downloadStarted, setDownloadStarted] = React.useState(false);
 
-  const handleDownloadMedia = () => {
-    console.log("handleDownloadMedia", handleDownloadMedia);
-    // TODO: Call the download media endpoint here
+  const dispatch = useWorkDispatch();
+  const { dcApiToken } = useWorkState();
+  const currentUser = useContext(AuthContext);
 
-    toastWrapper(
-      "is-success",
-      `Your media download is being prepared. You will receive an email when it is ready.`
-    );
+  const { getWebVttString } = useFileSet();
+  const { isAuthorized } = useIsAuthorized();
+  const { data: dataDcApiEndpoint } = useQuery(GET_DCAPI_ENDPOINT);
 
+  const handleDownloadMedia = async () => {
     setDownloadStarted(true);
+
+    const dcApiFileSet = `${dataDcApiEndpoint?.dcapiEndpoint?.url}/file-set/${fileSet.id}`;
+    const uri = `${dcApiFileSet}/download?email=${currentUser?.email}`;
+
+    try {
+      const response = await getApiResponse(uri, dcApiToken);
+      if (response?.status !== 200) throw Error(response);
+
+      toastWrapper(
+        "is-success",
+        `Your media for <em>${fileSet.coreMetadata.label}</em> is being prepared for download. You will receive an email at <strong>${currentUser?.email}</strong> when it is ready.`,
+      );
+    } catch (error) {
+      console.error(error);
+      toastWrapper("is-danger", `The download request failed.`);
+    }
   };
 
   if (!fileSet) return null;
@@ -35,6 +52,7 @@ export function MediaButtons({ fileSet }) {
     <div className="buttons is-grouped is-right">
       {isAuthorized() && (
         <Button
+          data-testid="edit-structure-button"
           onClick={() =>
             dispatch({
               type: "toggleWebVttModal",
@@ -46,11 +64,14 @@ export function MediaButtons({ fileSet }) {
           Edit structure (vtt)
         </Button>
       )}
-      {/* //TODO: Re-enable once backend is ready to support the link *}
-      {/* <Button onClick={handleDownloadMedia} disabled={downloadStarted}>
+      <Button
+        data-testid="download-fileset-button"
+        onClick={handleDownloadMedia}
+        disabled={downloadStarted}
+      >
         <IconDownload />
         Download
-      </Button> */}
+      </Button>
     </div>
   );
 }
@@ -87,11 +108,12 @@ const WorkFilesetActionButtonsAccess = ({ fileSet }) => {
   const iiifServerUrl = useContext(IIIFContext);
   const { coreMetadata } = fileSet;
   const isImageType = coreMetadata.mimeType?.includes("image");
+  const isVideoType = coreMetadata.mimeType?.includes("video");
 
   if (isImageType) {
     return <ImageButtons iiifServerUrl={iiifServerUrl} fileSet={fileSet} />;
   }
-  if (!isImageType) {
+  if (isVideoType) {
     return <MediaButtons fileSet={fileSet} />;
   }
 };

--- a/app/assets/js/components/Work/Fileset/ActionButtons/MediaButtons.test.jsx
+++ b/app/assets/js/components/Work/Fileset/ActionButtons/MediaButtons.test.jsx
@@ -1,10 +1,14 @@
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 
 import { MediaButtons } from "./Access";
 import React from "react";
 import { WorkProvider } from "@js/context/work-context";
 import { mockUser } from "@js/components/Auth/auth.gql.mock";
 import useIsAuthorized from "@js/hooks/useIsAuthorized";
+import { dcApiEndpointMock } from "@js/components/UI/ui.gql.mock";
+import { renderWithRouterApollo } from "@js/services/testing-helpers";
+
+const mocks = [dcApiEndpointMock];
 
 jest.mock("@js/hooks/useIsAuthorized");
 useIsAuthorized.mockReturnValue({
@@ -56,17 +60,18 @@ const initialState = {
     webVttString: "",
   },
   workType: "VIDEO",
+  dcApiToken: "abcZ4323823092mccas999",
 };
 
 describe("MediaButtons", () => {
   it("renders the Edit VTT button and Download Video button for a video mime/type Fileset", () => {
-    render(
+    renderWithRouterApollo(
       <WorkProvider initialState={initialState}>
         <MediaButtons fileSet={mockFileSet} />
-      </WorkProvider>
+      </WorkProvider>,
+      { mocks },
     );
-
-    expect(screen.getByText("Edit structure (vtt)")).toBeInTheDocument();
-    //expect(screen.getByText("Download")).toBeInTheDocument();
+    expect(screen.getByTestId("edit-structure-button")).toBeInTheDocument();
+    expect(screen.getByTestId("download-fileset-button")).toBeInTheDocument();
   });
 });

--- a/app/assets/js/components/Work/Tabs/Tabs.test.js
+++ b/app/assets/js/components/Work/Tabs/Tabs.test.js
@@ -80,7 +80,7 @@ xdescribe("Tabs component", () => {
       fireEvent.click(queryByTestId("tab-administrative"));
 
       expect(queryByTestId("tab-administrative-content")).not.toHaveClass(
-        "is-hidden"
+        "is-hidden",
       );
       expect(queryByTestId("tab-about-content")).toHaveClass("is-hidden");
 
@@ -88,11 +88,11 @@ xdescribe("Tabs component", () => {
 
       expect(queryByTestId("tab-about-content")).toHaveClass("is-hidden");
       expect(queryByTestId("tab-administrative-content")).toHaveClass(
-        "is-hidden"
+        "is-hidden",
       );
       expect(queryByTestId("tab-structure-content")).toHaveClass("is-hidden");
       expect(queryByTestId("tab-preservation-content")).not.toHaveClass(
-        "is-hidden"
+        "is-hidden",
       );
     });
   });

--- a/app/assets/js/components/Work/Work.test.js
+++ b/app/assets/js/components/Work/Work.test.js
@@ -6,6 +6,7 @@ import {
   workArchiverEndpointMock,
   dcApiTokenMock,
 } from "./work.gql.mock";
+import { dcApiEndpointMock } from "@js/components/UI/ui.gql.mock";
 import { iiifServerUrlMock } from "@js/components/IIIF/iiif.gql.mock";
 import { screen } from "@testing-library/react";
 import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
@@ -17,6 +18,8 @@ import {
 } from "@js/components/Collection/collection.gql.mock";
 import { WorkProvider } from "@js/context/work-context";
 
+jest.mock("@js/services/get-api-response-headers");
+
 jest.mock("@js/hooks/useIsAuthorized");
 useIsAuthorized.mockReturnValue({
   user: mockUser,
@@ -25,6 +28,7 @@ useIsAuthorized.mockReturnValue({
 
 const mocks = [
   dcApiTokenMock,
+  dcApiEndpointMock,
   iiifServerUrlMock,
   getCollectionMock,
   getCollectionsMock,
@@ -39,7 +43,7 @@ jest.mock("@samvera/clover-iiif/viewer", () => {
       // Call the canvasCallback with a string when the component is rendered
       if (props.canvasCallback) {
         props.canvasCallback(
-          "https://mat.dev.rdc.library.northwestern.edu:3002/works/a1239c42-6e26-4a95-8cde-0fa4dbf0af6a?as=iiif/canvas/access/0"
+          "https://mat.dev.rdc.library.northwestern.edu:3002/works/a1239c42-6e26-4a95-8cde-0fa4dbf0af6a?as=iiif/canvas/access/0",
         );
       }
       return <div></div>;
@@ -53,7 +57,7 @@ describe("Work component", () => {
       <WorkProvider>
         <Work work={mockWork} />
       </WorkProvider>,
-      { mocks }
+      { mocks },
     );
   });
 

--- a/app/assets/js/context/work-context.js
+++ b/app/assets/js/context/work-context.js
@@ -5,6 +5,7 @@ const WorkDispatchContext = React.createContext();
 
 const defaultState = {
   activeMediaFileSet: null,
+  dcApiToken: null,
   webVttModal: {
     fileSetId: null,
     isOpen: false,
@@ -38,6 +39,12 @@ function workReducer(state, action) {
         workTypeId: action.workTypeId,
       };
     }
+    case "updateDcApiToken": {
+      return {
+        ...state,
+        dcApiToken: action.dcApiToken,
+      };
+    }
     default: {
       throw new Error(`Unhandled action type: ${action.type}`);
     }
@@ -46,8 +53,9 @@ function workReducer(state, action) {
 
 function WorkProvider({ initialState = defaultState, children }) {
   const [state, dispatch] = React.useReducer(workReducer, initialState);
+
   return (
-    <WorkStateContext.Provider value={state}>
+    <WorkStateContext.Provider value={{ ...state }}>
       <WorkDispatchContext.Provider value={dispatch}>
         {children}
       </WorkDispatchContext.Provider>

--- a/app/assets/js/services/__mocks__/get-api-response.js
+++ b/app/assets/js/services/__mocks__/get-api-response.js
@@ -1,0 +1,3 @@
+export async function getApiResponse(uri, token) {
+  return {};
+}

--- a/app/assets/js/services/get-api-response.js
+++ b/app/assets/js/services/get-api-response.js
@@ -1,0 +1,12 @@
+export async function getApiResponse(uri, token) {
+  try {
+    return await fetch(uri, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+  } catch (error) {
+    console.error(error);
+  }
+}

--- a/app/assets/js/services/helpers.ts
+++ b/app/assets/js/services/helpers.ts
@@ -158,6 +158,7 @@ export function toastWrapper(
     dismissible: true,
     duration: 8000,
     position: "top-center",
+    extraClasses: "meadow-toast-wrapper",
   });
 }
 

--- a/app/assets/styles/scss/_base.scss
+++ b/app/assets/styles/scss/_base.scss
@@ -147,3 +147,7 @@ table {
 .switch[type="checkbox"]:checked + label:before {
   background: $primary;
 }
+
+.meadow-toast-wrapper {
+  display: block !important;
+}


### PR DESCRIPTION
# Summary 
Building off of some previous work by @adamjarling, this makes functional a DOWNLOAD button for Video file sets in the Structure tab on a work. The work here also moves the token from GET_DC_API_TOKEN to a higher level in the work context. This was previously only used by the IIIF Viewer.

**Download Button renders**
![image](https://github.com/nulib/meadow/assets/7376450/7651a0d5-c64f-44f2-b37d-327f577be0a4)

**On Click,** a Toast message will appear if the response from the `https://USER_PREFIX.dev.rdc.library.northwestern.edu:3002/file-sets/{id}/download?email={youremailhere}` path is a **200**.
![image](https://github.com/nulib/meadow/assets/7376450/2b2d5363-66d7-4b27-bc36-8db1546bc096)

To prevent multiple requests, the DOWNLOAD button will be `disabled` if clicked.
![image](https://github.com/nulib/meadow/assets/7376450/315fdb69-977c-4084-aa74-22fb679fa80d)


# Specific Changes in this PR
- Adds download button to `video/*` file sets
- Bundles file set id and current user's email to submit GET request to API route of `/file-sets/{id}/download?email={youremailhere}`
- Moves GET_DC_API_TOKEN gql query to a higher level in the Work context

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

To test in dev, you must first follow these directions: https://github.com/nulib/repodev_planning_and_docs/issues/4268#issue-1942055718

Then:

- Login to Meadow
- Go to a Video work
- Click Structure tab
- Click **Download** button on a Video access file.
- Observe Toast message
- Receive Email?

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

