### PR TITLE
Explicitly map date_created_edtf as keyword type

### DIFF
--- a/app/priv/search/v2/settings/work.json
+++ b/app/priv/search/v2/settings/work.json
@@ -109,6 +109,15 @@
         }
       },
       {
+        "edtf_date": {
+          "match": "^date_created_edtf$",
+          "match_pattern": "regex",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      },
+      {
         "latlong": {
           "match": ".*Geo|^geo",
           "match_pattern": "regex",


### PR DESCRIPTION
# Summary 

Explicitly map `date_created_edtf` as `keyword` type so that it won't infer as `date` type

# Specific Changes in this PR
- Update `dc-v2-work `mappings to explicitly map `date_created_edtf` as `keyword` type
- 
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- [ ] After reindex, from Kibana get work mappings and verify `date_created_edtf` field type is keyword.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

