### PR TITLE
Implement backend for bulk updating local authority records

### DIFF
--- a/app/lib/meadow_web/router.ex
+++ b/app/lib/meadow_web/router.ex
@@ -57,6 +57,7 @@ defmodule MeadowWeb.Router do
 
     post("/export/:file", MeadowWeb.ExportController, :export)
     post("/authority_records/bulk_create", MeadowWeb.AuthorityRecordsController, :bulk_create)
+    post("/authority_records/bulk_update", MeadowWeb.AuthorityRecordsController, :bulk_update)
     post("/authority_records/:file", MeadowWeb.AuthorityRecordsController, :export)
     post("/create_shared_links/:file", MeadowWeb.SharedLinksController, :export)
 

--- a/app/lib/nul/schemas/authority_record.ex
+++ b/app/lib/nul/schemas/authority_record.ex
@@ -25,6 +25,7 @@ defmodule NUL.Schemas.AuthorityRecord do
   def update_changeset(record, params) do
     record
     |> cast(params, [:label, :hint])
+    |> validate_required([:label])
     |> unique_constraint(:label)
   end
 

--- a/app/test/meadow_web/controllers/authority_records_controller_test.exs
+++ b/app/test/meadow_web/controllers/authority_records_controller_test.exs
@@ -6,6 +6,8 @@ defmodule MeadowWeb.AuthorityRecordsControllerTest do
   alias NUL.AuthorityRecords
   alias NUL.Schemas.AuthorityRecord
 
+  alias NimbleCSV.RFC4180, as: CSV
+
   describe "POST /api/authority_records/:filename (failure)" do
     test "unauthorized request", %{conn: conn} do
       conn =
@@ -134,6 +136,118 @@ defmodule MeadowWeb.AuthorityRecordsControllerTest do
       assert conn.state == :chunked
       assert response_content_type(conn, :csv)
       assert response(conn, 200)
