### PR TITLE
Make all work preservation tab columns sortable.

### DIFF
--- a/app/assets/js/components/Icon/SortDown.jsx
+++ b/app/assets/js/components/Icon/SortDown.jsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { FaSortDown } from "react-icons/fa";
+
+export default function IconSortDown(props) {
+  return <FaSortDown {...props} />;
+}

--- a/app/assets/js/components/Icon/SortUp.jsx
+++ b/app/assets/js/components/Icon/SortUp.jsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { FaSortUp } from "react-icons/fa";
+
+export default function IconSortUp(props) {
+  return <FaSortUp {...props} />;
+}

--- a/app/assets/js/components/Icon/index.js
+++ b/app/assets/js/components/Icon/index.js
@@ -28,6 +28,8 @@ import IconProjects from "@js/components/Icon/Projects";
 import IconReplace from "@js/components/Icon/Replace";
 import IconSearch from "@js/components/Icon/Search";
 import IconSort from "@js/components/Icon/Sort";
+import IconSortDown from "@js/components/Icon/SortDown";
+import IconSortUp from "@js/components/Icon/SortUp";
 import IconTrashCan from "@js/components/Icon/TrashCan";
 import IconUpload from "@js/components/Icon/Upload";
 import IconVideo from "@js/components/Icon/Video";
@@ -65,6 +67,8 @@ export {
   IconReplace,
   IconSearch,
   IconSort,
+  IconSortDown,
+  IconSortUp,
   IconTrashCan,
   IconUpload,
   IconVideo,

--- a/app/assets/js/components/UI/OrderBy.jsx
+++ b/app/assets/js/components/UI/OrderBy.jsx
@@ -1,0 +1,54 @@
+import React from "react";
+
+import { IconSort, IconSortDown, IconSortUp } from "@js/components/Icon";
+
+const UIOrderBy = ({ columnName, label, orderedFileSets, onClickCallback }) => {
+  const { order, orderBy } = orderedFileSets;
+
+  const handleOrderClick = () => {
+    onClickCallback({
+      order: orderBy === columnName && order === "asc" ? "desc" : "asc",
+      orderBy: columnName,
+    });
+  };
+
+  const isActive = orderBy === columnName;
+
+  return (
+    <a
+      className="ml-2"
+      onClick={handleOrderClick}
+      role="link"
+      style={{
+        cursor: "pointer",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "flex-start",
+        gap: "0.5rem",
+        whiteSpace: "nowrap",
+        fontWeight: isActive ? "700" : "400",
+      }}
+    >
+      {label}
+      {isActive ? (
+        order === "asc" ? (
+          <IconSortDown data-sort="asc" />
+        ) : (
+          <IconSortUp data-sort="desc" />
+        )
+      ) : (
+        <span
+          style={{
+            color: "var(--colors-richBlack20)",
+            display: "inline-flex",
+            alignItems: "center",
+          }}
+        >
+          <IconSort data-sort="" />
+        </span>
+      )}
+    </a>
+  );
+};
+
+export default UIOrderBy;

--- a/app/assets/js/components/UI/OrderBy.test.jsx
+++ b/app/assets/js/components/UI/OrderBy.test.jsx
@@ -1,0 +1,93 @@
+import React from "react";
+import UIOrderBy from "./OrderBy";
+import { render, screen } from "@testing-library/react";
+
+describe("UIOrderBy", () => {
+  it("renders active order by link with asc", () => {
+    render(
+      <UIOrderBy
+        label="Date"
+        columnName="date"
+        orderedFileSets={{
+          order: "asc",
+          orderBy: "date",
+          orderedFileSets: [],
+        }}
+      />,
+    );
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveTextContent("Date");
+    expect(link).toHaveStyle("font-weight: 700");
+
+    const icon = link.querySelector("svg");
+    expect(icon.dataset["sort"]).toBe("asc");
+  });
+
+  it("renders active order by link with desc", () => {
+    render(
+      <UIOrderBy
+        label="Date"
+        columnName="date"
+        orderedFileSets={{
+          order: "desc",
+          orderBy: "date",
+          orderedFileSets: [],
+        }}
+      />,
+    );
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveTextContent("Date");
+    expect(link).toHaveStyle("font-weight: 700");
+
+    const icon = link.querySelector("svg");
+    expect(icon.dataset["sort"]).toBe("desc");
+  });
+
+  it("renders an inactive order by link", () => {
+    render(
+      <UIOrderBy
+        label="Date"
+        columnName="date"
+        orderedFileSets={{
+          order: "asc",
+          orderBy: "location",
+          orderedFileSets: [],
+        }}
+      />,
+    );
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveTextContent("Date");
+    expect(link).toHaveStyle("font-weight: 400");
+
+    const icon = link.querySelector("svg");
+    expect(icon.dataset["sort"]).toBe("");
+  });
+
+  it("handles the onClickCallback correctly", () => {
+    const onClickCallback = jest.fn();
+
+    render(
+      <UIOrderBy
+        label="Date"
+        columnName="date"
+        orderedFileSets={{
+          order: "asc",
+          orderBy: "date",
+          orderedFileSets: [],
+        }}
+        onClickCallback={onClickCallback}
+      />,
+    );
+
+    screen.getByRole("link").click();
+
+    expect(onClickCallback).toHaveBeenCalledTimes(1);
+    expect(onClickCallback).toHaveBeenCalledWith({
+      order: "desc",
+      orderBy: "date",
+    });
+  });
+});

--- a/app/assets/js/components/Work/Tabs/Preservation/Preservation.test.js
+++ b/app/assets/js/components/Work/Tabs/Preservation/Preservation.test.js
@@ -25,7 +25,7 @@ describe("WorkTabsPreservation component", () => {
       </CodeListProvider>,
       {
         mocks: [verifyFileSetsMock, ...allCodeListMocks],
-      }
+      },
     );
   });
 
