### PR TITLE
Fix names of upload/preservation buckets in dev

### DIFF
--- a/app/lib/meadow/config/pipeline.ex
+++ b/app/lib/meadow/config/pipeline.ex
@@ -21,7 +21,7 @@ defmodule Meadow.Config.Pipeline do
     |> configure!()
   end
 
-  def configure!(true), do: Logger.warn("Pipeline already configured. Skipping.")
+  def configure!(true), do: Logger.warning("Pipeline already configured. Skipping.")
 
   def configure!(_) do
     prefix =

--- a/app/lib/meadow/config/runtime.ex
+++ b/app/lib/meadow/config/runtime.ex
@@ -318,8 +318,8 @@ defmodule Meadow.Config.Runtime do
       ingest_bucket: get_secret(:meadow, ["buckets", "ingest"], prefix("ingest")),
       preservation_bucket:
         get_secret(:meadow, ["buckets", "preservation"], prefix("preservation")),
-      pyramid_bucket: get_secret(:meadow, ["buckets", "pyramid"], prefix("pyramid")),
-      upload_bucket: get_secret(:meadow, ["buckets", "upload"], prefix("upload")),
+      pyramid_bucket: get_secret(:meadow, ["buckets", "pyramid"], prefix("pyramids")),
+      upload_bucket: get_secret(:meadow, ["buckets", "upload"], prefix("uploads")),
       preservation_check_bucket:
         get_secret(:meadow, ["buckets", "preservation_check"], prefix("preservation-checks")),
       streaming_bucket: get_secret(:meadow, ["buckets", "streaming"], prefix("streaming"))

--- a/app/test/meadow/config_test.exs
+++ b/app/test/meadow/config_test.exs
@@ -61,13 +61,13 @@ defmodule Meadow.ConfigTest do
 
   test "aws_environment/0" do
     with env <- Config.aws_environment() |> Enum.into(%{}) do
-      assert env |> Map.has_key?('TMPDIR')
+      assert env |> Map.has_key?(~c"TMPDIR")
 
       if Application.get_env(:ex_aws, :s3) do
-        assert env |> Map.get('AWS_REGION') == 'us-east-1'
-        assert env |> Map.get('AWS_SECRET_ACCESS_KEY') == 'fake'
-        assert env |> Map.get('AWS_ACCESS_KEY_ID') == 'fake'
-        assert env |> Map.get('AWS_S3_ENDPOINT') |> Enum.slice(0..15) == 'http://localhost'
+        assert env |> Map.get(~c"AWS_REGION") == ~c"us-east-1"
+        assert env |> Map.get(~c"AWS_SECRET_ACCESS_KEY") == ~c"fake"
+        assert env |> Map.get(~c"AWS_ACCESS_KEY_ID") == ~c"fake"
+        assert env |> Map.get(~c"AWS_S3_ENDPOINT") |> Enum.slice(0..15) == ~c"http://localhost"
       end
     end
   end
@@ -102,13 +102,6 @@ defmodule Meadow.ConfigTest do
 
       assert Config.iiif_manifest_url_deprecated() ==
                "http://no-slash-test/minio/test-pyramids/public/"
-    end
-
-    test "validate release config" do
-      System.put_env("__COMPILE_CHECK__", "TRUE")
-      assert ConfigReader.read!("config/releases.exs") |> is_list()
-    after
-      System.delete_env("__COMPILE_CHECK__")
     end
   end
 end

--- a/infrastructure/deploy/secrets.tf
+++ b/infrastructure/deploy/secrets.tf
@@ -1,4 +1,6 @@
 locals {
+  dc_base = trimsuffix(var.digital_collections_url, "/")
+
   config_secrets = {
     buckets = {
       ingest             = aws_s3_bucket.meadow_ingest.bucket
@@ -20,6 +22,10 @@ locals {
 
     dc = {
       base_url = var.digital_collections_url
+    }
+
+    ezid = {
+      target_base_url = "${local.dc_base}/items/"
     }
 
     geonames = {


### PR DESCRIPTION
# Summary 
Fix names of upload/preservation buckets in dev

# Specific Changes in this PR
- Fix ezid config
- Change `'charlist'` to `~c"charlist"` per Credo
- Change `Logger.warn` to `Logger.warning`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

This is a dev-environment only change. Make sure you can upload/process/view images in the UI.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

