### PR TITLE
Add more logging to ARK listener

### DIFF
--- a/app/lib/meadow/utils/arks.ex
+++ b/app/lib/meadow/utils/arks.ex
@@ -52,14 +52,18 @@ defmodule Meadow.Arks do
   """
   def mint_ark(%Work{descriptive_metadata: %{ark: ark}} = work)
       when not is_nil(ark) do
+    Logger.warn("Not minting ARK for work #{work.id} because it already has one: #{ark}")
     {:noop, work}
   end
 
   def mint_ark(nil), do: {:noop, nil}
 
   def mint_ark(%Work{} = work) do
+    Logger.info("Minting ARK for work #{work.id}")
+
     case work |> initial_ark() |> Ark.mint() do
       {:ok, result} ->
+        Logger.info("Minted ARK #{result.ark} for work #{work.id}")
         Works.update_work(work, %{descriptive_metadata: %{ark: result.ark}})
 
       {:error, error_message} ->
@@ -106,6 +110,8 @@ defmodule Meadow.Arks do
   end
 
   defp update_existing_ark(work, _, ark) do
+    Logger.info("Updating ARK #{ark.ark} for work #{work.id}")
+
     case Ark.put(ark) do
       {:ok, result} ->
         Logger.info("Ark successfully updated. #{inspect(result)}")


### PR DESCRIPTION
# Summary 

Adds additional logging to try to pinpoint why work inserts/updates aren't triggering ARK minting/updating

# Specific Changes in this PR
- Add logging statements to `ArkListener` and `Arks` modules

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

