### PR TITLE
Add UI changes to accomodate fileset `Choice` using `group_with`

### DIFF
--- a/app/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
+++ b/app/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
@@ -50,7 +50,7 @@ export function MediaButtons({ fileSet }) {
 
   return (
     <div className="buttons is-grouped is-right">
-      {isAuthorized() && (
+      {!fileSet.group_with && isAuthorized() && (
         <Button
           data-testid="edit-structure-button"
           onClick={() =>

--- a/app/assets/js/components/Work/Fileset/ActionButtons/GroupAdd.jsx
+++ b/app/assets/js/components/Work/Fileset/ActionButtons/GroupAdd.jsx
@@ -1,0 +1,219 @@
+/** @jsx jsx */
+
+import React, { useEffect } from "react";
+import { css, jsx } from "@emotion/react";
+
+const WorkFilesetActionButtonsGroupAdd = ({
+  fileSetId,
+  candidateFileSets,
+  handleUpdateFileSet,
+  iiifServerUrl,
+}) => {
+  const addRef = React.useRef(null);
+  const inputRef = React.useRef(null);
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [filteredCandidateFileSets, setFilteredCandidateFileSets] =
+    React.useState(candidateFileSets);
+
+  useEffect(() => {
+    const handleClick = (e) => {
+      if (addRef.current.contains(e.target)) {
+        return;
+      }
+
+      setIsOpen(false);
+    };
+
+    const handleEscape = (e) => {
+      if (e.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("click", handleClick);
+    document.addEventListener("keydown", handleEscape);
+
+    return () => {
+      document.removeEventListener("click", handleClick);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, []);
+
+  useEffect(() => {
+    setFilteredCandidateFileSets(candidateFileSets);
+  }, [candidateFileSets]);
+
+  const handleFocus = () => {
+    setIsOpen(!isOpen);
+    inputRef.current.style.width = "300px";
+  };
+
+  const handleBlur = () => {
+    inputRef.current.style.width = "150px";
+  };
+
+  const handleChange = (e) => {
+    const value = e.target.value.toLowerCase().normalize();
+    if (value === "") {
+      setFilteredCandidateFileSets(candidateFileSets);
+      return;
+    }
+
+    // get the filtered filesets matching label or accession number
+    const filtered = candidateFileSets.filter(
+      (candidate) =>
+        candidate.coreMetadata.label
+          .toLowerCase()
+          .normalize()
+          .includes(value) ||
+        candidate.accessionNumber.toLowerCase().normalize().includes(value),
+    );
+
+    setFilteredCandidateFileSets(filtered);
+  };
+
+  const handleOnClick = (candidateId) => {
+    handleUpdateFileSet(candidateId, fileSetId);
+    setIsOpen(false);
+  };
+
+  const add = css`
+    position: relative;
+    z-index: ${isOpen ? 3 : 1};
+
+    input {
+      width: 150px;
+      transition: width 0.25s ease;
+    }
+
+    input::placeholder {
+      color: var(--colors-richBlack50) !important;
+    }
+  `;
+
+  const content = css`
+    position: absolute;
+    right: 0;
+    z-index: 2;
+    display: ${isOpen ? "block" : "none"};
+    background: white;
+    width: 300px;
+    max-height: 300px;
+    transition: all 0.25s ease;
+    overflow-x: hidden;
+    overflow-y: scroll;};
+    padding: 0.5rem;
+
+    button.candidate-option {
+      display: flex; 
+      width: 100%;
+      align-items: flex-start;
+      background: transparent;
+      border: none;
+      font-family: var(--fonts-sans);
+      cursor: pointer;
+      gap: 0.5rem;
+      text-transform: none;
+      margin-bottom: 0.25rem;
+      padding: 0.5rem;
+      font-size: 1rem;
+
+      div {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.25rem;
+        overflow: hidden;
+        flex-grow: 1;
+        text-align: left;
+        font-size: 0.8333rem;
+
+        label,
+        span {
+          width: 100%;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+      }
+
+      &:hover,
+      &:focus {
+        background: #f0f0f0;
+
+        label {
+          font-family: var(--fonts-sansBold);
+          font-weight: 400;
+        }
+      }
+
+      &:last-of-type {
+        margin-bottom: 0;
+      }
+
+      figure {
+        width: 32px;
+        height: 32px;
+        flex-shrink: 0;
+
+        img {
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
+          border-radius: 0.25rem;
+        }
+      }
+    }
+  `;
+
+  return (
+    <div ref={addRef} css={add} data-testid="fileset-group-add">
+      <input
+        ref={inputRef}
+        className="input"
+        type="text"
+        placeholder="Attach filesets..."
+        aria-haspopup="true"
+        aria-controls="searchbox"
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onChange={handleChange}
+      />
+      <div
+        className="box"
+        css={content}
+        role="searchbox"
+        aria-expanded={isOpen}
+      >
+        {filteredCandidateFileSets.length ? (
+          filteredCandidateFileSets.map((candidate) => (
+            <button
+              key={candidate.id}
+              value={candidate.id}
+              className="candidate-option"
+              data-testid="fileset-group-add-candidate"
+              type="button"
+              onClick={() => handleOnClick(candidate.id, fileSetId)}
+            >
+              <figure>
+                <img
+                  src={`${iiifServerUrl}${candidate.id}/square/32,32/0/default.jpg`}
+                  placeholder="Fileset Image"
+                  data-testid="fileset-image"
+                />
+              </figure>
+              <div>
+                <label>{candidate.coreMetadata.label}</label>
+                <span className="is-muted">{candidate.accessionNumber}</span>
+              </div>
+            </button>
+          ))
+        ) : (
+          <p>Applicable fileset(s) not found.</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default WorkFilesetActionButtonsGroupAdd;

--- a/app/assets/js/components/Work/Fileset/ActionButtons/GroupAdd.test.jsx
+++ b/app/assets/js/components/Work/Fileset/ActionButtons/GroupAdd.test.jsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { mockFileSets } from "@js/mock-data/filesets";
+import userEvent from "@testing-library/user-event";
+import { WorkProvider } from "@js/context/work-context";
+import WorkFilesetActionButtonsGroupAdd from "./GroupAdd";
+
+const mockUpdateFileSetFn = jest.fn();
+
+const fileSet = mockFileSets[0];
+const candidateFileSets = [mockFileSets[1], mockFileSets[2]];
+
+describe("WorkFilesetActionButtonsGroupAdd component", () => {
+  beforeEach(() => {
+    render(
+      <WorkProvider>
+        <WorkFilesetActionButtonsGroupAdd
+          fileSetId={fileSet.id}
+          candidateFileSets={candidateFileSets}
+          handleUpdateFileSet={mockUpdateFileSetFn}
+          iiifServerUrl="http://example.org/iiif/"
+        />
+      </WorkProvider>,
+    );
+  });
+
+  it("renders the FileSet GroupAdd component", async () => {
+    const groupAdd = await screen.findByTestId("fileset-group-add");
+    expect(groupAdd).toBeInTheDocument();
+
+    // renders and input
+    const input = groupAdd.querySelector("input");
+    expect(input.getAttribute("placeholder")).toBe("Attach filesets...");
+
+    // renders the searchbox expanded as false
+    const searchbox = groupAdd.querySelector("div[role='searchbox']");
+    expect(searchbox.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("renders the handles user interactions", async () => {
+    const groupAdd = await screen.findByTestId("fileset-group-add");
+    const input = groupAdd.querySelector("input");
+    const searchbox = groupAdd.querySelector("div[role='searchbox']");
+
+    // focus the input and type
+    const user = userEvent.setup();
+    await user.click(input);
+
+    // expands the searchbox on focus
+    expect(searchbox.getAttribute("aria-expanded")).toBe("true");
+
+    // renders candidate options
+    const candidatesDefaultState = await screen.findAllByTestId(
+      "fileset-group-add-candidate",
+    );
+    expect(candidatesDefaultState).toHaveLength(2);
+
+    // users types in the input to filter
+    await user.type(input, "2572813");
+    const candidatesFiltered = await screen.findAllByTestId(
+      "fileset-group-add-candidate",
+    );
+    expect(candidatesFiltered).toHaveLength(1);
+
+    const filteredCandidate = candidatesFiltered[0];
+    expect(filteredCandidate).toHaveTextContent(
+      "inu-dil-41913a91-037f-494b-9113-06004a8a98fb.jpg",
+    );
+    expect(filteredCandidate).toHaveTextContent("Voyager:2572813_FILE_0");
+    expect(filteredCandidate.querySelector("img")).toHaveAttribute(
+      "src",
+      "http://example.org/iiif/109b9a5c-3c6f-4a98-b98b-12402b871dc7/square/32,32/0/default.jpg",
+    );
+
+    // click the candidate to add
+    await user.click(filteredCandidate);
+    expect(mockUpdateFileSetFn).toHaveBeenCalledWith(
+      "109b9a5c-3c6f-4a98-b98b-12402b871dc7",
+      fileSet.id,
+    );
+  });
+
+  it("renders message if no applicable candidates are found", async () => {
+    const groupAdd = await screen.findByTestId("fileset-group-add");
+    const input = groupAdd.querySelector("input");
+    const searchbox = groupAdd.querySelector("div[role='searchbox']");
+
+    // focus the input and type
+    const user = userEvent.setup();
+    await user.click(input);
+
+    // renders searchbox expanded, with 0 candidates, and a message
+    await user.type(input, "foo bar");
+    await waitFor(() => {
+      expect(
+        screen.queryAllByTestId("fileset-group-add-candidate"),
+      ).toHaveLength(0);
+    });
+    expect(searchbox).toHaveTextContent("Applicable fileset(s) not found.");
+  });
+});

--- a/app/assets/js/components/Work/Fileset/ActionButtons/GroupRemove.jsx
+++ b/app/assets/js/components/Work/Fileset/ActionButtons/GroupRemove.jsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+
+import React from "react";
+import { css, jsx } from "@emotion/react";
+
+const WorkFilesetActionButtonsGroupRemove = ({
+  fileSetId,
+  handleUpdateFileSet,
+}) => {
+  const button = css`
+    color: var(--colors-richBlack50);
+    text-transform: none;
+    text-decoration: underline;
+  `;
+
+  const handleRemoveClick = () => {
+    handleUpdateFileSet(fileSetId, null);
+  };
+
+  return (
+    <button
+      className="button is-text"
+      css={button}
+      onClick={handleRemoveClick}
+      data-testid="fileset-group-remove"
+    >
+      Detach
+    </button>
+  );
+};
+
+export default WorkFilesetActionButtonsGroupRemove;

--- a/app/assets/js/components/Work/Fileset/ActionButtons/GroupRemove.test.jsx
+++ b/app/assets/js/components/Work/Fileset/ActionButtons/GroupRemove.test.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { mockFileSets } from "@js/mock-data/filesets";
+import userEvent from "@testing-library/user-event";
+import { WorkProvider } from "@js/context/work-context";
+import WorkFilesetActionButtonsGroupRemove from "./GroupRemove";
+
+const mockUpdateFileSetFn = jest.fn();
+
+const fileSet = mockFileSets[1];
+
+describe("WorkFilesetActionButtonsGroupAdd component", () => {
+  beforeEach(() => {
+    render(
+      <WorkProvider>
+        <WorkFilesetActionButtonsGroupRemove
+          fileSetId={fileSet.id}
+          handleUpdateFileSet={mockUpdateFileSetFn}
+        />
+      </WorkProvider>,
+    );
+  });
+
+  it("renders the FileSet GroupRemove component", async () => {
+    const groupRemove = await screen.findByTestId("fileset-group-remove");
+    expect(groupRemove).toBeInTheDocument();
+
+    // renders the remove button
+    expect(groupRemove.textContent).toBe("Detach");
+
+    // triggers the remove function
+    const user = userEvent.setup();
+    await user.click(groupRemove);
+    expect(mockUpdateFileSetFn).toHaveBeenCalledWith(fileSet.id, null);
+  });
+});

--- a/app/assets/js/components/Work/Fileset/Draggable.jsx
+++ b/app/assets/js/components/Work/Fileset/Draggable.jsx
@@ -1,52 +1,150 @@
+/** @jsx jsx */
+
 import React, { useContext } from "react";
 import PropTypes from "prop-types";
-import { Draggable } from "react-beautiful-dnd";
-import UIFormField from "@js/components/UI/Form/Field";
+import { Draggable, Droppable } from "react-beautiful-dnd";
 import { IIIFContext } from "@js/components/IIIF/IIIFProvider";
-
-/** @jsx jsx */
 import { css, jsx } from "@emotion/react";
+import WorkFilesetActionButtonsGroupRemove from "./ActionButtons/GroupRemove";
+import WorkFilesetActionButtonsGroupAdd from "./ActionButtons/GroupAdd";
 
-const content = css`
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-`;
-
-function WorkFilesetDraggable({ fileSet, index }) {
+function WorkFilesetDraggable({
+  fileSet,
+  handleUpdateFileSet,
+  index,
+  isGrouped = false,
+  candidateFileSets = [],
+  groupedFileSets = [],
+}) {
   const iiifServerUrl = useContext(IIIFContext);
+
+  const article = css`
+    background: white;
+    transition: all 0.25s ease;
+    padding: 1rem;
+    outline: none;
+    margin-top: 0;
+
+    &[data-is-dragging="true"] {
+      background: rgb(233, 244, 255);
+      outline: 2px solid #5091cd;
+
+      article[data-is-grouped="true"] {
+        background: rgb(233, 244, 255) !important;
+      }
+    }
+  `;
+
+  const figure = css`
+    width: 48px;
+    height: 48px;
+    flex-shrink: 0;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      border-radius: 0.25rem;
+    }
+  `;
+
+  const content = css`
+    gap: 1rem;
+  `;
+
+  const metadata = css`
+    flex-grow: 1;
+  `;
+
+  const actions = css`
+    min-width: 150px;
+    flex-shrink: 0;
+    justify-content: flex-end;
+    display: flex;
+  `;
+
+  const fileSetGroup = css`
+    margin-top: 1rem;
+    padding: 1.5rem;
+    background: #0001;
+    border-radius: 0.25rem;
+  `;
 
   return (
     <Draggable draggableId={fileSet.id} index={index}>
-      {(provided) => (
-        <article
-          ref={provided.innerRef}
-          {...provided.draggableProps}
-          {...provided.dragHandleProps}
-          className="box"
-          data-testid="fileset-draggable-item"
-        >
-          <div css={content}>
-            <figure className="image mr-4">
-              <img
-                src={`${iiifServerUrl}${fileSet.id}/square/64,64/0/default.jpg`}
-                placeholder="Fileset Image"
-                data-testid="fileset-image"
-              />
-            </figure>
-            <UIFormField label="Label">
-              <p className="mr-6" data-testid="fileset-label">
-                {fileSet.coreMetadata.label}
-              </p>
-            </UIFormField>
+      {(provided, snapshot) => (
+        <>
+          <article
+            ref={provided.innerRef}
+            {...provided.draggableProps}
+            {...provided.dragHandleProps}
+            className="box"
+            css={article}
+            data-testid="fileset-draggable-item"
+            data-is-dragging={snapshot.isDragging}
+            data-is-grouped={isGrouped}
+            data-fileset-id={fileSet.id}
+          >
+            <div css={content} className="is-flex">
+              <figure css={figure}>
+                <img
+                  src={`${iiifServerUrl}${fileSet.id}/square/64,64/0/default.jpg`}
+                  placeholder="Fileset Image"
+                  data-testid="fileset-image"
+                />
+              </figure>
+              <div css={metadata}>
+                <span data-testid="fileset-label" className="is-bold">
+                  {fileSet.coreMetadata.label}
+                </span>
+                <p data-testid="fileset-accession-number" className="is-muted">
+                  {fileSet.accessionNumber}
+                </p>
+              </div>
+              <div css={actions}>
+                {fileSet.group_with ? (
+                  <WorkFilesetActionButtonsGroupRemove
+                    fileSetId={fileSet.id}
+                    handleUpdateFileSet={handleUpdateFileSet}
+                  />
+                ) : (
+                  <WorkFilesetActionButtonsGroupAdd
+                    fileSetId={fileSet.id}
+                    candidateFileSets={candidateFileSets}
+                    handleUpdateFileSet={handleUpdateFileSet}
+                    iiifServerUrl={iiifServerUrl}
+                  />
+                )}
+              </div>
+            </div>
 
-            <UIFormField label="Description">
-              <p data-testid="fileset-description">
-                {fileSet.coreMetadata.description}
-              </p>
-            </UIFormField>
-          </div>
-        </article>
+            {groupedFileSets.length ? (
+              <div css={fileSetGroup}>
+                <Droppable
+                  droppableId={fileSet.id}
+                  type={`fileset-group-with-${fileSet.id}`}
+                >
+                  {(provided) => (
+                    <div ref={provided.innerRef} {...provided.droppableProps}>
+                      {groupedFileSets.map((groupedFileSet, index) => (
+                        <WorkFilesetDraggable
+                          key={groupedFileSet.id}
+                          fileSet={groupedFileSet}
+                          index={index}
+                          isGrouped={true}
+                          handleUpdateFileSet={handleUpdateFileSet}
+                        />
+                      ))}
+                      {provided.placeholder}
+                    </div>
+                  )}
+                </Droppable>
+              </div>
+            ) : (
+              <></>
+            )}
+          </article>
+        </>
       )}
     </Draggable>
   );

--- a/app/assets/js/components/Work/Fileset/Draggable.test.js
+++ b/app/assets/js/components/Work/Fileset/Draggable.test.js
@@ -1,6 +1,11 @@
 import React from "react";
 import WorkFilesetDraggable from "./Draggable";
-import { render, screen } from "@testing-library/react";
+import {
+  getAllByTestId,
+  getByTestId,
+  render,
+  screen,
+} from "@testing-library/react";
 import { mockFileSets } from "@js/mock-data/filesets";
 import { withReactBeautifulDND } from "@js/services/testing-helpers";
 
@@ -10,21 +15,43 @@ describe("WorkFilesetDraggable components", () => {
       withReactBeautifulDND(WorkFilesetDraggable, {
         fileSet: mockFileSets[0],
         index: 0,
-      })
+        candidateFileSets: [mockFileSets[2]],
+        groupedFileSets: [mockFileSets[1]],
+      }),
     );
   });
 
   it("renders a draggable list component", () => {
-    expect(screen.getByTestId("fileset-draggable-item"));
-  });
+    const filesets = screen.getAllByTestId("fileset-draggable-item");
+    expect(filesets).toHaveLength(2);
 
-  it("renders image, label and description", () => {
-    expect(screen.getByTestId("fileset-image"));
-    expect(screen.getByTestId("fileset-label")).toHaveTextContent(
-      mockFileSets[0].coreMetadata.label
-    );
-    expect(screen.getByTestId("fileset-description")).toHaveTextContent(
-      mockFileSets[0].coreMetadata.description
-    );
+    filesets.forEach((fs, index) => {
+      expect(fs).toHaveTextContent(mockFileSets[index].coreMetadata.label);
+      expect(fs).toHaveTextContent(mockFileSets[index].accessionNumber);
+
+      if (index === 0) {
+        expect(fs).toHaveAttribute("data-is-dragging", "false");
+        expect(fs).toHaveAttribute("data-is-grouped", "false");
+        expect(fs).toHaveAttribute("data-fileset-id", mockFileSets[index].id);
+
+        // attach filesets component is present
+        expect(
+          fs.querySelector('div[data-testid="fileset-group-add"]'),
+        ).toBeInTheDocument();
+
+        // has grouped filesets within it
+        const children = fs.querySelectorAll("article");
+        expect(children).toHaveLength(1);
+      } else {
+        expect(fs).toHaveAttribute("data-is-dragging", "false");
+        expect(fs).toHaveAttribute("data-is-grouped", "true");
+        expect(fs).toHaveAttribute("data-fileset-id", mockFileSets[index].id);
+
+        // detach fileset component is present
+        expect(
+          fs.querySelector('button[data-testid="fileset-group-remove"]'),
+        ).toBeInTheDocument();
+      }
+    });
   });
 });

--- a/app/assets/js/components/Work/Tabs/Structure/FilesetsDragAndDrop.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/FilesetsDragAndDrop.jsx
@@ -1,23 +1,44 @@
 import React, { useState } from "react";
-import WorkFilesetList from "@js/components/Work/Fileset/List";
 import PropTypes from "prop-types";
-import { DragDropContext, Droppable } from "react-beautiful-dnd";
 import { Button } from "@nulib/design-system";
+import { DragDropContext } from "react-beautiful-dnd";
+import WorkFilesetList from "@js/components/Work/Fileset/List";
 
-const reorder = (list, startIndex, endIndex) => {
+function reorder(list, startIndex, endIndex) {
   const result = Array.from(list);
   const [removed] = result.splice(startIndex, 1);
   result.splice(endIndex, 0, removed);
 
   return result;
-};
+}
 
 function FilesetsDragAndDrop({
   fileSets,
   handleCancelReorder,
   handleSaveReorder,
+  handleGroupWithUpdate,
 }) {
   const [state, setState] = useState({ fileSets });
+
+  const indexArray = state.fileSets.map((fs) => ({
+    id: fs.id,
+    group_with: fs.group_with,
+    droppableId: fs.group_with ? fs.group_with : "access",
+  }));
+
+  function handleSaveClick() {
+    // Update order of all filesets
+    handleSaveReorder(state.fileSets.map((fs) => fs.id));
+
+    // Update group_with values for applicable filesets
+    const updateGroupWith = state.fileSets.filter((fs) =>
+      fileSets.find(
+        (fs2) => fs2.id === fs.id && fs2.group_with !== fs.group_with,
+      ),
+    );
+
+    handleGroupWithUpdate(updateGroupWith);
+  }
 
   function handleCancelClick() {
     setState({ fileSets });
@@ -25,19 +46,49 @@ function FilesetsDragAndDrop({
   }
 
   function onDragEnd(result) {
-    if (!result.destination) {
-      return;
-    }
+    if (!result.destination) return;
+    if (result.destination.index === result.source.index) return;
 
-    if (result.destination.index === result.source.index) {
-      return;
-    }
+    const { source, destination } = result;
 
-    const updatedFileSets = reorder(
-      state.fileSets,
-      result.source.index,
-      result.destination.index
+    // 1) Find absolute start index
+    const sourceSubset = indexArray.filter(
+      (fs) => fs.droppableId === source.droppableId,
     );
+    const draggedItem = sourceSubset[source.index];
+    const startIndex = indexArray.findIndex((fs) => fs.id === draggedItem?.id);
+
+    // 2) Find absolute end index
+    const destinationSubset = indexArray.filter(
+      (fs) => fs.droppableId === destination.droppableId,
+    );
+
+    let endIndex;
+    if (destination.index >= destinationSubset.length) {
+      // Dropping at the end of the subset
+      endIndex =
+        indexArray.findIndex(
+          (fs) => fs.id === destinationSubset[destinationSubset.length - 1]?.id,
+        ) + 1;
+    } else {
+      const targetItem = destinationSubset[destination.index];
+      endIndex = indexArray.findIndex((fs) => fs.id === targetItem?.id);
+    }
+
+    if (startIndex === -1 || endIndex === -1) return;
+
+    // 3) Reorder the state
+    const updatedFileSets = reorder(state.fileSets, startIndex, endIndex);
+    setState({ fileSets: updatedFileSets });
+  }
+
+  function handleUpdateFileSet(id, groupWith) {
+    const updatedFileSets = state.fileSets.map((fs) => {
+      if (fs.id === id) {
+        return { ...fs, group_with: groupWith };
+      }
+      return fs;
+    });
 
     setState({ fileSets: updatedFileSets });
   }
@@ -48,13 +99,12 @@ function FilesetsDragAndDrop({
         <div className="buttons is-justify-content-center my-4">
           <Button
             isPrimary
-            onClick={() => handleSaveReorder(state.fileSets.map((fs) => fs.id))}
+            onClick={handleSaveClick}
             data-testid="button-reorder-save"
           >
-            Save Fileset Order
+            Save
           </Button>
           <Button
-            isText
             onClick={handleCancelClick}
             data-testid="button-reorder-cancel"
           >
@@ -63,17 +113,11 @@ function FilesetsDragAndDrop({
         </div>
       </div>
       <DragDropContext onDragEnd={onDragEnd}>
-        <Droppable droppableId="list">
-          {(provided) => (
-            <div ref={provided.innerRef} {...provided.droppableProps}>
-              <WorkFilesetList
-                fileSets={{ access: state.fileSets }}
-                isReordering
-              />
-              {provided.placeholder}
-            </div>
-          )}
-        </Droppable>
+        <WorkFilesetList
+          fileSets={{ access: state.fileSets }}
+          handleUpdateFileSet={handleUpdateFileSet}
+          isReordering
+        />
       </DragDropContext>
     </div>
   );

--- a/app/assets/js/components/Work/Tabs/Structure/FilesetsDragAndDrop.test.js
+++ b/app/assets/js/components/Work/Tabs/Structure/FilesetsDragAndDrop.test.js
@@ -7,6 +7,7 @@ import { WorkProvider } from "@js/context/work-context";
 
 const mockHandleCancelFn = jest.fn();
 const mockHandleSaveFn = jest.fn();
+const mockGroupWithFn = jest.fn();
 
 describe("WorkTabsStructureFilesetsDragAndDrop component", () => {
   beforeEach(() => {
@@ -16,8 +17,9 @@ describe("WorkTabsStructureFilesetsDragAndDrop component", () => {
           fileSets={mockFileSets}
           handleCancelReorder={mockHandleCancelFn}
           handleSaveReorder={mockHandleSaveFn}
+          handleGroupWithUpdate={mockGroupWithFn}
         />
-      </WorkProvider>
+      </WorkProvider>,
     );
   });
 
@@ -32,10 +34,9 @@ describe("WorkTabsStructureFilesetsDragAndDrop component", () => {
 
     await user.click(saveBtn);
     expect(mockHandleSaveFn).toHaveBeenCalled();
+    expect(mockGroupWithFn).toHaveBeenCalled();
 
     await user.click(cancelBtn);
     expect(mockHandleCancelFn).toHaveBeenCalled();
   });
-
-  it("renders file sets", () => {});
 });

--- a/app/assets/js/components/Work/work.gql.js
+++ b/app/assets/js/components/Work/work.gql.js
@@ -255,6 +255,7 @@ export const GET_WORK = gql`
           }
         }
         extractedMetadata
+        group_with
         insertedAt
         role {
           id
@@ -387,7 +388,7 @@ export const LIST_INGEST_BUCKET_OBJECTS = gql`
       }
     }
   }
-`
+`;
 
 export const SET_WORK_IMAGE = gql`
   mutation SetWorkImage($fileSetId: ID!, $workId: ID!) {
@@ -598,6 +599,15 @@ export const UPDATE_FILE_SETS = gql`
         description
         label
       }
+    }
+  }
+`;
+
+export const GROUP_WITH_FILE_SET = gql`
+  mutation UpdateFileSet($id: ID!, $groupWith: ID) {
+    updateFileSet(id: $id, groupWith: $groupWith) {
+      id
+      groupWith
     }
   }
 `;

--- a/app/assets/js/mock-data/filesets.js
+++ b/app/assets/js/mock-data/filesets.js
@@ -14,6 +14,7 @@ export const mockFileSets = [
       originalFilename: "inu-dil-9d35d0ba-a84b-4e0a-99e6-9c6b548a46db.jpg",
     },
     id: "45226a50-87ca-443e-bc05-f47884e14505",
+    group_with: null,
     representativeImageUrl:
       "https://iiif.dev.rdc.library.northwestern.edu/iiif/2/wildcat-dev/posters/6d6bb649-2a5c-40d2-8d1b-23835de1c40a",
     role: {
@@ -38,6 +39,7 @@ export const mockFileSets = [
       originalFilename: "inu-dil-41913a91-037f-494b-9113-06004a8a98fb.jpg",
     },
     id: "109b9a5c-3c6f-4a98-b98b-12402b871dc7",
+    group_with: "45226a50-87ca-443e-bc05-f47884e14505",
     representativeImageUrl:
       "https://iiif.dev.rdc.library.northwestern.edu/iiif/2/wildcat-dev/posters/6d6bb649-2a5c-40d2-8d1b-23835de1c40a",
     role: {
@@ -62,6 +64,7 @@ export const mockFileSets = [
       originalFilename: "inu-dil-96e6d167-5022-42e7-9de7-7f851a866f44.jpg",
     },
     id: "d414d3d4-b72c-49cc-b7cc-faa9bc0f256e",
+    group_with: null,
     representativeImageUrl:
       "https://iiif.dev.rdc.library.northwestern.edu/iiif/2/wildcat-dev/posters/6d6bb649-2a5c-40d2-8d1b-23835de1c40a",
     role: {

--- a/app/assets/styles/scss/_base.scss
+++ b/app/assets/styles/scss/_base.scss
@@ -1,7 +1,6 @@
 button,
 .button {
   border-radius: 2px;
-  text-transform: uppercase;
 }
 
 table {
@@ -105,7 +104,12 @@ table {
 }
 
 .is-bold {
+  font-weight: 400 !important;
   font-family: $AkkuratProBold;
+}
+
+.is-muted {
+  color: $rich-black-50 !important;
 }
 
 .small-title {
@@ -150,4 +154,32 @@ table {
 
 .meadow-toast-wrapper {
   display: block !important;
+}
+
+.fileset-group-with {
+  margin-left: 4em;
+
+  &::before {
+    content: "";
+    display: block;
+    position: absolute;
+    width: 4px;
+    height: 130%;
+    border-radius: 2px;
+    background: $rich-black-10;
+    left: -2em;
+    top: calc((-100% / 2) - 30% + 4px);
+  }
+
+  &::after {
+    content: "";
+    display: block;
+    position: absolute;
+    width: 2em;
+    height: 4px;
+    border-radius: 2px;
+    background: linear-gradient(to right, $rich-black-10, transparent);
+    left: -2em;
+    top: 50%;
+  }
 }


### PR DESCRIPTION
# Summary 

This chunk of work refactors the **Access files** tab, (formerly Structure) and allows for grouping of filesets, and ordering of these grouped filesets.

![image](https://github.com/user-attachments/assets/d7add0c3-6c2d-4aa2-acd1-0f2d162e3737)

![image](https://github.com/user-attachments/assets/3c4cb189-6da9-4580-af11-4131ebf09931)


# Specific Changes in this PR
- Refactors **Access Files** page
- Nests grouped filesets within "parents" targeted by `group_with` value
- Allows for filter by _title_ and _accessionNumber_ to Attach applicable filesets
- Allows for detach to remove filesets
- Allows for live reordering and grouping prior to save
- Saving will send `GROUP_WITH_FILE_SET` mutations for each applicable change to `group_with` values

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test

- Go to any **Work**, preferably one with many Access files.
- Go to **Access files** tab
  + Attach a number filesets to a relative fileset
  + Filter items by testing label and accession number filtering
  + Detach items as necessary to test reset of `group_with` to `null` 
- Reorder as you go, both within a relative group and around it
- Click save
- Note order and groups reflect expected state
- Repeat as necessary


# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

