### PR TITLE
Auto-detect correct exiftool version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,7 +118,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: dependencies
     env:
-      EXIFTOOL_VERSION: 12.74
       MIX_ENV: test
     services:
       db:
@@ -185,14 +184,13 @@ jobs:
           echo "FFMPEG VERSION: $(ffmpeg -version | sed -n "s/ffmpeg version \([-0-9.]*\).*/\1/p;")"
       - name: Install ExifTool
         run: |
+          EXIFTOOL_VERSION=$(curl -s https://exiftool.org/ver.txt)
           mkdir -p ${{ runner.temp }}/exiftool && \
           cd ${{ runner.temp }}/exiftool && \
           curl -L -s https://exiftool.org/Image-ExifTool-${EXIFTOOL_VERSION}.tar.gz | tar xz && \
           cd Image-ExifTool-${EXIFTOOL_VERSION} && \
           perl Makefile.PL && \
           sudo make install
-        env:
-          EXIFTOOL_VERSION: ${{ env.EXIFTOOL_VERSION }}
       - name: Cache Elixir dependencies
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
# Summary 
Auto-detect correct exiftool version

# Specific Changes in this PR
- Update github actions test script to retrieve the current version of `exiftool` on the fly

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

