### PR TITLE
Save width and height as S3 metadata on posters

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,22 @@ And force a re-index:
 Meadow.Data.Indexer.reindex_all()
 ```
 
+### Doing development on the Meadow Pipeline lambdas
+
+In the AWS developer environment, the lambdas associated with the pipeline are shared amongst developers. In order to do development and see whether it's working you can override the configuration to use your local files instead of the deployed lambdas. Example below (you don't have to override them all. Just the ones you need).
+
+Edit `config/dev.local.exs` to get the lambdas to use the local copy through the port:`
+
+```elixir
+  config :meadow, :lambda,
+    digester: {:local, {Path.expand("../lambdas/digester/index.js"), "handler"}},
+    exif: {:local, {Path.expand("../lambdas/exif/index.js"), "handler"}},
+    frame_extractor: {:local, {Path.expand("../lambdas/frame-extractor/index.js"), "handler"}},
+    mediainfo: {:local, {Path.expand("../lambdas/mediainfo/index.js"), "handler"}},
+    mime_type: {:local, {Path.expand("../lambdas/mime-type/index.js"), "handler"}},
+    tiff: {:local, {Path.expand("../lambdas/pyramid-tiff/index.js"), "handler"}}
+```
+
 ### TypeScript/GraphQL Types
 
 Meadow now supports TypeScript and GraphQL types in the React app. To generate types, run the following commands:

--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "@absinthe/socket-apollo-link": "^0.2.1",
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",

--- a/app/test/pipeline/actions/generate_poster_image_test.exs
+++ b/app/test/pipeline/actions/generate_poster_image_test.exs
@@ -61,6 +61,13 @@ defmodule Meadow.Pipeline.Actions.GeneratePosterImageTest do
 
       assert(object_exists?(FileSets.poster_uri_for(file_set)))
 
+      with {:ok, %{headers: headers}} <-
+             ExAws.S3.head_object(@pyramid_bucket, "posters/#{Pairtree.poster_path(file_set.id)}")
+             |> ExAws.request() do
+        assert headers |> Enum.member?({"x-amz-meta-width", "1920"})
+        assert headers |> Enum.member?({"x-amz-meta-height", "1080"})
+      end
+
       assert(
         FileSets.get_file_set!(file_set.id).derivatives["poster"] ==
           FileSets.poster_uri_for(file_set)


### PR DESCRIPTION
# Summary 

Posters should save with width and height as S3 object metadata (same as regular pyramids).

Note: Adding metadata to existing posters is separate issue. [#3811](https://github.com/nulib/repodev_planning_and_docs/issues/3811)

# Specific Changes in this PR

- Adjust frame extractor lambda code to determine width and height of the poster from the video or playlist file. Then write width and height as user defined S3 object metadata `x-amz-meta-width` and `x-amz-meta-height` when saving the poster image.
- Update README with instructions for how to use local lambda code rather than the shared dev environment lambdas.


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Please let end users know what they need to do to test on staging or production
 - requires someone with access to pyramids bucket to test

Also please let developers know if there are any special instructions to test this in the development environment. 
 - Use local frame extractor lambda code on this branch or deploy to dev envs (not sure of our process here)
 - Create a poster image for a video in the UI
 - Check the poster in S3 (it's in the pyramids bucket, in a `posters` directory with the pairtreed file set id as the filename).
 - Make sure the `amz-meta-width` and `amz-meta-height` keys are present and correctly populated in S3 object metadata

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [x] Other specific instructions/tasks
  - [x] (?) How do dev environment lambdas get updated? Can't recall....


# Tested/Verified
- [ ] End users/stakeholders

