### PR TITLE
Refetch token for the work provider using the `expires` datetime.

### DIFF
--- a/app/assets/js/components/UI/IIIF/Viewer.jsx
+++ b/app/assets/js/components/UI/IIIF/Viewer.jsx
@@ -40,9 +40,12 @@ const IIIFViewer = ({ fileSets, iiifContent, workTypeId }) => {
    */
   const handleCanvasIdCallback = (canvasId) => {
     if (canvasId) {
+      const canvasIndex = canvasId.split("/").pop();
+      if (fileSets[canvasIndex]?.id === activeMediaFileSet?.id) return;
+
       dispatch({
         type: "updateActiveMediaFileSet",
-        fileSet: fileSets[canvasId.split("/").pop()],
+        fileSet: fileSets[canvasIndex],
       });
     }
     return;


### PR DESCRIPTION
# Summary 
On the Work component, this removes the polling on that was previously used in the Apollo Client useQuery() for **GET_DC_API_TOKEN**. The token is now [refetched](https://www.apollographql.com/docs/react/data/refetching) when the token is 1 minute (60000ms) from expiring.

This work also revises a re-rendering issue caused by UI/IIIF/Viewer component infinitely dispatching the activeFileSet from the Clover canvasIdCallback. This now only dispatches if the activeFileSet ID does not match.

# Specific Changes in this PR
- Revises useQuery() function to use `refetch` function instead of polling interval
- Fixes re-rerender bug caused by unchecked conditional in IIIF Viewer component

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
- Your meadow environment should have a video or audio work with a time of longer than 5 minutes (the current expire time for the token).
- Go to the Work, begin playing the video or audio work.
- Wait 5 minutes, you can `console.log(currentDate, expiresDate, expireDifference, token);` in the  
`handleTokenUpdate()` to watch things...
- The video/audio file should continue playing after the token updates (and to the end)

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

