### PR TITLE
Preserve inserted_at during CSV metadata update jobs

### DIFF
--- a/app/lib/meadow/data/csv/bulk_import.ex
+++ b/app/lib/meadow/data/csv/bulk_import.ex
@@ -54,6 +54,10 @@ defmodule Meadow.Data.CSV.BulkImport do
       # credo:disable-for-previous-line Credo.Check.Warning.UnusedEnumOperation
 
       repo.query(
+        "UPDATE #{temp_table} SET inserted_at = works.inserted_at FROM works WHERE #{temp_table}.id = works.id"
+      )
+
+      repo.query(
         "UPDATE works SET #{set_clause} FROM #{temp_table} WHERE works.id = #{temp_table}.id"
       )
 

--- a/app/test/meadow/data/csv/metadata_update_jobs_test.exs
+++ b/app/test/meadow/data/csv/metadata_update_jobs_test.exs
@@ -59,11 +59,9 @@ defmodule Meadow.Data.CSV.MetadataUpdateJobsTest do
       assert MetadataUpdateJobs.apply_job(job) ==
                {:error, "Update Job cannot be applied: status is complete."}
 
-      with work <-
-             Enum.at(works, 31)
-             |> Map.get(:id)
-             |> Works.get_work()
-             |> Repo.preload(:metadata_update_jobs) do
+      with original <- Enum.at(works, 31),
+           work <- Works.get_work(original.id) |> Repo.preload(:metadata_update_jobs) do
+        assert work.inserted_at == original.inserted_at
         assert work.published
         assert work.visibility.id == "AUTHENTICATED"
 


### PR DESCRIPTION
# Summary 
Preserve inserted_at during CSV metadata update jobs

# Specific Changes in this PR
- Add SQL query to pull inserted_at from works table to temp table before copying back
- Add test

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Do a CSV metadata export/update and make sure the `inserted_at` column (or the **Work Created** attribute on the Administrative Metadata tab of the work page) still shows the original work creation timestamp.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

