### PR TITLE
Fix IIIF Image API syntax in download image for v3

### DIFF
--- a/app/assets/js/services/global-vars.js
+++ b/app/assets/js/services/global-vars.js
@@ -30,8 +30,8 @@ export const REACTIVESEARCH_SORT_OPTIONS = [
 
 export const IIIF_SIZES = {
   IIIF_SQUARE: "/square/500,500/0/default.jpg",
-  IIIF_FULL: "/full/full/0/default.jpg",
-  IIIF_FULL_TIFF: "/full/full/0/default.tif",
+  IIIF_FULL: "/full/max/0/default.jpg",
+  IIIF_FULL_TIFF: "/full/max/0/default.tif",
 };
 
 // Browser localStorage variable used to hold code lists


### PR DESCRIPTION
# Summary 

Download images is currently broken since changing our image urls to `iiif/3`

# Specific Changes in this PR

- Update download image requests from `/full/full/0/default.jpg` to `/full/max/0/default.jpg`
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- go to the structure tab on an image work
- click to download a tiff

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

