### PR TITLE
Fix FileSets.pyramid_uri_for/1 logic

### DIFF
--- a/app/lib/meadow/pipeline/actions/create_pyramid_tiff.ex
+++ b/app/lib/meadow/pipeline/actions/create_pyramid_tiff.ex
@@ -12,13 +12,13 @@ defmodule Meadow.Pipeline.Actions.CreatePyramidTiff do
   def actiondoc, do: "Create pyramid TIFF from source image"
 
   def already_complete?(file_set, _) do
-    FileSets.pyramid_uri_for(file_set.id)
+    FileSets.pyramid_uri_for(file_set)
     |> Meadow.Utils.Stream.exists?()
   end
 
   def process(file_set, attributes) do
     source = file_set.core_metadata.location
-    target = FileSets.pyramid_uri_for(file_set.id)
+    target = FileSets.pyramid_uri_for(file_set)
 
     case create_pyramid_tiff(source, target) do
       {:ok, dest} ->

--- a/app/lib/meadow/seed/export.ex
+++ b/app/lib/meadow/seed/export.ex
@@ -149,7 +149,7 @@ defmodule Meadow.Seed.Export do
     )
     |> Repo.all()
     |> Enum.map(fn fs ->
-      Map.put(fs, :pyramid_file, FileSets.pyramid_uri_for(fs.id))
+      Map.put(fs, :pyramid_file, FileSets.pyramid_uri_for(fs))
     end)
   end
 
@@ -165,7 +165,7 @@ defmodule Meadow.Seed.Export do
     )
     |> Repo.all()
     |> Enum.map(fn fs ->
-      Map.put(fs, :pyramid_file, FileSets.pyramid_uri_for(fs.id))
+      Map.put(fs, :pyramid_file, FileSets.pyramid_uri_for(fs))
     end)
   end
 


### PR DESCRIPTION
# Summary 

#4391 changed the way pyramid URIs are calculated, but didn't account for parts of the code that pass in the FileSet ID instead of the FileSet. This PR updates those calls to pass in the FileSet.

# Specific Changes in this PR
- Change how `Meadow.Pipeline.Actions.CreatePyramidTiff` calls `Meadow.Data.FileSets.pyramid_uri_for/1`
- Change how `Meadow.Seed.Export` calls `Meadow.Data.FileSets.pyramid_uri_for/1`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Run an ingest with some access file TIFFs

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

