### PR TITLE
Read preservation check schedule from secrets manager

### DIFF
--- a/app/config/releases.exs
+++ b/app/config/releases.exs
@@ -125,8 +125,11 @@ config :meadow, Meadow.Scheduler,
   overlap: false,
   timezone: "America/Chicago",
   jobs: [
-    # Runs daily at 2AM Central Time
-    {"0 2 * * *", {Meadow.Data.PreservationChecks, :start_job, []}}
+    # Runs daily at the configured time (default: 2AM Central)
+    {
+      aws_secret("meadow", dig: ["scheduler", "preservation_check"], default: "0 2 * * *"),
+      {Meadow.Data.PreservationChecks, :start_job, []}
+    }
   ]
 
 config :ueberauth, Ueberauth,

--- a/infrastructure/deploy/secrets.tf
+++ b/infrastructure/deploy/secrets.tf
@@ -87,6 +87,10 @@ locals {
       tiff            = module.pipeline_lambda["tiff"].lambda_function_arn
     }
 
+    scheduler = {
+      preservation_check = var.preservation_check_schedule
+    }
+    
     streaming = {
       base_url = "https://${aws_route53_record.meadow_streaming_cloudfront.fqdn}/"
       distribution_id = aws_cloudfront_distribution.meadow_streaming.id

--- a/infrastructure/deploy/variables.tf
+++ b/infrastructure/deploy/variables.tf
@@ -195,6 +195,11 @@ variable "streaming_config" {
   }
 }
 
+variable "preservation_check_schedule" {
+  type    = string
+  default = "0 2 * * *"
+}
+
 variable "trusted_referers" {
   type    = string
   default = ""


### PR DESCRIPTION
Default is the production schedule (2am Chicago time)

# Summary 
Read preservation check schedule from secrets manager so that staging can run at a different time

# Specific Changes in this PR
- Update config to read scheduler value from config
- Update Terraform to write schedule to config
- Update staging.tfvars (other repo) to include staging schedule

New config already applied to staging.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

