### PR TITLE
Fix bug where Work image toggle removed for video filesets which have a poster set

### DIFF
--- a/app/assets/js/components/Work/Fileset/List.test.js
+++ b/app/assets/js/components/Work/Fileset/List.test.js
@@ -1,14 +1,15 @@
-import React from "react";
-import WorkFilesetList from "@js/components/Work/Fileset/List";
-import { screen, waitFor } from "@testing-library/react";
-import { mockFileSets } from "@js/mock-data/filesets";
 import {
   renderWithRouterApollo,
   withReactBeautifulDND,
 } from "@js/services/testing-helpers";
+import { screen, waitFor } from "@testing-library/react";
+
+import React from "react";
+import WorkFilesetList from "@js/components/Work/Fileset/List";
+import { WorkProvider } from "@js/context/work-context";
+import { mockFileSets } from "@js/mock-data/filesets";
 import { mockUser } from "@js/components/Auth/auth.gql.mock";
 import useIsAuthorized from "@js/hooks/useIsAuthorized";
-import { WorkProvider } from "@js/context/work-context";
 
 jest.mock("@js/hooks/useIsAuthorized");
 useIsAuthorized.mockReturnValue({
@@ -25,7 +26,7 @@ describe("WorkFilesetList component", () => {
           isReordering: true,
         })}
       </WorkProvider>,
-      {}
+      {},
     );
     await waitFor(() => {
       expect(screen.getByTestId("fileset-draggable-list"));
@@ -39,7 +40,7 @@ describe("WorkFilesetList component", () => {
           fileSets: { access: mockFileSets, auxiliary: [] },
         })}
       </WorkProvider>,
-      {}
+      {},
     );
     await waitFor(() => {
       expect(screen.getByTestId("fileset-list"));
@@ -53,10 +54,10 @@ describe("WorkFilesetList component", () => {
           fileSets: { access: mockFileSets, auxiliary: [] },
         })}
       </WorkProvider>,
-      {}
+      {},
     );
     await waitFor(() => {
-      expect(screen.getAllByTestId("fileset-item")).toHaveLength(3);
+      expect(screen.getAllByTestId("fileset-item")).toHaveLength(4);
     });
   });
 });

--- a/app/assets/js/components/Work/Fileset/ListItem.jsx
+++ b/app/assets/js/components/Work/Fileset/ListItem.jsx
@@ -1,11 +1,9 @@
-import { Button, Tag } from "@nulib/design-system";
-import React, { useContext } from "react";
 import { useWorkDispatch, useWorkState } from "@js/context/work-context";
 
 import AuthDisplayAuthorized from "@js/components/Auth/DisplayAuthorized";
-import { IIIFContext } from "@js/components/IIIF/IIIFProvider";
-import { IconPlay } from "@js/components/Icon";
 import PropTypes from "prop-types";
+import React from "react";
+import { Tag } from "@nulib/design-system";
 import UIFormField from "@js/components/UI/Form/Field";
 import UIFormInput from "@js/components/UI/Form/Input";
 import UIFormTextarea from "@js/components/UI/Form/Textarea";
