### PR TITLE
Give Meadow its own custom User-Agent string (for Internet politeness)

### DIFF
--- a/app/config/config.exs
+++ b/app/config/config.exs
@@ -75,10 +75,13 @@ config :authoritex,
 
 config :httpoison_retry, wait: 50
 
-config :ex_aws, :hackney_opts,
-  pool: :default,
-  max_connections: 500,
-  checkout_timeout: 30_000
+config :ex_aws,
+  http_client: Meadow.Utils.AWS.HttpClient,
+  hackney_opts: [
+    pool: :default,
+    max_connections: 500,
+    checkout_timeout: 30_000
+  ]
 
 config :meadow, :extra_mime_types, %{
   "aif" => "audio/x-aiff",

--- a/app/lib/meadow/ark/client.ex
+++ b/app/lib/meadow/ark/client.ex
@@ -3,10 +3,10 @@ defmodule Meadow.Ark.Client do
   HTTPoison-based client for the CDLib EZID API
   """
 
-  use HTTPoison.Base
+  use Meadow.HTTP.Base
   alias Meadow.Config
 
-  def process_request_headers(headers) do
+  def reprocess_request_headers(headers) do
     with config <- Config.ark_config(),
          credentials <- Base.encode64("#{config.user}:#{config.password}") do
       headers ++ [{"Authorization", "Basic #{credentials}"}, {"Content-Type", "text/plain"}]

--- a/app/lib/meadow/events/file_sets/cleanup.ex
+++ b/app/lib/meadow/events/file_sets/cleanup.ex
@@ -5,7 +5,6 @@ defmodule Meadow.Events.FileSets.Cleanup do
 
   alias Meadow.Config
   alias Meadow.Data.FileSets
-  alias Meadow.Utils.AWS
 
   use Meadow.Utils.Logging
   use WalEx.Event, name: Meadow
@@ -72,7 +71,7 @@ defmodule Meadow.Events.FileSets.Cleanup do
     Logger.warning("Removing structural metadata for #{id}")
 
     ExAws.S3.delete_object(Config.pyramid_bucket(), FileSets.vtt_location(id))
-    |> AWS.request()
+    |> ExAws.request()
 
     file_set_data
   end
@@ -86,7 +85,7 @@ defmodule Meadow.Events.FileSets.Cleanup do
 
   defp delete_s3_uri(uri, true) do
     with %{host: bucket, path: "/" <> key} <- URI.parse(uri) do
-      case ExAws.S3.head_bucket(bucket) |> AWS.request() do
+      case ExAws.S3.head_bucket(bucket) |> ExAws.request() do
         {:error, {:http_error, 404, _}} ->
           :noop
 
@@ -97,7 +96,7 @@ defmodule Meadow.Events.FileSets.Cleanup do
             |> Stream.map(& &1.key)
 
           ExAws.S3.delete_all_objects(bucket, keys)
-          |> AWS.request()
+          |> ExAws.request()
       end
     end
   end
@@ -105,7 +104,7 @@ defmodule Meadow.Events.FileSets.Cleanup do
   defp delete_s3_uri(uri, false) do
     with %{host: bucket, path: "/" <> key} <- URI.parse(uri) do
       ExAws.S3.delete_object(bucket, key)
-      |> AWS.request()
+      |> ExAws.request()
     end
   end
 end

--- a/app/lib/meadow/events/file_sets/structural_metadata.ex
+++ b/app/lib/meadow/events/file_sets/structural_metadata.ex
@@ -5,7 +5,6 @@ defmodule Meadow.Events.FileSets.StructuralMetadata do
 
   alias Meadow.Config
   alias Meadow.Data.FileSets
-  alias Meadow.Utils.AWS
 
   use Meadow.Utils.Logging
   use WalEx.Event, name: Meadow
@@ -34,7 +33,7 @@ defmodule Meadow.Events.FileSets.StructuralMetadata do
     ExAws.S3.put_object(Config.pyramid_bucket(), FileSets.vtt_location(id), vtt,
       content_type: "text/vtt"
     )
-    |> AWS.request()
+    |> ExAws.request()
   end
 
   defp do_write_structural_metadata(_), do: :noop

--- a/app/lib/meadow/http.ex
+++ b/app/lib/meadow/http.ex
@@ -1,0 +1,36 @@
+defmodule Meadow.HTTP.Base do
+  @moduledoc """
+  Base module for Meadow HTTP clients
+  """
+  defmacro __using__(_) do
+    quote do
+      use HTTPoison.Base
+
+      @callback reprocess_request_headers(headers :: Keyword.t()) :: Keyword.t()
+
+      def process_request_headers(headers) do
+        headers
+        |> Keyword.put_new(:"User-Agent", Meadow.HTTP.Base.ua())
+        |> reprocess_request_headers()
+      end
+
+      def reprocess_request_headers(headers), do: headers
+      defoverridable reprocess_request_headers: 1
+    end
+  end
+
+  def ua do
+    meadow_version = Application.spec(:meadow, :vsn) |> to_string()
+    hackney_version = Application.spec(:hackney, :vsn) |> to_string()
+    httpoison_version = Application.spec(:httpoison, :vsn) |> to_string()
+
+    "Meadow/#{meadow_version} (https://github.com/nulib/meadow; contact: repository@northwestern.edu) httpoison/#{httpoison_version} hackney/#{hackney_version}"
+  end
+end
+
+defmodule Meadow.HTTP do
+  @moduledoc """
+  Meadow HTTP client
+  """
+  use Meadow.HTTP.Base
+end

--- a/app/lib/meadow/search/http.ex
+++ b/app/lib/meadow/search/http.ex
@@ -54,6 +54,8 @@ defmodule Meadow.Search.HTTP do
   def request(method, path, body, headers, options) do
     with cluster <- SearchConfig.cluster_url(),
          url <- ElastixHTTP.prepare_url(cluster, path) do
+      headers = headers |> Keyword.put_new(:"User-Agent", Meadow.HTTP.Base.ua())
+
       retry with: exponential_backoff() |> randomize() |> cap(1_000) |> Stream.take(10),
             atoms: [:retry],
             rescue_only: [] do

--- a/app/lib/meadow/utils/aws.ex
+++ b/app/lib/meadow/utils/aws.ex
@@ -6,61 +6,12 @@ defmodule Meadow.Utils.AWS do
   """
   alias Meadow.Config
   alias Meadow.Config.Secrets
-  alias Meadow.Error
   alias Meadow.Utils.AWS.MultipartCopy
   alias Meadow.Utils.Pairtree
 
   use Retry
 
-  import SweetXml, only: [sigil_x: 2]
-
   require Logger
-
-  @doc """
-  Drop-in replacement for ExAws.request/2 that reports errors to Honeybadger
-  """
-  def request(op, config_overrides \\ []) do
-    retry with: exponential_backoff() |> randomize() |> cap(1_000) |> Stream.take(10),
-          atoms: [:retry],
-          rescue_only: [] do
-      case ExAws.request(op, config_overrides) |> handle_response() do
-        :timeout ->
-          {:retry, :timeout}
-
-        {:error, {:http_error, status, _}} = response when status in [429, 503, 504] ->
-          {:retry, response}
-
-        {:ok, result} ->
-          {:ok, result}
-
-        error ->
-          error
-      end
-    after
-      {:ok, result} -> {:ok, result}
-      {:error, error} -> {:error, error}
-    else
-      {:retry, error} -> error
-      error -> error
-    end
-  end
-
-  @doc """
-  Drop-in replacement for ExAws.request!/2 that reports errors to Honeybadger
-  """
-  def request!(op, config_overrides \\ []) do
-    case request(op, config_overrides) do
-      {:ok, result} ->
-        result
-
-      error ->
-        raise ExAws.Error, """
-        ExAws Request Error!
-
-        #{inspect(error)}
-        """
-    end
-  end
 
   def presigned_url(bucket, %{upload_type: "preservation_check", filename: filename}) do
     generate_presigned_url(bucket, "#{filename}", :get)
@@ -82,7 +33,7 @@ defmodule Meadow.Utils.AWS do
     bucket
     |> check_bucket()
     |> ExAws.S3.put_object("#{name}/.folder", "")
-    |> request()
+    |> ExAws.request()
   end
 
   def add_aws_signature(request) do
@@ -223,7 +174,7 @@ defmodule Meadow.Utils.AWS do
           {:error, {:http_error, 404, _}} ->
             bucket
             |> ExAws.S3.put_bucket("us-east-1")
-            |> request!()
+            |> ExAws.request!()
 
             {:ok, :created}
 
@@ -241,71 +192,6 @@ defmodule Meadow.Utils.AWS do
     |> check_bucket()
 
     ExAws.S3.presigned_url(ExAws.Config.new(:s3), method, bucket, path)
-  end
-
-  def handle_response(response) do
-    {:current_stacktrace, [_ | [_ | stacktrace]]} = Process.info(self(), :current_stacktrace)
-    [{module, _, _, _} | _] = stacktrace
-
-    case response do
-      {:error, {:http_error, _status, response}} ->
-        {message, context} = extract_aws_error(response)
-        Error.report(%Meadow.AwsError{message: message}, module, stacktrace, context)
-
-      {:error, message} ->
-        Error.report(%Meadow.AwsError{message: to_string(message)}, module, stacktrace)
-
-      _ ->
-        :noop
-    end
-
-    response
-  end
-
-  def handle_response!(response) do
-    case handle_response(response) do
-      {:ok, result} ->
-        result
-
-      error ->
-        raise ExAws.Error, """
-        ExAws Request Error!
-
-        #{inspect(error)}
-        """
-    end
-  end
-
-  defp extract_aws_error(%{body: body, status_code: status_code}) do
-    case SweetXml.parse(body) |> SweetXml.xpath(~x"/Error") do
-      nil ->
-        status_code
-
-      {:xmlElement, :Error, _, _, _, _, _, _, children, _, _, _} ->
-        context = map_children(children) |> Enum.reject(&is_nil/1) |> Enum.into(%{})
-        {code, context} = Map.pop(context, :Code)
-        {message, context} = Map.pop(context, :Message)
-        message = "#{status_code} (#{code}): #{message}"
-
-        {message, context}
-    end
-  end
-
-  defp extract_aws_error(%{status_code: status_code}), do: {to_string(status_code), %{}}
-
-  defp extract_aws_error(other), do: {"unknown error: #{inspect(other)}", %{}}
-
-  defp map_children([]), do: []
-  defp map_children([child | children]), do: [map_child(child) | map_children(children)]
-
-  defp map_child(child) do
-    case child do
-      {:xmlElement, tag, _, _, _, _, _, _, _, _, _, _} ->
-        {tag, SweetXml.xpath(child, ~x"./text()") |> to_string()}
-
-      _ ->
-        nil
-    end
   end
 
   defp prefix, do: Secrets.prefix()

--- a/app/lib/meadow/utils/aws/http_client.ex
+++ b/app/lib/meadow/utils/aws/http_client.ex
@@ -1,0 +1,36 @@
+defmodule Meadow.Utils.AWS.HttpClient do
+  @behaviour ExAws.Request.HttpClient
+
+  @moduledoc """
+  HTTP client for ExAws requests
+  """
+  use Retry
+
+  def request(method, url, body \\ "", headers \\ [], http_opts \\ []) do
+    http_opts = Application.get_env(:ex_aws, :hackney_opts) |> Keyword.merge(http_opts)
+
+    retry with: exponential_backoff() |> randomize() |> cap(1_000) |> Stream.take(10),
+          atoms: [:retry],
+          rescue_only: [] do
+      case Meadow.HTTP.request(method, url, body, headers, http_opts) do
+        {:error, %{reason: :timeout}} ->
+          {:retry, :timeout}
+
+        {:ok, %{status_code: status}} = response when status in [429, 503, 504] ->
+          {:retry, response}
+
+        {:ok, %HTTPoison.Response{} = result} ->
+          {:ok, Map.from_struct(result)}
+
+        error ->
+          error
+      end
+    after
+      {:ok, result} -> {:ok, result}
+      {:error, error} -> {:error, error}
+    else
+      {:retry, error} -> error
+      error -> error
+    end
+  end
+end

--- a/app/lib/meadow/utils/stream.ex
+++ b/app/lib/meadow/utils/stream.ex
@@ -19,7 +19,7 @@ defmodule Meadow.Utils.Stream do
   def exists?("file://" <> filename), do: File.exists?(filename)
 
   def exists?(url) do
-    case HTTPoison.head(url, %{}, follow_redirect: true) do
+    case Meadow.HTTP.head(url, %{}, follow_redirect: true) do
       {:ok, %{status_code: status}} when status in 200..299 -> true
       _ -> false
     end
@@ -94,20 +94,20 @@ defmodule Meadow.Utils.Stream do
     end
   end
 
-  defp async_stream_start(url), do: HTTPoison.get!(url, %{}, stream_to: self(), async: :once)
+  defp async_stream_start(url), do: Meadow.HTTP.get!(url, [], stream_to: self(), async: :once)
 
   defp async_stream_next(%HTTPoison.AsyncResponse{id: id} = resp) do
     receive do
       %HTTPoison.AsyncStatus{id: ^id} ->
-        HTTPoison.stream_next(resp)
+        Meadow.HTTP.stream_next(resp)
         {[], resp}
 
       %HTTPoison.AsyncHeaders{id: ^id} ->
-        HTTPoison.stream_next(resp)
+        Meadow.HTTP.stream_next(resp)
         {[], resp}
 
       %HTTPoison.AsyncChunk{id: ^id, chunk: chunk} ->
-        HTTPoison.stream_next(resp)
+        Meadow.HTTP.stream_next(resp)
         {[chunk], resp}
 
       %HTTPoison.AsyncEnd{id: ^id} ->

--- a/app/lib/mix/tasks/nul_authorities.ex
+++ b/app/lib/mix/tasks/nul_authorities.ex
@@ -143,7 +143,7 @@ defmodule Mix.Tasks.NulAuthorities.Retrieve do
 
   defp post!(base_url, path, data) do
     with url <- URI.parse(base_url) |> Map.put(:path, path) |> URI.to_string() do
-      case HTTPoison.post(url, Jason.encode!(data), @headers)
+      case Meadow.HTTP.post(url, Jason.encode!(data), @headers)
            |> HTTPoison.Retry.autoretry() do
         {:ok, response} -> response
         {:error, :timeout} -> post!(base_url, path, data)

--- a/app/test/meadow/utils/aws_test.exs
+++ b/app/test/meadow/utils/aws_test.exs
@@ -1,7 +1,6 @@
 defmodule Meadow.Utils.AWSTest do
   use Honeybadger.Case
   use Meadow.S3Case
-  alias Meadow.Config
   alias Meadow.Utils.AWS
 
   @project_folder_name "name-of-folder"
@@ -52,77 +51,6 @@ defmodule Meadow.Utils.AWSTest do
     with {:ok, presigned_url} <-
            AWS.presigned_url(@bucket, %{upload_type: "file_set", filename: "original.jpg"}) do
       assert presigned_url =~ regex
-    end
-  end
-
-  describe "error handling" do
-    setup do
-      {:ok, _} = Honeybadger.API.start(self())
-      restart_with_config(exclude_envs: [])
-
-      on_exit(&Honeybadger.API.stop/0)
-    end
-
-    test "request/2 does not report to Honeybadger when request is successful" do
-      ExAws.S3.head_bucket(Config.upload_bucket())
-      |> AWS.request()
-
-      refute_receive {:api_request, _report}, 1000
-    end
-
-    test "request/2 reports error when AWS returns an HTTP error with a body" do
-      ExAws.S3.put_object(@random_bucket, "/path/to/key", "contents")
-      |> AWS.request()
-
-      assert_receive {:api_request, report}, 1000
-
-      assert report |> get_in(["error", "class"]) == "Meadow.AwsError"
-
-      assert report |> get_in(["error", "message"]) ==
-               "404 (NoSuchBucket): The specified bucket does not exist"
-
-      assert report |> get_in(["request", "context", "BucketName"]) == @random_bucket
-    end
-
-    test "request/2 reports error when AWS returns an HTTP error without a body" do
-      ExAws.S3.head_bucket(@random_bucket)
-      |> AWS.request()
-
-      assert_receive {:api_request, report}, 1000
-
-      assert report |> get_in(["error", "class"]) == "Meadow.AwsError"
-      assert report |> get_in(["error", "message"]) == "404"
-    end
-
-    test "request/2 reports error when ExAws fails any other way" do
-      {:error, "Catastrophic Failure"}
-      |> AWS.handle_response()
-
-      assert_receive {:api_request, report}, 1000
-
-      assert report |> get_in(["error", "class"]) == "Meadow.AwsError"
-      assert report |> get_in(["error", "message"]) == "Catastrophic Failure"
-    end
-
-    test "request!/2 does not raise or report when AWS request is successful" do
-      ExAws.S3.head_bucket(Config.upload_bucket())
-      |> AWS.request!()
-
-      refute_receive {:api_request, _report}, 1000
-    end
-
-    test "request!/2 reports and raises when it encounters an error" do
-      assert_raise(ExAws.Error, fn ->
-        ExAws.S3.put_object(@random_bucket, "/path/to/key", "contents")
-        |> AWS.request!()
-      end)
-
-      assert_receive {:api_request, report}, 1000
-
-      assert report |> get_in(["error", "message"]) ==
-               "404 (NoSuchBucket): The specified bucket does not exist"
-
-      assert report |> get_in(["request", "context", "BucketName"]) == @random_bucket
     end
   end
 end


### PR DESCRIPTION
# Summary 
Have Meadow send all HTTP requests with the following `User-Agent`:
```
Meadow/#{meadow_version} (https://github.com/nulib/meadow; contact: repository@northwestern.edu) httpoison/#{httpoison_version} hackney/#{hackney_version}
```

# Specific Changes in this PR
- Create a `Meadow.HTTP` implementation of the `HTTPoison.Base` behaviour that attaches the Meadow user agent
- Create a `Meadow.Utils.AWS.HttpClient` implementation of the `ExAws.Request.HttpClient` behaviour that attaches the Meadow user agent and also takes over the retry logic that used to be in `Meadow.Utils.AWS.request`
- Change all `HTTPoison` calls into `Meadow.HTTP` calls
- Change all `Meadow.Utils.AWS.request` (and `request!`) calls back into regular `ExAws` calls

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test

Just make sure everything still works as expected.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