@@ -34,13 +34,31 @@ describe("WorkTabsPreservation component", () => {
     expect(screen.getByText("Preservation and Access"));
   });
 
+  it("renders the table in the default order and orderBy", async () => {
+    const table = await screen.findByTestId("preservation-table");
+    expect(table).toBeInTheDocument();
+    expect(table.dataset["order"]).toBe("asc");
+    expect(table.dataset["orderBy"]).toBe("created");
+  });
+
   it("renders preservation column headers", async () => {
-    const cols = ["Role", "Filename", "Created", "Verified"];
+    const cols = [
+      "ID",
+      "Role",
+      "Filename",
+      "Accession #",
+      "Created",
+      "Verified",
+    ];
     const th = await screen.findByText("Filename");
     const row = th.closest("tr");
     const utils = within(row);
-    for (let col of cols) {
-      expect(await utils.findByText(col));
+    const links = await utils.findAllByRole("link");
+
+    expect(links).toHaveLength(6);
+
+    for (let link of links) {
+      expect(cols.includes(link.textContent)).toBe(true);
     }
   });
 

--- a/app/assets/js/services/helpers.test.js
+++ b/app/assets/js/services/helpers.test.js
@@ -78,12 +78,13 @@ describe("Sort file sets", () => {
   const originalFileSets = [
     {
       id: "2357ea03-9dd5-49f2-a88c-dfc9aa88be3c",
-      role: { id: "A", scheme: "FILE_SET_ROLE" },
+      role: { label: "A", scheme: "FILE_SET_ROLE" },
       accessionNumber: "inu-fava-5145080_FILE_0",
+      insertedAt: "2022-06-23T18:05:47.239216Z",
       coreMetadata: {
         __typename: "FileSetCoreMetadata",
         description: "inu-fava-5145080-6.tif",
-        originalFilename: "BBBBBBB.jpg",
+        originalFilename: "A.jpg",
         label: "inu-fava-5145080-6.jpg",
         location:
           "s3://dev-preservation/23/57/ea/03/83397074acde5c737ede5ea7b09b267940d1ddba93eaef2456ae85c928e7abe2",
@@ -95,12 +96,13 @@ describe("Sort file sets", () => {
     },
     {
       id: "26357d25-b5e0-4e27-b683-c6844a13dc6b",
-      role: { id: "A", scheme: "FILE_SET_ROLE" },
+      role: { label: "A", scheme: "FILE_SET_ROLE" },
       accessionNumber: "inu-fava-5145080_FILE_1",
+      insertedAt: "2025-08-17T18:05:47.239216Z",
       coreMetadata: {
         __typename: "FileSetCoreMetadata",
         description: "inu-fava-5145080-5.tif",
-        originalFilename: "CCCCCC.jpg",
+        originalFilename: "B.jpg",
         label: "inu-fava-5145080-5.jpg",
         location:
           "s3://dev-preservation/26/35/7d/25/033a20e54f4ef254749c0e554e0378ba96242be159c7ed6e8d57810297423f69",
@@ -112,12 +114,13 @@ describe("Sort file sets", () => {
     },
     {
       id: "0607a735-9f99-4d38-b75a-6c10027f0937",
-      role: { id: "A", scheme: "FILE_SET_ROLE" },
+      role: { label: "P", scheme: "FILE_SET_ROLE" },
       accessionNumber: "inu-fava-5145080_FILE_2",
+      insertedAt: "2023-01-10T18:05:47.239216Z",
       coreMetadata: {
         __typename: "FileSetCoreMetadata",
         description: "inu-fava-5145080-1.tif",
-        originalFilename: "AAAAA.jpg",
+        originalFilename: "C.jpg",
         label: "inu-fava-5145080-1.jpg",
         location:
           "s3://dev-preservation/06/07/a7/35/e3420d439e9770bdc804a19c559ca818120f67e81c303a92a33f774eab199056",
@@ -129,15 +132,159 @@ describe("Sort file sets", () => {
     },
   ];
 
-  it("should order file sets in ascending order", () => {
-    const sorted = sortFileSets({ fileSets: originalFileSets });
-    expect(sorted[0].coreMetadata.originalFilename).toEqual("AAAAA.jpg");
-    expect(sorted[2].coreMetadata.originalFilename).toEqual("CCCCCC.jpg");
+  // Filename
+
+  it("should order file sets in ascending order by filename", () => {
+    const sorted = sortFileSets({
+      order: "asc",
+      orderBy: "filename",
+      fileSets: originalFileSets,
+      verifiedFileSets: [],
+    });
+    expect(sorted[0].coreMetadata.originalFilename).toEqual("A.jpg");
+    expect(sorted[1].coreMetadata.originalFilename).toEqual("B.jpg");
+    expect(sorted[2].coreMetadata.originalFilename).toEqual("C.jpg");
   });
 
-  it("should order file sets in descending order", () => {
-    const sorted = sortFileSets({ order: "desc", fileSets: originalFileSets });
-    expect(sorted[2].coreMetadata.originalFilename).toEqual("AAAAA.jpg");
-    expect(sorted[0].coreMetadata.originalFilename).toEqual("CCCCCC.jpg");
+  it("should order file sets in descending order by filename", () => {
+    const sorted = sortFileSets({
+      order: "desc",
+      orderBy: "filename",
+      fileSets: originalFileSets,
+      verifiedFileSets: [],
+    });
+    expect(sorted[0].coreMetadata.originalFilename).toEqual("C.jpg");
+    expect(sorted[1].coreMetadata.originalFilename).toEqual("B.jpg");
+    expect(sorted[2].coreMetadata.originalFilename).toEqual("A.jpg");
+  });
+
+  // Created
+
+  it("should order file sets in ascending order by created", () => {
+    const sorted = sortFileSets({
+      order: "asc",
+      orderBy: "created",
+      fileSets: originalFileSets,
+      verifiedFileSets: [],
+    });
+    expect(sorted[0].insertedAt).toEqual("2022-06-23T18:05:47.239216Z");
+    expect(sorted[1].insertedAt).toEqual("2023-01-10T18:05:47.239216Z");
+    expect(sorted[2].insertedAt).toEqual("2025-08-17T18:05:47.239216Z");
+  });
+
+  it("should order file sets in descending order by created", () => {
+    const sorted = sortFileSets({
+      order: "desc",
+      orderBy: "created",
+      fileSets: originalFileSets,
+      verifiedFileSets: [],
+    });
+    expect(sorted[0].insertedAt).toEqual("2025-08-17T18:05:47.239216Z");
+    expect(sorted[1].insertedAt).toEqual("2023-01-10T18:05:47.239216Z");
+    expect(sorted[2].insertedAt).toEqual("2022-06-23T18:05:47.239216Z");
+  });
+
+  // Accession Number
+
+  it("should order file sets in ascending order by accessionNumber", () => {
+    const sorted = sortFileSets({
+      order: "asc",
+      orderBy: "accessionNumber",
+      fileSets: originalFileSets,
+      verifiedFileSets: [],
+    });
+    expect(sorted[0].accessionNumber).toEqual("inu-fava-5145080_FILE_0");
+    expect(sorted[1].accessionNumber).toEqual("inu-fava-5145080_FILE_1");
+    expect(sorted[2].accessionNumber).toEqual("inu-fava-5145080_FILE_2");
+  });
+
+  it("should order file sets in descending order by accessionNumber", () => {
+    const sorted = sortFileSets({
+      order: "desc",
+      orderBy: "accessionNumber",
+      fileSets: originalFileSets,
+      verifiedFileSets: [],
+    });
+    expect(sorted[0].accessionNumber).toEqual("inu-fava-5145080_FILE_2");
+    expect(sorted[1].accessionNumber).toEqual("inu-fava-5145080_FILE_1");
+    expect(sorted[2].accessionNumber).toEqual("inu-fava-5145080_FILE_0");
+  });
+
+  // Role
+
+  it("should order file sets in ascending order by role", () => {
+    const sorted = sortFileSets({
+      order: "asc",
+      orderBy: "role",
+      fileSets: originalFileSets,
+      verifiedFileSets: [],
+    });
+    expect(sorted[0].role.label).toEqual("A");
+    expect(sorted[1].role.label).toEqual("A");
+    expect(sorted[2].role.label).toEqual("P");
+  });
+
+  it("should order file sets in descending order by role", () => {
+    const sorted = sortFileSets({
+      order: "desc",
+      orderBy: "role",
+      fileSets: originalFileSets,
+      verifiedFileSets: [],
+    });
+    expect(sorted[0].role.label).toEqual("P");
+    expect(sorted[1].role.label).toEqual("A");
+    expect(sorted[2].role.label).toEqual("A");
+  });
+
+  // ID
+
+  it("should order file sets in ascending order by role", () => {
+    const sorted = sortFileSets({
+      order: "asc",
+      orderBy: "id",
+      fileSets: originalFileSets,
+      verifiedFileSets: [],
+    });
+    expect(sorted[0].id).toEqual("0607a735-9f99-4d38-b75a-6c10027f0937");
+    expect(sorted[1].id).toEqual("2357ea03-9dd5-49f2-a88c-dfc9aa88be3c");
+    expect(sorted[2].id).toEqual("26357d25-b5e0-4e27-b683-c6844a13dc6b");
+  });
+
+  it("should order file sets in descending order by role", () => {
+    const sorted = sortFileSets({
+      order: "desc",
+      orderBy: "id",
+      fileSets: originalFileSets,
+      verifiedFileSets: [],
+    });
+    expect(sorted[0].id).toEqual("26357d25-b5e0-4e27-b683-c6844a13dc6b");
+    expect(sorted[1].id).toEqual("2357ea03-9dd5-49f2-a88c-dfc9aa88be3c");
+    expect(sorted[2].id).toEqual("0607a735-9f99-4d38-b75a-6c10027f0937");
+  });
+
+  // Verified
+
+  it("should order file sets in ascending order by role", () => {
+    const sorted = sortFileSets({
+      order: "asc",
+      orderBy: "verified",
+      fileSets: originalFileSets,
+      verifiedFileSets: ["2357ea03-9dd5-49f2-a88c-dfc9aa88be3c"],
+    });
+    expect(sorted[0].id).toEqual("26357d25-b5e0-4e27-b683-c6844a13dc6b");
+    expect(sorted[1].id).toEqual("0607a735-9f99-4d38-b75a-6c10027f0937");
+    expect(sorted[2].id).toEqual("2357ea03-9dd5-49f2-a88c-dfc9aa88be3c");
+  });
+
+  it("should order file sets in descending order by role", () => {
+    const sorted = sortFileSets({
+      order: "desc",
+      orderBy: "verified",
+      fileSets: originalFileSets,
+      verifiedFileSets: ["2357ea03-9dd5-49f2-a88c-dfc9aa88be3c"],
+    });
+    expect(sorted[0].id).toEqual("2357ea03-9dd5-49f2-a88c-dfc9aa88be3c");
+    expect(sorted[1].id).toEqual("26357d25-b5e0-4e27-b683-c6844a13dc6b");
+    expect(sorted[2].id).toEqual("0607a735-9f99-4d38-b75a-6c10027f0937");
   });
 });

--- a/app/assets/js/services/helpers.ts
+++ b/app/assets/js/services/helpers.ts
@@ -122,30 +122,66 @@ export function setVisibilityClass(visibility = "") {
 
 interface SortFileSetsProps {
   order?: "asc" | "desc";
+  orderBy:
+    | "accessionNumber"
+    | "created"
+    | "filename"
+    | "id"
+    | "role"
+    | "verified";
   fileSets: FileSet[];
+  verifiedFileSets: string[];
 }
 
 export function sortFileSets({
   order = "asc",
+  orderBy = "created",
   fileSets = [],
-}: SortFileSetsProps) {
-  const orderedFileSets = [...fileSets].sort((a, b) => {
-    const aName = a.coreMetadata?.originalFilename || "";
-    const bName = b.coreMetadata?.originalFilename || "";
+  verifiedFileSets = [],
+}: SortFileSetsProps): FileSet[] {
+  if (!Array.isArray(fileSets) || fileSets.length === 0) {
+    return [];
+  }
 
-    if (aName === bName) return 0;
+  return [...fileSets].sort((a, b) => {
+    let valA: string | number = "";
+    let valB: string | number = "";
 
-    switch (order) {
-      case "asc":
-        return aName < bName ? -1 : 1;
-      case "desc":
-        return aName < bName ? 1 : -1;
-      default:
-        return 0;
+    switch (orderBy) {
+      case "id":
+        valA = a.id;
+        valB = b.id;
+        break;
+      case "filename":
+        valA = String(a?.coreMetadata?.originalFilename);
+        valB = String(b?.coreMetadata?.originalFilename);
+        break;
+      case "role":
+        valA = String(a.role.label);
+        valB = String(b.role.label);
+        break;
+      case "accessionNumber":
+        valA = a.accessionNumber;
+        valB = b.accessionNumber;
+        break;
+      case "created":
+        valA = new Date(a.insertedAt).getTime().toString();
+        valB = new Date(b.insertedAt).getTime().toString();
+        break;
+      case "verified":
+        valA = String(verifiedFileSets.includes(a.id));
+        valB = String(verifiedFileSets.includes(b.id));
+        break;
     }
-  });
 
-  return orderedFileSets;
+    if (typeof valA === "number" && typeof valB === "number") {
+      return order === "asc" ? valA - valB : valB - valA;
+    }
+
+    return order === "asc"
+      ? valA.localeCompare(valB as string)
+      : (valB as string).localeCompare(valA as string);
+  });
 }
 
 export function toastWrapper(


### PR DESCRIPTION
# Summary 

This makes all columns on a Preservation tab of a Work sortable.

- ID
- Accession #
- Role
- Filename
- Created
- Verified 

<img width="1396" alt="image" src="https://github.com/user-attachments/assets/0e777b49-50be-43a0-8278-ba3196f928c6" />

# Specific Changes in this PR
- Updates file sorting helper to accommodate eligible columns 
- Adds generic OrderBy component

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

The best way to test this is to go to a work with a variance of filesets having different created dates, roles, etc... When sorting, a newly activated column should default asc and then proceed to go desc on the second click. When not sorted, a neutral sort icon should appear.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

