### PR TITLE
Remove ping option from sitemap generation

### DIFF
--- a/app/lib/mix/tasks/sitemap.ex
+++ b/app/lib/mix/tasks/sitemap.ex
@@ -1,10 +1,6 @@
 defmodule Mix.Tasks.Sitemap.Generate do
   @moduledoc """
   Generate and upload Digital Collections sitemaps
-
-  ## Command line options
-
-    * `--ping` - ping Google and Bing to update after generating sitemaps (default: `false`)
   """
   use Mix.Task
   alias Meadow.Utils.Sitemap
@@ -16,13 +12,8 @@ defmodule Mix.Tasks.Sitemap.Generate do
     System.put_env("MEADOW_PROCESSES", "none")
     Mix.Task.run("app.start")
 
-    %{ping: ping} =
-      with {opts, _} <- OptionParser.parse!(args, strict: [ping: :boolean]) do
-        opts |> Enum.into(%{ping: false})
-      end
-
     Logger.configure(level: :info)
     Logger.info("Generating sitemaps")
-    Sitemap.generate(ping)
+    Sitemap.generate()
   end
 end


### PR DESCRIPTION
Remove ping option from sitemap generation as it is no longer supported by Google or Bing

# Summary 
Stop (optionally) pinging Google or Bing when a sitemap is generated

# Specific Changes in this PR
- Remove ping from `Sitemap.generate/1` (which is now `Sitemap.generate/0`
- Remove `--ping` from Sitemap task

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

