### PR TITLE
Fix download_url api path

### DIFF
--- a/app/lib/meadow/data/file_sets.ex
+++ b/app/lib/meadow/data/file_sets.ex
@@ -214,10 +214,10 @@ defmodule Meadow.Data.FileSets do
   end
 
   def derivative_key(file_set) do
-      Path.join([
-        "derivatives",
-        Pairtree.derivative_path(file_set.id)
-      ])
+    Path.join([
+      "derivatives",
+      Pairtree.derivative_path(file_set.id)
+    ])
   end
 
   def download_uri_for(%FileSet{id: id, role: %{id: "X"}}), do: download_uri(id)
@@ -225,12 +225,9 @@ defmodule Meadow.Data.FileSets do
   def download_uri_for(_), do: nil
 
   defp download_uri(id) do
-    with uri <- URI.parse(Application.get_env(:meadow, :dc_api) |> get_in([:v2, "base_url"])) do
-      uri
-      |> URI.merge("file-sets/" <> id <> "/download")
-      |> URI.to_string()
+    api_url = Application.get_env(:meadow, :dc_api) |> get_in([:v2, "base_url"])
+    "#{api_url}/file-sets/#{id}/download"
   end
-end
 
   defp multi_update(file_set_updates) do
     file_set_updates


### PR DESCRIPTION
# Summary 

We were indexing `https://dcapi.rdc-staging.library.northwestern.edu/api/file-sets/id/download` instead of `https://dcapi.rdc-staging.library.northwestern.edu/api/v2/file-sets/id/download` .

In dev we don't surface this difference.

# Specific Changes in this PR

- Corrects API url 

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Make sure download_url in index is correct



# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

