### PR TITLE
Make embedding keys configurable

### DIFF
--- a/app/config/config.exs
+++ b/app/config/config.exs
@@ -81,7 +81,29 @@ config :meadow, Meadow.Search.Cluster,
       default: nil
     ),
   embedding_dimensions:
-    aws_secret("meadow", dig: ["search", "embedding_dimensions"], default: nil)
+    aws_secret("meadow", dig: ["search", "embedding_dimensions"], default: nil),
+  embedding_text_fields: [
+    :title,
+    :description,
+    :collection,
+    # :alternate_title,
+    # :caption,
+    # :table_of_contents,
+    # :abstract,
+    # :contributor,
+    # :creator,
+    # :date_created,
+    # :genre,
+    # :subject,
+    # :style_period,
+    # :language,
+    # :location,
+    # :publisher,
+    # :scope_and_contents,
+    # :technique,
+    # :physical_description_material,
+    # :physical_description_size,
+  ]
 
 config :meadow,
   ark: %{

--- a/app/lib/meadow/indexing/v2/work.ex
+++ b/app/lib/meadow/indexing/v2/work.ex
@@ -5,6 +5,7 @@ defmodule Meadow.Indexing.V2.Work do
 
   alias Meadow.Data.FileSets
   alias Meadow.Data.Schemas.{ControlledMetadataEntry, NoteEntry, RelatedURLEntry}
+  alias Meadow.Search.Config
 
   def encode(work) do
     %{
@@ -77,32 +78,9 @@ defmodule Meadow.Indexing.V2.Work do
     |> prepare_embedding_field()
   end
 
-  @embedding_keys [
-    :title,
-    :description,
-    :collection,
-    :alternate_title,
-    :caption,
-    :table_of_contents,
-    :abstract,
-    :contributor,
-    :creator,
-    :date_created,
-    :genre,
-    :subject,
-    :style_period,
-    :language,
-    :location,
-    :publisher,
-    :scope_and_contents,
-    :technique,
-    :physical_description_material,
-    :physical_description_size,
-  ]
-
   defp prepare_embedding_field(map) do
     value =
-      @embedding_keys
+      Config.embedding_text_fields()
       |> Enum.reduce([], fn field_name, acc ->
         v = prepare_embedding_value(Map.get(map, field_name))
         [v | acc]

--- a/app/lib/meadow/search/config.ex
+++ b/app/lib/meadow/search/config.ex
@@ -76,6 +76,11 @@ defmodule Meadow.Search.Config do
     |> Keyword.get(:embedding_dimensions)
   end
 
+  def embedding_text_fields do
+    Application.get_env(:meadow, Meadow.Search.Cluster)
+    |> Keyword.get(:embedding_text_fields)
+  end
+
   def index_versions do
     index_configs()
     |> Enum.map(& &1.version)


### PR DESCRIPTION
# Summary 

Make embedding keys configurable

# Specific Changes in this PR
- Make embedding keys configurable

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

