### PR TITLE
Fix "files is not defined" error in S3 object picker

### DIFF
--- a/app/assets/js/components/Work/Tabs/Preservation/S3ObjectPicker.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/S3ObjectPicker.jsx
@@ -47,7 +47,7 @@ const S3ObjectPicker = ({
       case ChonkyActions.ChangeSelection.id:
         if (
           action.payload.selection.size == 0 &&
-          files.find(({ id }) => selectedFile == id)
+          files?.find(({ id }) => selectedFile == id)
         ) {
           fileBrowserRef.current.setFileSelection(new Set([selectedFile]));
           return;

--- a/app/assets/js/components/Work/Tabs/Preservation/S3ObjectProvider.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/S3ObjectProvider.jsx
@@ -39,9 +39,9 @@ const S3ObjectProvider = forwardRef(
     useImperativeHandle(ref, () => ({
       findFileSetByUri: (value) => {
         const objects = data?.ListIngestBucketObjects?.objects;
-        if (!objects) return null;
+        const found = objects?.find(({ uri }) => uri == value);
+        if (!found) return null;
 
-        const found = objects.find(({ uri }) => uri == value);
         return { ...found, key: found.uri, uri: undefined };
       },
     }));


### PR DESCRIPTION
# Summary 
Fix intermittent "files is not defined" error in S3 object picker

# Specific Changes in this PR
- add conditional chain operator to `handleFileAction`
- add conditional chain operator to `findFileSetByUri`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

1. Browse to a work and open the browser's developer tools to the console tab.
2. Click *Add A Fileset*
3. Navigate around the file picker and make sure there are no errors reported in the console.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

