### PR TITLE
Allow searching NUL authorities by URI

### DIFF
--- a/app/lib/meadow_web/resolvers/authorities_search.ex
+++ b/app/lib/meadow_web/resolvers/authorities_search.ex
@@ -3,6 +3,16 @@ defmodule MeadowWeb.Resolvers.Data.AuthoritiesSearch do
 
   alias Meadow.Data.ControlledTerms
 
+  def search(
+        %{authority: "nul-authority", query: <<"info:nul/", _::binary-size(36)>> = query},
+        _
+      ) do
+    case Authoritex.fetch(query) do
+      {:ok, %{id: id, label: label, hint: hint}} -> {:ok, [%{id: id, label: label, hint: hint}]}
+      _ -> Authoritex.search("nul-authority", query)
+    end
+  end
+
   def search(%{authority: code, query: query}, _) do
     Authoritex.search(code, query)
   end

--- a/app/test/meadow_web/schema/query/controlled_types/authorities_search_test.exs
+++ b/app/test/meadow_web/schema/query/controlled_types/authorities_search_test.exs
@@ -4,6 +4,8 @@ defmodule MeadowWeb.Schema.Query.AuthoritiesSearchTest do
   use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 
+  alias NUL.Schemas.AuthorityRecord
+
   load_gql(MeadowWeb.Schema, "test/gql/AuthoritiesSearch.gql")
 
   describe "AuthoritiesSearch.gql" do
@@ -20,6 +22,65 @@ defmodule MeadowWeb.Schema.Query.AuthoritiesSearchTest do
                  "label" => "Second Result",
                  "hint" => "(2)"
                })
+      end
+    end
+  end
+
+  describe "NUL Authorities" do
+    @describetag shared: true
+
+    setup do
+      record = %{
+        id: "info:nul/b9a963ed-afa3-4f95-b3fd-ed440a974d76",
+        label: "Harrison and Abramovitz (American architectural firm, 1945-1976)",
+        hint: nil
+      }
+
+      Ecto.Changeset.change(%AuthorityRecord{}, record)
+      |> Meadow.Repo.insert()
+
+      {:ok, record}
+    end
+
+    test "Finds a NUL authority record by regular search" do
+      result =
+        query_gql(
+          variables: %{
+            "authority" => "nul-authority",
+            "query" => "Abram"
+          },
+          context: gql_context()
+        )
+
+      assert {:ok, %{data: query_data}} = result
+
+      with [result | _] <- get_in(query_data, ["authoritiesSearch"]) do
+        assert result == %{
+                 "id" => "info:nul/b9a963ed-afa3-4f95-b3fd-ed440a974d76",
+                 "label" => "Harrison and Abramovitz (American architectural firm, 1945-1976)",
+                 "hint" => nil
+               }
+      end
+    end
+
+    test "Finds a NUL authority record by URI" do
+      result =
+        query_gql(
+          variables: %{
+            "authority" => "nul-authority",
+            "query" => "info:nul/b9a963ed-afa3-4f95-b3fd-ed440a974d76"
+          },
+          context: gql_context()
+        )
+
+      assert {:ok, %{data: query_data}} = result
+
+      with [result | _] <- get_in(query_data, ["authoritiesSearch"]) do
+        assert result == %{
+                 "id" => "info:nul/b9a963ed-afa3-4f95-b3fd-ed440a974d76",
+                 "label" => "Harrison and Abramovitz (American architectural firm, 1945-1976)",
+                 "hint" => nil
+               }
       end
     end
   end


### PR DESCRIPTION
# Summary 
Allow searching NUL authorities by URI

# Specific Changes in this PR
- Add a pattern match to `MeadowWeb.Resolvers.Data.AuthoritiesSearch` to treat a NUL Authority URI as a special case
- Add tests for searching NUL Authorities by term and by URI

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Edit a work and add a controlled term from the NUL Local Authorities. Search by text and also paste an existing ID in.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

