### PR TITLE
Change IIIF image requests to v3

### DIFF
--- a/app/config/config.exs
+++ b/app/config/config.exs
@@ -134,7 +134,7 @@ config :meadow,
   iiif_server_url:
     aws_secret("meadow",
       dig: ["iiif", "base_url"],
-      default: "https://iiif.dev.rdc.library.northwestern.edu/iiif/2/#{prefix()}"
+      default: "https://iiif.dev.rdc.library.northwestern.edu/iiif/3/#{prefix()}"
     ),
   iiif_manifest_url_deprecated:
     aws_secret("meadow",

--- a/app/config/test.exs
+++ b/app/config/test.exs
@@ -21,7 +21,7 @@ config :meadow,
   index_interval: 1234,
   mediaconvert_client: MediaConvert.Mock,
   streaming_url: "https://test-streaming-url/",
-  iiif_server_url: "http://localhost:8184/iiif/2/",
+  iiif_server_url: "http://localhost:8184/iiif/3/",
   iiif_manifest_url_deprecated: "http://test-pyramids.s3.localhost.localstack.cloud:4566/public/",
   digital_collections_url: "https://fen.rdc-staging.library.northwestern.edu/"
 

--- a/app/lib/meadow/utils/aws.ex
+++ b/app/lib/meadow/utils/aws.ex
@@ -80,12 +80,12 @@ defmodule Meadow.Utils.AWS do
     do: MultipartCopy.copy_object(dest_bucket, dest_object, src_bucket, src_object, opts)
 
   def invalidate_cache(file_set, invalidation_type), do: invalidate_cache(file_set, invalidation_type, Config.environment())
-  def invalidate_cache(file_set, :pyramid, :dev), do: perform_iiif_invalidation("/iiif/2/#{prefix()}/#{file_set.id}/*")
-  def invalidate_cache(file_set, :pyramid, :test), do: perform_iiif_invalidation("/iiif/2/#{prefix()}/#{file_set.id}/*")
-  def invalidate_cache(file_set, :pyramid, _), do: perform_iiif_invalidation("/iiif/2/#{file_set.id}/*")
-  def invalidate_cache(file_set, :poster, :dev), do: perform_iiif_invalidation("/iiif/2/#{prefix()}/posters/#{file_set.id}/*")
-  def invalidate_cache(file_set, :poster, :test), do: perform_iiif_invalidation("/iiif/2/#{prefix()}/posters/#{file_set.id}/*")
-  def invalidate_cache(file_set, :poster, _), do: perform_iiif_invalidation("/iiif/2/posters/#{file_set.id}/*")
+  def invalidate_cache(file_set, :pyramid, :dev), do: perform_iiif_invalidation("/iiif/3/#{prefix()}/#{file_set.id}/*")
+  def invalidate_cache(file_set, :pyramid, :test), do: perform_iiif_invalidation("/iiif/3/#{prefix()}/#{file_set.id}/*")
+  def invalidate_cache(file_set, :pyramid, _), do: perform_iiif_invalidation("/iiif/3/#{file_set.id}/*")
+  def invalidate_cache(file_set, :poster, :dev), do: perform_iiif_invalidation("/iiif/3/#{prefix()}/posters/#{file_set.id}/*")
+  def invalidate_cache(file_set, :poster, :test), do: perform_iiif_invalidation("/iiif/3/#{prefix()}/posters/#{file_set.id}/*")
+  def invalidate_cache(file_set, :poster, _), do: perform_iiif_invalidation("/iiif/3/posters/#{file_set.id}/*")
   def invalidate_cache(_file_set, :streaming, :dev), do: :ok
   def invalidate_cache(_file_set, :streaming, :test), do: :ok
   def invalidate_cache(file_set, :streaming, _), do: perform_streaming_invalidation("/#{Pairtree.generate!(file_set.id)}/*")

--- a/app/test/meadow/config_test.exs
+++ b/app/test/meadow/config_test.exs
@@ -90,7 +90,7 @@ defmodule Meadow.ConfigTest do
     end
 
     test "trailing slashes/0" do
-      Application.put_env(:meadow, :iiif_server_url, "http://no-slash-test/iiif/2")
+      Application.put_env(:meadow, :iiif_server_url, "http://no-slash-test/iiif/3")
 
       Application.put_env(
         :meadow,
@@ -98,7 +98,7 @@ defmodule Meadow.ConfigTest do
         "http://no-slash-test/minio/test-pyramids/public"
       )
 
-      assert Config.iiif_server_url() == "http://no-slash-test/iiif/2/"
+      assert Config.iiif_server_url() == "http://no-slash-test/iiif/3/"
 
       assert Config.iiif_manifest_url_deprecated() ==
                "http://no-slash-test/minio/test-pyramids/public/"

--- a/app/test/meadow/data/file_sets_test.exs
+++ b/app/test/meadow/data/file_sets_test.exs
@@ -216,7 +216,7 @@ defmodule Meadow.Data.FileSetsTest do
 
       with uri <- file_set |> FileSets.representative_image_url_for() |> URI.parse() do
         assert uri.host == "localhost"
-        assert uri.path == "/iiif/2/posters/#{file_set.id}"
+        assert uri.path == "/iiif/3/posters/#{file_set.id}"
       end
     end
 
@@ -230,7 +230,7 @@ defmodule Meadow.Data.FileSetsTest do
 
       with uri <- file_set |> FileSets.representative_image_url_for() |> URI.parse() do
         assert uri.host == "localhost"
-        assert uri.path == "/iiif/2/#{file_set.id}"
+        assert uri.path == "/iiif/3/#{file_set.id}"
       end
     end
 

--- a/app/test/pipeline/actions/generate_poster_image_test.exs
+++ b/app/test/pipeline/actions/generate_poster_image_test.exs
@@ -85,7 +85,7 @@ defmodule Meadow.Pipeline.Actions.GeneratePosterImageTest do
 
       assert log
              |> String.contains?(
-               "Skipping cache invalidation for: /iiif/2/#{prefix()}/posters/#{file_set_id}/*. No distribution id found."
+               "Skipping cache invalidation for: /iiif/3/#{prefix()}/posters/#{file_set_id}/*. No distribution id found."
              )
     end
   end


### PR DESCRIPTION
# Summary 

Change the path in our indexed image urls to call the IIIF Image v3 API via our IIIF server.

# Specific Changes in this PR

- update IIIF Image paths to use IIIF Image API v3


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Reindex
- Check that image url paths in the `?as=iiif` responses contain `/iiif/3`
 
# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

