### PR TITLE
Use Meadow's canonical hostname for the Livebook URL

### DIFF
--- a/infrastructure/deploy/ecs_services.tf
+++ b/infrastructure/deploy/ecs_services.tf
@@ -2,11 +2,11 @@ locals {
   container_ports = tolist([4000, 4369, 8080, 24601])
 
   meadow_urls = [for hostname in concat([aws_route53_record.app_hostname.fqdn], var.additional_hostnames) : "//${hostname}"]
-
+  canonical_hostname = coalesce(var.canonical_hostname, aws_route53_record.app_hostname.fqdn)
   container_config = {
     docker_tag                      = terraform.workspace
     honeybadger_api_key             = var.honeybadger_api_key
-    host_name                       = aws_route53_record.app_hostname.fqdn
+    host_name                       = local.canonical_hostname
     internal_host_name              = "${var.stack_name}.${data.aws_service_discovery_dns_namespace.internal_dns_zone.name}"
     log_group                       = aws_cloudwatch_log_group.meadow_logs.name
     meadow_urls                     = join(",", local.meadow_urls)

--- a/infrastructure/deploy/variables.tf
+++ b/infrastructure/deploy/variables.tf
@@ -3,6 +3,11 @@ variable "additional_hostnames" {
   default = []
 }
 
+variable "canonical_hostname" {
+  type    = string
+  default = ""
+}
+
 variable "agentless_sso_key" {
   type = string
 }


### PR DESCRIPTION
# Summary 

Fixes Livebook link in Dashboards menu. Terraform only change. Already applied to staging.

# Specific Changes in this PR
- Add `canonical_hostname` variable to terraform
- Use `canonical_hostname` for the Meadow hostname if it exists

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [x] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

