### PR TITLE
Adds versioning to the pyramid and streaming buckets, with lifecycle rules for versions

### DIFF
--- a/infrastructure/deploy/main.tf
+++ b/infrastructure/deploy/main.tf
@@ -239,7 +239,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "meadow_streaming" {
     }
     
     noncurrent_version_expiration {
-      noncurrent_days = 30
+      noncurrent_days = 90
     }
 
     transition {
@@ -280,7 +280,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "meadow_pyramids" {
     id = "expire_old_versions"
 
     noncurrent_version_expiration {
-      noncurrent_days = 30
+      noncurrent_days = 90
     }
 
     status = "Enabled"

--- a/infrastructure/deploy/main.tf
+++ b/infrastructure/deploy/main.tf
@@ -265,8 +265,19 @@ data "aws_s3_bucket" "pyramid_bucket" {
   bucket = var.pyramid_bucket
 }
 
+resource "aws_s3_bucket_cors_configuration" "pyramid_bucket" {
+  bucket = data.aws_s3_bucket.pyramid_bucket.id
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "HEAD"]
+    allowed_origins = ["*"]
+    expose_headers  = ["ETag", "Access-Control-Allow-Origin", "Access-Control-Allow-Headers"]
+    max_age_seconds = 3000
+  }
+}
+
 resource "aws_s3_bucket_versioning" "pyramid_bucket" {
-  bucket = aws_s3_bucket.pyramid_bucket.id
+  bucket = data.aws_s3_bucket.pyramid_bucket.id
   versioning_configuration {
     status = "Enabled"
   }
@@ -274,7 +285,7 @@ resource "aws_s3_bucket_versioning" "pyramid_bucket" {
 
 resource "aws_s3_bucket_lifecycle_configuration" "meadow_pyramids" {
   depends_on = [aws_s3_bucket_versioning.pyramid_bucket]
-  bucket = aws_s3_bucket.pyramid_bucket.id
+  bucket = data.aws_s3_bucket.pyramid_bucket.id
 
   rule {
     id = "expire_old_versions"

--- a/infrastructure/deploy/main.tf
+++ b/infrastructure/deploy/main.tf
@@ -218,7 +218,15 @@ resource "aws_s3_bucket" "meadow_streaming" {
   tags   = var.tags
 }
 
+resource "aws_s3_bucket_versioning" "meadow_streaming" {
+  bucket = aws_s3_bucket.meadow_streaming.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 resource "aws_s3_bucket_lifecycle_configuration" "meadow_streaming" {
+  depends_on = [aws_s3_bucket_versioning.meadow_streaming]
   bucket = "${var.stack_name}-${var.environment}-streaming"
 
   rule {
@@ -228,6 +236,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "meadow_streaming" {
 
     filter {
       prefix = ""
+    }
+    
+    noncurrent_version_expiration {
+      noncurrent_days = 30
     }
 
     transition {
@@ -251,6 +263,28 @@ resource "aws_s3_bucket_cors_configuration" "meadow_streaming" {
 
 data "aws_s3_bucket" "pyramid_bucket" {
   bucket = var.pyramid_bucket
+}
+
+resource "aws_s3_bucket_versioning" "pyramid_bucket" {
+  bucket = aws_s3_bucket.pyramid_bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "meadow_pyramids" {
+  depends_on = [aws_s3_bucket_versioning.pyramid_bucket]
+  bucket = aws_s3_bucket.pyramid_bucket.id
+
+  rule {
+    id = "expire_old_versions"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+
+    status = "Enabled"
+  }
 }
 
 data "aws_s3_bucket" "digital_collections_bucket" {


### PR DESCRIPTION
# Summary 
Adds some s3 functionality for the `pyramids` and `streaming` derivative buckets as a simple backup in case they get wiped:
- Enables s3 object versioning on both buckets
- Adds lifecycle rules for expiring s3 object versions after 30 days (does not apply to the current s3 object) 

# Specific Changes in this PR
- solely limited to `main.tf`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

