### PR TITLE
Tweak Sitemap generation

### DIFF
--- a/app/config/dev.exs
+++ b/app/config/dev.exs
@@ -124,6 +124,7 @@ if prefix = System.get_env("DEV_PREFIX") do
 end
 
 config :meadow, :sitemaps,
+  base_url: "https://dc.library.northwestern.edu/",
   gzip: false,
   store: Sitemapper.FileStore,
   sitemap_url: "https://devbox.library.northwestern.edu:3333/",

--- a/app/config/test.exs
+++ b/app/config/test.exs
@@ -119,6 +119,7 @@ config :honeybadger,
 config :meadow, :sitemaps,
   gzip: true,
   store: Sitemapper.S3Store,
+  base_url: "http://localhost:3333/",
   sitemap_url: "http://localhost:3333/",
   store_config: [bucket: prefix("uploads"), path: ""]
 

--- a/app/lib/meadow/utils/sitemap.ex
+++ b/app/lib/meadow/utils/sitemap.ex
@@ -2,8 +2,11 @@ defmodule Meadow.Utils.Sitemap do
   @moduledoc """
   Generate and upload Digital Collection sitemaps
   """
-  alias Meadow.Data.{Collections, Works}
+  alias Meadow.Data.Collections
+  alias Meadow.Data.Schemas.Work
   alias Meadow.Repo
+
+  import Ecto.Query
 
   require Logger
 
@@ -74,7 +77,7 @@ defmodule Meadow.Utils.Sitemap do
   end
 
   defp work_urls do
-    Works.work_query(visibility: "OPEN", work_type: "IMAGE")
+    from(w in Work, where: w.visibility["id"] == ^"OPEN" and w.published)
     |> Repo.stream()
     |> Stream.map(fn %{id: id, updated_at: updated_at} ->
       %Sitemapper.URL{
@@ -88,7 +91,7 @@ defmodule Meadow.Utils.Sitemap do
 
   defp expand_url(path) do
     config()
-    |> Keyword.get(:sitemap_url)
+    |> Keyword.get(:base_url)
     |> URI.parse()
     |> URI.merge(path)
     |> URI.to_string()


### PR DESCRIPTION
This will make DC's existing `/api/sitemap/sitemap-xxxx.xml.gz` route work and allow Google to load the sitemaps.

# Summary 
Brief high level description of this feature or fix

# Specific Changes in this PR
- Include all public, published items in sitemap
- Have index point at `api/sitemap/` route
- Add job to scheduler to regenerate sitemap at 1am daily

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

