### PR TITLE
Move processing of Ark actions to rate limited GenServer

### DIFF
--- a/app/lib/meadow/application/children.ex
+++ b/app/lib/meadow/application/children.ex
@@ -17,7 +17,9 @@ defmodule Meadow.Application.Children do
         |> Enum.map(&IndexBatcher.child_spec(&1)),
       "csv_update_driver" => Meadow.CSVMetadataUpdateDriver,
       "database_listeners" => [
-        {WalEx.Supervisor, Application.get_env(:meadow, WalEx)}
+        {WalEx.Supervisor, Application.get_env(:meadow, WalEx)},
+        {Meadow.Events.Works.Arks.Processor,
+         token_count: 100, interval: 1_000, replenish_count: 10}
       ],
       "scheduler" => Meadow.Scheduler,
       "work_creator" => [Meadow.Ingest.WorkCreator, Meadow.Ingest.WorkRedriver]

--- a/app/lib/meadow/events/works/arks.ex
+++ b/app/lib/meadow/events/works/arks.ex
@@ -3,39 +3,169 @@ defmodule Meadow.Events.Works.Arks do
   Handles events related to ARKs.
   """
 
-  alias Meadow.Arks
-  alias Meadow.Data.Works
+  defmodule Processor do
+    @moduledoc """
+    Rate-limited processor for ARK-related events.
 
