### PR TITLE
Move export/import business logic out of tasks and into modules

### DIFF
--- a/app/lib/meadow/seed/export.ex
+++ b/app/lib/meadow/seed/export.ex
@@ -238,18 +238,18 @@ defmodule Meadow.Seed.Export do
 
   defp missing?(value), do: is_nil(value) or value == ""
 
+  defp get_ids(nil), do: []
+  defp get_ids(""), do: []
   defp get_ids("s3://" <> _ = url), do: ids_from_csv(url)
   defp get_ids("file://" <> _ = url), do: ids_from_csv(url)
   defp get_ids("http://" <> _ = url), do: ids_from_csv(url)
   defp get_ids("https://" <> _ = url), do: ids_from_csv(url)
   defp get_ids(url), do: ids_from_csv("file://" <> url)
 
-  defp ids_from_csv(url) when is_binary(url) and byte_size(url) > 0 do
+  defp ids_from_csv(url) do
     Meadow.Utils.Stream.stream_from(url)
     |> CSV.parse_stream(skip_headers: false)
     |> Stream.map(fn [id | _] -> id end)
     |> Enum.to_list()
   end
-
-  defp ids_from_csv(_), do: []
 end

--- a/app/lib/mix/tasks/seed/import.ex
+++ b/app/lib/mix/tasks/seed/import.ex
@@ -13,9 +13,6 @@ defmodule Mix.Tasks.Meadow.Seed.Import do
 
   use Mix.Task
 
-  alias Meadow.Data.Schemas.{ActionState, Collection, FileSet, Work}
-  alias Meadow.Ingest.Schemas.{Progress, Project, Row, Sheet}
-  alias Meadow.Repo
   alias Meadow.Seed.Import
 
   require Logger
@@ -31,40 +28,14 @@ defmodule Mix.Tasks.Meadow.Seed.Import do
     Mix.Task.run("app.start")
     Logger.configure(level: :info)
 
-    if all_clear?() do
-      parsed_opts =
-        with {opts, _} <- OptionParser.parse!(args, strict: @opts) do
-          opts
-          |> Enum.into(%{prefix: nil, threads: 1})
-        end
+    parsed_opts =
+      with {opts, _} <- OptionParser.parse!(args, strict: @opts) do
+        opts
+        |> Enum.into(%{prefix: nil, threads: 1})
+      end
 
-      prefix =
-        parsed_opts
-        |> Map.get(:prefix)
-        |> normalize_prefix()
-
-      Import.import_assets(prefix, parsed_opts.threads)
-      Import.import(prefix)
-    else
-      Logger.error("Import can only be run on an empty database.")
-    end
+    Import.import(parsed_opts)
   rescue
     exception -> Logger.error(exception.message)
   end
-
-  defp all_clear? do
-    [ActionState, Collection, FileSet, Work, Progress, Project, Row, Sheet]
-    |> Enum.all?(&(Repo.aggregate(&1, :count) == 0))
-  end
-
-  defp normalize_prefix("s3://" <> _ = prefix), do: prefix
-  defp normalize_prefix("file://" <> path), do: normalize_prefix(path)
-
-  defp normalize_prefix(prefix) when is_binary(prefix) do
-    if File.dir?(prefix),
-      do: "file://#{Path.expand(prefix)}",
-      else: raise(ArgumentError, "#{prefix} is not a directory")
-  end
-
-  defp normalize_prefix(_), do: raise(ArgumentError, "Prefix is required")
 end

--- a/infrastructure/deploy/streaming.tf
+++ b/infrastructure/deploy/streaming.tf
@@ -1,5 +1,5 @@
 data "aws_acm_certificate" "wildcard_cert" {
-  domain        = "*.${trimsuffix(data.aws_route53_zone.app_zone.name, ".")}"
+  domain        = "${trimsuffix(data.aws_route53_zone.app_zone.name, ".")}"
   most_recent   = true
 }
 


### PR DESCRIPTION
# Summary 

This PR moves all of the seed export/import business logic (loading CSVs, resolving prefixes, checking conditions) out of the `Mix.Tasks.Meadow.Seed.{Export, Import}` modules and into the `Meadow.Seed.{Export, Import}` modules so that they can be run from Livebook. It also updates the inputs to the `export` process so that the CSVs containing the IDs of resources to export can be streamed directly from S3 instead of having to reside on the local disk, which also makes it easier to run the process from Livebook.

# Specific Changes in this PR
- Refactor `Meadow.Seed.Export.export/1` and `Meadow.Seed.Import.import/1` to take keyword lists
- Move the logic of applying defaults and interpreting those keyword lists from the tasks into the modules
- Keep the tasks as command line parsing wrappers for the modules

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Same as #3774, with a slight change:

- Create a CSV with a couple ingest sheet IDs in the first column and another with a few work IDs in the first column
- Run `mix meadow.seed.export --ingest-sheets ingest_sheet_export.csv --works works_export.csv --bucket SOME_BUCKET --prefix SOME/PATH/`
- When the process is finished, run `aws s3 ls --recursive s3://SOME_BUCKET/SOME/PATH/` to make sure there's export data there
- Repeat but omit the `--ingest-sheets` or `--works` parameter to make sure it skips that step (by exporting 0 of the given type of asset).
- Repeat but use `file:` URIs for the CSVs (e.g., `file:///path/to/ingest_sheet_export.csv`)
- Upload the CSVs to a bucket and use `s3://bucket/path/to/csv` URIs for the CSVs
- Try all of the above again, but this time do it from within `iex` to test the direct module call:
    ```
    Meadow.Seed.Export.export(ingest_sheets: "ingest_sheet_export.csv",
      works: "works_export.csv", bucket: "SOME_BUCKET", prefix: "SOME/PATH/`)
    ```

If you want to be truly ambitious, you can wipe your data and empty your buckets and run `mix meadow.seed.import --prefix s3://SOME_BUCKET/SOME/PATH/` (or `Meadow.Seed.Import.import(prefix: ...)`) to re-import the data you just exported, but obviously you'll lose all the resources that _weren't_ exported.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

