### PR TITLE
Dynamically determine dimensionality of embedding field

### DIFF
--- a/app/config/config.exs
+++ b/app/config/config.exs
@@ -75,10 +75,13 @@ config :meadow, Meadow.Search.Cluster,
   bulk_page_size: 200,
   bulk_wait_interval: 500,
   json_encoder: Ecto.Jason,
-  embedding_model_id: aws_secret("meadow",
-    dig: ["search", "embedding_model_id"],
-    default: nil
-  )
+  embedding_model_id:
+    aws_secret("meadow",
+      dig: ["search", "embedding_model_id"],
+      default: nil
+    ),
+  embedding_dimensions:
+    aws_secret("meadow", dig: ["search", "embedding_dimensions"], default: nil)
 
 config :meadow,
   ark: %{

--- a/app/lib/meadow/search/config.ex
+++ b/app/lib/meadow/search/config.ex
@@ -6,8 +6,6 @@ defmodule Meadow.Search.Config do
 
   require Logger
 
-  @default_embedding_dimensions 384
-
   def index_configs do
     Application.get_env(:meadow, Meadow.Search.Cluster)
     |> Keyword.get(:indexes)
@@ -59,40 +57,23 @@ defmodule Meadow.Search.Config do
   def add_embedding_dimension(
         %{"mappings" => %{"properties" => %{"embedding" => %{"dimension" => _}}}} = settings
       ) do
-    settings
-    |> put_in(
-      ["mappings", "properties", "embedding", "dimension"],
-      embedding_model_dimensions(embedding_model_id())
-    )
-  end
-
-  def add_embedding_dimension(settings), do: settings
-
-  def embedding_model_dimensions(nil) do
-    Logger.warning(
-      "No embedding model id found in config, using default of #{@default_embedding_dimensions} dimensions"
-    )
-
-    @default_embedding_dimensions
-  end
-
-  def embedding_model_dimensions(model_id) do
-    case ["_plugins", "_ml", "_predict", "text_embedding", model_id]
-         |> HTTP.post!(%{text_docs: ["How many dimensions?"]}, [], recv_timeout: 30_000)
-         |> Map.get(:body)
-         |> get_in(["inference_results", Access.at(0), "output", Access.at(0), "data"]) do
-      nil ->
-        Logger.warning(
-          "Unable to determine model dimensions, using default of #{@default_embedding_dimensions}"
-        )
-
-        @default_embedding_dimensions
-
-      embedding ->
-        dims = length(embedding)
-        Logger.info("Model #{model_id} generates a #{dims}-dimension embedding")
-        dims
+    case embedding_model_dimensions() do
+      nil -> settings
+      _ -> insert_embedding_dimension(settings)
     end
+  end
+
+  def insert_embedding_dimension(settings),
+    do:
+      put_in(
+        settings,
+        ["mappings", "properties", "embedding", "dimension"],
+        embedding_model_dimensions()
+      )
+
+  def embedding_model_dimensions do
+    Application.get_env(:meadow, Meadow.Search.Cluster)
+    |> Keyword.get(:embedding_dimensions)
   end
 
   def index_versions do


### PR DESCRIPTION
# Summary 
Dynamically determine dimensionality of embedding field when creating work index

# Specific Changes in this PR
- When model ID and embedding field are both present, generate a test embedding and use its length to set the dimensionality of the `embedding` field

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

You can test this in the dev environment by doing a full reindex and:
- Looking for the log message about embedding dimensions while the index is being created
- Looking at the resulting mappings in OpenSearch Dashboards with `GET /mbk-dev-dc-v2-work` (or whatever your work index is called)

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

