### PR TITLE
Update Clover

### DIFF
--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "@absinthe/socket-apollo-link": "^0.2.1",
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",
@@ -20,7 +20,7 @@
         "@honeybadger-io/react": "^6.1.7",
         "@nulib/design-system": "^1.5.1",
         "@radix-ui/react-dialog": "^1.0.5",
-        "@samvera/clover-iiif": "^2.3.1",
+        "@samvera/clover-iiif": "^2.3.2",
         "@samvera/image-downloader": "^1.1.1",
         "bulma": "^0.9.4",
         "bulma-checkradio": "^2.1.3",
@@ -6858,9 +6858,9 @@
       "dev": true
     },
     "node_modules/@samvera/clover-iiif": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-2.3.1.tgz",
-      "integrity": "sha512-Y/oejxhZLnmT7YQe4/jNfg0sQnVgOdrv0+WjwO2LNUuQzzRO4mmayLbDWr9XP+z2r+G7scLC1nztgmmr1Q964w==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-2.3.2.tgz",
+      "integrity": "sha512-gaCytUUqbKXQAl8Ms4lcmqhVBlHkZIzAQduvZ+XvneVxtAB+MFS5xlNkdB9rP61z+s0NP1OfzVv51RxRz2IEBw==",
       "dependencies": {
         "@iiif/parser": "^1.1.2",
         "@iiif/vault": "^0.9.22",

--- a/app/assets/package.json
+++ b/app/assets/package.json
@@ -30,7 +30,7 @@
     "@honeybadger-io/react": "^6.1.7",
     "@nulib/design-system": "^1.5.1",
     "@radix-ui/react-dialog": "^1.0.5",
-    "@samvera/clover-iiif": "^2.3.1",
+    "@samvera/clover-iiif": "^2.3.2",
     "@samvera/image-downloader": "^1.1.1",
     "bulma": "^0.9.4",
     "bulma-checkradio": "^2.1.3",


### PR DESCRIPTION
# Summary 
Update `@samvera/clover-iiif` package to fix a bug when rendering VTT navigation in the Work page (via Clover Viewer)

# Specific Changes in this PR
- Clover dependency updated

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
1. Go to a Video Work w/ VTT content
2. Note "Chapters" tab appears in Clover's Information Panel, and clicking on VTT links will successfully navigate the video

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

