### PR TITLE
Improve Meadow Livebook user experience

### DIFF
--- a/bin/meadow-livebook
+++ b/bin/meadow-livebook
@@ -15,11 +15,13 @@ echo -n "   Starting Livebook..."
 docker buildx build -t nulib/meadow:livebook $ROOT/livebook > /dev/null 2>&1
 LIVEBOOK_CONTAINER=$(docker run --rm -d --network host \
   -v ${HOME}/.meadow_livebooks:/data/books \
+  -v ${HOME}/environment/meadow_kino:/meadow_kino \
   -e LB_MEADOW_COOKIE=${COOKIE} \
   -e LB_MEADOW_NODE=meadow@${HOST} \
   -e LIVEBOOK_NODE=livebook@${HOST} \
   -e LIVEBOOK_DISTRIBUTION=name \
   -e LIVEBOOK_COOKIE=${COOKIE} \
+  -e MEADOW_LIVEBOOK_BUCKET=${MEADOW_LIVEBOOK_BUCKET} \
   -e MEADOW_URL=https://${MEADOW_HOSTNAME}:3001/ \
   nulib/meadow:livebook)
 https-proxy start 8082 8080 > /dev/null 2>&1

--- a/infrastructure/deploy/modules/meadow_task/main.tf
+++ b/infrastructure/deploy/modules/meadow_task/main.tf
@@ -26,6 +26,7 @@ locals {
       db_queue_interval     = var.db_queue_interval,
       db_queue_target       = var.db_queue_target,
       docker_repository     = data.aws_ecr_repository.meadow.repository_url,
+      livebook_bucket       = var.livebook_shared_bucket,
       name                  = var.name,
       processes             = var.meadow_processes
     }

--- a/infrastructure/deploy/task-definitions/meadow_app.json
+++ b/infrastructure/deploy/task-definitions/meadow_app.json
@@ -187,6 +187,10 @@
       {
         "name": "LIVEBOOK_COOKIE",
         "value": "${secret_key_base}"
+      },
+      {
+        "name": "MEADOW_LIVEBOOK_BUCKET",
+        "value": "${livebook_bucket}"
       }
     ],
     "mountPoints": [],

--- a/infrastructure/deploy/variables.tf
+++ b/infrastructure/deploy/variables.tf
@@ -208,3 +208,8 @@ variable "trusted_referers" {
   type    = string
   default = ""
 }
+
+variable "livebook_shared_bucket" {
+  type    = string
+  default = ""
+}

--- a/livebook/Dockerfile
+++ b/livebook/Dockerfile
@@ -7,4 +7,5 @@ ENV LIVEBOOK_IDENTITY_PROVIDER=custom:MeadowLivebookAuth
 ENV LIVEBOOK_IP=0.0.0.0
 ENV LIVEBOOK_TOKEN_ENABLED=false
 RUN mkdir -p ${LIVEBOOK_DATA_PATH}/books
-ADD ./meadow_livebook_auth.exs /app/user/extensions/meadow_livebook_auth.exs
+RUN git clone https://github.com/nulib/meadow_kino.git /meadow_kino
+ADD ./extensions/* /app/user/extensions/


### PR DESCRIPTION
# Summary 
Make Livebook automatically configure shared notebook storage on startup, and include `meadow_kino` in build

# Specific Changes in this PR
- Add optional `livebook_shared_bucket` to Terraform config
- Add environment variable to Meadow Livebook container
- Add code to Livebook Meadow extension to configure S3 storage if environment variable is present
- Clone `meadow_kino` into the `meadow:livebook` image at build time so it's available even if github is down

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [x] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

