### PR TITLE
PDF file sets should not have a pyramid location

### DIFF
--- a/app/lib/meadow/data/file_sets.ex
+++ b/app/lib/meadow/data/file_sets.ex
@@ -291,21 +291,15 @@ defmodule Meadow.Data.FileSets do
   @doc """
   Get the pyramid path for a file set
   """
-  def pyramid_uri_for(%FileSet{role: %{id: "P"}}), do: nil
-  def pyramid_uri_for(%FileSet{role: %{id: "S"}}), do: nil
+  def pyramid_uri_for(%FileSet{role: %{id: "A"}, core_metadata: %{mime_type: "image/" <> _thing}} = file_set),
+    do: pyramid_uri_from_id(file_set.id)
 
-  def pyramid_uri_for(%FileSet{core_metadata: %{mime_type: "video/" <> _thing}}),
-    do: nil
+  def pyramid_uri_for(%FileSet{role: %{id: "X"}, core_metadata: %{mime_type: "image/" <> _thing}} = file_set),
+    do: pyramid_uri_from_id(file_set.id)
 
-  def pyramid_uri_for(%FileSet{core_metadata: %{mime_type: "audio/" <> _thing}}),
-    do: nil
+  def pyramid_uri_for(_), do: nil
 
-  def pyramid_uri_for(%FileSet{core_metadata: %{mime_type: "application/pdf"}}),
-    do: nil
-
-  def pyramid_uri_for(%FileSet{} = file_set), do: pyramid_uri_for(file_set.id)
-
-  def pyramid_uri_for(file_set_id) do
+  defp pyramid_uri_from_id(file_set_id) do
     dest_bucket = Config.pyramid_bucket()
 
     dest_key = Path.join(["/", Pairtree.pyramid_path(file_set_id)])

--- a/app/lib/meadow/data/file_sets.ex
+++ b/app/lib/meadow/data/file_sets.ex
@@ -300,6 +300,9 @@ defmodule Meadow.Data.FileSets do
   def pyramid_uri_for(%FileSet{core_metadata: %{mime_type: "audio/" <> _thing}}),
     do: nil
 
+  def pyramid_uri_for(%FileSet{core_metadata: %{mime_type: "application/pdf"}}),
+    do: nil
+
   def pyramid_uri_for(%FileSet{} = file_set), do: pyramid_uri_for(file_set.id)
 
   def pyramid_uri_for(file_set_id) do

--- a/app/test/meadow/data/file_sets_test.exs
+++ b/app/test/meadow/data/file_sets_test.exs
@@ -252,7 +252,17 @@ defmodule Meadow.Data.FileSetsTest do
       file_set_a = file_set_fixture(role: %{id: "A", scheme: "FILE_SET_ROLE"})
       file_set_s = file_set_fixture(role: %{id: "S", scheme: "FILE_SET_ROLE"})
       file_set_p = file_set_fixture(role: %{id: "P", scheme: "FILE_SET_ROLE"})
-      file_set_x = file_set_fixture(role: %{id: "X", scheme: "FILE_SET_ROLE"})
+      file_set_x_image = file_set_fixture(role: %{id: "X", scheme: "FILE_SET_ROLE"})
+
+      file_set_x_pdf =
+        file_set_fixture(
+          role: %{id: "X", scheme: "FILE_SET_ROLE"},
+          core_metadata: %{
+            mime_type: "application/pdf",
+            location: "s3://foo",
+            original_filename: "s3://bar"
+          }
+        )
 
       file_set_video =
         file_set_fixture(
@@ -282,8 +292,9 @@ defmodule Meadow.Data.FileSetsTest do
       assert is_nil(FileSets.pyramid_uri_for(file_set_p))
       assert is_nil(FileSets.pyramid_uri_for(file_set_video))
       assert is_nil(FileSets.pyramid_uri_for(file_set_audio))
+      assert is_nil(FileSets.pyramid_uri_for(file_set_x_pdf))
 
-      with uri <- file_set_x |> FileSets.pyramid_uri_for() |> URI.parse() do
+      with uri <- file_set_x_image |> FileSets.pyramid_uri_for() |> URI.parse() do
         assert uri.host == Config.pyramid_bucket()
       end
     end

--- a/app/test/meadow/data/preservation_check_writer_test.exs
+++ b/app/test/meadow/data/preservation_check_writer_test.exs
@@ -232,4 +232,37 @@ defmodule Meadow.Data.PreservationCheckWriterTest do
                PreservationCheckWriter.generate_report(@report_filename)
     end
   end
+
+  describe "generate_report/1 with pdf (X) files" do
+    setup do
+      video_work = work_fixture(%{work_type: %{id: "VIDEO", scheme: "work_type"}})
+
+      video_access_file_set =
+        file_set_fixture(%{
+          work_id: video_work.id,
+          accession_number: "101113",
+          role: %{id: "X", scheme: "FILE_SET_ROLE"},
+          core_metadata: %{
+            digests: %{
+              "sha256" => @sha256,
+              "sha1" => @sha1,
+              "md5" => @md5
+            },
+            location: "s3://#{@preservation_bucket}/#{Pairtree.preservation_path(@sha256)}",
+            mime_type: "application/pdf",
+            original_filename: "test.pdf"
+          }
+        })
+
+      {:ok, file_set: pdf_aux_file_set}
+    end
+
+    @describetag s3: [@preservation_fixture]
+    test "does not record an error if pdf aux file set pyramids are missing", %{
+      file_set: _file_set
+    } do
+      assert {:ok, "s3://#{@preservation_check_bucket}/pres_check.csv", 0} =
+               PreservationCheckWriter.generate_report(@report_filename)
+    end
+  end
 end


### PR DESCRIPTION
# Summary 

On the preservation report, Auxiliary files of type PDF were erroring because the pyramid was not found.

# Specific Changes in this PR

- Update `Meadow.Data.FileSets.pyramid_uri_for()` so that it does not return a pyramid location for a file set with `mime-type` of `application/pdf`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Check preservation report for a pdf Auxiliary file. 
- The `pyramid_location` column should be empty and the `pyramid_exists` column value should be `N/A`

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