-  use Meadow.Utils.Logging
+    Supports the following init arguments:
+    * `:token_count` - the maximum number of ARK requests to process in a given interval (default: 100)
+    * `:interval` - the interval in milliseconds over which to process the maximum number of ARK requests (default: 1_000)
+    * `:replenish_count` - the number of tokens added back to the pool per replenishment (default: `:token_count`)
+    * `:replenish_interval` - the replenishment interval in milliseconds (default: `:interval`)
+    """
+    use GenServer
+
+    alias Meadow.Arks
+    alias Meadow.Data.Works
+
+    use Meadow.Utils.Logging
+
+    require Logger
+
+    @token_count 100
+    @interval 1_000
+
+    # Client API
+    def start_link(opts \\ []) do
+      GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+    end
+
+    def mint_ark(work_id), do: GenServer.cast(__MODULE__, {:mint_ark, work_id})
+    def update_ark(work_id), do: GenServer.cast(__MODULE__, {:update_ark, work_id})
+    def delete_ark(work_id), do: GenServer.cast(__MODULE__, {:delete_ark, work_id})
+
+    # Server callbacks
+    def init(init_arg) do
+      token_count = Keyword.get(init_arg, :token_count, @token_count)
+      interval = Keyword.get(init_arg, :interval, @interval)
+      replenish_count = Keyword.get(init_arg, :replenish_count, token_count)
+      replenish_interval = Keyword.get(init_arg, :replenish_interval, interval)
+
+      if Enum.any?([token_count, interval, replenish_count, replenish_interval], &(&1 <= 0)) do
+        raise ArgumentError, "Token counts and intervals must be positive integers"
+      end
+
+      with_log_metadata module: __MODULE__ do
+        Logger.info(
+          "Rate limiting Ark requests to #{token_count} requests per #{interval}ms, replenishing #{replenish_count} tokens every #{replenish_interval}ms"
+        )
+      end
+
+      state = %{
+        max_tokens: token_count,
+        rate: {token_count, interval},
+        replenish: {replenish_count, replenish_interval},
+        tokens: token_count,
+        queue: []
+      }
+
+      # Schedule token replenishment
+      Process.send_after(self(), :replenish, interval)
+      {:ok, state}
+    end
+
+    def handle_cast({action, work_id}, state) do
+      if state.tokens > 0 do
+        # Process the request immediately
+        process_ark_action(action, work_id)
+        {:noreply, %{state | tokens: state.tokens - 1}}
+      else
+        # Enqueue the request for later processing
+        {:noreply, %{state | queue: state.queue ++ [{action, work_id}]}}
+      end
+    end
+
+    def handle_info(:replenish, state) do
+      {replenish_count, replenish_interval} = state.replenish
+
+      state =
+        if state.tokens < state.max_tokens do
+          new_tokens = min(state.tokens + replenish_count, state.max_tokens)
+          # Replenish tokens
+          %{state | tokens: new_tokens}
+        else
+          state
+        end
+        |> process_queue()
+
+      # Reschedule the next replenishment
+      Process.send_after(self(), :replenish, replenish_interval)
+      {:noreply, state}
+    end
+
+    defp process_queue(state) do
+      {to_process, remaining_queue} = Enum.split(state.queue, state.tokens)
+      Enum.each(to_process, fn {action, work_id} -> process_ark_action(action, work_id) end)
+      new_tokens = state.tokens - length(to_process)
+
+      if new_tokens == 0 && not Enum.empty?(state.queue) do
+        Logger.warning("Ark request rate limit reached. Queueing request for later processing.")
+      end
+
+      %{state | tokens: new_tokens, queue: remaining_queue}
+    end
+
+    defp process_ark_action(:mint_ark, work_id) do
+      with_log_metadata module: __MODULE__, id: work_id do
+        Works.get_work(work_id) |> Arks.mint_ark()
+      end
+    end
+
+    defp process_ark_action(:update_ark, work_id) do
+      with_log_metadata module: __MODULE__, id: work_id do
+        case Works.get_work!(work_id) do
+          nil -> :noop
+          work -> update_ark_metadata(work)
+        end
+      end
+    end
+
+    defp process_ark_action(:delete_ark, work_id) do
+      with_log_metadata module: __MODULE__, id: work_id do
+        Arks.work_deleted(work_id)
+      end
+    end
+
+    defp update_ark_metadata(work) do
+      Logger.info(
+        "Updating ARK metadata for work: #{work.id}, with ark: #{work.descriptive_metadata.ark}"
+      )
+
+      case Arks.update_ark_metadata(work) do
+        :noop ->
+          :noop
+
+        {:ok, _result} ->
+          :noop
+
+        {:error, error_message} ->
+          Logger.error(
+            "Error updating ARK metadata for work: #{work.id}, with ark: #{work.descriptive_metadata.ark}. #{error_message}"
+          )
+      end
+    end
+  end
+
   use WalEx.Event, name: Meadow
 
   require Logger
 
   on_event(:works, %{}, [{__MODULE__, :handle_event}], & &1)
 
-  def handle_event(%{type: :insert, name: name, new_record: record}) do
-    with_log_metadata module: __MODULE__, id: record.id, name: name do
-      Works.get_work(record.id) |> Arks.mint_ark()
-    end
+  def handle_event(%{type: :insert, new_record: record}) do
+    Processor.mint_ark(record.id)
   end
 
-  def handle_event(%{type: :update, name: name, new_record: record, changes: changes}) do
+  def handle_event(%{type: :update, new_record: record, changes: changes}) do
     unless ark_changed(changes) do
-      with_log_metadata module: __MODULE__, id: record.id, name: name do
-        case Works.get_work!(record.id) do
-          nil -> :noop
-          work -> update_ark_metadata(work)
-        end
-      end
+      Processor.update_ark(record.id)
     end
   rescue
     Ecto.NoResultsError -> :noop
   end
 
-  def handle_event(%{type: :delete, name: name, old_record: record}) do
-    with_log_metadata module: __MODULE__, id: record.id, name: name do
-      Arks.work_deleted(record.id)
-    end
+  def handle_event(%{type: :delete, old_record: record}) do
+    Processor.delete_ark(record.id)
   end
 
   defp ark_changed(%{published: _}), do: false
@@ -51,23 +181,4 @@ defmodule Meadow.Events.Works.Arks do
   end
 
   defp ark_changed(_), do: false
-
-  defp update_ark_metadata(work) do
-    Logger.info(
-      "Updating ARK metadata for work: #{work.id}, with ark: #{work.descriptive_metadata.ark}"
-    )
-
-    case Arks.update_ark_metadata(work) do
-      :noop ->
-        :noop
-
-      {:ok, _result} ->
-        :noop
-
-      {:error, error_message} ->
-        Logger.error(
-          "Error updating ARK metadata for work: #{work.id}, with ark: #{work.descriptive_metadata.ark}. #{error_message}"
-        )
-    end
-  end
 end

--- a/app/lib/meadow/utils/aws.ex
+++ b/app/lib/meadow/utils/aws.ex
@@ -189,6 +189,8 @@ defmodule Meadow.Utils.AWS do
         security_token -> [{"Host", host}, {"X-Amz-Security-Token", security_token}]
       end
 
+    encode_fn = fn c -> (URI.char_unescaped?(c) || URI.char_reserved?(c)) && c != ?* end
+
     :aws_signature.sign_v4(
       config.access_key_id,
       config.secret_access_key,
@@ -196,7 +198,7 @@ defmodule Meadow.Utils.AWS do
       "es",
       {{now.year, now.month, now.day}, {now.hour, now.minute, now.second}},
       request.method |> to_string() |> String.upcase(),
-      request.url,
+      request.url |> URI.encode(encode_fn),
       headers,
       request.body,
       []


### PR DESCRIPTION
# Summary 
Move processing of Ark actions to rate limited GenServer

# Specific Changes in this PR
- Create `Meadow.Events.Works.Arks.Processor` GenServer that implments token-based rate limiting
- Have `Meadow.Events.Works.Arks` WAL event handler pass work to the `Processor`
- Add test for rate limiting

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

1. Create a few hundred works all at once, either via ingest sheet or just something like
    ```
    works = 1..200 |> Enum.map(fn num -> 
      Works.create_work(%{accession_number: "ARK_RATE_LIMIT_#{num}"})
    end); nil
    ```
2. Watch the log for ARK minting notifications. The first 100 should fly by before rate limiting kicks in, after which an additional 10 will process per second.
3. If you want to try different rates, you can read the `@moduledoc` for the [`Meadow.Events.Arks.Processor`](https://github.com/nulib/meadow/pull/4473/files#diff-d94c1b714951c53b1cc5c288c9428f8ff6a3d9b57ffd609406d95128565d2233R10-R14) and change the init args in [`children.ex`](https://github.com/nulib/meadow/pull/4473/files#diff-8596b3992d2aa0236356aab4f5123e25cc80b84d496fec420cf826054b72eb8eR21-R22).

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

