### PR TITLE
Use CSV manifests instead of random IDs for export

### DIFF
--- a/app/lib/mix/tasks/seed/export.ex
+++ b/app/lib/mix/tasks/seed/export.ex
@@ -4,8 +4,8 @@ defmodule Mix.Tasks.Meadow.Seed.Export do
 
   ## Command line options
 
-    * `--ingest_sheets` - how many ingest sheets (with associated data) to export (default: `0`)
-    * `--works` - how many non-ingest-sheet works (with associated data) to export (default: `0`)
+    * `--ingest_sheets` - CSV file with ingest sheet IDs to export in the first column (default: `nil`)
+    * `--works` - CSV file with standalone work IDs to export in the first column (default: `nil`)
     * `--bucket` - target S3 bucket (default: the configured Meadow uploads bucket)
     * `--prefix` - (required) S3 prefix for exported assets
     * `--skip-assets` - output data only, no preservation or pyramid files (default: `false`)
@@ -15,12 +15,13 @@ defmodule Mix.Tasks.Meadow.Seed.Export do
   use Mix.Task
 
   alias Meadow.Seed.Export
+  alias NimbleCSV.RFC4180, as: CSV
 
   require Logger
 
   @opts [
-    ingest_sheets: :integer,
-    works: :integer,
+    ingest_sheets: :string,
+    works: :string,
     bucket: :string,
     prefix: :string,
     skip_assets: :boolean,
@@ -38,14 +39,16 @@ defmodule Mix.Tasks.Meadow.Seed.Export do
       with {opts, _} <- OptionParser.parse!(args, strict: @opts) do
         opts
         |> Enum.into(%{
-          ingest_sheets: 0,
-          works: 0,
+          ingest_sheets: nil,
+          works: nil,
           bucket: System.get_env("SHARED_BUCKET"),
           prefix: nil,
           skip_assets: false,
           threads: 1
         })
       end
+      |> Map.update(:ingest_sheets, nil, &ids_from_csv/1)
+      |> Map.update(:works, nil, &ids_from_csv/1)
 
     if missing?(parsed_opts.bucket), do: raise(ArgumentError, "Bucket is required")
     if missing?(parsed_opts.prefix), do: raise(ArgumentError, "Prefix is required")
@@ -56,7 +59,7 @@ defmodule Mix.Tasks.Meadow.Seed.Export do
     Logger.info("Exporting collections and nul_authorities")
     Export.export_common(parsed_opts.bucket, parsed_opts.prefix)
 
-    Logger.info("Exporting #{parsed_opts.ingest_sheets} ingest sheets")
+    Logger.info("Exporting #{length(parsed_opts.ingest_sheets)} ingest sheets")
 
     sheet_ids =
       Export.export_ingest_sheets(
@@ -70,7 +73,7 @@ defmodule Mix.Tasks.Meadow.Seed.Export do
       |> Export.export_assets(parsed_opts.bucket, parsed_opts.prefix, parsed_opts.threads)
     end
 
-    Logger.info("Exporting #{parsed_opts.works} works")
+    Logger.info("Exporting #{length(parsed_opts.works)} works")
 
     work_ids =
       Export.export_standalone_works(parsed_opts.works, parsed_opts.bucket, parsed_opts.prefix)
@@ -84,4 +87,13 @@ defmodule Mix.Tasks.Meadow.Seed.Export do
   end
 
   def missing?(value), do: is_nil(value) or value == ""
+
+  defp ids_from_csv(filename) when is_binary(filename) and byte_size(filename) > 0 do
+    File.stream!(filename, [:trim_bom], :line)
+    |> CSV.parse_stream(skip_headers: false)
+    |> Stream.map(fn [id | _] -> id end)
+    |> Enum.to_list()
+  end
+
+  defp ids_from_csv(_), do: []
 end


### PR DESCRIPTION
# Summary 

Use CSV manifests instead of random IDs for export

# Specific Changes in this PR
- Change `Meadow.Seed.Export.export_ingest_sheets/3` and `Meadow.Seed.Export.export_standalone_works/3` to take a list of IDs instead of a number of IDs to pick at random
- Change `Mix.Tasks.Meadow.Seed.Export` to take CSV files with ingest sheet and work IDs as parameters instead of integers

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Create a CSV with a couple ingest sheet IDs in the first column and another with a few work IDs in the first column
- Run `mix meadow.seed.export --ingest-sheets ingest_sheet_export.csv --works works_export.csv --bucket SOME_BUCKET --prefix SOME/PATH/`
- When the process is finished, run `aws s3 ls --recursive s3://SOME_BUCKET/SOME/PATH/` to make sure there's export data there

Try again but omit the `--ingest-sheets` or `--works` parameter to make sure it skips that step (by exporting 0 of the given type of asset).

If you want to be truly ambitious, you can wipe your data and empty your buckets and run `mix meadow.seed.import --prefix s3://SOME_BUCKET/SOME/PATH/` to re-import the data you just exported, but obviously you'll lose all the resources that _weren't_ exported. But since the only change to the export functionality is where the IDs come from, making sure the data gets exported properly is more important than testing the import.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

