### PR TITLE
Add both backend & frontend for bulk creation of local authorities

### DIFF
--- a/app/assets/js/components/Dashboards/LocalAuthorities/ModalBulkAdd.jsx
+++ b/app/assets/js/components/Dashboards/LocalAuthorities/ModalBulkAdd.jsx
@@ -1,0 +1,120 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Button } from "@nulib/design-system";
+import { useDropzone } from "react-dropzone";
+import { useForm, FormProvider } from "react-hook-form";
+import { IconCsv } from "@js/components/Icon";
+import UIIconText from "@js/components/UI/IconText";
+
+/** @jsx jsx */
+import { css, jsx } from "@emotion/react";
+const dropZone = css`
+  background: #efefef;
+  border: 3px dashed #ccc;
+`;
+
+function DashboardsLocalAuthoritiesModalBulkAdd({
+  isOpen,
+  handleClose,
+}) {
+  const methods = useForm();
+  const [currentFile, setCurrentFile] = React.useState();
+
+  const onDrop = React.useCallback((acceptedFiles) => {
+    setCurrentFile(acceptedFiles[0]);
+  }, []);
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({ onDrop });
+
+  return (
+    <FormProvider {...methods}>
+      <form
+        method="POST"
+        action="/api/authority_records/bulk_create"
+        encType="multipart/form-data"
+        name="modal-nul-authority-bulk-add"
+        data-testid="modal-nul-authority-bulk-add"
+        className={`modal ${isOpen ? "is-active" : ""}`}
+        onSubmit={() => {
+          methods.reset();
+          handleClose();
+        }}
+        role="form"
+      >
+        <div className="modal-background"></div>
+        <div className="modal-card">
+          <header className="modal-card-head">
+            <p className="modal-card-title">
+              Bulk add new NUL Authority Records
+            </p>
+            <button
+              className="delete"
+              aria-label="close"
+              type="button"
+              onClick={handleClose}
+            ></button>
+          </header>
+          <section className="modal-card-body">
+            <div
+              {...getRootProps()}
+              className="p-6 is-clickable has-text-centered"
+              css={dropZone}
+            >
+              <input
+                {...getInputProps()}
+                data-testid="dropzone-input"
+                name="records"
+              />
+              <p className="has-text-centered">
+                <UIIconText
+                  icon={<IconCsv className="has-text-grey" />}
+                  isCentered
+                >
+                  {isDragActive
+                    ? "Drop the file here ..."
+                    : "Drag 'n' drop a file here, or click to select file"}
+                </UIIconText>
+              </p>
+            </div>
+            {currentFile && (
+              <React.Fragment>
+                <p className="mt-5 pb-0 mb-0 subtitle">Current file</p>
+                <table className="table is-fullwidth">
+                  <thead>
+                    <tr>
+                      <th>Name</th>
+                      <th>Path</th>
+                      <th>Size</th>
+                      <th>Type</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>{currentFile.name}</td>
+                      <td>{currentFile.path}</td>
+                      <td>{currentFile.size}</td>
+                      <td>{currentFile.type}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </React.Fragment>
+            )}
+          </section>
+          <footer className="modal-card-foot buttons is-right">
+            <Button isText onClick={handleClose} data-testid="cancel-button">
+              Cancel
+            </Button>
+            <Button isPrimary type="submit" data-testid="submit-button">
+              Upload
+            </Button>
+          </footer>
+        </div>
+      </form>
+    </FormProvider>
+  );
+}
+
+DashboardsLocalAuthoritiesModalBulkAdd.propTypes = {
+  isOpen: PropTypes.bool,
+};
+
+export default DashboardsLocalAuthoritiesModalBulkAdd;

--- a/app/assets/js/components/Dashboards/LocalAuthorities/ModalBulkAdd.test.js
+++ b/app/assets/js/components/Dashboards/LocalAuthorities/ModalBulkAdd.test.js
@@ -1,0 +1,34 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import DashboardsLocalAuthoritiesModalBulkAdd from "./ModalBulkAdd";
+import userEvent from "@testing-library/user-event";
+
+const cancelCallback = jest.fn();
+
+const props = {
+  isOpen: true,
+  handleClose: cancelCallback,
+};
+
+describe("DashboardsLocalAuthoritiesModalBulkAdd component", () => {
+  beforeEach(() => {
+    render(<DashboardsLocalAuthoritiesModalBulkAdd {...props} />);
+  });
+
+  it("renders", () => {
+    expect(screen.getByTestId("modal-nul-authority-bulk-add"));
+  });
+
+  it("renders all add form elements ", () => {
+    expect(screen.getByRole("form"));
+    expect(screen.getByTestId("dropzone-input"));
+    expect(screen.getByTestId("submit-button"));
+    expect(screen.getByTestId("cancel-button"));
+  });
+
+  it("calls the Cancel callback function", async () => {
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("cancel-button"));
+    expect(cancelCallback).toHaveBeenCalled();
+  });
+});

