### PR TITLE
Add group_with field to file sets

### DIFF
--- a/app/lib/meadow/data/schemas/file_set.ex
+++ b/app/lib/meadow/data/schemas/file_set.ex
@@ -104,7 +104,13 @@ defmodule Meadow.Data.Schemas.FileSet do
     if is_nil(group_with_id) do
       changeset
     else
-      validate_group_with_target(changeset, group_with_id)
+      role = get_field(changeset, :role)
+
+      if role && role.id == "A" do
+        validate_group_with_target(changeset, group_with_id)
+      else
+        add_error(changeset, :group_with, "Only file sets with role 'Access (A)' can be grouped")
+      end
     end
   end
 
@@ -112,8 +118,11 @@ defmodule Meadow.Data.Schemas.FileSet do
     work_id = get_field(changeset, :work_id)
 
     case Meadow.Repo.get(__MODULE__, group_with_id) do
-      %__MODULE__{group_with: nil, work_id: ^work_id} ->
+      %__MODULE__{group_with: nil, work_id: ^work_id, role: %{id: "A"}} ->
         changeset
+
+      %__MODULE__{group_with: nil, work_id: ^work_id} ->
+        add_error(changeset, :group_with, "Target file set must have role 'Access (A)'")
 
       %__MODULE__{group_with: nil} ->
         add_error(changeset, :group_with, "Target file set belongs to a different work")

--- a/app/lib/meadow/data/schemas/file_set.ex
+++ b/app/lib/meadow/data/schemas/file_set.ex
@@ -37,11 +37,16 @@ defmodule Meadow.Data.Schemas.FileSet do
       foreign_key: :object_id,
       on_delete: :delete_all
     )
+
+    belongs_to(:group_with_file_set, __MODULE__,
+      foreign_key: :group_with,
+      type: Ecto.UUID
+    )
   end
 
   defp changeset_params do
     {[:accession_number, :role],
-     [:work_id, :position, :extracted_metadata, :derivatives, :poster_offset]}
+     [:work_id, :position, :extracted_metadata, :derivatives, :poster_offset, :group_with]}
   end
 
   def changeset(file_set \\ %__MODULE__{}, params) do
@@ -55,9 +60,12 @@ defmodule Meadow.Data.Schemas.FileSet do
       |> validate_required([:core_metadata | required_params])
       |> validate_number(:poster_offset, greater_than_or_equal_to: 0)
       |> assoc_constraint(:work)
+      |> assoc_constraint(:group_with_file_set)
       |> unsafe_validate_unique([:accession_number], Meadow.Repo)
       |> unique_constraint(:accession_number)
       |> set_rank(scope: [:work_id, :role])
+      |> validate_group_with()
+      |> foreign_key_constraint(:group_with)
     end
   end
 
@@ -71,6 +79,8 @@ defmodule Meadow.Data.Schemas.FileSet do
       |> cast_embed(:structural_metadata)
       |> set_rank(scope: [:work_id, :role])
       |> validate_number(:poster_offset, greater_than_or_equal_to: 0)
+      |> validate_group_with()
+      |> foreign_key_constraint(:group_with)
     end
   end
 
@@ -87,4 +97,32 @@ defmodule Meadow.Data.Schemas.FileSet do
   end
 
   defp rename_core_metadata(params), do: params
+
+  defp validate_group_with(changeset) do
+    group_with_id = get_field(changeset, :group_with)
+
+    if is_nil(group_with_id) do
+      changeset
+    else
+      validate_group_with_target(changeset, group_with_id)
+    end
+  end
+
+  defp validate_group_with_target(changeset, group_with_id) do
+    work_id = get_field(changeset, :work_id)
+
+    case Meadow.Repo.get(__MODULE__, group_with_id) do
+      %__MODULE__{group_with: nil, work_id: ^work_id} ->
+        changeset
+
+      %__MODULE__{group_with: nil} ->
+        add_error(changeset, :group_with, "Target file set belongs to a different work")
+
+      %__MODULE__{} ->
+        add_error(changeset, :group_with, "Target file set already has a group_with value")
+
+      nil ->
+        add_error(changeset, :group_with, "Target file set not found")
+    end
+  end
 end