@@ -19,10 +17,9 @@ function WorkFilesetListItem({
   isEditing,
   workImageFilesetId,
 }) {
-  const iiifServerUrl = useContext(IIIFContext);
   const { id, coreMetadata } = fileSet;
-  const dispatch = useWorkDispatch();
-  const {isImage, isMedia, isPDF, isZip } = useFileSet();
+  const { hasRepresentativeImage, isImage, isMedia, isPDF, isZip } =
+    useFileSet();
   const workContextState = useWorkState();
 
   // Helper for media type file sets
@@ -46,25 +43,25 @@ function WorkFilesetListItem({
     }
   };
 
-  const placeholderImage = (fileSet) =>  {
+  const placeholderImage = (fileSet) => {
     if (isMedia(fileSet)) {
       return "/images/video-placeholder2.png";
-    } else if (isPDF(fileSet)) {  
+    } else if (isPDF(fileSet)) {
       return "/images/placeholder-pdf.png";
-    } else if (isZip(fileSet)) {  
+    } else if (isZip(fileSet)) {
       return "/images/placeholder-zip.png";
     } else {
       return "/images/placeholder.png";
     }
-  }
+  };
 
   const showWorkImageToggle = () => {
     if (fileSet.role.id === "A" && workContextState.workTypeId === "AUDIO") {
       return false;
     } else {
-      return isImage(fileSet);
+      return isImage(fileSet) || hasRepresentativeImage(fileSet);
     }
-  }
+  };
 
   return (
     <article className="box" data-testid="fileset-item">
@@ -120,9 +117,7 @@ function WorkFilesetListItem({
         <div className="column is-5 has-text-right is-clearfix">
           {!isEditing && (
             <>
-              {(
-                showWorkImageToggle()
-              ) && (
+              {showWorkImageToggle() && (
                 <AuthDisplayAuthorized>
                   <div className="field">
                     <input
@@ -146,9 +141,6 @@ function WorkFilesetListItem({
               )}
               {fileSet.role.id === "X" && (
                 <WorkFilesetActionButtonsAuxillary fileSet={fileSet} />
-              )}
-              {fileSet.role.id === "S" && (
-                <WorkFilesetActionButtonsSupplemental fileSet={fileSet} />
               )}
             </>
           )}

--- a/app/assets/js/hooks/useFileSet.js
+++ b/app/assets/js/hooks/useFileSet.js
@@ -19,6 +19,10 @@ export default function useFileSet() {
     return webVtt;
   }
 
+  function hasRepresentativeImage(fileSet = {}) {
+    return !!fileSet.representativeImageUrl;
+  }
+
   function isEmpty(fileSet = {}) {
     return !fileSet || Object.keys(fileSet).length === 0;
   }
@@ -78,6 +82,7 @@ export default function useFileSet() {
     altFileFormat,
     filterFileSets,
     getWebVttString,
+    hasRepresentativeImage,
     isAltFormat,
     isEmpty,
     isImage,

--- a/app/assets/js/mock-data/filesets.js
+++ b/app/assets/js/mock-data/filesets.js
@@ -1,57 +1,109 @@
 export const mockFileSets = [
   {
-    id: "45226a50-87ca-443e-bc05-f47884e14505",
-    role: { id: "A", scheme: "FILE_SET_ROLE" },
     accessionNumber: "Voyager:2569254_FILE_0",
     coreMetadata: {
       description: "inu-dil-9d35d0ba-a84b-4e0a-99e6-9c6b548a46db.tif",
-      originalFilename: "inu-dil-9d35d0ba-a84b-4e0a-99e6-9c6b548a46db.jpg",
-      label: "inu-dil-9d35d0ba-a84b-4e0a-99e6-9c6b548a46db.jpg",
-      location:
-        "s3://dev-preservation/45/22/6a/50/6be181760c0adb1f3425a0ae3438f3633b0baa9a6f74afa973c94ae6de6f45cb",
-      mimeType: "image/jpeg",
       digests: {
         sha256:
           "6be181760c0adb1f3425a0ae3438f3633b0baa9a6f74afa973c94ae6de6f45cb",
       },
+      label: "inu-dil-9d35d0ba-a84b-4e0a-99e6-9c6b548a46db.jpg",
+      location:
+        "s3://dev-preservation/45/22/6a/50/6be181760c0adb1f3425a0ae3438f3633b0baa9a6f74afa973c94ae6de6f45cb",
+      mimeType: "image/jpeg",
+      originalFilename: "inu-dil-9d35d0ba-a84b-4e0a-99e6-9c6b548a46db.jpg",
+    },
+    id: "45226a50-87ca-443e-bc05-f47884e14505",
+    representativeImageUrl:
+      "https://iiif.dev.rdc.library.northwestern.edu/iiif/2/wildcat-dev/posters/6d6bb649-2a5c-40d2-8d1b-23835de1c40a",
+    role: {
+      id: "A",
+      scheme: "FILE_SET_ROLE",
     },
   },
   {
     __typename: "FileSet",
-    id: "109b9a5c-3c6f-4a98-b98b-12402b871dc7",
-    role: { id: "A", scheme: "FILE_SET_ROLE" },
     accessionNumber: "Voyager:2572813_FILE_0",
     coreMetadata: {
       __typename: "FileSetCoreMetadata",
       description: "inu-dil-41913a91-037f-494b-9113-06004a8a98fb.tif",
-      originalFilename: "inu-dil-41913a91-037f-494b-9113-06004a8a98fb.jpg",
-      label: "inu-dil-41913a91-037f-494b-9113-06004a8a98fb.jpg",
-      location:
-        "s3://dev-preservation/10/9b/9a/5c/1477fbefbeeb04f0d02ac3cbd9594df0d9e7edca993ec076272d7fea67ab26a8",
-      mimeType: "image/jpeg",
       digests: {
         sha256:
           "1477fbefbeeb04f0d02ac3cbd9594df0d9e7edca993ec076272d7fea67ab26a8",
       },
+      label: "inu-dil-41913a91-037f-494b-9113-06004a8a98fb.jpg",
+      location:
+        "s3://dev-preservation/10/9b/9a/5c/1477fbefbeeb04f0d02ac3cbd9594df0d9e7edca993ec076272d7fea67ab26a8",
+      mimeType: "image/jpeg",
+      originalFilename: "inu-dil-41913a91-037f-494b-9113-06004a8a98fb.jpg",
+    },
+    id: "109b9a5c-3c6f-4a98-b98b-12402b871dc7",
+    representativeImageUrl:
+      "https://iiif.dev.rdc.library.northwestern.edu/iiif/2/wildcat-dev/posters/6d6bb649-2a5c-40d2-8d1b-23835de1c40a",
+    role: {
+      id: "A",
+      scheme: "FILE_SET_ROLE",
     },
   },
   {
     __typename: "FileSet",
-    id: "d414d3d4-b72c-49cc-b7cc-faa9bc0f256e",
-    role: { id: "A", scheme: "FILE_SET_ROLE" },
     accessionNumber: "Voyager:2553177_FILE_0",
     coreMetadata: {
       __typename: "FileSetCoreMetadata",
       description: "inu-dil-96e6d167-5022-42e7-9de7-7f851a866f44.tif",
-      originalFilename: "inu-dil-96e6d167-5022-42e7-9de7-7f851a866f44.jpg",
-      label: "inu-dil-96e6d167-5022-42e7-9de7-7f851a866f44.jpg",
-      location:
-        "s3://dev-preservation/d4/14/d3/d4/f7f1324a418e2c7c6ef17c45fc14ec6ce5a6124e636cb96272a7f35dc72d9664",
-      mimeType: "image/jpeg",
       digests: {
         sha256:
           "f7f1324a418e2c7c6ef17c45fc14ec6ce5a6124e636cb96272a7f35dc72d9664",
       },
+      label: "inu-dil-96e6d167-5022-42e7-9de7-7f851a866f44.jpg",
+      location:
+        "s3://dev-preservation/d4/14/d3/d4/f7f1324a418e2c7c6ef17c45fc14ec6ce5a6124e636cb96272a7f35dc72d9664",
+      mimeType: "image/jpeg",
+      originalFilename: "inu-dil-96e6d167-5022-42e7-9de7-7f851a866f44.jpg",
     },
+    id: "d414d3d4-b72c-49cc-b7cc-faa9bc0f256e",
+    representativeImageUrl:
+      "https://iiif.dev.rdc.library.northwestern.edu/iiif/2/wildcat-dev/posters/6d6bb649-2a5c-40d2-8d1b-23835de1c40a",
+    role: {
+      id: "A",
+      scheme: "FILE_SET_ROLE",
+    },
+  },
+  {
+    __typename: "FileSet",
+    id: "6d6bb649-2a5c-40d2-8d1b-23835de1c40a",
+    accessionNumber: "asdf45764567",
+    coreMetadata: {
+      __typename: "FileSetCoreMetadata",
+      description: "asdf",
+      label: "Big buck",
+      location:
+        "s3://adam-dev-preservation/6d/6b/b6/49/6d6bb649-2a5c-40d2-8d1b-23835de1c40a",
+      mimeType: "video/mp4",
+      originalFilename: "Big_Buck_Bunny_720_10s_1MB.mp4",
+      digests: {
+        __typename: "Digests",
+        md5: "626cc0e47eda47c080553ac8d25c3d3d",
+        sha1: null,
+        sha256: null,
+      },
+    },
+    extractedMetadata: "",
+    insertedAt: "2024-05-10T15:54:20.611963Z",
+    role: {
+      __typename: "CodedTerm",
+      id: "A",
+      label: "Access",
+    },
+    representativeImageUrl:
+      "https://iiif.dev.rdc.library.northwestern.edu/iiif/2/adam-dev/posters/6d6bb649-2a5c-40d2-8d1b-23835de1c40a",
+    streamingUrl:
+      "https://adam-dev-streaming.s3.amazonaws.com/6d/6b/b6/49/-2/a5/c-/40/d2/-8/d1/b-/23/83/5d/e1/c4/0a/6d6bb649-2a5c-40d2-8d1b-23835de1c40a.m3u8",
+    structuralMetadata: {
+      __typename: "FileSetStructuralMetadata",
+      type: null,
+      value: null,
+    },
+    updatedAt: "2024-05-10T15:57:25.290859Z",
   },
 ];

--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "@absinthe/socket-apollo-link": "^0.2.1",
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",


### PR DESCRIPTION
# Summary 
The alternative display format work might have knocked loose how we're displaying the Work Image toggle for Filesets.  This code will render the Work Image toggle when a video Fileset has a poster image set.  It will also not render the Work Image toggle if a video Fileset does not have a poster set.

![image](https://github.com/nulib/meadow/assets/3020266/6cc11e00-351c-40bb-88f8-f3554c63e828)

# Specific Changes in this PR
- Fix regression bug described above
- Add a unit test to cover this scenario
- Remove some unused code

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
1. Create a test Video work
2. Upload a new Fileset Access type, and do not set a poster.  Notice the Work Image toggle does not display
3. Add a poster image for the Fileset
4. Note the Work Image toggle displays


# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