+    end
+  end
+
+  describe "POST /api/authority_records/bulk_update" do
+    setup do
+      records =
+        AuthorityRecords.create_authority_records([
+          %{label: "First Imported Thing", hint: "preexisting entry"},
+          %{label: "Second Imported Thing", hint: "preexisting entry"},
+          %{label: "Third Imported Thing", hint: "preexisting entry"}
+        ])
+        |> Enum.map(fn {:created, record} -> record end)
+
+      {:ok, path} = Briefly.create()
+
+      upload = %Plug.Upload{
+        content_type: "text/csv",
+        filename: "authority_update.csv",
+        path: path
+      }
+
+      {:ok, %{records: records, upload: upload}}
+    end
+
+    test "update all records", %{conn: conn, records: records, upload: upload} do
+      [record_1, record_2, record_3] = records
+
+      update =
+        [
+          ["id", "label", "hint"],
+          [record_1.id, "First Updated Thing", "updated entry"],
+          [record_2.id, "Second Updated Thing", "updated entry"],
+          [record_3.id, "Third Updated Thing", "updated entry"]
+        ]
+
+      File.write!(upload.path, update |> CSV.dump_to_stream() |> Enum.join())
+
+      conn =
+        conn
+        |> auth_user(user_fixture("TestAdmins"))
+        |> post("/api/authority_records/bulk_update", %{records: upload})
+
+      assert conn.state == :chunked
+      assert response_content_type(conn, :csv)
+      assert body = response(conn, 200)
+
+      assert body =~ "#{record_1.id},First Updated Thing,updated entry,updated"
+      assert body =~ "#{record_2.id},Second Updated Thing,updated entry,updated"
+      assert body =~ "#{record_3.id},Third Updated Thing,updated entry,updated"
+
+      update
+      |> Enum.drop(1)
+      |> Enum.each(fn [id, label, hint] ->
+        assert updated = AuthorityRecords.get_authority_record!(id)
+        assert updated.label == label
+        assert updated.hint == hint
+      end)
+    end
+
+    test "record doesn't exist", %{conn: conn, records: records, upload: upload} do
+      new_id = "info:nul/" <> Ecto.UUID.generate()
+      [record_1, _, record_3] = records
+
+      update =
+        [
+          ["id", "label", "hint"],
+          [record_1.id, "First Updated Thing", "updated entry"],
+          [new_id, "Second Updated Thing", "updated entry"],
+          [record_3.id, "Third Updated Thing", "updated entry"]
+        ]
+
+      File.write!(upload.path, update |> CSV.dump_to_stream() |> Enum.join())
+
+      conn =
+        conn
+        |> auth_user(user_fixture("TestAdmins"))
+        |> post("/api/authority_records/bulk_update", %{records: upload})
+
+      assert conn.state == :chunked
+      assert response_content_type(conn, :csv)
+      assert body = response(conn, 200)
+
+      assert body =~ "#{record_1.id},First Updated Thing,updated entry,updated"
+      assert body =~ "#{new_id},Second Updated Thing,updated entry,not_found"
+      assert body =~ "#{record_3.id},Third Updated Thing,updated entry,updated"
+    end
+
+    test "record is unchanged", %{conn: conn, records: records, upload: upload} do
+      [record_1, record_2, record_3] = records
+
+      update =
+        [
+          ["id", "label", "hint"],
+          [record_1.id, "First Updated Thing", "updated entry"],
+          [record_2.id, record_2.label, record_2.hint],
+          [record_3.id, "Third Updated Thing", "updated entry"]
+        ]
+
+      File.write!(upload.path, update |> CSV.dump_to_stream() |> Enum.join())
+
+      conn =
+        conn
+        |> auth_user(user_fixture("TestAdmins"))
+        |> post("/api/authority_records/bulk_update", %{records: upload})
+
+      assert conn.state == :chunked
+      assert response_content_type(conn, :csv)
+      assert body = response(conn, 200)
+
+      assert body =~ "#{record_1.id},First Updated Thing,updated entry,updated"
+      assert body =~ "#{record_2.id},#{record_2.label},#{record_3.hint},unchanged"
+      assert body =~ "#{record_3.id},Third Updated Thing,updated entry,updated"
     end
   end
 end


### PR DESCRIPTION
# Summary 

Implement backend for bulk updating local authority records

# Specific Changes in this PR
- Add bulk update logic to `NUL.AuthorityRecords` context
- Add `bulk_update` route and handler to `MeadowWeb.AuthorityRecordsController`
- Add tests for bulk update functionality

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test

Test before the front end is implemented requires manually `POST`ing the update file to the right route, with a logged in user cookie:

1. Log into Meadow.
2. Bulk export NUL local authorities
3. Alter the spreadsheet – update some labels and hints, leave some records completely unchanged, and change a couple IDs to IDs that don't really exist
4. Using the value of the `_meadow_key` cookie from any logged-in request:
    ```
    POST /api/authority_records/bulk_update
    Cookie: _meadow_key=[YOUR_MEADOW_KEY]
    Content-Type: multipart/form-data

    records=[CONTENT_OF_UPDATED_CSV_FILE]
    ```
    You can do this in `curl` with:
    ```
    curl -X POST 'https://mbk.dev.rdc.library.northwestern.edu:3001/api/authority_records/bulk_update' \
      --header 'Cookie: _meadow_key=[YOUR_MEADOW_KEY]' \
      --header 'Content-Type: multipart/form-data' \
      --form records=@/path/to/authority_records_update.csv
    ```
    or in Postman by selecting a `form-data` body with a field of type `file`, which will allow you to select a local file:
    ![image](https://github.com/user-attachments/assets/5baf8138-70df-4eac-8da3-c8669e6745d6)

You should receive back a CSV file with the status of each update:
- `updated` for records that were updated
- `unchanged` for records that were identified but the `label` and `hint` were not changed
- `not_found` for IDs referring to nonexistent records

It's possible for unchanged records to sometimes return `updated` because of Ecto transaction stuff. This is probably fine as long as the records still look OK in the dashboard.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [x] Local authorities API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

