### PR TITLE
Add embeddings to Meadow's index pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,7 +138,7 @@ jobs:
           - 389:389
           - 636:636
       opensearch:
-        image: opensearchproject/opensearch:1.3.1
+        image: opensearchproject/opensearch:2.11.1
         env:
           bootstrap.memory_lock: true
           OPENSEARCH_JAVA_OPTS: "-Xms256m -Xmx256m"

--- a/app/config/config.exs
+++ b/app/config/config.exs
@@ -75,7 +75,10 @@ config :meadow, Meadow.Search.Cluster,
   bulk_page_size: 200,
   bulk_wait_interval: 500,
   json_encoder: Ecto.Jason,
-  embedding_model_id: "test"
+  embedding_model_id: aws_secret("meadow",
+    dig: ["search", "embedding_model_id"],
+    default: nil
+  )
 
 config :meadow,
   ark: %{

--- a/app/config/config.exs
+++ b/app/config/config.exs
@@ -52,7 +52,8 @@ config :meadow, Meadow.Search.Cluster,
       name: prefix("dc-v2-work"),
       settings: "priv/search/v2/settings/work.json",
       version: 2,
-      schemas: [Meadow.Data.Schemas.Work]
+      schemas: [Meadow.Data.Schemas.Work],
+      pipeline: prefix("dc-v2-work-pipeline")
     },
     %{
       name: prefix("dc-v2-file-set"),
@@ -73,7 +74,8 @@ config :meadow, Meadow.Search.Cluster,
   ],
   bulk_page_size: 200,
   bulk_wait_interval: 500,
-  json_encoder: Ecto.Jason
+  json_encoder: Ecto.Jason,
+  embedding_model_id: "test"
 
 config :meadow,
   ark: %{

--- a/app/config/test.exs
+++ b/app/config/test.exs
@@ -14,7 +14,8 @@ config :meadow, Meadow.Search.Cluster,
       default: "http://localhost:9200"
     ),
   bulk_page_size: 3,
-  bulk_wait_interval: 2
+  bulk_wait_interval: 2,
+  embedding_model_id: nil
 
 config :meadow,
   index_interval: 1234,

--- a/app/lib/meadow/data/shared_links.ex
+++ b/app/lib/meadow/data/shared_links.ex
@@ -107,10 +107,7 @@ defmodule Meadow.Data.SharedLinks do
   defp create_shared_link_docs([]), do: :noop
 
   defp create_shared_link_docs(payload) do
