### PR TITLE
Adds iiif_collection field to collection index

### DIFF
--- a/app/lib/meadow/indexing/v2/collection.ex
+++ b/app/lib/meadow/indexing/v2/collection.ex
@@ -14,6 +14,7 @@ defmodule Meadow.Indexing.V2.Collection do
       featured: collection.featured,
       finding_aid_url: collection.finding_aid_url,
       id: collection.id,
+      iiif_collection: iiif_collection_id(collection),
       indexed_at: NaiveDateTime.utc_now(),
       keywords: collection.keywords,
       modified_date: collection.updated_at,
@@ -40,4 +41,6 @@ defmodule Meadow.Indexing.V2.Collection do
 
   def encode_label(%{label: label}), do: label
   def encode_label(_), do: nil
+
+  defp iiif_collection_id(collection), do: "#{api_url()}/collections/#{collection.id}?as=iiif"
 end


### PR DESCRIPTION
# Summary 

- Adds `iiif_collection` field to collection index so that it can be used by the API
- Note: this is part 1 of the work for issue 5174 - part 2 will take place in DCAPI

# Specific Changes in this PR

- Adds `iiif_collection` field to collection index

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test

- Perform after Meadow reindex
- Look at a collection Opensearch response document (either in Kibana or the regular DCAPI response (not the as=iiif one))
- Confirm that you see a `iiif_collection` field 
- Confirm that the field links to the correct as=iiif collection response in DCAPI

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [x] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

