### PR TITLE
Make status a facet and fix link from work page

### DIFF
--- a/app/assets/js/components/Work/Tabs/Administrative/General.jsx
+++ b/app/assets/js/components/Work/Tabs/Administrative/General.jsx
@@ -101,7 +101,7 @@ function WorkAdministrativeTabsGeneral({
             className="break-word"
             onClick={() =>
               handlePassedInSearchTerm(
-                "administrativeMetadata.status.label",
+                "status",
                 status.label
               )
             }

--- a/app/assets/js/services/reactive-search.js
+++ b/app/assets/js/services/reactive-search.js
@@ -188,6 +188,13 @@ export const FACET_SENSORS = [
   },
   {
     ...defaultListItemValues,
+    componentId: "Status",
+    dataField: "status",
+    showSearch: true,
+    title: "Status",
+  },
+  {
+    ...defaultListItemValues,
     componentId: "StylePeriod",
     dataField: "style_period.label",
     showSearch: true,


### PR DESCRIPTION
# Summary 

- Add status to the facets on the search page
- Fix link from an item's status on the administrative tab into search results

# Specific Changes in this PR
- Add status to the facets on the search page
- Fix link from an item's status on the administrative tab into search results


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Go to the search page and make sure you see "Status" as a facet
  - Make sure it works correctly
- Go to a work page, administrative tab and click on the "Status" link
  - Make sure it correctly fires off a search and retrieves works with the same status

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

