### PR TITLE
Adjust ExAws hackney max connections

### DIFF
--- a/app/config/config.exs
+++ b/app/config/config.exs
@@ -75,6 +75,11 @@ config :authoritex,
 
 config :httpoison_retry, wait: 50
 
+config :ex_aws, :hackney_opts,
+  pool: :default,
+  max_connections: 500,
+  checkout_timeout: 30_000
+
 config :meadow, :extra_mime_types, %{
   "aif" => "audio/x-aiff",
   "aifc" => "audio/x-aiff",


### PR DESCRIPTION
# Summary 

Ingest sheets of multiple large videos were failing the multipart copy step.

Adjust ExAws hackney max connections

# Specific Changes in this PR
- Bump ExAws Hackney `max_connection` to 500

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Ingest an ingest sheet containing 40+ large videos (>75GB)

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

