### PR TITLE
Address performance bugs related to works with a large number of file sets.

### DIFF
--- a/app/assets/js/components/Work/Fileset/ActionButtons/GroupAdd.jsx
+++ b/app/assets/js/components/Work/Fileset/ActionButtons/GroupAdd.jsx
@@ -11,6 +11,7 @@ const WorkFilesetActionButtonsGroupAdd = ({
 }) => {
   const addRef = React.useRef(null);
   const inputRef = React.useRef(null);
+  const contentRef = React.useRef(null);
   const [isOpen, setIsOpen] = React.useState(false);
   const [filteredCandidateFileSets, setFilteredCandidateFileSets] =
     React.useState(candidateFileSets);
@@ -38,6 +39,10 @@ const WorkFilesetActionButtonsGroupAdd = ({
       document.removeEventListener("keydown", handleEscape);
     };
   }, []);
+
+  useEffect(() => {
+    if (isOpen) contentRef.current.scrollTop = 0;
+  }, [isOpen]);
 
   useEffect(() => {
     setFilteredCandidateFileSets(candidateFileSets);
@@ -103,6 +108,13 @@ const WorkFilesetActionButtonsGroupAdd = ({
     overflow-x: hidden;
     overflow-y: scroll;};
     padding: 0.5rem;
+
+    em {
+      display: block;
+      font-size: 0.75rem;
+      color: var(--colors-richBlack50);
+      margin-top: 0.5rem;
+    } 
 
     button.candidate-option {
       display: flex; 
@@ -184,9 +196,10 @@ const WorkFilesetActionButtonsGroupAdd = ({
         css={content}
         role="searchbox"
         aria-expanded={isOpen}
+        ref={contentRef}
       >
-        {filteredCandidateFileSets.length ? (
-          filteredCandidateFileSets.map((candidate) => (
+        {isOpen && filteredCandidateFileSets.length ? (
+          filteredCandidateFileSets.slice(0, 20).map((candidate) => (
             <button
               key={candidate.id}
               value={candidate.id}
@@ -210,6 +223,12 @@ const WorkFilesetActionButtonsGroupAdd = ({
           ))
         ) : (
           <p>Applicable fileset(s) not found.</p>
+        )}
+        {filteredCandidateFileSets.length > 20 && (
+          <em>
+            Showing the first 20 available filesets. Filter by title or
+            accession number to see more.
+          </em>
         )}
       </div>
     </div>

--- a/app/assets/js/components/Work/Fileset/ActionButtons/GroupAdd.test.jsx
+++ b/app/assets/js/components/Work/Fileset/ActionButtons/GroupAdd.test.jsx
@@ -35,6 +35,10 @@ describe("WorkFilesetActionButtonsGroupAdd component", () => {
     // renders the searchbox expanded as false
     const searchbox = groupAdd.querySelector("div[role='searchbox']");
     expect(searchbox.getAttribute("aria-expanded")).toBe("false");
+
+    // children of the collapsed searchbox are not rendered
+    const buttons = searchbox.querySelectorAll("button");
+    expect(buttons).toHaveLength(0);
   });
 
   it("renders the handles user interactions", async () => {
@@ -48,6 +52,10 @@ describe("WorkFilesetActionButtonsGroupAdd component", () => {
 
     // expands the searchbox on focus
     expect(searchbox.getAttribute("aria-expanded")).toBe("true");
+
+    // children of the expanded searchbox are buttons and rendered
+    const buttons = groupAdd.querySelectorAll("button");
+    expect(buttons).toHaveLength(2);
 
     // renders candidate options
     const candidatesDefaultState = await screen.findAllByTestId(

--- a/app/assets/js/components/Work/Tabs/Structure/Structure.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Structure.jsx
@@ -51,8 +51,11 @@ const WorkTabsStructure = ({ work }) => {
   });
 
   const [groupWithFileSet] = useMutation(GROUP_WITH_FILE_SET, {
-    onCompleted({ groupWithFileSet }) {
-      toastWrapper("is-success", `Fileset has been removed from group`);
+    onCompleted({ updateFileSet }) {
+      const groupWithAction = updateFileSet?.groupWith
+        ? "added to"
+        : "removed from";
+      toastWrapper("is-success", `File set has been ${groupWithAction} group`);
     },
   });
 
@@ -60,7 +63,7 @@ const WorkTabsStructure = ({ work }) => {
     UPDATE_FILE_SETS,
     {
       onCompleted({ updateFileSets }) {
-        toastWrapper("is-success", "Filesets have been updated");
+        toastWrapper("is-success", "File sets have been updated");
         setIsEditing(false);
       },
       onError(error) {


### PR DESCRIPTION
# Summary 
This addresses an issue where works with large number of filesets were being extremely taxing on the DOM when using the Re-order and Group functionality. The issue was causing by an error allowing each list to be rendered regardless even if the searchbox for the GroupAdd.jsx was not actively expanded.

Previous to this work, a work with 10 filesets would:

 - Render 10 dragabble items for each fileset
 - Render a GroupAdd.jsx component with 9 candidate filesets for each item

Essentially, flooding the DOM with 90 fileset references, but this problem grows exponentially as fileset counts increase:

 - **100**: `100 * 99 = 9900` potential fileset references
 - **1000**: `1000 * 999 = 999000` potential fileset references
 - **10000**: `10000 * 9999 = 99990000` potential fileset references

## Review

For ease in testing a work with a large number of filesets, you can access my dev environment:

  - 800+ https://mat.dev.rdc.library.northwestern.edu:3001/work/622a89cd-e921-487f-a019-0b5e9ade51b9
  - 300 https://mat.dev.rdc.library.northwestern.edu:3001/work/953da32f-ee4a-4447-8d19-b8d0e3f6669a 

## Note

This issue makes editing a work with MANY filesets usable, which it previously was not. This issue does not make saving of a large list lightning fast. You should still expect a small wait as the mutations are sent.

# Specific Changes in this PR

- Only render list of candidate filesets in GroupAdd.jsx if it is expanded
- Add `.slice` to array of candidates, only showing the first 20 items
- Add test to searchbox list to ensure children are not rendered unless expanded

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

