### PR TITLE
Add limit options to local authorities table.

### DIFF
--- a/app/assets/js/components/Dashboards/LocalAuthorities/List.jsx
+++ b/app/assets/js/components/Dashboards/LocalAuthorities/List.jsx
@@ -5,13 +5,9 @@ import {
   UPDATE_NUL_AUTHORITY_RECORD,
 } from "@js/components/Dashboards/dashboards.gql";
 import { IconEdit, IconImages, IconTrashCan } from "@js/components/Icon";
-import { Link, useHistory } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import { ModalDelete, SearchBarRow } from "@js/components/UI/UI";
-import {
-  useLazyQuery,
-  useMutation,
-  useQuery,
-} from "@apollo/client";
+import { useLazyQuery, useMutation, useQuery } from "@apollo/client";
 
 import { AUTHORITIES_SEARCH } from "@js/components/Work/controlledVocabulary.gql";
 import DashboardsLocalAuthoritiesModalEdit from "@js/components/Dashboards/LocalAuthorities/ModalEdit";
@@ -34,12 +30,15 @@ export default function DashboardsLocalAuthoritiesList() {
     },
   });
   const [searchValue, setSearchValue] = React.useState("");
+  const [limit, setLimit] = React.useState(100);
 
   // GraphQL
   const { loading, error, data } = useQuery(GET_NUL_AUTHORITY_RECORDS, {
-    variables: { limit: 100 },
-    pollInterval: 1000,
+    variables: { limit },
+    pollInterval: 10000,
   });
