### PR TITLE
Update the search processor to filter out unpublished works

### DIFF
--- a/app/lib/meadow/search/index.ex
+++ b/app/lib/meadow/search/index.ex
@@ -57,8 +57,19 @@ defmodule Meadow.Search.Index do
           "filter_query" => %{
             "description" => "Restricts requests to publicly visible documents",
             "query" => %{
-              "terms" => %{
-                "visibility" => ["public", "authenticated"]
+              "bool" => %{
+                "must" => [
+                  %{
+                    "terms" => %{
+                      "visibility" => ["Public", "Institution"]
+                    }
+                  },
+                  %{
+                    "term" => %{
+                      "published" => true
+                    }
+                  }
+                ]
               }
             }
           }


### PR DESCRIPTION
# Summary 
We also need to filter out unpublished works when using the search processor for vector searches.

# Specific Changes in this PR
- Adds `published: true` to search processor
- Fixes visibility name bug

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test
Same steps as https://github.com/nulib/meadow/pull/3872, except add a mix of unpublished and/or published works. You could also just point the search processor at another index once you reindex your meadow environment since they are reusable!

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [x] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