-    Elastix.Bulk.post(SearchConfig.cluster_url(), payload,
-      index: Config.shared_links_index(),
-      type: @type_name
-    )
+    Elastix.Bulk.post(SearchConfig.cluster_url(), payload, index: Config.shared_links_index())
   end
 
   @doc """
@@ -179,7 +176,7 @@ defmodule Meadow.Data.SharedLinks do
     case Elastix.Search.count(
            SearchConfig.cluster_url(),
            Config.shared_links_index(),
-           [@type_name],
+           [],
            %{
              query: %{match_all: %{}}
            }

--- a/app/lib/meadow/indexing/v2/work.ex
+++ b/app/lib/meadow/indexing/v2/work.ex
@@ -74,6 +74,43 @@ defmodule Meadow.Indexing.V2.Work do
       work_type: encode_label(work.work_type)
     }
     |> Meadow.Utils.Map.nillify_empty()
+    |> prepare_embedding_field()
+  end
+
+  @embedding_keys [
+    "abstract",
+    "alternate_title",
+    "caption",
+    "catalog_key",
+    "collection",
+    "contributor",
+    "creator",
+    "date_created",
+    "description",
+    "genre",
+    "keywords",
+    "language",
+    "location",
+    "physical_description_material",
+    "physical_description_size",
+    "publisher",
+    "scope_and_contents",
+    "source",
+    "subject",
+    "style_period",
+    "table_of_contents",
+    "title",
+    "technique"
+  ]
+
+  defp prepare_embedding_field(map) do
+    value =
+      map
+      |> Enum.filter(fn {k, _} -> k in @embedding_keys end)
+      |> Enum.into(%{})
+      |> Jason.encode!()
+
+    Map.put(map, "embedding_text", value)
   end
 
   def api_url, do: Application.get_env(:meadow, :dc_api) |> get_in([:v2, "base_url"])

--- a/app/lib/meadow/search/config.ex
+++ b/app/lib/meadow/search/config.ex
@@ -28,9 +28,22 @@ defmodule Meadow.Search.Config do
 
   def settings_for(schema, version) do
     case config_for(schema, version) do
-      %{settings: settings} -> File.read!(settings) |> Jason.decode!()
-      _ -> nil
+      %{settings: settings, pipeline: pipeline} ->
+        File.read!(settings)
+        |> Jason.decode!()
+        |> put_in(["settings", "default_pipeline"], pipeline)
+
+      %{settings: settings} ->
+        File.read!(settings) |> Jason.decode!()
+
+      _ ->
+        nil
     end
+  end
+
+  def embedding_model_id do
+    Application.get_env(:meadow, Meadow.Search.Cluster)
+    |> Keyword.get(:embedding_model_id)
   end
 
   def index_versions do

--- a/app/lib/meadow/search/index.ex
+++ b/app/lib/meadow/search/index.ex
@@ -26,7 +26,7 @@ defmodule Meadow.Search.Index do
         :noop
 
       pipeline ->
-        create_vector_pipeline(pipeline, SearchConfig.embedding_model_id(), "title")
+        create_vector_pipeline(pipeline, SearchConfig.embedding_model_id(), "embedding_text")
     end
 
     with timestamp <- DateTime.utc_now() |> DateTime.to_unix(:millisecond),
@@ -52,6 +52,11 @@ defmodule Meadow.Search.Index do
             "field_map" => %{
               source_field => target_field
             }
+          }
+        },
+        %{
+          "remove" => %{
+            "field" => source_field
           }
         }
       ]

--- a/app/lib/meadow/search/index.ex
+++ b/app/lib/meadow/search/index.ex
@@ -21,6 +21,14 @@ defmodule Meadow.Search.Index do
   Returns `{:ok, {alias, index}}`
   """
   def create(alias, settings \\ %{}) when is_binary(alias) and is_map(settings) do
+    case get_in(settings, ["settings", "default_pipeline"]) do
+      nil ->
+        :noop
+
+      pipeline ->
+        create_vector_pipeline(pipeline, SearchConfig.embedding_model_id(), "title")
+    end
+
     with timestamp <- DateTime.utc_now() |> DateTime.to_unix(:millisecond),
          new_index <- [alias, to_string(timestamp)] |> Enum.join("-") do
       case Elastix.Index.create(SearchConfig.cluster_url(), new_index, settings) do
@@ -28,6 +36,28 @@ defmodule Meadow.Search.Index do
         other -> other
       end
     end