+
+  const limitOptions = [25, 50, 100, 500];
 
   function filterValues() {
     if (!data) return;
@@ -64,7 +63,7 @@ export default function DashboardsLocalAuthoritiesList() {
         fields: {
           nulAuthorityRecords(existingNulAuthorityRefs = [], { readField }) {
             const newData = existingNulAuthorityRefs.filter(
-              (ref) => deleteNulAuthorityRecord.id !== readField("id", ref)
+              (ref) => deleteNulAuthorityRecord.id !== readField("id", ref),
             );
             return [...newData];
           },
@@ -74,10 +73,7 @@ export default function DashboardsLocalAuthoritiesList() {
     onError({ graphQLErrors, networkError }) {
       console.error("graphQLErrors", graphQLErrors);
       console.error("networkError", networkError);
-      toastWrapper(
-        "is-danger",
-        `Error deleting authority record.`
-      );
+      toastWrapper("is-danger", `Error deleting authority record.`);
     },
   });
 
@@ -88,7 +84,7 @@ export default function DashboardsLocalAuthoritiesList() {
     onCompleted({ updateNulAuthorityRecord }) {
       toastWrapper(
         "is-success",
-        `NUL Authority: ${updateNulAuthorityRecord.label} updated`
+        `NUL Authority: ${updateNulAuthorityRecord.label} updated`,
       );
       setCurrentAuthority(null);
       filterValues();
@@ -110,10 +106,7 @@ export default function DashboardsLocalAuthoritiesList() {
     onError({ graphQLErrors, networkError }) {
       console.error("graphQLErrors", graphQLErrors);
       console.error("networkError", networkError);
-      toastWrapper(
-        "is-danger",
-        `Error searching NUL local authorities.`
-      );
+      toastWrapper("is-danger", `Error searching NUL local authorities.`);
     },
   });
 
@@ -183,6 +176,28 @@ export default function DashboardsLocalAuthoritiesList() {
           value={searchValue}
         />
       </SearchBarRow>
+
+      <div
+        className="is-flex is-justify-content-flex-end is-align-items-center mb-5"
+        data-testid="local-authorities-dashboard-table-options"
+      >
+        <label className="is-flex is-align-items-center columns is-3">
+          <span className="column">Item Count</span>
+          <div className="is-flex is-align-items-center column">
+            {limitOptions.map((option) => {
+              return (
+                <button
+                  key={option}
+                  className={`button ${limit === option ? "is-primary active" : "is-ghost"}`}
+                  onClick={() => setLimit(option)}
+                >
+                  {option}
+                </button>
+              );
+            })}
+          </div>
+        </label>
+      </div>
 
       <div className="table-container">
         <table

--- a/app/assets/js/components/Dashboards/LocalAuthorities/List.test.jsx
+++ b/app/assets/js/components/Dashboards/LocalAuthorities/List.test.jsx
@@ -5,6 +5,7 @@ import DashboardsLocalAuthoritiesList from "./List";
 import {
   deleteNulAuthorityRecordMock,
   getNulAuthorityRecordsMock,
+  getNulAuthorityRecordsSetLimitMock,
   updateNulAuthorityRecordMock,
 } from "@js/components/Dashboards/dashboards.gql.mock";
 import { authoritiesSearchMock } from "@js/components/Work/controlledVocabulary.gql.mock";
@@ -16,6 +17,7 @@ describe("DashboardsLocalAuthoritiesList component", () => {
       mocks: [
         deleteNulAuthorityRecordMock,
         getNulAuthorityRecordsMock,
+        getNulAuthorityRecordsSetLimitMock,
         updateNulAuthorityRecordMock,
       ],
     });
@@ -32,7 +34,7 @@ describe("DashboardsLocalAuthoritiesList component", () => {
 
   it("renders correct nul authority row details", async () => {
     const td = await screen.findByText(
-      "info:nul/675ed59a-ab54-481a-9bd1-d9b7fd2604dc"
+      "info:nul/675ed59a-ab54-481a-9bd1-d9b7fd2604dc",
     );
     const row = td.closest("tr");
     const utils = within(row);
@@ -40,9 +42,33 @@ describe("DashboardsLocalAuthoritiesList component", () => {
     expect(utils.getByText(/Ima Hint 1/i));
   });
 
+  it("renders correct nul authority query limit options", async () => {
+    const options = await screen.findByTestId(
+      "local-authorities-dashboard-table-options",
+    );
+
+    const buttons = within(options).getAllByRole("button");
+
+    // expect 4 buttons
+    expect(buttons).toHaveLength(4);
+
+    // expect button text content
+    expect(buttons[0]).toHaveTextContent("25");
+    expect(buttons[1]).toHaveTextContent("50");
+    expect(buttons[2]).toHaveTextContent("100");
+    expect(buttons[3]).toHaveTextContent("500");
+
+    // expect default active button
+    expect(buttons[2]).toHaveClass("active", "is-primary");
+
+    // expect button click and active class change
+    await userEvent.click(buttons[0]);
+    expect(await screen.findByText("25")).toHaveClass("active", "is-primary");
+  });
+
   it("renders an edit, search, and delete buttons", async () => {
     const td = await screen.findByText(
-      "info:nul/675ed59a-ab54-481a-9bd1-d9b7fd2604dc"
+      "info:nul/675ed59a-ab54-481a-9bd1-d9b7fd2604dc",
     );
     const row = td.closest("tr");
     const utils = within(row);

--- a/app/assets/js/components/Dashboards/dashboards.gql.mock.js
+++ b/app/assets/js/components/Dashboards/dashboards.gql.mock.js
@@ -28,8 +28,7 @@ export const mockGetBatchesResults = [
     worksUpdated: 2,
   },
   {
-    add:
-      '{"administrative_metadata":{},"descriptive_metadata":{"alternate_title":["Alt title here"],"box_name":["Beta box"],"box_number":["14"],"contributor":[{"role":{"id":"asg","scheme":"marc_relator"},"term":"http://id.worldcat.org/fast/1204155"}],"keywords":["some key word","keyword2"]}}',
+    add: '{"administrative_metadata":{},"descriptive_metadata":{"alternate_title":["Alt title here"],"box_name":["Beta box"],"box_number":["14"],"contributor":[{"role":{"id":"asg","scheme":"marc_relator"},"term":"http://id.worldcat.org/fast/1204155"}],"keywords":["some key word","keyword2"]}}',
     delete: '{"genre":[{"term":"http://vocab.getty.edu/aat/300266117"}]}',
     error: null,
     id: "7b9fa4c5-fa97-46e8-8fd7-db0001dc76c3",
@@ -224,7 +223,21 @@ export const getNulAuthorityRecordsMock = {
     query: GET_NUL_AUTHORITY_RECORDS,
     variables: {
       limit: 100,
-    }
+    },
+  },
+  result: {
+    data: {
+      nulAuthorityRecords: mockNulAuthorityRecords,
+    },
+  },
+};
+
+export const getNulAuthorityRecordsSetLimitMock = {
+  request: {
+    query: GET_NUL_AUTHORITY_RECORDS,
+    variables: {
+      limit: 25,
+    },
   },
   result: {
     data: {


### PR DESCRIPTION
# Summary 
This adds limit options to the update the query for local authorities results. The options are now `25`, `50`, `100`, and `500`, with `100` being the default. On click of these options, the query will be updated and display the results according to the new limit.

![image](https://github.com/user-attachments/assets/571e372c-50df-4619-b39e-2fe8ef4aea02)


# Specific Changes in this PR
- Adds `limit` value using useState()
- Uses `limit` in conjunection with Apollo Client useQuery() hook to retrieve 

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Go to local authorities dashboard. 
- As the smallest limits is 25, testing this might require bulk adding a bit more. This test here can help to verify that the limit is working as intended: 

https://github.com/nulib/meadow/blob/216a3a95986581350c55aaed96000717c01f143a/app/assets/js/components/Dashboards/LocalAuthorities/List.test.jsx#L45-L67

- Default should be 100, you could adjust to test here 

https://github.com/nulib/meadow/blob/216a3a95986581350c55aaed96000717c01f143a/app/assets/js/components/Dashboards/LocalAuthorities/List.jsx#L33

- Toggle should adjust limit accordingly

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