--- a/app/lib/meadow/events/indexing.ex
+++ b/app/lib/meadow/events/indexing.ex
@@ -14,7 +14,7 @@ defmodule Meadow.Events.Indexing do
 
   @cascade_fields %{
     file_sets_works:
-      ~w[core_metadata derivatives extracted_metadata poster_offset rank role structural_metadata]a,
+      ~w[core_metadata derivatives extracted_metadata group_with poster_offset rank role structural_metadata]a,
     collections_works: ~w[title description]a,
     ingest_sheets_works: ~w[title]a,
     works_collections: ~w[representative_file_set_id]a,

--- a/app/lib/meadow/indexing/v2/file_set.ex
+++ b/app/lib/meadow/indexing/v2/file_set.ex
@@ -16,6 +16,7 @@ defmodule Meadow.Indexing.V2.FileSet do
       description: file_set.core_metadata.description,
       download_url: FileSets.download_uri_for(file_set),
       extracted_metadata: extracted_metadata(file_set.extracted_metadata),
+      group_with: file_set.group_with,
       id: file_set.id,
       indexed_at: NaiveDateTime.utc_now(),
       label: file_set.core_metadata.label,

--- a/app/lib/meadow/indexing/v2/work.ex
+++ b/app/lib/meadow/indexing/v2/work.ex
@@ -190,6 +190,7 @@ defmodule Meadow.Indexing.V2.Work do
           accession_number: file_set.accession_number,
           duration: FileSets.duration_in_seconds(file_set),
           download_url: FileSets.download_uri_for(file_set),
+          group_with: file_set.group_with,
           height: FileSets.height(file_set),
           label: file_set.core_metadata.label,
           mime_type: file_set.core_metadata.mime_type,

--- a/app/lib/meadow_web/schema/types/data/file_set_types.ex
+++ b/app/lib/meadow_web/schema/types/data/file_set_types.ex
@@ -40,6 +40,7 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
       arg(:poster_offset, :integer)
       arg(:core_metadata, :file_set_core_metadata_update)
       arg(:structural_metadata, :file_set_structural_metadata_input)
+      arg(:group_with, :id)
       middleware(Middleware.Authenticate)
       middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Data.update_file_set/3)
@@ -123,6 +124,7 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
     field(:work, :work, resolve: dataloader(Data))
     field(:core_metadata, :file_set_core_metadata)
     field(:poster_offset, :integer)
+    field(:group_with, :id)
 
     field :streaming_url, :string do
       resolve(fn file_set, _, _ ->

--- a/app/priv/repo/migrations/20250312165222_add_group_with_to_file_sets.exs
+++ b/app/priv/repo/migrations/20250312165222_add_group_with_to_file_sets.exs
@@ -1,0 +1,11 @@
+defmodule Meadow.Repo.Migrations.AddGroupWithToFileSets do
+  use Ecto.Migration
+
+  def change do
+    alter table(:file_sets) do
+      add :group_with, references(:file_sets, type: :uuid, on_delete: :nilify_all)
+    end
+
+    create index(:file_sets, [:group_with])
+  end
+end

--- a/app/test/gql/FileSetFields.frag.gql
+++ b/app/test/gql/FileSetFields.frag.gql
@@ -25,4 +25,5 @@ fragment FileSetFields on FileSet {
     originalFilename
   }
   extractedMetadata
+  groupWith
 }

--- a/app/test/meadow/data/file_sets_test.exs
+++ b/app/test/meadow/data/file_sets_test.exs
@@ -447,8 +447,8 @@ defmodule Meadow.Data.FileSetsTest do
 
   describe "group_with functionality" do
     test "update_file_set/2 with valid group_with value" do
-      file_set1 = file_set_fixture()
-      file_set2 = file_set_fixture(%{work_id: file_set1.work_id})
+      file_set1 = file_set_fixture(%{role: %{id: "A", scheme: "FILE_SET_ROLE"}})
+      file_set2 = file_set_fixture(%{work_id: file_set1.work_id, role: %{id: "A", scheme: "FILE_SET_ROLE"}})
 
       assert {:ok, %FileSet{} = updated_file_set} =
                FileSets.update_file_set(file_set1, %{group_with: file_set2.id})
@@ -456,8 +456,24 @@ defmodule Meadow.Data.FileSetsTest do
       assert updated_file_set.group_with == file_set2.id
     end
 
+    test "update_file_set/2 rejects group_with when source file set doesn't have role 'A'" do
+      file_set1 = file_set_fixture(%{role: %{id: "P", scheme: "FILE_SET_ROLE"}})
+      file_set2 = file_set_fixture(%{work_id: file_set1.work_id, role: %{id: "A", scheme: "FILE_SET_ROLE"}})
+
+      assert {:error, changeset} = FileSets.update_file_set(file_set1, %{group_with: file_set2.id})
+      assert %{group_with: ["Only file sets with role 'Access (A)' can be grouped"]} = errors_on(changeset)
+    end
+
+    test "update_file_set/2 rejects group_with when target file set doesn't have role 'A'" do
+      file_set1 = file_set_fixture(%{role: %{id: "A", scheme: "FILE_SET_ROLE"}})
+      file_set2 = file_set_fixture(%{work_id: file_set1.work_id, role: %{id: "P", scheme: "FILE_SET_ROLE"}})
+
+      assert {:error, changeset} = FileSets.update_file_set(file_set1, %{group_with: file_set2.id})
+      assert %{group_with: ["Target file set must have role 'Access (A)'"]} = errors_on(changeset)
+    end
+
     test "update_file_set/2 rejects group_with when target file set doesn't exist" do
