### PR TITLE
Use a durable replication slot for WalEx

### DIFF
--- a/app/lib/meadow/config/runtime.ex
+++ b/app/lib/meadow/config/runtime.ex
@@ -88,7 +88,8 @@ defmodule Meadow.Config.Runtime do
       publication: "events",
       subscriptions: ["works", "file_sets", "collections", "ingest_sheets", "projects"],
       name: Meadow,
-      slot_name: "meadow_#{prefix()}" 
+      slot_name: "meadow_#{prefix()}",
+      durable_slot: true
 
     host = System.get_env("MEADOW_HOSTNAME", "localhost")
     port = environment_int("PORT", 4000)


### PR DESCRIPTION
# Summary 

Use a [durable replication slot](https://github.com/cpursley/walex?tab=readme-ov-file#durable-slot) for WalEx. This changes the following behaviors:

- If the replication slot is unavailable when Meadow starts, it will keep trying to connect in the background every second until it is available. This will not prevent Meadow from starting any other processes or change its other behavior in any way.
- If database changes happen while Meadow is offline or disconnected, PostgreSQL will save them in the write-ahead log and deliver them when Meadow reconnects. This provides some protection against missed messages

# Specific Changes in this PR
- Add `durable_slot` parameter to WalEx configuration

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Replace the Meadow task while executing `SELECT * FROM pg_replication_slots` in TablePlus or the RDS query editor to make sure Meadow reconnects.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

