### PR TITLE
Address local authorities field retention bug.

### DIFF
--- a/app/assets/js/components/Dashboards/LocalAuthorities/ModalAdd.jsx
+++ b/app/assets/js/components/Dashboards/LocalAuthorities/ModalAdd.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { Button } from "@nulib/design-system";
 import { useForm, FormProvider } from "react-hook-form";
@@ -11,6 +11,10 @@ function DashboardsLocalAuthoritiesModalAdd({
   handleClose,
 }) {
   const methods = useForm();
+
+  useEffect(() => {
+    if (isOpen) methods.reset();
+  }, [isOpen]);
 
   const onSubmit = (data) => {
     handleAddLocalAuthority(data);

--- a/app/assets/js/components/Dashboards/LocalAuthorities/ModalEdit.jsx
+++ b/app/assets/js/components/Dashboards/LocalAuthorities/ModalEdit.jsx
@@ -12,19 +12,14 @@ function DashboardsLocalAuthoritiesModalEdit({
   isOpen,
 }) {
   if (!currentAuthority) return null;
-  const [defaultValues, setDefaultValues] = React.useState({
-    hint: "",
-    label: "",
-  });
-  const methods = useForm();
-  const { isDirty } = methods.formState;
-
-  React.useEffect(() => {
-    setDefaultValues({
+  const methods = useForm({
+    defaultValues: {
       hint: currentAuthority.hint,
       label: currentAuthority.label,
-    });
-  }, [currentAuthority]);
+    },
+  });
+
+  const { isDirty } = methods.formState;
 
   const onSubmit = (data) => {
     handleUpdate(data);
@@ -59,7 +54,6 @@ function DashboardsLocalAuthoritiesModalEdit({
               required
             >
               <UIFormInput
-                defaultValue={defaultValues.label}
                 isReactHookForm
                 required
                 id="nul-authority-edit-label"
@@ -70,7 +64,6 @@ function DashboardsLocalAuthoritiesModalEdit({
             </UIFormField>
             <UIFormField label="Hint" forId="nul-authority-edit-hint">
               <UIFormInput
-                defaultValue={defaultValues.hint}
                 isReactHookForm
                 id="nul-authority-edit-hint"
                 name="hint"


### PR DESCRIPTION
# Summary 

This fixes React timing issue where the local authorities edit form doesn't retain current authority values. The fix sets the default values at a higher level in the `useForm()` hook.

# Specific Changes in this PR

- Updates defaultValues setting to the useForm() hook
- Resets form methods on model open

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Go to Local Authorities dashboard

 1. **Add** an authority with a label, NO hint
 2. _Submit_
 3. **Edit** the authortity, **add** a hint
 4. _Submit_
 5. **Edit** the authortity, **edit** the label
 6. _Submit_

Authority should update each time with expected values, retaining previous values where edits were not made.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

