### PR TITLE
Convert FileSetModel modal to a Dialog component

### DIFF
--- a/app/assets/js/components/UI/Dialog/Dialog.styled.jsx
+++ b/app/assets/js/components/UI/Dialog/Dialog.styled.jsx
@@ -43,10 +43,20 @@ const DialogTitle = styled(Dialog.Title, {
   fontWeight: "700",
 });
 
+const DialogFooter = styled(Dialog.Footer, {
+  display: "flex",
+  justifyContent: "flex-end",
+  padding: "1rem",
+  borderTop: "1px solid #e5e7eb",
+  marginTop: "auto", // Pushes the footer to the bottom of the dialog
+});
+
+
 export {
   DialogClose,
   DialogContent,
   DialogOverlay,
   DialogTitle,
   DialogTrigger,
+  DialogFooter
 };

--- a/app/assets/js/components/UI/Dialog/Dialog.styled.jsx
+++ b/app/assets/js/components/UI/Dialog/Dialog.styled.jsx
@@ -43,12 +43,11 @@ const DialogTitle = styled(Dialog.Title, {
   fontWeight: "700",
 });
 
-const DialogFooter = styled(Dialog.Footer, {
+const DialogFooter = styled("footer", {
   display: "flex",
   justifyContent: "flex-end",
   padding: "1rem",
-  borderTop: "1px solid #e5e7eb",
-  marginTop: "auto", // Pushes the footer to the bottom of the dialog
+  marginTop: "1rem",
 });
 
 

--- a/app/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
@@ -1,4 +1,11 @@
-import { Button, Notification } from "@nulib/design-system";
+import * as Dialog from "@radix-ui/react-dialog";
+import {
+  DialogClose,
+  DialogContent,
+  DialogOverlay,
+  DialogTitle
+} from "@js/components/UI/Dialog/Dialog.styled";
+import { Button, Icon, Notification } from "@nulib/design-system";
 import { FormProvider, useForm } from "react-hook-form";
 import { GET_WORK, INGEST_FILE_SET } from "@js/components/Work/work.gql.js";
 import React, { useState } from "react";
@@ -14,14 +21,9 @@ import UIFormField from "@js/components/UI/Form/Field.jsx";
 import UIFormSelect from "@js/components/UI/Form/Select.jsx";
 import WorkTabsPreservationFileSetDropzone from "@js/components/Work/Tabs/Preservation/FileSetDropzone";
 import WorkTabsPreservationFileSetForm from "@js/components/Work/Tabs/Preservation/FileSetForm";
-import classNames from "classnames";
 import useAcceptedMimeTypes from "@js/hooks/useAcceptedMimeTypes";
 import { useCodeLists } from "@js/context/code-list-context";
 import S3ObjectPicker from "@js/components/Work/Tabs/Preservation/S3ObjectPicker"
-
-const modalCss = css`
-  z-index: 100;
-`;
 
 function WorkTabsPreservationFileSetModal({
   closeModal,
@@ -189,113 +191,109 @@ function WorkTabsPreservationFileSetModal({
   };
 
   return (
-    <div
-      className={classNames("modal", {
-        "is-active": isVisible,
-      })}
-      css={modalCss}
-    >
-      <div className="modal-background"></div>
+    <Dialog.Root open={isVisible} onOpenChange={closeModal}>
+      <Dialog.Portal>
+        <DialogOverlay />
+        <DialogContent data-testid="add-file-set">
+          <DialogClose>
+            <Icon isSmall aria-label="Close">
+              <Icon.Close />
+            </Icon>
+          </DialogClose>
+          <DialogTitle css={{ textAlign: "left" }}>
+            Add Fileset to Work
+          </DialogTitle>
 
-      {urlError ? (
-        <div className="modal-card">
-          <section className="modal-card-body">
-            <Notification isDanger>Error retrieving presigned url</Notification>
-          </section>
-        </div>
-      ) : (
-        <FormProvider {...methods}>
-          <form
-            onSubmit={methods.handleSubmit(handleSubmit)}
-            data-testid="fileset-form"
-          >
-            <div className="modal-card">
-              <header className="modal-card-head">
-                <p className="modal-card-title">Add Fileset to Work</p>
-                <button
-                  type="button"
-                  className="delete"
-                  aria-label="close"
-                  onClick={handleCancel}
-                ></button>
-              </header>
-              <section className="modal-card-body">
-                {uploadError && (
-                  <Notification isDanger>{uploadError}</Notification>
-                )}
-                {error && <Error error={error} />}
-
-                <UIFormField label="Fileset Role">
-                  <UIFormSelect
-                    isReactHookForm
-                    name="fileSetRole"
-                    label="Fileset Role"
-                    options={codeLists?.fileSetRoleData?.codeList}
-                    required={!Boolean(watchRole)}
-                    showHelper
-                    disabled={Boolean(s3UploadLocation)}
-                  />
-                </UIFormField>
-
-                {watchRole && (
-                  <>
-                    <div class="box">
-                      <h3>Option 1: Drag and Drop File</h3>
-                      <WorkTabsPreservationFileSetDropzone
-                        currentFile={currentFile}
-                        acceptedFileTypes={acceptedFileTypes}
-                        fileSetRole={watchRole}
-                        handleRemoveFile={resetForm}
-                        handleSetFile={handleSetFile}
-                        uploadProgress={uploadProgress}
-                        workTypeId={workTypeId}
-                        disabled={uploadMethod === 's3'}
-                      />
-                    </div>
-
-                    <div class="box">
-                      <h3>Option 2: Choose from S3 Ingest Bucket</h3>
-                      <S3ObjectPicker
-                        onFileSelect={handleSelectS3Object}
-                        fileSetRole={watchRole}
-                        workTypeId={workTypeId}
-                        disabled={uploadMethod === 'dragdrop'}
-                      />
-                    </div>
-                  </>
-                )}
-
-                {s3UploadLocation && (
-                  <WorkTabsPreservationFileSetForm
-                    s3UploadLocation={s3UploadLocation}
-                  />
-                )}
+          {urlError ? (
+            <div>
+              <section>
+                <Notification isDanger>Error retrieving presigned url</Notification>
               </section>
-
-              <footer className="modal-card-foot is-justify-content-flex-end">
-                {s3UploadLocation && (
-                  <>
-                    <Button
-                      isText
-                      type="button"
-                      onClick={() => {
-                        handleCancel();
-                      }}
-                      data-testid="cancel-button"
-                    >
-                      Cancel
-                    </Button>
-                    <Button isPrimary type="submit" data-testid="submit-button">
-                      Ingest fileset
-                    </Button>
-                  </>
-                )}
-              </footer>
             </div>
-          </form>
-        </FormProvider>
-      )}
-    </div>
+          ) : (
+            <FormProvider {...methods}>
+              <form
+                onSubmit={methods.handleSubmit(handleSubmit)}
+                data-testid="fileset-form"
+              >
+                <div>
+                  <section className="modal-card-body">
+                    {uploadError && (
+                      <Notification isDanger>{uploadError}</Notification>
+                    )}
+                    {error && <Error error={error} />}
+
+                    <UIFormField label="Fileset Role">
+                      <UIFormSelect
+                        isReactHookForm
+                        name="fileSetRole"
+                        label="Fileset Role"
+                        options={codeLists?.fileSetRoleData?.codeList}
+                        required={!Boolean(watchRole)}
+                        showHelper
+                        disabled={Boolean(s3UploadLocation)}
+                      />
+                    </UIFormField>
+
+                    {watchRole && (
+                      <>
+                        <div className="box">
+                          <h3>Option 1: Drag and Drop File</h3>
+                          <WorkTabsPreservationFileSetDropzone
+                            currentFile={currentFile}
+                            acceptedFileTypes={acceptedFileTypes}
+                            fileSetRole={watchRole}
+                            handleRemoveFile={resetForm}
+                            handleSetFile={handleSetFile}
+                            uploadProgress={uploadProgress}
+                            workTypeId={workTypeId}
+                            disabled={uploadMethod === 's3'}
+                          />
+                        </div>
+
+                        <div className="box">
+                          <h3>Option 2: Choose from S3 Ingest Bucket</h3>
+                          <S3ObjectPicker
+                            onFileSelect={handleSelectS3Object}
+                            fileSetRole={watchRole}
+                            workTypeId={workTypeId}
+                            disabled={uploadMethod === 'dragdrop'}
+                          />
+                        </div>
+                      </>
+                    )}
+
+                    {s3UploadLocation && (
+                      <WorkTabsPreservationFileSetForm
+                        s3UploadLocation={s3UploadLocation}
+                      />
+                    )}
+                  </section>
+
+                  <footer className="modal-card-foot is-justify-content-flex-end">
+                    {s3UploadLocation && (
+                      <>
+                        <Button
+                          isText
+                          type="button"
+                          onClick={handleCancel}
+                          data-testid="cancel-button"
+                        >
+                          Cancel
+                        </Button>
+                        <Button isPrimary type="submit" data-testid="submit-button">
+                          Ingest fileset
+                        </Button>
+                      </>
+                    )}
+                  </footer>
+                </div>
+              </form>
+            </FormProvider>
+          )}
+        </DialogContent>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }
 

--- a/app/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
@@ -2,6 +2,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import {
   DialogClose,
   DialogContent,
+  DialogFooter,
   DialogOverlay,
   DialogTitle
 } from "@js/components/UI/Dialog/Dialog.styled";
@@ -224,7 +225,7 @@ function WorkTabsPreservationFileSetModal({
                 data-testid="fileset-form"
               >
                 <div>
-                  <section className="modal-card-body">
+                  <section>
                     {uploadError && (
                       <Notification isDanger>{uploadError}</Notification>
                     )}
@@ -277,7 +278,7 @@ function WorkTabsPreservationFileSetModal({
                     )}
                   </section>
 
-                  <footer className="modal-card-foot is-justify-content-flex-end">
+                  <DialogFooter>
                     {s3UploadLocation && (
                       <>
                         <Button
@@ -288,12 +289,17 @@ function WorkTabsPreservationFileSetModal({
                         >
                           Cancel
                         </Button>
-                        <Button isPrimary type="submit" data-testid="submit-button">
+                        <Button
+                          disabled={!s3UploadLocation}
+                          isPrimary
+                          type="submit"
+                          data-testid="submit-button"
+                        >
                           Ingest fileset
                         </Button>
                       </>
                     )}
-                  </footer>
+                  </DialogFooter>
                 </div>
               </form>
             </FormProvider>

--- a/app/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
@@ -8,7 +8,7 @@ import {
 import { Button, Icon, Notification } from "@nulib/design-system";
 import { FormProvider, useForm } from "react-hook-form";
 import { GET_WORK, INGEST_FILE_SET } from "@js/components/Work/work.gql.js";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 /** @jsx jsx */
 import { css, jsx } from "@emotion/react";
 import { getFileNameFromS3Uri, s3Location, toastWrapper } from "@js/services/helpers";
@@ -36,7 +36,7 @@ function WorkTabsPreservationFileSetModal({
   const [s3UploadLocation, setS3UploadLocation] = useState();
   const [uploadError, setUploadError] = useState();
   const [stateXhr, setStateXhr] = useState(null);
-  const [acceptedFileTypes, setAcceptedFileTypes] = React.useState("");
+  const [acceptedFileTypes, setAcceptedFileTypes] = useState("");
   const [uploadMethod, setUploadMethod] = useState(null);
 
   const codeLists = useCodeLists();
@@ -45,6 +45,7 @@ function WorkTabsPreservationFileSetModal({
     accessionNumber: "",
     label: "",
     description: "",
+    fileSetRole: "",
   };
 
   const methods = useForm({
@@ -63,14 +64,14 @@ function WorkTabsPreservationFileSetModal({
     setUploadMethod('s3');
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!watchRole) return;
     const mimeTypes = useAcceptedMimeTypes({
       fileSetRole: watchRole,
       workTypeId,
     });
     setAcceptedFileTypes(mimeTypes);
-  }, [watchRole]);
+  }, [watchRole, workTypeId]);
 
   const [
     getPresignedUrl,
@@ -127,19 +128,25 @@ function WorkTabsPreservationFileSetModal({
     ingestFileSet(mutationInput);
   };
 
+  const resetForm = () => {
+    methods.reset(defaultValues);
+    setCurrentFile(null);
+    setS3UploadLocation(null);
+    setUploadProgress(0);
+    setUploadError(null);
+    setUploadMethod(null);
+    setAcceptedFileTypes("");
+  };
+
   const handleCancel = () => {
     if (stateXhr != null) stateXhr.abort();
     resetForm();
     closeModal();
   };
 
-  const resetForm = () => {
-    methods.reset();
-    setCurrentFile(null);
-    setS3UploadLocation(null);
-    setUploadProgress(0);
-    setUploadError(null);
-    setUploadMethod(null);
+  const handleCloseModal = () => {
+    resetForm();
+    closeModal();
   };
 
   const handleSetFile = (file) => {
@@ -191,7 +198,7 @@ function WorkTabsPreservationFileSetModal({
   };
 
   return (
-    <Dialog.Root open={isVisible} onOpenChange={closeModal}>
+    <Dialog.Root open={isVisible} onOpenChange={handleCloseModal}>
       <Dialog.Portal>
         <DialogOverlay />
         <DialogContent data-testid="add-file-set">

--- a/app/assets/js/components/Work/Tabs/Preservation/ReplaceFileSet.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/ReplaceFileSet.jsx
@@ -2,6 +2,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import {
   DialogClose,
   DialogContent,
+  DialogFooter,
   DialogOverlay,
   DialogTitle
 } from "@js/components/UI/Dialog/Dialog.styled";
@@ -269,25 +270,28 @@ function WorkTabsPreservationReplaceFileSet({
                     </UIFormField>
                   </section>
 
-                  <footer className="modal-card-foot is-justify-content-flex-end">
+                  <DialogFooter>
                     {s3UploadLocation && (
                       <>
                         <Button
                           isText
                           type="button"
-                          onClick={() => {
-                            handleCancel();
-                          }}
+                          onClick={handleCancel}
                           data-testid="cancel-button"
                         >
                           Cancel
                         </Button>
-                        <Button isPrimary type="submit" data-testid="submit-button">
+                        <Button
+                          isPrimary
+                          disabled={!s3UploadLocation}
+                          type="submit"
+                          data-testid="submit-button"
+                        >
                           Upload File
                         </Button>
                       </>
                     )}
-                  </footer>
+                  </DialogFooter>
                 </div>
               </form>
             </FormProvider>

--- a/app/assets/js/components/Work/Tabs/Preservation/ReplaceFileSet.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/ReplaceFileSet.jsx
@@ -102,18 +102,27 @@ function WorkTabsPreservationReplaceFileSet({
     });
   };
 
-  const handleCancel = () => {
-    if (stateXhr != null) stateXhr.abort();
-    resetForm();
-    closeModal();
-  };
-
   const resetForm = () => {
     setCurrentFile(null);
     setS3UploadLocation(null);
     setUploadProgress(0);
     setUploadError(null);
     setUploadMethod(null);
+    methods.reset({
+      label: fileset?.coreMetadata?.label || "",
+      description: fileset?.coreMetadata?.description || "",
+    });
+  };
+
+  const handleCancel = () => {
+    if (stateXhr != null) stateXhr.abort();
+    resetForm();
+    closeModal();
+  };
+
+  const handleCloseModal = () => {
+    resetForm();
+    closeModal();
   };
 
   const handleSelectS3Object = (s3Object) => {
@@ -174,7 +183,7 @@ function WorkTabsPreservationReplaceFileSet({
   };
 
   return (
-    <Dialog.Root open={isVisible} onOpenChange={closeModal}>
+    <Dialog.Root open={isVisible} onOpenChange={handleCloseModal}>
       <Dialog.Portal>
         <DialogOverlay />
         <DialogContent data-testid="replace-file-sets">
@@ -213,7 +222,7 @@ function WorkTabsPreservationReplaceFileSet({
                     )}
                     {error && <Error error={error} />}
 
-                    <div class="box">
+                    <div className="box">
                       <h3>Option 1: Drag and Drop File</h3>
                       <WorkTabsPreservationFileSetDropzone
                         currentFile={currentFile}
@@ -226,7 +235,7 @@ function WorkTabsPreservationReplaceFileSet({
                       />
                     </div>
 
-                    <div class="box">
+                    <div className="box">
                       <h3>Option 2: Choose from S3 Ingest Bucket</h3>
                       <S3ObjectPicker
                         onFileSelect={handleSelectS3Object}


### PR DESCRIPTION
# Summary 

The modal window is currently being vertically cut off after a certain height, obscuring the "close" button. This PR converts the `FileSetModal` to a `Dialog` component which does a better job of handling the z-index and scrolling issues.

![add_fileset_dialog](https://github.com/nulib/meadow/assets/1395707/1a7efe93-3f6f-48fd-a1f7-1a67ff1b0d24)

Also fixes a bug with the S3ObjectPicker when selecting an S3 object from the list (the behavior in the screenshot is visible on Meadow staging now, this commit makes it go away 😄 )

![SCR-20240627-ovji](https://github.com/nulib/meadow/assets/1395707/ddaafd51-1692-4ff3-80ca-d31546d040b2)


# Specific Changes in this PR
- Updates `FileSetModal.jsx`
- Fixes a small bug with the `S3ObjectPicker` component (see screenshot above)

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
- Go to the preservation and make sure the `Dialog` component is working properly when you hit the "Add a File Set" button

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

