### PR TITLE
Revert Clover to working `choice` version.

### DIFF
--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -21,7 +21,7 @@
         "@honeybadger-io/react": "^6.1.7",
         "@nulib/design-system": "^1.5.1",
         "@radix-ui/react-dialog": "^1.1.10",
-        "@samvera/clover-iiif": "^2.14.0",
+        "@samvera/clover-iiif": "^2.13.0",
         "@samvera/image-downloader": "^1.1.1",
         "bulma": "^0.9.4",
         "bulma-checkradio": "^2.1.3",
@@ -8323,9 +8323,9 @@
       "license": "MIT"
     },
     "node_modules/@samvera/clover-iiif": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-2.14.0.tgz",
-      "integrity": "sha512-cI+7n97ZZ0NenBPMCCJzfwinm037dMbyBKX0ENYFOQE+luLyNDbpXG4fOuMCoad2KFBSUEXpJR/drmtd+rxuYg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-2.13.0.tgz",
+      "integrity": "sha512-uyO9EdNpyFd1d97C0Jr+pU4rVgFYwHGkJNCfuhkst3GoZtMu55O5wefgLvOQ9QTNk2/Yca3nS+4+R4Emm7AsIA==",
       "license": "ISC",
       "dependencies": {
         "@iiif/helpers": "^1.2.19",

--- a/app/assets/package.json
+++ b/app/assets/package.json
@@ -31,7 +31,7 @@
     "@honeybadger-io/react": "^6.1.7",
     "@nulib/design-system": "^1.5.1",
     "@radix-ui/react-dialog": "^1.1.10",
-    "@samvera/clover-iiif": "^2.14.0",
+    "@samvera/clover-iiif": "^2.13.0",
     "@samvera/image-downloader": "^1.1.1",
     "bulma": "^0.9.4",
     "bulma-checkradio": "^2.1.3",


### PR DESCRIPTION
# Summary 
This reverts Clover to version v2.13.0 where `choice` body resources are respected. Clover at v2.14.0 introduced a regression related to that will be addressed in a future Clover update.

# Specific Changes in this PR
- Reverts Clover to previous minor version to support `choice` body resources that reflect the `group_with` relationships on filesets. 

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