--- a/app/assets/js/components/Dashboards/LocalAuthorities/TitleBar.jsx
+++ b/app/assets/js/components/Dashboards/LocalAuthorities/TitleBar.jsx
@@ -3,8 +3,9 @@ import { ActionHeadline, PageTitle } from "@js/components/UI/UI";
 import { Button } from "@nulib/design-system";
 import { CREATE_NUL_AUTHORITY_RECORD } from "@js/components/Dashboards/dashboards.gql";
 import DashboardsLocalAuthoritiesModalAdd from "@js/components/Dashboards/LocalAuthorities/ModalAdd";
+import DashboardsLocalAuthoritiesModalBulkAdd from "@js/components/Dashboards/LocalAuthorities/ModalBulkAdd";
 import FormDownloadWrapper from "@js/components/UI/Form/DownloadWrapper";
-import { IconAdd } from "@js/components/Icon";
+import { IconAdd, IconAddMany } from "@js/components/Icon";
 import { IconCsv } from "@js/components/Icon";
 import NLogo from "@js/components/northwesternN.svg";
 import React from "react";
@@ -14,6 +15,8 @@ import { useMutation } from "@apollo/client";
 
 function DashboardsLocalAuthoritiesTitleBar() {
   const [isAddModalOpen, setIsAddModalOpen] = React.useState();
+  const [isBulkAddModalOpen, setIsBulkAddModalOpen] = React.useState();
+
   const [createNulAuthorityRecord, { _data, _error, _loading }] = useMutation(
     CREATE_NUL_AUTHORITY_RECORD,
     {
@@ -63,6 +66,15 @@ function DashboardsLocalAuthoritiesTitleBar() {
               <span>Add Local Authority</span>
             </Button>
           </p>
+          <p className="control">
+            <Button
+              onClick={() => setIsBulkAddModalOpen(true)}
+              data-testid="bulk-add-button"
+            >
+              <IconAddMany />
+              <span>Bulk Add</span>
+            </Button>
+          </p>
           <span className="control">
             <FormDownloadWrapper formAction="/api/authority_records/nul_authority_records.csv">
               <Button data-testid="button-csv-authority-export" type="submit">
@@ -78,6 +90,11 @@ function DashboardsLocalAuthoritiesTitleBar() {
         isOpen={isAddModalOpen}
         handleAddLocalAuthority={handleAddLocalAuthority}
         handleClose={() => setIsAddModalOpen(false)}
+      />
+
+      <DashboardsLocalAuthoritiesModalBulkAdd
+        isOpen={isBulkAddModalOpen}
+        handleClose={() => setIsBulkAddModalOpen(false)}
       />
     </React.Fragment>
   );

--- a/app/assets/js/components/Dashboards/LocalAuthorities/TitleBar.test.js
+++ b/app/assets/js/components/Dashboards/LocalAuthorities/TitleBar.test.js
@@ -13,6 +13,7 @@ describe("DashboardsLocalAuthoritiesTitleBar component", () => {
     expect(screen.getByTestId("nul-authorities-title-bar"));
     expect(screen.getByTestId("local-authorities-dashboard-title"));
     expect(screen.getByTestId("add-button"));
+    expect(screen.getByTestId("bulk-add-button"));
     expect(screen.getByTestId("button-csv-authority-export"));
   });
 
@@ -21,6 +22,14 @@ describe("DashboardsLocalAuthoritiesTitleBar component", () => {
     const modalEl = screen.getByTestId("modal-nul-authority-add");
     expect(modalEl).not.toHaveClass("is-active");
     await user.click(screen.getByTestId("add-button"));
+    expect(modalEl).toHaveClass("is-active");
+  });
+
+  it("renders the Bulk Add modal and displays the modal successfully when clicking the Bulk Add button", async () => {
+    const user = userEvent.setup();
+    const modalEl = screen.getByTestId("modal-nul-authority-bulk-add");
+    expect(modalEl).not.toHaveClass("is-active");
+    await user.click(screen.getByTestId("bulk-add-button"));
     expect(modalEl).toHaveClass("is-active");
   });
 });

--- a/app/assets/js/components/Icon/AddMany.jsx
+++ b/app/assets/js/components/Icon/AddMany.jsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { GrChapterAdd } from "react-icons/gr";
+
+export default function IconAddMany(props) {
+  return <GrChapterAdd {...props} />;
+}

--- a/app/assets/js/components/Icon/index.js
+++ b/app/assets/js/components/Icon/index.js
@@ -1,4 +1,5 @@
 import IconAdd from "@js/components/Icon/Add";
+import IconAddMany from "@js/components/Icon/AddMany";
 import IconAlert from "@js/components/Icon/Alert";
 import IconArrowDown from "@js/components/Icon/ArrowDown";
 import IconArrowLeft from "@js/components/Icon/ArrowLeft";
@@ -35,6 +36,7 @@ import IconUser from "@js/components/Icon/User";
 
 export {
   IconAdd,
+  IconAddMany,
   IconAlert,
   IconArrowDown,
   IconArrowLeft,

--- a/app/lib/meadow_web/router.ex
+++ b/app/lib/meadow_web/router.ex
@@ -56,6 +56,7 @@ defmodule MeadowWeb.Router do
     pipe_through(:api)
 
     post("/export/:file", MeadowWeb.ExportController, :export)
+    post("/authority_records/bulk_create", MeadowWeb.AuthorityRecordsController, :bulk_create)
     post("/authority_records/:file", MeadowWeb.AuthorityRecordsController, :export)
     post("/create_shared_links/:file", MeadowWeb.SharedLinksController, :export)
 

--- a/app/lib/nul/authority_records.ex
+++ b/app/lib/nul/authority_records.ex
@@ -101,7 +101,7 @@ defmodule NUL.AuthorityRecords do
     records =
       Enum.map(list_of_attrs, fn attrs ->
         Map.merge(attrs, %{
-          id: Ecto.UUID.generate(),
+          id: "info:nul/" <> Ecto.UUID.generate(),
           inserted_at: inserted_at,
           updated_at: inserted_at
         })

--- a/app/test/fixtures/authority_records/bad_authority_import.csv
+++ b/app/test/fixtures/authority_records/bad_authority_import.csv
@@ -1,0 +1,4 @@
+not label,hint
+"First Imported Thing",created by test
+"Second Imported Thing",created by test
+"Third Imported Thing",created by test

--- a/app/test/fixtures/authority_records/good_authority_import.csv
+++ b/app/test/fixtures/authority_records/good_authority_import.csv
@@ -1,0 +1,4 @@
+label,hint
+"First Imported Thing",created by test
+"Second Imported Thing",created by test
+"Third Imported Thing",created by test

--- a/app/test/meadow_web/controllers/authority_records_controller_test.exs
+++ b/app/test/meadow_web/controllers/authority_records_controller_test.exs
@@ -78,13 +78,27 @@ defmodule MeadowWeb.AuthorityRecordsControllerTest do
     end
 
     @tag fixture: "test/fixtures/authority_records/bad_authority_import.csv"
-    test "bad data", %{conn: conn, upload: upload} do
+    test "bad data, no referer", %{conn: conn, upload: upload} do
       conn =
         conn
         |> auth_user(user_fixture("TestAdmins"))
         |> post("/api/authority_records/bulk_create", %{records: upload})
 
       assert response(conn, 400)
+    end
+
+    @tag fixture: "test/fixtures/authority_records/bad_authority_import.csv"
+    test "bad data, w/referer", %{conn: conn, upload: upload} do
+      referer = "https://example.edu/dashboards/nul-local-authorities"
+
+      conn =
+        conn
+        |> auth_user(user_fixture("TestAdmins"))
+        |> put_req_header("referer", referer)
+        |> post("/api/authority_records/bulk_create", %{records: upload})
+
+      assert response(conn, 302)
+      assert [^referer] = get_resp_header(conn, "location")
     end
 
     @tag fixture: "test/fixtures/authority_records/good_authority_import.csv"

--- a/app/test/nul/authority_records_test.exs
+++ b/app/test/nul/authority_records_test.exs
@@ -4,97 +4,154 @@ defmodule NUL.AuthorityRecordsTest do
   alias NUL.AuthorityRecords
   alias NUL.Schemas.AuthorityRecord
 
-  setup do
-    authority_records = [
-      authority_record_fixture(%{label: "Ver Steeg, Clarence L.", hint: "(The Legend)"}),
-      authority_record_fixture(%{label: "Ver Steeg, Dorothy A."}),
-      authority_record_fixture(%{label: "Netsch, Walter A."})
-    ]
+  describe "AuthorityRecords" do
+    setup do
+      authority_records = [
+        authority_record_fixture(%{label: "Ver Steeg, Clarence L.", hint: "(The Legend)"}),
+        authority_record_fixture(%{label: "Ver Steeg, Dorothy A."}),
+        authority_record_fixture(%{label: "Netsch, Walter A."})
+      ]
 
-    {:ok, authority_record: List.first(authority_records)}
-  end
-
-  def authority_record_fixture(attrs \\ %{}) do
-    attrs =
-      Enum.into(attrs, %{
-        label: attrs[:label] || Faker.Person.name(),
-        hint: attrs[:hint] || Faker.Lorem.sentence(2)
-      })
-
-    {:ok, authority_record} =
-      %AuthorityRecord{}
-      |> AuthorityRecord.changeset(attrs)
-      |> Repo.insert()
-
-    authority_record
-  end
-
-  test "list_authority_records/0" do
-    assert AuthorityRecords.list_authority_records() |> length() == 3
-  end
-
-  test "get_authority_record!/1", %{authority_record: authority_record} do
-    assert AuthorityRecords.get_authority_record!(authority_record.id)
-    assert_raise Ecto.NoResultsError, fn -> AuthorityRecords.get_authority_record!("M1SS1NG") end
-  end
-
-  test "get_authority_record/1", %{authority_record: authority_record} do
-    assert AuthorityRecords.get_authority_record(authority_record.id)
-    assert is_nil(AuthorityRecords.get_authority_record("M1SS1NG"))
-  end
-
-  test "create_authority_record/1" do
-    assert {:ok, _authority_record} =
-             AuthorityRecords.create_authority_record(%{
-               label: "test label",
-               hint: "test hint"
-             })
-
-    assert {:error, %Ecto.Changeset{}} =
-             AuthorityRecords.create_authority_record(%{hint: "test hint"})
-  end
-
-  test "create_authority_record!/1" do
-    assert %NUL.Schemas.AuthorityRecord{} =
-             AuthorityRecords.create_authority_record!(%{
-               label: "test label",
-               hint: "test hint"
-             })
-
-    assert_raise Ecto.InvalidChangesetError, fn ->
-      AuthorityRecords.create_authority_record!(%{hint: "test hint"})
+      {:ok, authority_record: List.first(authority_records)}
     end
-  end
 
-  test "create_authority_record!/1 labels are unique" do
-    AuthorityRecords.create_authority_record!(%{
-      label: "test label",
-      hint: "test hint"
-    })
+    def authority_record_fixture(attrs \\ %{}) do
+      attrs =
+        Enum.into(attrs, %{
+          label: attrs[:label] || Faker.Person.name(),
+          hint: attrs[:hint] || Faker.Lorem.sentence(2)
+        })
 
-    assert_raise Ecto.InvalidChangesetError, fn ->
+      {:ok, authority_record} =
+        %AuthorityRecord{}
+        |> AuthorityRecord.changeset(attrs)
+        |> Repo.insert()
+
+      authority_record
+    end
+
+    test "list_authority_records/0" do
+      assert AuthorityRecords.list_authority_records() |> length() == 3
+    end
+
+    test "get_authority_record!/1", %{authority_record: authority_record} do
+      assert AuthorityRecords.get_authority_record!(authority_record.id)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        AuthorityRecords.get_authority_record!("M1SS1NG")
+      end
+    end
+
+    test "get_authority_record/1", %{authority_record: authority_record} do
+      assert AuthorityRecords.get_authority_record(authority_record.id)
+      assert is_nil(AuthorityRecords.get_authority_record("M1SS1NG"))
+    end
+
+    test "create_authority_record/1" do
+      assert {:ok, _authority_record} =
+               AuthorityRecords.create_authority_record(%{
+                 label: "test label",
+                 hint: "test hint"
+               })
+
+      assert {:error, %Ecto.Changeset{}} =
+               AuthorityRecords.create_authority_record(%{hint: "test hint"})
+    end
+
+    test "create_authority_record!/1" do
+      assert %NUL.Schemas.AuthorityRecord{} =
+               AuthorityRecords.create_authority_record!(%{
+                 label: "test label",
+                 hint: "test hint"
+               })
+
+      assert_raise Ecto.InvalidChangesetError, fn ->
+        AuthorityRecords.create_authority_record!(%{hint: "test hint"})
+      end
+    end
+
+    test "create_authority_record!/1 labels are unique" do
       AuthorityRecords.create_authority_record!(%{
         label: "test label",
         hint: "test hint"
       })
+
+      assert_raise Ecto.InvalidChangesetError, fn ->
+        AuthorityRecords.create_authority_record!(%{
+          label: "test label",
+          hint: "test hint"
+        })
+      end
+    end
+
+    test "update_authority_record/2", %{authority_record: authority_record} do
+      assert {:ok, %NUL.Schemas.AuthorityRecord{label: "new label"}} =
+               AuthorityRecords.update_authority_record(authority_record, %{label: "new label"})
+    end
+
+    test "delete_authority_record/1", %{authority_record: authority_record} do
+      assert {:ok, _authority_record} = AuthorityRecords.delete_authority_record(authority_record)
+    end
+
+    test "with_stream/0" do
+      assert {:ok, 3} =
+               AuthorityRecords.with_stream(fn stream ->
+                 stream
+                 |> Stream.map(& &1)
+                 |> Enum.to_list()
+                 |> length()
+               end)
     end
   end
 
-  test "update_authority_record/2", %{authority_record: authority_record} do
-    assert {:ok, %NUL.Schemas.AuthorityRecord{label: "new label"}} =
-             AuthorityRecords.update_authority_record(authority_record, %{label: "new label"})
-  end
+  describe "create_authority_records/1" do
+    setup do
+      fixture_data = [
+        %{label: "First Imported Authority", hint: "created by test"},
+        %{label: "Second Imported Authority", hint: "created by test"},
+        %{label: "Third Imported Authority", hint: "created by test"}
+      ]
 
-  test "delete_authority_record/1", %{authority_record: authority_record} do
-    assert {:ok, _authority_record} = AuthorityRecords.delete_authority_record(authority_record)
-  end
+      {:ok, %{fixture_data: fixture_data}}
+    end
 
-  test "with_stream/0" do
-    assert {:ok, 3} = AuthorityRecords.with_stream(fn stream ->
-      stream
-      |> Stream.map(&(&1))
-      |> Enum.to_list()
-      |> length()
-    end)
+    @tag expected: [
+           {:created, %{label: "First Imported Authority", hint: "created by test"}},
+           {:created, %{label: "Second Imported Authority", hint: "created by test"}},
+           {:created, %{label: "Third Imported Authority", hint: "created by test"}}
+         ]
+    test "creates records", %{expected: expected, fixture_data: fixture_data} do
+      result = AuthorityRecords.create_authority_records(fixture_data)
+
+      assert length(result) == length(fixture_data)
+
+      expected
+      |> Enum.with_index()
+      |> Enum.each(fn {{status, %{label: label, hint: hint}}, i} ->
+        assert {^status, %AuthorityRecord{label: ^label, hint: ^hint}} = Enum.at(result, i)
+      end)
+    end
+
+    @tag expected: [
+           {:duplicate, %{label: "First Imported Authority", hint: "preexisting entry"}},
+           {:created, %{label: "Second Imported Authority", hint: "created by test"}},
+           {:duplicate, %{label: "Third Imported Authority", hint: "preexisting entry"}}
+         ]
+    test "handles duplicates", %{expected: expected, fixture_data: fixture_data} do
+      fixture_data
+      |> Enum.reject(fn %{label: label} -> String.starts_with?(label, "Second") end)
+      |> Enum.map(fn entry -> Map.put(entry, :hint, "preexisting entry") end)
+      |> AuthorityRecords.create_authority_records()
+
+      result = AuthorityRecords.create_authority_records(fixture_data)
+
+      assert length(result) == length(fixture_data)
+
+      expected
+      |> Enum.with_index()
+      |> Enum.each(fn {{status, %{label: label, hint: hint}}, i} ->
+        assert {^status, %AuthorityRecord{label: ^label, hint: ^hint}} = Enum.at(result, i)
+      end)
+    end
   end
 end


### PR DESCRIPTION
# Summary 
Implement bulk creation of local authorities

# Specific Changes in this PR
- Add `/api/authority_records/bulk_create` route for submission of CSV
- Add `Bulk Add` button to Local Authorities dashboard

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test
1. Create a CSV file with two columns (with headers): `label` and `hint` and several rows of new authorities. Feel free to include labels that already exist to test duplicate handling.
2. Log in as a user with access to the Local Authorities dashboard
3. Navigate to the Local Authorities dashboard
4. Click the `Bulk Add` button
5. Drag 'n' drop or click-to-select your CSV file.
6. Click **Upload**

The modal popup should close, and your browser should download a CSV file containing the results (labels, hints, IDs, and an indication of whether the line item was created or if it was a dupe).

You can do a "bad data" test by:
- submitting a CSV file with too many columns or headers with the wrong names
- submitting a file that isn't a CSV at all

Bad data should cause a redirect right back to the local authorities page. Due to the nature of how this direct `POST` works, displaying an error message would take a lot more work that might not be worth it.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
  - [x] New backend route
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

