### PR TITLE
Make it possible to use Meadow's livebook integration in dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ If you would like to interact directly with the database
 
 You can visit the GraphiQL interface at: [`https://[YOURENV].dev.rdc.library.northwestern.edu:3001/api/graphiql`](https:/[YOURENV].dev.rdc.library.northwestern.edu:3001/api/graphiql)
 
+### Livebook Integration
+
+To start meadow with superuser Livebook integration, run: `MEADOW_ROOT/bin/meadow-livebook [iex arguments]`
+
+For example, from Meadow's root directory: `./bin/meadow-livebook phx.server`
+
 ### Opensearch Dashboard
 
 - To start: `es-proxy start`

--- a/bin/meadow-livebook
+++ b/bin/meadow-livebook
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+ROOT=$(realpath $(dirname $0)/..)
+COOKIE=$(openssl rand -hex 32)
+HOST=$(hostname)
+MEADOW_HOSTNAME=${DEV_PREFIX}.dev.rdc.library.northwestern.edu
+LIVEBOOK_URL=https://${MEADOW_HOSTNAME}:8082/
+mkdir -p ${HOME}/.meadow_livebooks
+
+echo -n "   Opening ports..."
+sg open all 8080 3001 > /dev/null 2>&1
+echo -e "\r✅"
+
+echo -n "   Starting Livebook..."
+docker buildx build -t nulib/meadow:livebook $ROOT/livebook > /dev/null 2>&1
+LIVEBOOK_CONTAINER=$(docker run --rm -d --network host \
+  -v ${HOME}/.meadow_livebooks:/data/books \
+  -e LB_MEADOW_COOKIE=${COOKIE} \
+  -e LB_MEADOW_NODE=meadow@${HOST} \
+  -e LIVEBOOK_NODE=livebook@${HOST} \
+  -e LIVEBOOK_DISTRIBUTION=name \
+  -e LIVEBOOK_COOKIE=${COOKIE} \
+  -e MEADOW_URL=https://${MEADOW_HOSTNAME}:3001/ \
+  nulib/meadow:livebook)
+https-proxy start 8082 8080 > /dev/null 2>&1
+echo -e "\r✅"
+
+OLDDIR=$PWD
+cd $ROOT/app
+iex --name meadow@${HOST} --cookie ${COOKIE} -S mix $@
+cd $OLDDIR
+
+echo -n "   Stopping Livebook..."
+https-proxy stop 8082 > /dev/null 2>&1
+docker stop ${LIVEBOOK_CONTAINER} > /dev/null 2>&1
+echo -e "\r✅"

--- a/livebook/meadow_livebook_auth.exs
+++ b/livebook/meadow_livebook_auth.exs
@@ -23,12 +23,25 @@ defmodule MeadowLivebookAuth do
   @spec authenticate(GenServer.server(), Plug.Conn.t(), keyword()) ::
           {Plug.Conn.t(), map() | nil}
   def authenticate(server, conn, _) do
-    with [_ | [host | _]] <- Node.self() |> to_string() |> String.split("@"),
-         url <- "http://#{host}:4000/api/graphql" do
+    with url <- get_meadow_url() do
       set_state(server, :auth_url, url)
       {conn, meadow_auth(url, conn)}
     end
   end
+
+  defp get_meadow_url do
+    with base <- System.get_env("MEADOW_URL") |> get_meadow_url() do
+      Path.join(base, "api/graphql")
+    end
+  end
+
+  defp get_meadow_url(nil) do
+    with [_ | [host | _]] <- Node.self() |> to_string() |> String.split("@") do
+      "http://#{host}:4000/"
+    end
+  end
+
+  defp get_meadow_url(url), do: url
 
   defp meadow_auth(nil, _), do: nil
 


### PR DESCRIPTION
# Summary 

I needed to use Livebook with my dev instance so I wrote a script for it. Should start and stop all of its own resources cleanly.

# Specific Changes in this PR
- Add `bin/meadow-livebook` bash script to start/stop livebook, https-proxy, and meadow as a unit
- Update `README.md` to include instructions for starting meadow+livebook

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- The `meadow-livebook` script is designed to take the place of `iex -S mix`, so any environment variables you might add before or arguments you might add after are valid here.

    Ex: `./bin/meadow-livebook phx.server`

- Creates a directory at `~/.meadow_livebooks` to store local livebooks and mounts it on `/data/books` do Livebook can find it
- You can also add S3 storage in the LIvebook Hub to access livebooks shared in S3
- Should not affecting anything staging or prod. Double check Livebook integration on staging before merging to prod just in case.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

