### PR TITLE
Update display fonts.

### DIFF
--- a/app/assets/js/components/Home/StatsRow.tsx
+++ b/app/assets/js/components/Home/StatsRow.tsx
@@ -10,7 +10,7 @@ function LevelItem({ heading, title }: Stat) {
     <div className="has-text-centered py-3">
       <div>
         <p className="heading is-size-6">{heading}</p>
-        <p className="title is-size-2 is-campton-bold">{title}</p>
+        <p className="title is-size-2 is-display-bold">{title}</p>
       </div>
     </div>
   );

--- a/app/assets/js/components/UI/Layout/NavBar.jsx
+++ b/app/assets/js/components/UI/Layout/NavBar.jsx
@@ -161,9 +161,7 @@ const UILayoutNavBar = () => {
                       <AuthDisplayAuthorized level="SUPERUSER">
                         <UILayoutNavDropdownItem>
                           <UILivebookLink>
-                            <IconText icon={<GrMultiple />}>
-                              Livebook
-                            </IconText>
+                            <IconText icon={<GrMultiple />}>Livebook</IconText>
                           </UILivebookLink>
                         </UILayoutNavDropdownItem>
                       </AuthDisplayAuthorized>

--- a/app/assets/styles/scss/_base.scss
+++ b/app/assets/styles/scss/_base.scss
@@ -25,7 +25,7 @@ h1,
 }
 h3,
 .content h3 {
-  font-family: $CamptonBold;
+  font-family: $PoppinsBold;
   font-weight: 400;
 }
 
@@ -100,8 +100,8 @@ table {
   justify-content: flex-end;
 }
 
-.is-campton-bold {
-  font-family: $CamptonBold;
+.is-display-bold {
+  font-family: $PoppinsBold;
 }
 
 .is-bold {

--- a/app/assets/styles/scss/_fonts.scss
+++ b/app/assets/styles/scss/_fonts.scss
@@ -42,29 +42,29 @@
 }
 
 @font-face {
-  font-family: "Campton Book";
-  src: url("#{$path-fonts}/CamptonBook.woff") format("woff");
-  font-weight: normal;
+  font-family: "Poppins Light";
+  src: url("#{$path-fonts}/Poppins-Light.woff") format("woff");
+  font-weight: 300;
   font-style: normal;
 }
 
 @font-face {
-  font-family: "Campton Bold";
-  src: url("#{$path-fonts}/CamptonBold.woff") format("woff");
-  font-weight: normal;
+  font-family: "Poppins Bold";
+  src: url("#{$path-fonts}/Poppins-Bold.woff") format("woff");
+  font-weight: 700;
   font-style: normal;
 }
 
 @font-face {
-  font-family: "Campton Extra Bold";
-  src: url("#{$path-fonts}/CamptonExtraBold.woff") format("woff");
-  font-weight: normal;
+  font-family: "Poppins Extra Bold";
+  src: url("#{$path-fonts}/Poppins-ExtraBold.woff") format("woff");
+  font-weight: 800;
   font-style: normal;
 }
 
 @font-face {
-  font-family: "Campton Extra Light";
-  src: url("#{$path-fonts}/CamptonExtraLight.woff") format("woff");
-  font-weight: normal;
+  font-family: "Poppins Extra Light";
+  src: url("#{$path-fonts}/Poppins-ExtraLight.woff") format("woff");
+  font-weight: 100;
   font-style: normal;
 }

--- a/app/assets/styles/scss/_variables.scss
+++ b/app/assets/styles/scss/_variables.scss
@@ -46,10 +46,10 @@ $AkkuratProRegular: "Akkurat Pro Regular", Arial, sans-serif;
 $AkkuratProItalic: "Akkurat Pro Italic", Arial, sans-serif;
 $AkkuratProBold: "Akkurat Pro Bold", "Arial Black", sans-serif;
 $AkkuratProBoldItalic: "Akkurat Pro Bold Italic", "Arial Black", sans-serif;
-$CamptonBook: "Campton Book", Tahoma, sans-serif;
-$CamptonBold: "Campton Bold", Impact, sans-serif;
-$CamptonExtraBold: "Campton Extra Bold", Impact, sans-serif;
-$CamptonExtraLight: "Campton Extra Light", "Courier New", sans-serif;
+$PoppinsLight: "Poppins Light", $AkkuratProRegular, sans-serif;
+$PoppinsBold: "Poppins Bold", $AkkuratProBold, sans-serif;
+$PoppinsExtraBold: "Poppins Extra Bold", $AkkuratProBold, sans-serif;
+$PoppinsExtraLight: "Poppins Extra Light", $AkkuratLight, sans-serif;
 
 // Customize Bulma with these variables
 // Colors
@@ -64,9 +64,9 @@ $dark: $rich-black-80;
 // General
 $breadcrumb-item-separator-color: $rich-black-50;
 $family-primary: $AkkuratProRegular;
-$family-secondary: $CamptonBook;
+$family-secondary: $PoppinsLight;
 $navbar-height: 4rem;
 
-$title-family: $CamptonExtraLight;
+$title-family: $PoppinsExtraLight;
 $title-weight: 400;
 $grey: $rich-black-50;


### PR DESCRIPTION
# Summary 
This updates the display font that was Campton to the web-supported Poppins.

# Specific Changes in this PR
- Font face declarations for Campton removed, Poppins added
- Font variables switched from Campton to Poppins
- Meadow title in navbar has been made bolder due legibility differences of fonts

For speed, you can review here:
https://mat.dev.rdc.library.northwestern.edu:3001/

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Fonts should render as expected. Campton no longer exists.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

