### PR TITLE
Adds GraphQL query support for picking s3 objects in the ingest bucket

### DIFF
--- a/app/assets/js/components/UI/Dialog/Dialog.styled.jsx
+++ b/app/assets/js/components/UI/Dialog/Dialog.styled.jsx
@@ -5,7 +5,7 @@ const DialogOverlay = styled(Dialog.Overlay, {
   backgroundColor: "#000a",
   position: "fixed",
   inset: 0,
-  zIndex: 10,
+  zIndex: 9998,
 });
 
 const DialogTrigger = styled(Dialog.Trigger, {
@@ -28,7 +28,7 @@ const DialogContent = styled(Dialog.Content, {
   maxHeight: "85vh",
   padding: "1rem",
   overflowY: "scroll",
-  zIndex: 11,
+  zIndex: 9999,
 });
 
 const DialogClose = styled(Dialog.Close, {

--- a/app/assets/js/components/Work/Tabs/Preservation/ActionsCol.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/ActionsCol.jsx
@@ -176,7 +176,10 @@ const PreservationActionsCol = ({
           <AuthDisplayAuthorized>
             <a
               className={actionItemClasses}
-              onClick={() => handleReplaceFilesetClick(fileset)}
+              onClick={() => {
+                handleReplaceFilesetClick(fileset)
+                setIsActionsOpen(false);
+              }}
             >
               <IconReplace />
               <span style={{ marginLeft: "0.5rem" }}>Replace fileset</span>
@@ -202,11 +205,10 @@ const PreservationActionsCol = ({
                 </DialogClose>
                 <DialogTitle>
                   Delete
-                  {`Fileset: ${
-                    deleteFilesetModal.fileset.coreMetadata
+                  {`Fileset: ${deleteFilesetModal.fileset.coreMetadata
                       ? deleteFilesetModal.fileset.coreMetadata.label
                       : ""
-                  }`}
+                    }`}
                 </DialogTitle>
                 {work && (
                   <div

--- a/app/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
@@ -4,7 +4,7 @@ import { GET_WORK, INGEST_FILE_SET } from "@js/components/Work/work.gql.js";
 import React, { useState } from "react";
 /** @jsx jsx */
 import { css, jsx } from "@emotion/react";
-import { s3Location, toastWrapper } from "@js/services/helpers";
+import { getFileNameFromS3Uri, s3Location, toastWrapper } from "@js/services/helpers";
 import { useLazyQuery, useMutation } from "@apollo/client";
 
 import Error from "@js/components/UI/Error";
@@ -17,9 +17,23 @@ import WorkTabsPreservationFileSetForm from "@js/components/Work/Tabs/Preservati
 import classNames from "classnames";
 import useAcceptedMimeTypes from "@js/hooks/useAcceptedMimeTypes";
 import { useCodeLists } from "@js/context/code-list-context";
+import S3ObjectPicker from "@js/components/Work/Tabs/Preservation/S3ObjectPicker"
 
 const modalCss = css`
   z-index: 100;
+`;
+
+const sectionHeaderCss = css`
+  font-size: 1.2rem;
+  font-weight: bold;
+  margin-bottom: 1rem;
+`;
+
+const sectionCss = css`
+  margin-bottom: 2rem;
+  padding: 1rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
 `;
 
 function WorkTabsPreservationFileSetModal({
@@ -34,6 +48,7 @@ function WorkTabsPreservationFileSetModal({
   const [uploadError, setUploadError] = useState();
   const [stateXhr, setStateXhr] = useState(null);
   const [acceptedFileTypes, setAcceptedFileTypes] = React.useState("");
+  const [uploadMethod, setUploadMethod] = useState(null);
 
   const codeLists = useCodeLists();
 
@@ -48,9 +63,16 @@ function WorkTabsPreservationFileSetModal({
     shouldUnregister: false,
   });
 
-  // Watch form select element fileSetRole for changes, to determine what types
-  // of files are allowed to upload
   const watchRole = methods.watch("fileSetRole");
+
+  const handleSelectS3Object = (s3Object) => {
+    setCurrentFile({
+      location: s3Object.key,
+      name: getFileNameFromS3Uri(s3Object.key),
+    });
+    setS3UploadLocation(s3Object.key);
+    setUploadMethod('s3');
+  };
 
   React.useEffect(() => {
     if (!watchRole) return;
@@ -88,8 +110,6 @@ function WorkTabsPreservationFileSetModal({
       onError(error) {
         console.error(`error:`, error);
         resetForm();
-        // bug with this error not clearing/resetting
-        // https://github.com/apollographql/apollo-feature-requests/issues/170
       },
       refetchQueries: [
         {
@@ -102,7 +122,7 @@ function WorkTabsPreservationFileSetModal({
   );
 
   const handleSubmit = (data) => {
-    ingestFileSet({
+    const mutationInput = {
       variables: {
         accession_number: data.accessionNumber,
         workId,
@@ -113,8 +133,9 @@ function WorkTabsPreservationFileSetModal({
           original_filename: currentFile.name,
           location: s3UploadLocation,
         },
-      },
-    });
+      }
+    }
+    ingestFileSet(mutationInput);
   };
 
   const handleCancel = () => {
@@ -129,10 +150,12 @@ function WorkTabsPreservationFileSetModal({
     setS3UploadLocation(null);
     setUploadProgress(0);
     setUploadError(null);
+    setUploadMethod(null);
   };
 
   const handleSetFile = (file) => {
     setCurrentFile(file);
+    setUploadMethod('dragdrop');
     if (file) {
       getPresignedUrl({
         variables: {
@@ -228,17 +251,31 @@ function WorkTabsPreservationFileSetModal({
                 </UIFormField>
 
                 {watchRole && (
-                  <div className="block mt-5">
-                    <WorkTabsPreservationFileSetDropzone
-                      currentFile={currentFile}
-                      acceptedFileTypes={acceptedFileTypes}
-                      fileSetRole={watchRole}
-                      handleRemoveFile={resetForm}
-                      handleSetFile={handleSetFile}
-                      uploadProgress={uploadProgress}
-                      workTypeId={workTypeId}
-                    />
-                  </div>
+                  <>
+                    <div css={sectionCss}>
+                      <h3 css={sectionHeaderCss}>Option 1: Drag and Drop File</h3>
+                      <WorkTabsPreservationFileSetDropzone
+                        currentFile={currentFile}
+                        acceptedFileTypes={acceptedFileTypes}
+                        fileSetRole={watchRole}
+                        handleRemoveFile={resetForm}
+                        handleSetFile={handleSetFile}
+                        uploadProgress={uploadProgress}
+                        workTypeId={workTypeId}
+                        disabled={uploadMethod === 's3'}
+                      />
+                    </div>
+
+                    <div css={sectionCss}>
+                      <h3 css={sectionHeaderCss}>Option 2: Choose from S3 Ingest Bucket</h3>
+                      <S3ObjectPicker
+                        onFileSelect={handleSelectS3Object}
+                        fileSetRole={watchRole}
+                        workTypeId={workTypeId}
+                        disabled={uploadMethod === 'dragdrop'}
+                      />
+                    </div>
+                  </>
                 )}
 
                 {s3UploadLocation && (

--- a/app/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
@@ -23,19 +23,6 @@ const modalCss = css`
   z-index: 100;
 `;
 
-const sectionHeaderCss = css`
-  font-size: 1.2rem;
-  font-weight: bold;
-  margin-bottom: 1rem;
-`;
-
-const sectionCss = css`
-  margin-bottom: 2rem;
-  padding: 1rem;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-`;
-
 function WorkTabsPreservationFileSetModal({
   closeModal,
   isVisible,
@@ -252,8 +239,8 @@ function WorkTabsPreservationFileSetModal({
 
                 {watchRole && (
                   <>
-                    <div css={sectionCss}>
-                      <h3 css={sectionHeaderCss}>Option 1: Drag and Drop File</h3>
+                    <div class="box">
+                      <h3>Option 1: Drag and Drop File</h3>
                       <WorkTabsPreservationFileSetDropzone
                         currentFile={currentFile}
                         acceptedFileTypes={acceptedFileTypes}
@@ -266,8 +253,8 @@ function WorkTabsPreservationFileSetModal({
                       />
                     </div>
 
-                    <div css={sectionCss}>
-                      <h3 css={sectionHeaderCss}>Option 2: Choose from S3 Ingest Bucket</h3>
+                    <div class="box">
+                      <h3>Option 2: Choose from S3 Ingest Bucket</h3>
                       <S3ObjectPicker
                         onFileSelect={handleSelectS3Object}
                         fileSetRole={watchRole}

--- a/app/assets/js/components/Work/Tabs/Preservation/ReplaceFileSet.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/ReplaceFileSet.jsx
@@ -27,19 +27,6 @@ import UIIconText from "../../../UI/IconText";
 import WorkTabsPreservationFileSetDropzone from "@js/components/Work/Tabs/Preservation/FileSetDropzone";
 import S3ObjectPicker from "@js/components/Work/Tabs/Preservation/S3ObjectPicker"
 
-const sectionHeaderCss = css`
-  font-size: 1.2rem;
-  font-weight: bold;
-  margin-bottom: 1rem;
-`;
-
-const sectionCss = css`
-  margin-bottom: 2rem;
-  padding: 1rem;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-`;
-
 function WorkTabsPreservationReplaceFileSet({
   closeModal,
   fileset,
@@ -226,8 +213,8 @@ function WorkTabsPreservationReplaceFileSet({
                     )}
                     {error && <Error error={error} />}
 
-                    <div css={sectionCss}>
-                      <h3 css={sectionHeaderCss}>Option 1: Drag and Drop File</h3>
+                    <div class="box">
+                      <h3>Option 1: Drag and Drop File</h3>
                       <WorkTabsPreservationFileSetDropzone
                         currentFile={currentFile}
                         fileSetRole={fileset?.role?.id}
@@ -239,8 +226,8 @@ function WorkTabsPreservationReplaceFileSet({
                       />
                     </div>
 
-                    <div css={sectionCss}>
-                      <h3 css={sectionHeaderCss}>Option 2: Choose from S3 Ingest Bucket</h3>
+                    <div class="box">
+                      <h3>Option 2: Choose from S3 Ingest Bucket</h3>
                       <S3ObjectPicker
                         onFileSelect={handleSelectS3Object}
                         fileSetRole={fileset?.role?.id}

--- a/app/assets/js/components/Work/Tabs/Preservation/ReplaceFileSet.test.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/ReplaceFileSet.test.jsx
@@ -1,17 +1,27 @@
+import React from "react";
+import ReplaceFileSet from "./ReplaceFileSet";
 import {
   renderWithRouterApollo,
   withReactHookForm,
 } from "@js/services/testing-helpers";
-
 import { AuthProvider } from "@js/components/Auth/Auth";
-import { CodeListProvider } from "@js/context/code-list-context";
-import React from "react";
-import ReplaceFileSet from "@js/components/Work/Tabs/Preservation/ReplaceFileSet";
-import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
-import { getCurrentUserMock } from "@js/components/Auth/auth.gql.mock";
 import { getPresignedUrlForFileSetMock } from "@js/components/IngestSheet/ingestSheet.gql.mock";
 import { mockWork } from "@js/components/Work/work.gql.mock.js";
-import { screen } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { getCurrentUserMock } from "@js/components/Auth/auth.gql.mock";
+import { CodeListProvider } from "@js/context/code-list-context";
+import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
+
+// Mock the S3ObjectPicker component
+jest.mock("@js/components/Work/Tabs/Preservation/S3ObjectPicker", () => {
+  return function MockS3ObjectPicker({ onFileSelect }) {
+    return (
+      <button onClick={() => onFileSelect({ key: "mocked-file.jpg", size: 1000, mimeType: "image/jpeg" })}>
+        Select Mocked File
+      </button>
+    );
+  };
+});
 
 let isModalOpen = true;
 
@@ -19,12 +29,12 @@ const handleClose = () => {
   isModalOpen = false;
 };
 
-describe("ReplaceFileSet component", () => {
+describe("Replace fileset modal", () => {
   beforeEach(() => {
     const Wrapped = withReactHookForm(ReplaceFileSet, {
       closeModal: handleClose,
-      fileset: mockWork.fileSets[0],
       isVisible: isModalOpen,
+      fileset: mockWork.fileSets[0],
       workId: mockWork.id,
       workTypeId: mockWork.workType.id,
     });
@@ -44,23 +54,34 @@ describe("ReplaceFileSet component", () => {
     );
   });
 
-  it("renders the replace fileset modal and form", async () => {
-    expect(
-      await screen.findByTestId("replace-fileset-modal")
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByTestId("replace-fileset-form")
-    ).toBeInTheDocument();
+
+  it("renders replace fileset form", async () => {
+    expect(await screen.findByTestId("replace-fileset-form"));
   });
 
-  it("renders a warning message and a button to replace the fileset", async () => {
-    expect(
-      await screen.findByText(/Replacing a fileset cannot be undone/i)
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText(
-        /Drag 'n' drop a file here, or click to select file/i
-      )
-    ).toBeInTheDocument();
+  it("displays warning message", async () => {
+    expect(await screen.findByText(/Replacing a fileset cannot be undone/i));
+  });
+
+  it("renders file upload dropzone", async () => {
+    expect(await screen.findByText(/Drag 'n' drop a file here, or click to select file/i));
+  });
+
+  it("renders label input field", async () => {
+    expect(await screen.findByTestId("fileset-label-input"));
+  });
+
+  it("renders description input field", async () => {
+    expect(await screen.findByTestId("fileset-description-input"));
+  });
+
+  it("renders cancel and submit buttons when file is selected from S3ObjectPicker", async () => {
+    const selectFileButton = await screen.findByText("Select Mocked File");
+    fireEvent.click(selectFileButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("cancel-button")).toBeInTheDocument();
+      expect(screen.getByTestId("submit-button")).toBeInTheDocument();
+    });
   });
 });

--- a/app/assets/js/components/Work/Tabs/Preservation/S3ObjectPicker.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/S3ObjectPicker.jsx
@@ -1,0 +1,115 @@
+import useAcceptedMimeTypes from "@js/hooks/useAcceptedMimeTypes";
+import { Button } from "@nulib/design-system";
+import {
+  LIST_INGEST_BUCKET_OBJECTS,
+} from "@js/components/Work/work.gql.js";
+import React, { useState } from "react";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/react";
+import { useQuery } from "@apollo/client";
+import { FaSpinner } from "react-icons/fa";
+import { formatBytes } from "@js/services/helpers";
+
+import Error from "@js/components/UI/Error";
+import UIFormInput from "@js/components/UI/Form/Input.jsx";
+
+const tableContainerCss = css`
+  max-height: 30vh;
+  overflow-y: auto;
+`;
+
+const fileRowCss = css`
+  cursor: pointer;
+`;
+
+// a nice gentle blue
+const selectedRowCss = css`
+  background-color: #f0f8ff !important;
+`;
+
+const colHeaders = ["File Key", "Size", "Mime Type"];
+
+const { isFileValid } = useAcceptedMimeTypes();
+
+const S3ObjectPicker = ({ onFileSelect, fileSetRole, workTypeId, defaultPrefix = "" }) => {
+  const [prefix, setPrefix] = useState(defaultPrefix);
+  const [selectedFile, setSelectedFile] = useState(null);
+  const [error, _setError] = useState(null);
+
+  const { loading: queryLoading, error: queryError, data, refetch } = useQuery(LIST_INGEST_BUCKET_OBJECTS, {
+    variables: { prefix }
+  });
+
+  const handleClear = () => {
+    setPrefix(defaultPrefix);
+    refetch({ prefix: defaultPrefix });
+  };
+
+  const handlePrefixChange = (e) => {
+    const inputValue = e.target.value;
+    const newPrefix = inputValue.startsWith(defaultPrefix) ? inputValue : defaultPrefix + inputValue;
+    setPrefix(newPrefix);
+    refetch({ prefix: newPrefix });
+  };
+
+  const handleRefresh = async () => {
+    await refetch({ prefix: prefix });
+  };
+
+  const handleFileClick = (fileSet) => {
+    setSelectedFile(fileSet.key);
+    onFileSelect(fileSet);
+  };
+
+  if (queryLoading) return <FaSpinner className="spinner" />;
+  if (queryError) return <Error error={queryError} />;
+
+  return (
+    <div className="file-picker">
+      <UIFormInput
+        placeholder="Enter prefix"
+        name="prefixSearch"
+        label="Prefix Search"
+        onChange={handlePrefixChange}
+        value={prefix}
+      />
+      <div className="buttons mt-2">
+        <Button onClick={handleClear}>Clear</Button>
+        <Button onClick={handleRefresh}>Refresh</Button>
+      </div>
+      {error && <div className="error">{error}</div>}
+      {data && data.ListIngestBucketObjects && (
+        <div className="table-container" css={tableContainerCss}>
+          <table className="table is-striped is-fullwidth">
+            <thead>
+              <tr>
+                {colHeaders.map((col) => (
+                  <th key={col}>{col}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {data.ListIngestBucketObjects.filter(file => {
+                const { isValid } = isFileValid(fileSetRole, workTypeId, file.mimeType);
+                return isValid;
+              }).map((fileSet, index) => (
+                <tr
+                  key={index}
+                  onClick={() => handleFileClick(fileSet)}
+                  className={selectedFile === fileSet.key ? "selected" : ""}
+                  css={[fileRowCss, selectedFile === fileSet.key && selectedRowCss]}
+                >
+                  <td>{fileSet.key}</td>
+                  <td>{formatBytes(fileSet.size)}</td>
+                  <td>{fileSet.mimeType}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default S3ObjectPicker;

--- a/app/assets/js/components/Work/Tabs/Preservation/S3ObjectPicker.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/S3ObjectPicker.jsx
@@ -45,11 +45,11 @@ const S3ObjectPicker = ({ onFileSelect, fileSetRole, workTypeId, defaultPrefix =
     refetch({ prefix: defaultPrefix });
   };
 
-  const handlePrefixChange = (e) => {
+  const handlePrefixChange = async (e) => {
     const inputValue = e.target.value;
     const newPrefix = inputValue.startsWith(defaultPrefix) ? inputValue : defaultPrefix + inputValue;
     setPrefix(newPrefix);
-    refetch({ prefix: newPrefix });
+    await refetch({ prefix: newPrefix });
   };
 
   const handleRefresh = async () => {

--- a/app/assets/js/components/Work/Tabs/Preservation/S3ObjectPicker.test.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/S3ObjectPicker.test.jsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import { MockedProvider } from "@apollo/client/testing";
+import S3ObjectPicker from "@js/components/Work/Tabs/Preservation/S3ObjectPicker";
+import { LIST_INGEST_BUCKET_OBJECTS } from "@js/components/Work/work.gql.js";
+
+const mocks = [
+  {
+    request: {
+      query: LIST_INGEST_BUCKET_OBJECTS,
+      variables: { prefix: "file_sets/" },
+    },
+    result: {
+      data: {
+        ListIngestBucketObjects: [
+          { key: "file_sets/file3", size: 1000, mimeType: "image/jpeg" },
+          { key: "file_sets/file4", size: 2000, mimeType: "image/png" },
+        ],
+      },
+    },
+  },
+  {
+    request: {
+      query: LIST_INGEST_BUCKET_OBJECTS,
+      variables: { prefix: "" },
+    },
+    result: {
+      data: {
+        ListIngestBucketObjects: [
+          { key: "file1", size: 1000, mimeType: "image/jpeg" },
+          { key: "file2", size: 2000, mimeType: "image/png" },
+          { key: "file_sets/file3", size: 1000, mimeType: "image/jpeg" },
+          { key: "file_sets/file4", size: 2000, mimeType: "image/png" },
+        ],
+      },
+    },
+  },
+];
+
+describe("S3ObjectPicker component", () => {
+  it("renders without crashing", () => {
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <S3ObjectPicker onFileSelect={() => { }} fileSetRole="A" workTypeId="IMAGE" />
+      </MockedProvider>
+    );
+  });
+
+  it("renders an error message when there is a query error", async () => {
+    const errorMock = [
+      {
+        request: {
+          query: LIST_INGEST_BUCKET_OBJECTS,
+          variables: { prefix: "" },
+        },
+        error: new Error("An error occurred"),
+      },
+    ];
+    const { findByText } = render(
+      <MockedProvider mocks={errorMock} addTypename={false}>
+        <S3ObjectPicker onFileSelect={() => { }} fileSetRole="A" workTypeId="IMAGE" />
+      </MockedProvider>
+    );
+    expect(await findByText("An error occurred")).toBeInTheDocument();
+  });
+
+  it("renders the Clear and Refresh buttons", async () => {
+    const { findByText } = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <S3ObjectPicker onFileSelect={() => { }} fileSetRole="A" workTypeId="IMAGE" />
+      </MockedProvider>
+    );
+    expect(await findByText("Clear")).toBeInTheDocument();
+    expect(await findByText("Refresh")).toBeInTheDocument();
+  });
+
+  it("renders the table when data is available", async () => {
+    const { findByText } = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <S3ObjectPicker onFileSelect={() => { }} fileSetRole="A" workTypeId="IMAGE" />
+      </MockedProvider>
+    );
+    expect(await findByText("file1")).toBeInTheDocument();
+    expect(await findByText("file2")).toBeInTheDocument();
+  });
+
+  it("handles prefixed search", async () => {
+    const { findByText, getByPlaceholderText, queryByText } = render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <S3ObjectPicker onFileSelect={() => { }} fileSetRole="A" workTypeId="IMAGE" />
+      </MockedProvider>
+    );
+
+    await findByText("file1");
+
+    const input = getByPlaceholderText("Enter prefix");
+    fireEvent.change(input, { target: { value: "file_sets/" } });
+
+    await waitFor(() => {
+      expect(input.value).toBe("file_sets/");
+    });
+
+    // Check that the prefixed files are present
+    expect(await findByText("file_sets/file3")).toBeInTheDocument();
+    expect(await findByText("file_sets/file4")).toBeInTheDocument();
+
+    // Check that the non-prefixed files are not present
+    expect(queryByText("file1")).not.toBeInTheDocument();
+    expect(queryByText("file2")).not.toBeInTheDocument();
+  });
+
+});

--- a/app/assets/js/components/Work/work.gql.js
+++ b/app/assets/js/components/Work/work.gql.js
@@ -360,6 +360,18 @@ export const REPLACE_FILE_SET = gql`
   }
 `;
 
+export const LIST_INGEST_BUCKET_OBJECTS = gql`
+  query ListIngestBucketObjects($prefix: String) {
+    ListIngestBucketObjects(prefix: $prefix) {
+      key
+      storageClass
+      size
+      lastModified
+      mimeType
+    }
+  }
+`
+
 export const SET_WORK_IMAGE = gql`
   mutation SetWorkImage($fileSetId: ID!, $workId: ID!) {
     setWorkImage(fileSetId: $fileSetId, workId: $workId) {

--- a/app/assets/js/services/helpers.ts
+++ b/app/assets/js/services/helpers.ts
@@ -174,3 +174,8 @@ export function formatBytes(bytes: number, decimals: number) {
     i = Math.floor(Math.log(bytes) / Math.log(k));
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
 }
+
+export function getFileNameFromS3Uri(s3Uri: string) {
+  const segments = s3Uri.split("/");
+  return segments[segments.length - 1];
+}

--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "@absinthe/socket-apollo-link": "^0.2.1",
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",

--- a/app/lib/meadow/utils/aws/s3.ex
+++ b/app/lib/meadow/utils/aws/s3.ex
@@ -1,0 +1,64 @@
+defmodule Meadow.Utils.AWS.S3 do
+  @moduledoc """
+  S3 utility functions
+  """
+
+  alias Meadow.Config
+
+  require Logger
+
+  @doc """
+  Lists the file sets in the ingest bucket with the given user prefix.
+
+  ## Parameters
+
+  - user_prefix: The prefix to filter the file sets.
+
+  ## Returns
+
+  A list of file sets in the ingest bucket.
+  """
+  def list_ingest_bucket_objects(opts \\ []) do
+    user_prefix = Keyword.get(opts, :prefix, "")
+    bucket = Config.ingest_bucket()
+
+    bucket
+    |> ExAws.S3.list_objects(prefix: user_prefix)
+    |> ExAws.stream!()
+    |> Enum.into([])
+    |> Enum.filter(&(!String.ends_with?(&1.key, "/")))
+    |> Enum.map(&get_object_metadata(bucket, &1))
+  end
+
+  defp get_object_metadata(bucket, file_set) do
+    s3_key = "s3://" <> bucket <> "/" <> file_set.key
+    mime_type = fetch_mime_type(bucket, file_set.key)
+
+    Map.put(file_set, :mime_type, mime_type)
+    |> Map.put(:key, s3_key)
+  end
+
+  defp fetch_mime_type(bucket, key) do
+    bucket
+    |> do_fetch_mime_type(key)
+    |> case do
+      nil -> "application/octet-stream"
+      mime_type -> mime_type
+    end
+  end
+
+  defp do_fetch_mime_type(bucket, key) do
+    case ExAws.S3.head_object(bucket, key) |> ExAws.request() do
+      {:ok, %{headers: headers}} -> extract_content_type(headers)
+      _ -> nil
+    end
+  end
+
+  defp extract_content_type(headers) do
+    Enum.find_value(headers, fn
+      {"content-type", value} -> value
+      {"Content-Type", value} -> value
+      _ -> false
+    end)
+  end
+end

--- a/app/lib/meadow_web/resolvers/data.ex
+++ b/app/lib/meadow_web/resolvers/data.ex
@@ -6,6 +6,7 @@ defmodule MeadowWeb.Resolvers.Data do
   alias Meadow.Pipeline
   alias Meadow.Data.{FileSets, Works}
   alias Meadow.Data.Works.TransferFileSets
+  alias Meadow.Utils.AWS.S3, as: S3Utils
   alias Meadow.Utils.ChangesetErrors
 
   def works(_, args, _) do
@@ -135,6 +136,28 @@ defmodule MeadowWeb.Resolvers.Data do
           message: "Could not delete file_set",
           details: ChangesetErrors.humanize_errors(changeset)
         }
+
+      {:ok, file_set} ->
+        {:ok, file_set}
+    end
+  end
+
+  def list_ingest_bucket_objects(_, %{prefix: prefix}, _) do
+    {:ok, S3Utils.list_ingest_bucket_objects(prefix: prefix)}
+  end
+
+  def list_ingest_bucket_objects(_, _, _) do
+    {:ok, S3Utils.list_ingest_bucket_objects()}
+  end
+
+  def replace_file_set(_, %{id: id} = params, _) do
+    file_set = FileSets.get_file_set!(id)
+
+    case Pipeline.replace_the_file_set(file_set, Map.delete(params, :id)) do
+      {:error, changeset} ->
+        {:error,
+         message: "Could not replace file set",
+         details: ChangesetErrors.humanize_errors(changeset)}
 
       {:ok, file_set} ->
         {:ok, file_set}

--- a/app/lib/meadow_web/schema/schema.ex
+++ b/app/lib/meadow_web/schema/schema.ex
@@ -21,6 +21,7 @@ defmodule MeadowWeb.Schema do
   import_types(__MODULE__.Data.FileSetTypes)
   import_types(__MODULE__.Data.FieldTypes)
   import_types(__MODULE__.Data.PreservationCheckTypes)
+  import_types(__MODULE__.Data.S3Types)
   import_types(__MODULE__.Data.SharedLinkTypes)
   import_types(__MODULE__.HelperTypes)
   import_types(__MODULE__.Data.CSVMetadataUpdateTypes)
@@ -38,6 +39,7 @@ defmodule MeadowWeb.Schema do
     import_fields(:csv_metadata_update_queries)
     import_fields(:nul_authority_queries)
     import_fields(:preservation_check_queries)
+    import_fields(:s3_queries)
     import_fields(:work_queries)
   end
 

--- a/app/lib/meadow_web/schema/types/data/file_set_types.ex
+++ b/app/lib/meadow_web/schema/types/data/file_set_types.ex
@@ -165,7 +165,9 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
     field(:md5, :string, do: resolve(fn digests, _, _ -> {:ok, Map.get(digests, "md5")} end))
     field(:sha1, :string, do: resolve(fn digests, _, _ -> {:ok, Map.get(digests, "sha1")} end))
 
-    field(:sha256, :string, do: resolve(fn digests, _, _ -> {:ok, Map.get(digests, "sha256")} end))
+    field(:sha256, :string,
+      do: resolve(fn digests, _, _ -> {:ok, Map.get(digests, "sha256")} end)
+    )
   end
 
   @desc "`file_set_structural_metadata` represents the structural metadata within a file set object."

--- a/app/lib/meadow_web/schema/types/data/s3_types.ex
+++ b/app/lib/meadow_web/schema/types/data/s3_types.ex
@@ -1,0 +1,35 @@
+defmodule MeadowWeb.Schema.Data.S3Types do
+  @moduledoc """
+  Absinthe Schema for S3Types
+
+  """
+  use Absinthe.Schema.Notation
+
+  alias MeadowWeb.Resolvers
+  alias MeadowWeb.Schema.Middleware
+
+  object :s3_queries do
+    @desc "List ingest bucket objects"
+    field :list_ingest_bucket_objects, list_of(:s3_object) do
+      arg(:prefix, :string)
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Resolvers.Data.list_ingest_bucket_objects/3)
+    end
+  end
+
+  object :s3_object do
+    field(:owner, :s3_owner)
+    field(:size, :string)
+    field(:key, :string)
+    field(:last_modified, :string)
+    field(:storage_class, :string)
+    field(:e_tag, :string)
+    field(:mime_type, :string)
+  end
+
+  object :s3_owner do
+    field(:id, :string)
+    field(:display_name, :string)
+  end
+end

--- a/app/test/meadow_web/schema/query/s3_objects_test.exs
+++ b/app/test/meadow_web/schema/query/s3_objects_test.exs
@@ -1,0 +1,108 @@
+defmodule MeadowWeb.Schema.Query.S3ObjectsTest do
+  use Meadow.DataCase
+  use Meadow.S3Case
+  use MeadowWeb.ConnCase, async: true
+
+  alias Meadow.Config
+  alias Meadow.Utils.AWS
+
+  import WaitForIt
+
+  @query """
+  query ($prefix: String) {
+    ListIngestBucketObjects(prefix: $prefix) {
+      key
+      storageClass
+      size
+      lastModified
+      mimeType
+    }
+  }
+  """
+
+  @image_fixture "test/fixtures/coffee.tif"
+  @json_fixture "test/fixtures/details.json"
+
+  setup do
+    file_fixtures = [
+      {@ingest_bucket, "coffee/coffee.tif", File.read!(@image_fixture)},
+      {@ingest_bucket, "details.json", File.read!(@json_fixture)}
+    ]
+
+    setup_fixtures(file_fixtures)
+
+    on_exit(fn -> cleanup_fixtures(file_fixtures) end)
+
+    {:ok, %{file_fixtures: file_fixtures}}
+  end
+
+  test "ListIngestBucketObjects query returns objects with a prefix", %{
+    file_fixtures: _file_fixtures
+  } do
+    conn = build_conn() |> auth_user(user_fixture())
+    variables = %{"prefix" => "coffee"}
+
+    response =
+      conn
+      |> get("/api/graphql", query: @query, variables: variables)
+      |> json_response(200)
+
+    assert %{
+             "data" => %{
+               "ListIngestBucketObjects" => [s3_object]
+             }
+           } = response
+
+    assert s3_object["key"] == "s3://#{@ingest_bucket}/coffee/coffee.tif"
+    assert s3_object["mimeType"] == "application/octet-stream"
+    assert s3_object["size"] == "3179982"
+    assert s3_object["storageClass"] == "STANDARD"
+    assert_valid_iso8601_datetime(s3_object["lastModified"])
+
+    refute Enum.any?(
+             response["data"]["ListIngestBucketObjects"],
+             &(&1["key"] == "s3://#{@ingest_bucket}/details.json")
+           )
+  end
+
+  test "ListIngestBucketObjects query returns all objects in the ingest bucket", %{
+    file_fixtures: file_fixtures
+  } do
+    conn = build_conn() |> auth_user(user_fixture())
+
+    response =
+      conn
+      |> get("/api/graphql", query: @query)
+      |> json_response(200)
+
+    s3_objects = response["data"]["ListIngestBucketObjects"]
+
+    assert Enum.all?(file_fixtures, fn {bucket, key, _} ->
+             expected_key = "s3://#{bucket}/#{key}"
+             Enum.any?(s3_objects, &(&1["key"] == expected_key))
+           end)
+  end
+
+  defp setup_fixtures(fixtures) do
+    fixtures
+    |> Task.async_stream(&upload_and_tag_fixture/1, timeout: Config.checksum_wait_timeout())
+    |> Stream.run()
+  end
+
+  defp upload_and_tag_fixture({bucket, key, content}) do
+    upload_object(bucket, key, content)
+
+    AWS.check_object_tags!(bucket, key, Config.required_checksum_tags())
+    |> wait(timeout: Config.checksum_wait_timeout(), frequency: 250)
+  end
+
+  defp cleanup_fixtures(fixtures) do
+    fixtures
+    |> Task.async_stream(fn {bucket, key, _} -> delete_object(bucket, key) end)
+    |> Stream.run()
+  end
+
+  defp assert_valid_iso8601_datetime(datetime_string) do
+    assert {:ok, _, 0} = DateTime.from_iso8601(datetime_string)
+  end
+end


### PR DESCRIPTION
# Summary 
Users can now choose between drag-and-drop or an s3 object picker for adding and replacing file sets in the UI.

# Specific Changes in this PR
- Adds GraphQL query support for picking s3 objects in the ingest bucket
- Backend implemented with a new S3 backend utility module.
- Defines a `S3ObjectPicker` component, now used by the file set modal and file set replace modal. The `S3ObjectPicker` automatically filters the objects based on their `mime_type` (gathered via head requests), while reusing existing mime type validator code.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test
- Spin up Meadow in your dev environment and add a work.
- Add a few files to your ingest bucket in s3 that matches the mime type of your work. Files that will be replacements need to be uploaded under the `file_sets/` prefix in the ingest bucket.
- Go to the preservation tab and hit the button to add a file set.
- Pick the file from the s3 object picker and fill out the form to ingest it
- Go the preservation tab and select the "replace file set" option in the dropdown menu for the file set.
- When the modal pops up replace the file set with another one from the ingest bucket and submit the form.
- File set should be replaced in the background shortly (can check the action states in the preservation tab dropdown to check)

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [x] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