+  end
+
+  @doc """
+  Create a vector pipeline, takes a name, model id, source field, and a target field
+  Returns {:ok, {}}
+  """
+  def create_vector_pipeline(name, model_id, source_field, target_field \\ "embedding") do
+    pipeline = %{
+      "description" => "Vector pipeline for #{name}",
+      "processors" => [
+        %{
+          "text_embedding" => %{
+            "model_id" => model_id,
+            "field_map" => %{
+              source_field => target_field
+            }
+          }
+        }
+      ]
+    }
+
+    HTTP.put(["_ingest", "pipeline", name], pipeline)
   end
 
   @doc """

--- a/app/priv/search/v2/settings/work.json
+++ b/app/priv/search/v2/settings/work.json
@@ -1,7 +1,8 @@
 {
   "settings": {
     "index": {
-      "max_result_window": "50000"
+      "max_result_window": "50000",
+      "knn": true
     },
     "analysis": {
       "analyzer": {
@@ -46,10 +47,20 @@
       "all_ids": {
         "type": "keyword"
       },
-      "indexed_at": {
+      "create_date": {
         "type": "date_nanos"
       },
-      "create_date": {
+      "embedding": {
+        "type": "knn_vector",
+        "dimension": 384,
+        "data_type": "byte",
+        "method": {
+          "name": "hnsw",
+          "space_type": "cosinesimil",
+          "engine": "lucene"
+        }
+      },
+      "indexed_at": {
         "type": "date_nanos"
       },
       "modified_date": {

--- a/app/priv/search/v2/settings/work.json
+++ b/app/priv/search/v2/settings/work.json
@@ -9,14 +9,25 @@
         "full_analyzer": {
           "type": "custom",
           "tokenizer": "standard",
-          "char_filter": ["html_strip"],
-          "filter": ["lowercase", "asciifolding"]
+          "char_filter": [
+            "html_strip"
+          ],
+          "filter": [
+            "lowercase",
+            "asciifolding"
+          ]
         },
         "stopword_analyzer": {
           "type": "custom",
           "tokenizer": "standard",
-          "char_filter": ["html_strip"],
-          "filter": ["lowercase", "asciifolding", "english_stop"]
+          "char_filter": [
+            "html_strip"
+          ],
+          "filter": [
+            "lowercase",
+            "asciifolding",
+            "english_stop"
+          ]
         }
       },
       "filter": {
@@ -53,7 +64,6 @@
       "embedding": {
         "type": "knn_vector",
         "dimension": 384,
-        "data_type": "byte",
         "method": {
           "name": "hnsw",
           "space_type": "cosinesimil",
@@ -77,7 +87,9 @@
             "analyzer": "full_analyzer",
             "search_analyzer": "stopword_analyzer",
             "search_quote_analyzer": "full_analyzer",
-            "copy_to": ["all_text"]
+            "copy_to": [
+              "all_text"
+            ]
           }
         }
       },
@@ -87,7 +99,9 @@
           "match_pattern": "regex",
           "mapping": {
             "type": "keyword",
-            "copy_to": ["all_ids"]
+            "copy_to": [
+              "all_ids"
+            ]
           }
         }
       },
@@ -126,7 +140,9 @@
                 "ignore_above": 256
               }
             },
-            "copy_to": ["all_text"]
+            "copy_to": [
+              "all_text"
+            ]
           }
         }
       },
@@ -144,7 +160,9 @@
           "match_mapping_type": "string",
           "mapping": {
             "type": "keyword",
-            "copy_to": ["all_text"]
+            "copy_to": [
+              "all_text"
+            ]
           }
         }
       }

--- a/app/test/meadow/search/config_test.exs
+++ b/app/test/meadow/search/config_test.exs
@@ -1,0 +1,21 @@
+defmodule Meadow.Search.ConfigTest do
+  use ExUnit.Case
+
+  import ExUnit.CaptureLog
+
+  alias Meadow.Data.Schemas.Work
+  alias Meadow.Search.Config, as: SearchConfig
+
+  describe "Meadow.Search.Config" do
+    test "config_for/2" do
+      logged =
+        capture_log(fn ->
+          config = SearchConfig.settings_for(Work, 2)
+          refute config["default_pipeline"]
+        end)
+
+      assert logged
+             |> String.contains?("No embedding model id found in config, skipping pipeline")
+    end
+  end
+end

--- a/infrastructure/deploy/secrets.tf
+++ b/infrastructure/deploy/secrets.tf
@@ -56,8 +56,9 @@ locals {
 
     search = {
       cluster_endpoint    = var.elasticsearch_url
-      access_key_id     = aws_iam_access_key.meadow_elasticsearch_access_key.id
-      secret_access_key = aws_iam_access_key.meadow_elasticsearch_access_key.secret
+      access_key_id       = aws_iam_access_key.meadow_elasticsearch_access_key.id
+      secret_access_key   = aws_iam_access_key.meadow_elasticsearch_access_key.secret
+      embedding_model_id  = var.embedding_model_id
     }
 
     ldap = {

--- a/infrastructure/deploy/variables.tf
+++ b/infrastructure/deploy/variables.tf
@@ -45,6 +45,10 @@ variable "digital_collections_url" {
   type = string
 }
 
+variable "embedding_model_id" {
+  type = string
+}
+
 variable "fixity_function" {
   type = string
 }


### PR DESCRIPTION
# Summary 

Index vectors into Meadow's `dc-v2-work` index

# Specific Changes in this PR

- Configure infrastructure including OS ingest pipeline
- Updated Meadow mappings to a `knn_vector` type index and to index vectors 
- Updated Meadow indexing document to include an `embedding_text` field
- Fixed bug in shared_links index w/Opensearch 2.x upgrade


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test

Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [x] Terraform changes
  - [x] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

