### PR TITLE
Switch from owned postgres RDS instance to infrastructure Aurora Serverless DB

### DIFF
--- a/infrastructure/deploy/.terraform.lock.hcl
+++ b/infrastructure/deploy/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/cyrilgdn/postgresql" {
+  version     = "1.25.0"
+  constraints = "~> 1.25"
+  hashes = [
+    "h1:4Hlupc8gYrPnFKisesXs9lypK6LXslU4L4tjBZOhmiE=",
+    "zh:0f9db6e1274603d642e96b58eaf6cc4223f7118f2d7ce909dc4812d332cc002a",
+    "zh:1819470f0304c6a60b2b51817cb43f6ff59a49e08cc9e50644b86b3a76c91601",
+    "zh:27bfb544983cac101a7c7c2e4cb9939a712dffcdd7ddcab83c2f8afc334e33c5",
+    "zh:46166f6f05771b0495df18459fdf3a63fae8b38e95a1b2754f03d006e17ea33d",
+    "zh:64d53afc52f26e8214990acc3e07f3b47bef628aa6b317595a8faec05b252209",
+    "zh:944d7ded418c022dd3ee513246677d601376fa38d76c9c4aecff2c2eefcaa35b",
+    "zh:9819551b61542a6d322d6a323bbb552ce02e769ce2222fd9bb1935473c7c4b3c",
+    "zh:c38bd73e208fe216efab48d099c85b8ad1e51ff102b3892443febc9778e7236e",
+    "zh:c73de133274dcc7a03e95f598550facc59315538f355e57e14b36e222b298826",
+    "zh:c7af02f5338bfe7f1976e01d3fcf82e05b3551893e732539a84c568d25571a84",
+    "zh:d1aa3d7432c7de883873f8f70e9a6207c7b536d874486d37aee0ca8c8853a890",
+    "zh:e17e9809fc7cc2d6f89078b8bfe6308930117b2270be8081820da40029b04828",
+    "zh:e1b21b7b7022e0d468d72f4534d226d57a7bfd8c96a4c7dc2c2fa0bb0b99298d",
+    "zh:f24b73645d8bc225f692bdf9c035411099ef57138569f45f3605ec79ac872e3b",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/archive" {
   version = "2.4.0"
   hashes = [

--- a/infrastructure/deploy/db.tf
+++ b/infrastructure/deploy/db.tf
@@ -1,0 +1,32 @@
+resource "random_string" "db_password" {
+  length  = "16"
+  special = "false"
+}
+
+provider "postgresql" {
+  host            = module.data_services.outputs.aurora.endpoint
+  port            = module.data_services.outputs.aurora.port
+  username        = module.data_services.outputs.aurora.admin_user
+  password        = module.data_services.outputs.aurora.admin_password
+  sslmode         = "require"
+  connect_timeout = 15
+  superuser       = false
+}
+
+resource "postgresql_role" "meadow" {
+  name        = "meadow"
+  password    = random_string.db_password.result
+  login       = true
+}
+
+resource "postgresql_database" "meadow" {
+  name        = "meadow"
+  owner       = postgresql_role.meadow.name
+  encoding    = "UTF8"
+  lc_collate  = "en_US.UTF-8"
+  template    = "template0"
+}
+
+resource "postgresql_extension" "uuid" {
+  name = "uuid-ossp"
+}

--- a/infrastructure/deploy/secrets.tf
+++ b/infrastructure/deploy/secrets.tf
@@ -13,11 +13,11 @@ locals {
     }
 
     db = {
-      host     = module.rds.db_instance_address
-      port     = module.rds.db_instance_port
-      user     = module.rds.db_instance_username
-      password = module.rds.db_instance_password
-      database = module.rds.db_instance_username
+      host     = module.data_services.outputs.aurora.endpoint
+      port     = module.data_services.outputs.aurora.port
+      user     = postgresql_role.meadow.name
+      password = postgresql_role.meadow.password
+      database = postgresql_database.meadow.name
     }
 
     dc = {


### PR DESCRIPTION
# Summary 
Switch from owned postgres RDS instance to infrastructure Aurora Serverless DB

This change only involves Terraform and some manual copying of data. Already applied on staging. 

Applying this change on a running system requires some manual steps to copy the data over safely. Set the `PGHOST`, `PGPORT`, `PGUSER`, and `PGPASSWORD` environment variables for each server to make the commands work.

1. Apply the Terraform in `infrastructure/data_services` changes to get Aurora up and running
2. Dump the data from `meadow-db`:
    ```shell
    pg_dump --format custom --file meadow_rds_staging.dump --verbose postgres
    ```
3. Manually create the role and DB in Aurora:
    ```sql
    CREATE ROLE meadow LOGIN PASSWORD '[terraform_password]';
    CREATE DATABASE meadow LC_COLLATE 'en_US.UTF-8' ENCODING 'UTF-8';
    ALTER DATABASE meadow OWNER TO meadow;
    ```
4. Import the data into the new DB:
    ```shell
    pg_restore --format=custom --jobs=4 --verbose meadow_rds_staging.dump
    ```
5. Check the data in Aurora to make sure it looks right.
6. Apply the Terraform in Meadow.

# Specific Changes in this PR
- remove provisioned RDS instance from Terraform
- use Aurora config from infrastructure to create Meadow role and DB on Aurora

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Generally test Meadow to make sure everything is working as expected, especially cascading reindexing after changes (e.g., updating a file set causes the work to get reindexed with the new fileset info).

After the changes are applied, developers will need to update any saved configurations (e.g., TablePlus) to point to the new location with the new credentials.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [x] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

