### PR TITLE
Add pages metadata to frame extractor

### DIFF
--- a/app/test/pipeline/actions/generate_poster_image_test.exs
+++ b/app/test/pipeline/actions/generate_poster_image_test.exs
@@ -64,8 +64,10 @@ defmodule Meadow.Pipeline.Actions.GeneratePosterImageTest do
       with {:ok, %{headers: headers}} <-
              ExAws.S3.head_object(@pyramid_bucket, "posters/#{Pairtree.poster_path(file_set.id)}")
              |> ExAws.request() do
+        assert headers |> Enum.member?({"Content-Type", "image/tiff"})
         assert headers |> Enum.member?({"x-amz-meta-width", "1920"})
         assert headers |> Enum.member?({"x-amz-meta-height", "1080"})
+        assert headers |> Enum.member?({"x-amz-meta-pages", "1"})
       end
 
       assert(

--- a/lambdas/frame-extractor/index.js
+++ b/lambdas/frame-extractor/index.js
@@ -189,9 +189,9 @@ const parsePlaylist = async (bucket, key, offset) => {
 
 const uploadToS3 = (data, destination, dimensions) => {
   const metadata = {
-    "Content-Type": "image",
     width: dimensions.width.toString(),
-    height: dimensions.height.toString()
+    height: dimensions.height.toString(),
+    pages: "1"
   };
   return new Promise((resolve, reject) => {
     const poster = URI.parse(destination);
@@ -200,6 +200,7 @@ const uploadToS3 = (data, destination, dimensions) => {
       Bucket: poster.host,
       Key: getS3Key(poster),
       Body: data,
+      ContentType: "image/tiff",
       Metadata: metadata
     });
     s3Client


### PR DESCRIPTION
# Summary 
The IIIF server is displaying posters incorrectly at anything at full size, because the posters aren't pyramids and (by default) the server expects them to be. Explicitly adding S3 metadata to let the server know that these are single-page images fixes the issue.

As long as I was in there, I moved the `Content-Type` setting to the right place as well.

Already terraformed to staging.

# Specific Changes in this PR
- Update `frame-extractor` lambda to include `pages` and fix `Content-Type`
- Update `GeneratePosterImage` pipeline action test to check for correct `pages` and `Content-Type`
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Upload a video and make sure its poaster displays correctly in the structure tab

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

