### PR TITLE
Don't mint a new ark for a work that already has one

### DIFF
--- a/app/lib/meadow/utils/arks.ex
+++ b/app/lib/meadow/utils/arks.ex
@@ -50,7 +50,7 @@ defmodule Meadow.Arks do
   {:noop,
    %Work{...}}
   """
-  def mint_ark(%Work{descriptive_metadata: %{ark: ark}} = work, _)
+  def mint_ark(%Work{descriptive_metadata: %{ark: ark}} = work)
       when not is_nil(ark) do
     {:noop, work}
   end

--- a/app/test/meadow/arks_test.exs
+++ b/app/test/meadow/arks_test.exs
@@ -2,6 +2,7 @@ defmodule Meadow.ArksTest do
   use Meadow.DataCase
 
   alias Meadow.{Ark, Arks}
+  alias Meadow.Data.Schemas.Work
   alias Meadow.Data.Works
   alias Meadow.Utils.ArkClient.MockServer
 
@@ -23,6 +24,12 @@ defmodule Meadow.ArksTest do
         assert Arks.mint_ark!(work)
       end
     end)
+
+    @tag work_type: "IMAGE"
+    test "mint_ark/1 does not mint a new ark for a work that already has an ark", %{work: work} do
+      assert {:ok, %Work{descriptive_metadata: %{ark: ark}} = work} = Arks.mint_ark(work)
+      assert {:noop, %Work{descriptive_metadata: %{ark: ^ark}}} = Arks.mint_ark(work)
+    end
   end
 
   describe "update_ark_metadata/1" do

--- a/app/test/meadow/data/csv/export_test.exs
+++ b/app/test/meadow/data/csv/export_test.exs
@@ -50,10 +50,8 @@ defmodule Meadow.Data.CSV.ExportTest do
     assert Enum.member?(header, "collection_id")
     assert Map.get(sample_record, "collection_id") == collection.id
 
-    with shoulder <- Meadow.Config.ark_config() |> Map.get(:default_shoulder) do
-      assert Enum.member?(header, "ark")
-      assert Map.get(sample_record, "ark") |> String.starts_with?(shoulder)
-    end
+    assert Enum.member?(header, "ark")
+    assert Map.get(sample_record, "ark") |> String.starts_with?("ark:/")
 
     @sample_record
     |> Enum.each(fn {field, expected_value} ->


### PR DESCRIPTION
# Summary 
Don't mint a new ark for a work that already has one

# Specific Changes in this PR
- Remote extra vestigial argument from one of the `Arks.mint_ark` function heads
- Add test for ark idempotency
- Fix test that was only passing because of the lack of idempotency 🤯 

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