-      file_set = file_set_fixture()
+      file_set = file_set_fixture(%{role: %{id: "A", scheme: "FILE_SET_ROLE"}})
       non_existent_id = Ecto.UUID.generate()
 
       assert {:error, changeset} = FileSets.update_file_set(file_set, %{group_with: non_existent_id})
@@ -465,18 +481,18 @@ defmodule Meadow.Data.FileSetsTest do
     end
 
     test "update_file_set/2 rejects group_with when target file set belongs to different work" do
-      file_set1 = file_set_fixture()
+      file_set1 = file_set_fixture(%{role: %{id: "A", scheme: "FILE_SET_ROLE"}})
       work = work_fixture()
-      file_set2 = file_set_fixture(%{work_id: work.id})
+      file_set2 = file_set_fixture(%{work_id: work.id, role: %{id: "A", scheme: "FILE_SET_ROLE"}})
 
       assert {:error, changeset} = FileSets.update_file_set(file_set1, %{group_with: file_set2.id})
       assert %{group_with: ["Target file set belongs to a different work"]} = errors_on(changeset)
     end
 
     test "update_file_set/2 rejects group_with when target file set already has a group_with value" do
-      file_set1 = file_set_fixture()
-      file_set2 = file_set_fixture(%{work_id: file_set1.work_id})
-      file_set3 = file_set_fixture(%{work_id: file_set1.work_id})
+      file_set1 = file_set_fixture(%{role: %{id: "A", scheme: "FILE_SET_ROLE"}})
+      file_set2 = file_set_fixture(%{work_id: file_set1.work_id, role: %{id: "A", scheme: "FILE_SET_ROLE"}})
+      file_set3 = file_set_fixture(%{work_id: file_set1.work_id, role: %{id: "A", scheme: "FILE_SET_ROLE"}})
 
       # First set file_set2 to group with file_set3
       assert {:ok, %FileSet{}} = FileSets.update_file_set(file_set2, %{group_with: file_set3.id})
@@ -487,10 +503,11 @@ defmodule Meadow.Data.FileSetsTest do
     end
 
     test "create_file_set/1 with valid group_with value" do
-      existing_file_set = file_set_fixture()
+      existing_file_set = file_set_fixture(%{role: %{id: "A", scheme: "FILE_SET_ROLE"}})
 
       attrs = Map.merge(@valid_attrs, %{
         work_id: existing_file_set.work_id,
+        role: %{id: "A", scheme: "FILE_SET_ROLE"},
         group_with: existing_file_set.id
       })
 


### PR DESCRIPTION
# Summary 

Allow file sets to be "grouped" with another file set in order to be displayed as an alternate view or choice.

# Specific Changes in this PR

- Adds `group_with` field to `file_sets` table
  - Only allow a file set to be associated with another file set in the same work
  - Only allow a file set to be associated with a file set that does not already have it's own `group_with` field set
- Adds `group_with` field to the `dc-v2-file-set` and `dc-v2-work` indexes
- Updates `updateFileSet` GraphQL mutation to accept `group_with`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test

- cd `app`
- Run `mix exto.migrate`
- Run a reindex `Meadow.Data.Indexer.reindex_all()`
- Startup Meadow `mix phx.server`
- Navigate to GraphiQL: `api/graphiql`
- Try to add a `group_with` relationship to a file set:
Example ( to unset group with send `groupWith: null`):
```
mutation {
  updateFileSet(
	id: "411831c9-2838-485d-8cdb-684b8f062797", 
	groupWith: "072f8020-7e39-4539-b5d6-51010aef3ad9"){
    id, 
    groupWith
  }
}
```
- Test that you can only group with file sets in the same work
- Test that you can not group with a file set that already has it's own `group_with` set
- Test that if you delete the target file set that a file set is grouped with, the value of `group_with` on the source file set will be set to `null`
- Test that both the source and target files must be role "A"
- Test that `group_with` appears in both the `*-dev-dc-v2-file-set` and `*-dev-dc-v2-work` indexes

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [x] Database Schema changes
  - [x] GraphQL API
  - [x] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

