### PR TITLE
Don't start index pipeline name with "-" in release

### DIFF
--- a/app/test/env_test.exs
+++ b/app/test/env_test.exs
@@ -1,0 +1,67 @@
+defmodule EnvTest do
+  use ExUnit.Case
+
+  import Env
+
+  setup %{environment: environment} do
+    set_env = fn
+      {key, nil} -> System.delete_env(key)
+      {key, value} -> System.put_env(key, value)
+    end
+
+    saved = Enum.map(environment, fn {key, _} -> {key, System.get_env(key)} end)
+    Enum.each(environment, set_env)
+    on_exit(fn -> Enum.each(saved, set_env) end)
+  end
+
+  describe "hush" do
+    @describetag environment: [{"SECRETS_PATH", "foo/config"}]
+
+    test "aws_secret/2" do
+      assert aws_secret("meadow", test: :value) ==
+               {:hush, Hush.Provider.AwsSecretsManager, "foo/config/meadow", [test: :value]}
+    end
+
+    test "meadow_secret/2" do
+      assert meadow_secret(test: :value) ==
+               {:hush, Hush.Provider.AwsSecretsManager, "foo/config/meadow", [test: :value]}
+    end
+
+    test "environment_secret/2" do
+      assert environment_secret("DEV_PREFIX", test: :value) ==
+               {:hush, Hush.Provider.SystemEnvironment, "DEV_PREFIX", [test: :value]}
+    end
+  end
+
+  describe "dev environment" do
+    @describetag environment: [{"DEV_PREFIX", "env"}]
+
+    test "prefix/0" do
+      assert prefix() == "env-test"
+    end
+
+    test "prefix/1" do
+      assert prefix("database") == "env-test-database"
+    end
+
+    test "atom_prefix/1" do
+      assert atom_prefix("database") == :"env-test-database"
+    end
+  end
+
+  describe "release environment" do
+    @describetag environment: [{"DEV_PREFIX", nil}, {"RELEASE_NAME", "meadow"}]
+
+    test "prefix/0" do
+      assert prefix() == ""
+    end
+
+    test "prefix/1" do
+      assert prefix("database") == "database"
+    end
+
+    test "atom_prefix/1" do
+      assert atom_prefix("database") == :database
+    end
+  end
+end


### PR DESCRIPTION
# Summary 
Fixes bug where index pipeline names would start with "-" when there was no dev prefix

# Specific Changes in this PR
- Reject empty strings when building prefixed names
- Don't use Mix environment when `RELEASE_NAME` is present (for testing)
- Add tests for dev and release

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

