### PR TITLE
Add retry to indexing event

### DIFF
--- a/app/lib/meadow/config/runtime.ex
+++ b/app/lib/meadow/config/runtime.ex
@@ -67,7 +67,8 @@ defmodule Meadow.Config.Runtime do
       port: get_secret(:meadow, ["db", "port"]),
       pool_size: 5,
       queue_target: environment_int("DB_QUEUE_TARGET", 50),
-      queue_interval: environment_int("DB_QUEUE_INTERVAL", 1000)
+      queue_interval: environment_int("DB_QUEUE_INTERVAL", 1000),
+      parameters: [application_name: "Meadow.Repo.Indexing"]
 
     config :meadow, Meadow.Repo,
       username: get_secret(:meadow, ["db", "user"]),
@@ -85,7 +86,8 @@ defmodule Meadow.Config.Runtime do
       port: get_secret(:meadow, ["db", "port"]),
       pool_size: environment_int("DB_POOL_SIZE", 10) - 5,
       queue_target: environment_int("DB_QUEUE_TARGET", 50),
-      queue_interval: environment_int("DB_QUEUE_INTERVAL", 1000)
+      queue_interval: environment_int("DB_QUEUE_INTERVAL", 1000),
+      parameters: [application_name: "Meadow.Repo"]
 
     Logger.info("Configuring WalEx")
 


### PR DESCRIPTION
# Summary 
Add `Retry` code to indexing event

# Specific Changes in this PR
- Wrap the `send_to_batcher` function in a retry in case it can't get a DB connection
- Remove pointless database queries from `Meadow.Events.Indexing`
- Use `IndexBatcher` for deletes as well as updates

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

