### PR TITLE
Use a small, dedicated connection pool for indexing

### DIFF
--- a/app/lib/meadow/application.ex
+++ b/app/lib/meadow/application.ex
@@ -21,6 +21,7 @@ defmodule Meadow.Application do
 
     unless System.get_env("MEADOW_NO_REPO") do
       DynamicSupervisor.start_child(Meadow.Supervisor, Meadow.Repo)
+      DynamicSupervisor.start_child(Meadow.Supervisor, Meadow.Repo.Indexing)
       Meadow.Repo.wait_for_connection()
     end
 

--- a/app/lib/meadow/config/runtime.ex
+++ b/app/lib/meadow/config/runtime.ex
@@ -59,6 +59,16 @@ defmodule Meadow.Config.Runtime do
 
     Logger.info("Configuring Meadow.Repo")
 
+    config :meadow, Meadow.Repo.Indexing,
+      username: get_secret(:meadow, ["db", "user"]),
+      password: get_secret(:meadow, ["db", "password"]),
+      database: get_secret(:meadow, ["db", "database"], prefix("meadow")),
+      hostname: get_secret(:meadow, ["db", "host"]),
+      port: get_secret(:meadow, ["db", "port"]),
+      pool_size: 5,
+      queue_target: environment_int("DB_QUEUE_TARGET", 50),
+      queue_interval: environment_int("DB_QUEUE_INTERVAL", 1000)
+
     config :meadow, Meadow.Repo,
       username: get_secret(:meadow, ["db", "user"]),
       password: get_secret(:meadow, ["db", "password"]),
@@ -73,7 +83,7 @@ defmodule Meadow.Config.Runtime do
       ],
       migration_timestamps: [type: :utc_datetime_usec],
       port: get_secret(:meadow, ["db", "port"]),
-      pool_size: environment_int("DB_POOL_SIZE", 10),
+      pool_size: environment_int("DB_POOL_SIZE", 10) - 5,
       queue_target: environment_int("DB_QUEUE_TARGET", 50),
       queue_interval: environment_int("DB_QUEUE_INTERVAL", 1000)
 

--- a/app/lib/meadow/events/indexing.ex
+++ b/app/lib/meadow/events/indexing.ex
@@ -8,7 +8,7 @@ defmodule Meadow.Events.Indexing do
   alias Meadow.Data.IndexBatcher
   alias Meadow.Data.Schemas.{Collection, FileSet, Work}
   alias Meadow.Ingest.Schemas.Sheet
-  alias Meadow.Repo
+  alias Meadow.Repo.Indexing, as: IndexingRepo
   alias Meadow.Search.Bulk
   alias Meadow.Search.Config, as: SearchConfig
 
@@ -138,7 +138,7 @@ defmodule Meadow.Events.Indexing do
   defp send_to_batcher(queryable, schema) do
     queryable
     |> select([q], q.id)
-    |> Repo.all()
+    |> IndexingRepo.all()
     |> IndexBatcher.reindex(schema)
   end
 end

--- a/app/lib/meadow/repo/indexing.ex
+++ b/app/lib/meadow/repo/indexing.ex
@@ -1,0 +1,11 @@
+defmodule Meadow.Repo.Indexing do
+  @moduledoc """
+  Dedicated Repo for indexing operations
+  """
+
+  use Ecto.Repo,
+    otp_app: :meadow,
+    adapter: Ecto.Adapters.Postgres
+
+  def init(_, opts), do: {:ok, opts}
+end


### PR DESCRIPTION
# Summary 

# Specific Changes in this PR
- Add dedicated Ecto repo (`Meadow.Repo.Indexing`) with its own small connection pool for asynchronous indexing operations
- Remove duplication check before deleting preservation file, because preservation files are stored by ID – we haven't stored FileSets by hash for years
- Use synchronous `GenServer.call/2` instead of asynchronous `Kernel.send/2` to control the index batcher so that it handles its messages in a more orderly fashion

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Run an ingest. Run a batch update. Run a CSV metadata update. Change large amounts of data and watch the log.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

