### PR TITLE
Remove email from aux file download call

### DIFF
--- a/app/assets/js/components/Work/Fileset/ActionButtons/Auxillary.jsx
+++ b/app/assets/js/components/Work/Fileset/ActionButtons/Auxillary.jsx
@@ -8,7 +8,6 @@ import { Button } from "@nulib/design-system";
 import { IconDownload } from "@js/components/Icon";
 import { toastWrapper } from "@js/services/helpers";
 import { useWorkState } from "@js/context/work-context";
-import { AuthContext } from "@js/components/Auth/Auth";
 import { GET_DCAPI_ENDPOINT } from "@js/components/UI/ui.gql";
 import { getApiResponse } from "@js/services/get-api-response";
 import { useQuery } from "@apollo/client";
@@ -18,12 +17,11 @@ const WorkFilesetActionButtonsAuxiliary = ({ fileSet }) => {
   const url = `${iiifServerUrl}${fileSet.id}${IIIF_SIZES.IIIF_FULL}`;
   const { altFileFormat, isImage, isAltFormat } = useFileSet();
   const { dcApiToken } = useWorkState();
-  const currentUser = useContext(AuthContext);
   const { data: dataDcApiEndpoint } = useQuery(GET_DCAPI_ENDPOINT);
 
   const handleDownloadFile = async () => {
     const dcApiFileSet = `${dataDcApiEndpoint?.dcapiEndpoint?.url}/file-sets/${fileSet.id}`;
-    const uri = `${dcApiFileSet}/download?email=${currentUser?.email}`;
+    const uri = `${dcApiFileSet}/download`;
 
     try {
       const response = await getApiResponse(uri, dcApiToken);


### PR DESCRIPTION
# Summary 

Straggler from https://github.com/nulib/repodev_planning_and_docs/issues/4546. There is no reason to have the email in the query string here.

# Specific Changes in this PR

-remove email from query string. 


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Make sure PDF/ZIP download of AUX file still works w/out email address (or in the UI) 
- Video download still requires email.


# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

