### PR TITLE
Run doc count check before updating alias

### DIFF
--- a/app/lib/meadow/search/client.ex
+++ b/app/lib/meadow/search/client.ex
@@ -54,11 +54,19 @@ defmodule Meadow.Search.Client do
       {:ok, _} ->
         SearchAlias.update(alias, index)
 
+      {:incomplete, reason} ->
+        Error.log_and_report(
+          "Incomplete hot swap on #{alias}. Alias left unchanged.",
+          reason,
+          __MODULE__,
+          []
+        )
+
       {:error, reason} ->
         SearchIndex.delete(index)
 
         Error.log_and_report(
-          "Problem performing hot swap",
+          "Problem performing hot swap on #{alias}",
           reason,
           __MODULE__,
           []

--- a/app/lib/meadow/utils/sitemap.ex
+++ b/app/lib/meadow/utils/sitemap.ex
@@ -10,7 +10,7 @@ defmodule Meadow.Utils.Sitemap do
   @doc """
   Generate a sitemap, upload it to the configured bucket
   """
-  def generate() do
+  def generate do
     with config <- config() do
       Repo.transaction(
         fn ->

--- a/app/lib/mix/tasks/sitemap.ex
+++ b/app/lib/mix/tasks/sitemap.ex
@@ -8,7 +8,7 @@ defmodule Mix.Tasks.Sitemap.Generate do
   require Logger
 
   @shortdoc @moduledoc
-  def run(args) do
+  def run(_args) do
     System.put_env("MEADOW_PROCESSES", "none")
     Mix.Task.run("app.start")
 

--- a/app/test/meadow/search/client_test.exs
+++ b/app/test/meadow/search/client_test.exs
@@ -80,6 +80,18 @@ defmodule Meadow.Search.ClientTest do
       assert log =~ ~r/Problem performing hot swap/
       assert log =~ ~r/Whoa, reindexing .+ blew up/
     end
+
+    test "doesn't swap alias if hot swap is incomplete" do
+      log =
+        capture_log(fn ->
+          Client.hot_swap(Work, 2, fn _index ->
+            {:incomplete, "Some documents are missing"}
+          end)
+        end)
+
+      assert log =~ ~r/Incomplete hot swap/
+      assert log =~ ~r/Some documents are missing/
+    end
   end
 
   test "most_recent/2" do


### PR DESCRIPTION
# Summary 
Warn and leave old alias if reindexed doc count doesn't match

# Specific Changes in this PR
- Update `Indexer.reindex_all/2` to return an incomplete status if the count is off
- Update `Client.perform_hot_swap/2` to handle the incomplete status by logging and alerting Honeybadger, leaving the incomplete index for investigation, and leaving the alias pointing at the previous index
- Fixed a couple credo complaints

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

