### PR TITLE
Rename structure tab -> Access files

### DIFF
--- a/app/assets/js/components/Work/Tabs/Structure/Structure.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Structure.jsx
@@ -128,7 +128,7 @@ const WorkTabsStructure = ({ work }) => {
         name="work-structure-form"
         onSubmit={methods.handleSubmit(onSubmit)}
       >
-        <UITabsStickyHeader title="Structure of Filesets">
+        <UITabsStickyHeader title="Access & Auxiliary Filesets">
           {!isEditing && (
             <Button
               isPrimary

--- a/app/assets/js/components/Work/Tabs/Tabs.jsx
+++ b/app/assets/js/components/Work/Tabs/Tabs.jsx
@@ -48,7 +48,7 @@ const WorkTabs = ({ work }) => {
                 data-testid="tab-structure"
                 onClick={handleTabClick}
               >
-                Structure
+                Access files
               </a>
             </li>
             <AuthDisplayAuthorized>

--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "@absinthe/socket-apollo-link": "^0.2.1",
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",


### PR DESCRIPTION
# Summary 

The current "Structure" tab should be renamed to "Access files"

# Specific Changes in this PR
- Label on "Structure" tab changed to "Access files"

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Visit a work page in Meadow
- Make sure the third tab is not labeled "Structure" but rather than "Access files"

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

