### PR TITLE
Fix Safari bug when adding a new Work FileSet by dragging into the dropzone

### DIFF
--- a/app/assets/js/components/Work/Tabs/Preservation/FileSetDropzone.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/FileSetDropzone.jsx
@@ -27,7 +27,7 @@ function WorkTabsPreservationFileSetDropzone({
     const { isValid, code, message } = isFileValid(
       fileSetRole,
       workTypeId,
-      file.type
+      file.type,
     );
 
     // Dropzone validator: null means valid

--- a/app/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
@@ -1,22 +1,23 @@
-import React, { useState } from "react";
-import PropTypes from "prop-types";
 import { Button, Notification } from "@nulib/design-system";
-import { GET_PRESIGNED_URL } from "@js/components/IngestSheet/ingestSheet.gql.js";
+import { FormProvider, useForm } from "react-hook-form";
 import { GET_WORK, INGEST_FILE_SET } from "@js/components/Work/work.gql.js";
-import { useLazyQuery, useMutation } from "@apollo/client";
-import { s3Location, toastWrapper } from "@js/services/helpers";
-import { useForm, FormProvider } from "react-hook-form";
-import WorkTabsPreservationFileSetDropzone from "@js/components/Work/Tabs/Preservation/FileSetDropzone";
-import WorkTabsPreservationFileSetForm from "@js/components/Work/Tabs/Preservation/FileSetForm";
-import Error from "@js/components/UI/Error";
-import classNames from "classnames";
-import UIFormField from "@js/components/UI/Form/Field.jsx";
-import UIFormSelect from "@js/components/UI/Form/Select.jsx";
-import { useCodeLists } from "@js/context/code-list-context";
-import useAcceptedMimeTypes from "@js/hooks/useAcceptedMimeTypes";
-
+import React, { useState } from "react";
 /** @jsx jsx */
 import { css, jsx } from "@emotion/react";
+import { s3Location, toastWrapper } from "@js/services/helpers";
+import { useLazyQuery, useMutation } from "@apollo/client";
+
+import Error from "@js/components/UI/Error";
+import { GET_PRESIGNED_URL } from "@js/components/IngestSheet/ingestSheet.gql.js";
+import PropTypes from "prop-types";
+import UIFormField from "@js/components/UI/Form/Field.jsx";
+import UIFormSelect from "@js/components/UI/Form/Select.jsx";
+import WorkTabsPreservationFileSetDropzone from "@js/components/Work/Tabs/Preservation/FileSetDropzone";
+import WorkTabsPreservationFileSetForm from "@js/components/Work/Tabs/Preservation/FileSetForm";
+import classNames from "classnames";
+import useAcceptedMimeTypes from "@js/hooks/useAcceptedMimeTypes";
+import { useCodeLists } from "@js/context/code-list-context";
+
 const modalCss = css`
   z-index: 100;
 `;
@@ -79,7 +80,7 @@ function WorkTabsPreservationFileSetModal({
       onCompleted({ ingestFileSet }) {
         toastWrapper(
           "is-success",
-          `FileSet record id: ${ingestFileSet.id} created successfully and ${ingestFileSet.coreMetadata.original_filename} was submitted to the ingest pipeline.`
+          `FileSet record id: ${ingestFileSet.id} created successfully and ${ingestFileSet.coreMetadata.original_filename} was submitted to the ingest pipeline.`,
         );
         resetForm();
         closeModal();
@@ -97,7 +98,7 @@ function WorkTabsPreservationFileSetModal({
         },
       ],
       awaitRefetchQueries: true,
-    }
+    },
   );
 
   const handleSubmit = (data) => {
@@ -161,7 +162,7 @@ function WorkTabsPreservationFileSetModal({
         setS3UploadLocation(s3Location(presignedUrl));
       } else {
         setUploadError(
-          `Error uploading file to S3. Response status: ${request.status}`
+          `Error uploading file to S3. Response status: ${request.status}`,
         );
         setCurrentFile(null);
       }
@@ -220,7 +221,7 @@ function WorkTabsPreservationFileSetModal({
                     name="fileSetRole"
                     label="Fileset Role"
                     options={codeLists?.fileSetRoleData?.codeList}
-                    required
+                    required={!Boolean(watchRole)}
                     showHelper
                     disabled={Boolean(s3UploadLocation)}
                   />

--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "@absinthe/socket-apollo-link": "^0.2.1",
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",


### PR DESCRIPTION
# Summary 
This fixes a Safari bug when selecting a new FileSet for a Work on the Preservation tab, the FileSet Role form field (though selected) was not passing form validation.  It only happened when a file was dragged into the form file select drop zone for some reason... 

![image](https://github.com/nulib/meadow/assets/3020266/50dec780-887a-4cd4-95f0-660e2e65801d)


# Specific Changes in this PR
- Update how we calculate the `required` attribute on FileSet Role select

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
In a Safari browser, navigate to a Work page, Preservation tab, and add a new "Preservation" Role Fileset file.  
- Verify it works dragging a file into the drop zone
- Verify it works manually selecting a file by clicking in the drop zone first

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

