### PR TITLE
Add behavior selector

### DIFF
--- a/app/assets/js/__generated__/fragment-masking.ts
+++ b/app/assets/js/__generated__/fragment-masking.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import {
   ResultOf,
   DocumentTypeDecoration,
@@ -22,7 +23,17 @@ export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: FragmentType<DocumentTypeDecoration<TType, any>>,
 ): TType;
+// return nullable if `fragmentType` is undefined
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | undefined,
+): TType | undefined;
 // return nullable if `fragmentType` is nullable
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: FragmentType<DocumentTypeDecoration<TType, any>> | null,
+): TType | null;
+// return nullable if `fragmentType` is nullable or undefined
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType:
@@ -33,9 +44,22 @@ export function useFragment<TType>(
 // return array of non-nullable if `fragmentType` is array of non-nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType: Array<FragmentType<DocumentTypeDecoration<TType, any>>>,
+): Array<TType>;
+// return array of nullable if `fragmentType` is array of nullable
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
+  fragmentType:
+    | Array<FragmentType<DocumentTypeDecoration<TType, any>>>
+    | null
+    | undefined,
+): Array<TType> | null | undefined;
+// return readonly array of non-nullable if `fragmentType` is array of non-nullable
+export function useFragment<TType>(
+  _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType: ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>,
 ): ReadonlyArray<TType>;
-// return array of nullable if `fragmentType` is array of nullable
+// return readonly array of nullable if `fragmentType` is array of nullable
 export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType:
@@ -47,10 +71,11 @@ export function useFragment<TType>(
   _documentNode: DocumentTypeDecoration<TType, any>,
   fragmentType:
     | FragmentType<DocumentTypeDecoration<TType, any>>
+    | Array<FragmentType<DocumentTypeDecoration<TType, any>>>
     | ReadonlyArray<FragmentType<DocumentTypeDecoration<TType, any>>>
     | null
     | undefined,
-): TType | ReadonlyArray<TType> | null | undefined {
+): TType | Array<TType> | ReadonlyArray<TType> | null | undefined {
   return fragmentType as any;
 }
 

--- a/app/assets/js/__generated__/graphql.ts
+++ b/app/assets/js/__generated__/graphql.ts
@@ -240,6 +240,8 @@ export enum BatchType {
 export enum CodeListScheme {
   /** Authority */
   Authority = "AUTHORITY",
+  /** IIIF Behavior */
+  Behavior = "BEHAVIOR",
   /** File Set Role */
   FileSetRole = "FILE_SET_ROLE",
   /** Library Unit */
@@ -413,6 +415,7 @@ export type FileSet = {
   accessionNumber: Scalars["String"]["output"];
   coreMetadata?: Maybe<FileSetCoreMetadata>;
   extractedMetadata?: Maybe<Scalars["String"]["output"]>;
+  groupWith?: Maybe<Scalars["ID"]["output"]>;
   id: Scalars["ID"]["output"];
   insertedAt: Scalars["DateTime"]["output"];
   position?: Maybe<Scalars["String"]["output"]>;
@@ -572,6 +575,11 @@ export type NulAuthorityRecord = {
   hint?: Maybe<Scalars["String"]["output"]>;
   id: Scalars["ID"]["output"];
   label: Scalars["String"]["output"];
+};
+
+export type NullableUrl = {
+  __typename?: "NullableUrl";
+  url?: Maybe<Scalars["String"]["output"]>;
 };
 
 /** Fields for a `preservation_check` object */
@@ -833,6 +841,7 @@ export type RootMutationTypeUpdateCollectionArgs = {
 
 export type RootMutationTypeUpdateFileSetArgs = {
   coreMetadata?: InputMaybe<FileSetCoreMetadataUpdate>;
+  groupWith?: InputMaybe<Scalars["ID"]["input"]>;
   id: Scalars["ID"]["input"];
   posterOffset?: InputMaybe<Scalars["Int"]["input"]>;
   structuralMetadata?: InputMaybe<FileSetStructuralMetadataInput>;
@@ -913,8 +922,10 @@ export type RootQueryType = {
   ingestSheetWorkCount?: Maybe<IngestSheetCounts>;
   /** Get works created for an Ingest Sheet */
   ingestSheetWorks?: Maybe<Array<Maybe<Work>>>;
+  /** List ingest bucket objects */
+  listIngestBucketObjects?: Maybe<S3Listing>;
   /** Get the livebook URL */
-  livebookUrl?: Maybe<Url>;
+  livebookUrl?: Maybe<NullableUrl>;
   /** Get the currently signed-in user */
   me?: Maybe<User>;
   /** Get an NUL AuthorityRecord by ID */
@@ -929,6 +940,8 @@ export type RootQueryType = {
   project?: Maybe<Project>;
   /** Get a list of projects */
   projects?: Maybe<Array<Maybe<Project>>>;
+  /** Search for projects by title */
+  projectsSearch?: Maybe<Array<Maybe<Project>>>;
   /** Get a list of members of a role */
   roleMembers?: Maybe<Array<Maybe<Entry>>>;
   /** Get the list of Roles */
@@ -1015,6 +1028,10 @@ export type RootQueryTypeIngestSheetWorksArgs = {
   limit?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
+export type RootQueryTypeListIngestBucketObjectsArgs = {
+  prefix?: InputMaybe<Scalars["String"]["input"]>;
+};
+
 export type RootQueryTypeNulAuthorityRecordArgs = {
   id: Scalars["ID"]["input"];
 };
@@ -1039,6 +1056,10 @@ export type RootQueryTypeProjectArgs = {
 export type RootQueryTypeProjectsArgs = {
   limit?: InputMaybe<Scalars["Int"]["input"]>;
   order?: InputMaybe<SortOrder>;
+};
+
+export type RootQueryTypeProjectsSearchArgs = {
+  query: Scalars["String"]["input"];
 };
 
 export type RootQueryTypeRoleMembersArgs = {
@@ -1098,6 +1119,30 @@ export type RowErrors = {
   __typename?: "RowErrors";
   errors?: Maybe<Array<Maybe<Errors>>>;
   row?: Maybe<Scalars["Int"]["output"]>;
+};
+
+export type S3Listing = {
+  __typename?: "S3Listing";
+  folders?: Maybe<Array<Maybe<Scalars["String"]["output"]>>>;
+  objects?: Maybe<Array<Maybe<S3Object>>>;
+};
+
+export type S3Object = {
+  __typename?: "S3Object";
+  eTag?: Maybe<Scalars["String"]["output"]>;
+  key?: Maybe<Scalars["String"]["output"]>;
+  lastModified?: Maybe<Scalars["String"]["output"]>;
+  mimeType?: Maybe<Scalars["String"]["output"]>;
+  owner?: Maybe<S3Owner>;
+  size?: Maybe<Scalars["String"]["output"]>;
+  storageClass?: Maybe<Scalars["String"]["output"]>;
+  uri?: Maybe<Scalars["String"]["output"]>;
+};
+
+export type S3Owner = {
+  __typename?: "S3Owner";
+  displayName?: Maybe<Scalars["String"]["output"]>;
+  id?: Maybe<Scalars["String"]["output"]>;
 };
 
 export enum S3UploadType {
@@ -1171,14 +1216,14 @@ export type User = {
 
 /** Meadow user roles */
 export enum UserRole {
-  /** superuser */
-  SuperUser = "SUPERUSER",
   /** administrator */
   Administrator = "ADMINISTRATOR",
   /** editor */
   Editor = "EDITOR",
   /** manager */
   Manager = "MANAGER",
+  /** superuser */
+  Superuser = "SUPERUSER",
   /** user */
   User = "USER",
 }
@@ -1195,6 +1240,7 @@ export type Work = {
   __typename?: "Work";
   accessionNumber: Scalars["String"]["output"];
   administrativeMetadata?: Maybe<WorkAdministrativeMetadata>;
+  behavior?: Maybe<CodedTerm>;
   collection?: Maybe<Collection>;
   descriptiveMetadata?: Maybe<WorkDescriptiveMetadata>;
   fileSets?: Maybe<Array<Maybe<FileSet>>>;
@@ -1359,6 +1405,7 @@ export type WorkIngestProgress = {
 /** Fields that can be updated on a work object */
 export type WorkUpdateInput = {
   administrativeMetadata?: InputMaybe<WorkAdministrativeMetadataInput>;
+  behavior?: InputMaybe<CodedTermInput>;
   collectionId?: InputMaybe<Scalars["ID"]["input"]>;
   descriptiveMetadata?: InputMaybe<WorkDescriptiveMetadataInput>;
   published?: InputMaybe<Scalars["Boolean"]["input"]>;

--- a/app/assets/js/components/Work/Fileset/List.test.js
+++ b/app/assets/js/components/Work/Fileset/List.test.js
@@ -3,13 +3,18 @@ import {
   withReactBeautifulDND,
 } from "@js/services/testing-helpers";
 import { screen, waitFor } from "@testing-library/react";
-
+import { CodeListProvider } from "@js/context/code-list-context";
 import React from "react";
 import WorkFilesetList from "@js/components/Work/Fileset/List";
 import { WorkProvider } from "@js/context/work-context";
 import { mockFileSets } from "@js/mock-data/filesets";
 import { mockUser } from "@js/components/Auth/auth.gql.mock";
 import useIsAuthorized from "@js/hooks/useIsAuthorized";
+import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
+import {
+  mockWork,
+  mockWork2
+} from "../work.gql.mock";
 
 jest.mock("@js/hooks/useIsAuthorized");
 useIsAuthorized.mockReturnValue({
@@ -18,15 +23,61 @@ useIsAuthorized.mockReturnValue({
 });
 
 describe("WorkFilesetList component", () => {
+  it("renders the behavior dropdow with no behavior", async () => {
+    renderWithRouterApollo(
+      <CodeListProvider>
+          <WorkProvider>
+            {withReactBeautifulDND(WorkFilesetList, {
+              fileSets: { access: mockFileSets, auxiliary: [] },
+              isReordering: false,
+              work: mockWork,
+            })}
+          </WorkProvider>
+      </CodeListProvider>,
+      {
+        mocks: allCodeListMocks,
+      }
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("behavior-select"));
+      expect(screen.getByTestId("behavior-select").value).toBe("");
+    });
+  });
+
+  it("renders the behavior dropdown with no work behavior", async () => {
+    renderWithRouterApollo(
+      <CodeListProvider>
+          <WorkProvider>
+            {withReactBeautifulDND(WorkFilesetList, {
+              fileSets: { access: mockFileSets, auxiliary: [] },
+              isReordering: false,
+              work: mockWork2,
+            })}
+          </WorkProvider>
+      </CodeListProvider>,
+      {
+        mocks: allCodeListMocks,
+      }
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("behavior-select"));
+      expect(screen.getByTestId("behavior-select").value).toBe("individuals");
+    });
+  });
+
   it("renders a draggable list component if re-ordering the list", async () => {
     renderWithRouterApollo(
-      <WorkProvider>
-        {withReactBeautifulDND(WorkFilesetList, {
-          fileSets: { access: mockFileSets, auxiliary: [] },
-          isReordering: true,
-        })}
-      </WorkProvider>,
-      {},
+      <CodeListProvider>
+        <WorkProvider>
+          {withReactBeautifulDND(WorkFilesetList, {
+            fileSets: { access: mockFileSets, auxiliary: [] },
+            isReordering: true,
+          })}
+        </WorkProvider>
+      </CodeListProvider>,
+      {
+        mocks: allCodeListMocks,
+      }
     );
     await waitFor(() => {
       expect(screen.getByTestId("fileset-draggable-list"));
@@ -35,12 +86,16 @@ describe("WorkFilesetList component", () => {
 
   it("renders a non-draggable list if not-reordering", async () => {
     renderWithRouterApollo(
-      <WorkProvider>
-        {withReactBeautifulDND(WorkFilesetList, {
-          fileSets: { access: mockFileSets, auxiliary: [] },
-        })}
-      </WorkProvider>,
-      {},
+      <CodeListProvider>
+        <WorkProvider>
+          {withReactBeautifulDND(WorkFilesetList, {
+            fileSets: { access: mockFileSets, auxiliary: [] },
+          })}
+        </WorkProvider>
+      </CodeListProvider>,
+      {
+        mocks: allCodeListMocks,
+      }
     );
     await waitFor(() => {
       expect(screen.getByTestId("fileset-list"));
@@ -49,12 +104,16 @@ describe("WorkFilesetList component", () => {
 
   it("renders the correct number of list elements", async () => {
     renderWithRouterApollo(
-      <WorkProvider>
-        {withReactBeautifulDND(WorkFilesetList, {
-          fileSets: { access: mockFileSets, auxiliary: [] },
-        })}
-      </WorkProvider>,
-      {},
+      <CodeListProvider>
+        <WorkProvider>
+          {withReactBeautifulDND(WorkFilesetList, {
+            fileSets: { access: mockFileSets, auxiliary: [] },
+          })}
+        </WorkProvider>
+      </CodeListProvider>,
+      {
+        mocks: allCodeListMocks,
+      }
     );
     await waitFor(() => {
       expect(screen.getAllByTestId("fileset-item")).toHaveLength(4);

--- a/app/assets/js/components/Work/Tabs/Structure/FilesetsDragAndDrop.test.js
+++ b/app/assets/js/components/Work/Tabs/Structure/FilesetsDragAndDrop.test.js
@@ -1,9 +1,14 @@
+import {
+  renderWithRouterApollo,
+} from "@js/services/testing-helpers";
 import React from "react";
 import WorkTabsStructureFilesetsDragAndDrop from "./FilesetsDragAndDrop";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { mockFileSets } from "@js/mock-data/filesets";
+import { CodeListProvider } from "@js/context/code-list-context";
 import userEvent from "@testing-library/user-event";
 import { WorkProvider } from "@js/context/work-context";
+import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
 
 const mockHandleCancelFn = jest.fn();
 const mockHandleSaveFn = jest.fn();
@@ -11,15 +16,20 @@ const mockGroupWithFn = jest.fn();
 
 describe("WorkTabsStructureFilesetsDragAndDrop component", () => {
   beforeEach(() => {
-    render(
-      <WorkProvider>
-        <WorkTabsStructureFilesetsDragAndDrop
-          fileSets={mockFileSets}
-          handleCancelReorder={mockHandleCancelFn}
-          handleSaveReorder={mockHandleSaveFn}
-          handleGroupWithUpdate={mockGroupWithFn}
-        />
-      </WorkProvider>,
+    renderWithRouterApollo(
+      <CodeListProvider>
+        <WorkProvider>
+          <WorkTabsStructureFilesetsDragAndDrop
+            fileSets={mockFileSets}
+            handleCancelReorder={mockHandleCancelFn}
+            handleSaveReorder={mockHandleSaveFn}
+            handleGroupWithUpdate={mockGroupWithFn}
+          />
+        </WorkProvider>
+      </CodeListProvider>,
+      {
+        mocks: allCodeListMocks,
+      }
     );
   });
 

--- a/app/assets/js/components/Work/Tabs/Structure/Structure.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Structure.jsx
@@ -235,6 +235,7 @@ const WorkTabsStructure = ({ work }) => {
               handleWorkImageChange={handleWorkImageChange}
               isEditing={isEditing}
               workImageFilesetId={workImageFilesetId}
+              work={work}
             />
           )}
         </div>

--- a/app/assets/js/components/Work/controlledVocabulary.gql.mock.js
+++ b/app/assets/js/components/Work/controlledVocabulary.gql.mock.js
@@ -385,8 +385,37 @@ export const codeListFileSetRoleMock = {
   },
 };
 
+export const codeListBehaviorMock = {
+  request: {
+    query: CODE_LIST_QUERY,
+    variables: { scheme: "BEHAVIOR" },
+  },
+  result: {
+    data: {
+      codeList: [
+        {
+          id: "individuals",
+          label: "Individuals",
+          __typename: "CodedTerm",
+        },
+        {
+          id: "continuous",
+          label: "Continuous",
+          __typename: "CodedTerm",
+        },
+        {
+          id: "paged",
+          label: "Paged",
+          __typename: "CodedTerm",
+        },
+      ],
+    },
+  },
+}
+
 export const allCodeListMocks = [
   codeListAuthorityMock,
+  codeListBehaviorMock,
   codeListFileSetRoleMock,
   codeListLibraryUnitMock,
   codeListLicenseMock,

--- a/app/assets/js/components/Work/work.gql.js
+++ b/app/assets/js/components/Work/work.gql.js
@@ -101,6 +101,10 @@ export const GET_WORK = gql`
     work(id: $id) {
       id
       accessionNumber
+      behavior {
+        id
+        label
+      }
       administrativeMetadata {
         libraryUnit {
           id
@@ -505,6 +509,10 @@ export const UPDATE_WORK = gql`
         label
       }
       visibility {
+        id
+        label
+      }
+      behavior {
         id
         label
       }

--- a/app/assets/js/components/Work/work.gql.mock.js
+++ b/app/assets/js/components/Work/work.gql.mock.js
@@ -34,6 +34,7 @@ export const mockWork = {
     },
     visibility: mockVisibility,
   },
+  behavior: null,
   collection: {
     id: "7a6c7b35-41a6-465a-9be2-0587c6b39ae0",
     title: "Collection 1232432 Name",
@@ -241,7 +242,7 @@ export const mockWork = {
   workType: mockWorkType(),
 };
 
-const mockWork2 = {
+export const mockWork2 = {
   accessionNumber: "Donohue_002b",
   administrativeMetadata: {
     libraryUnit: null,
@@ -253,6 +254,11 @@ const mockWork2 = {
     projectProposer: [],
     projectTaskNumber: [],
     status: null,
+  },
+  behavior: {
+    id: "individuals",
+    label: "Individuals",
+    scheme: "BEHAVIOR",
   },
   collection: null,
   descriptiveMetadata: {

--- a/app/assets/js/context/code-list-context.js
+++ b/app/assets/js/context/code-list-context.js
@@ -139,10 +139,22 @@ function CodeListProvider({ children }) {
     throw new Error("Error getting file set role data");
   }
 
+  // GET IIIF BEHAVIORS
+  const {
+    data: behaviorData,
+    error: behaviorError,
+    loading: behaviorLoading,
+  } = useQuery(CODE_LIST_QUERY, { variables: { scheme: "BEHAVIOR" } });
+
+  if (behaviorError) {
+    throw new Error("Error getting behavior data");
+  }
+
   return (
     <CodeListContext.Provider
       value={{
         authorityData,
+        behaviorData,
         fileSetRoleData,
         libraryUnitData,
         licenseData,
@@ -155,7 +167,8 @@ function CodeListProvider({ children }) {
         subjectRoleData,
         visibilityData,
         isLoading: Boolean(
-          fileSetRoleLoading ||
+          behaviorLoading ||
+            fileSetRoleLoading ||
             authorityLoading ||
             libraryUnitLoading ||
             licenseLoading ||

--- a/app/lib/meadow/data/schemas/work.ex
+++ b/app/lib/meadow/data/schemas/work.ex
@@ -33,6 +33,8 @@ defmodule Meadow.Data.Schemas.Work do
 
     field(:work_type, Types.CodedTerm)
 
+    field(:behavior, Types.CodedTerm)
+
     timestamps()
 
     embeds_one(:descriptive_metadata, WorkDescriptiveMetadata, on_replace: :update)
@@ -78,7 +80,8 @@ defmodule Meadow.Data.Schemas.Work do
        :published,
        :representative_file_set_id,
        :visibility,
-       :work_type
+       :work_type,
+       :behavior
      ]}
   end
 
@@ -108,7 +111,8 @@ defmodule Meadow.Data.Schemas.Work do
       :ingest_sheet_id,
       :published,
       :representative_file_set_id,
-      :visibility
+      :visibility,
+      :behavior,
     ]
 
     work

--- a/app/lib/meadow/indexing/v2/work.ex
+++ b/app/lib/meadow/indexing/v2/work.ex
@@ -16,6 +16,7 @@ defmodule Meadow.Indexing.V2.Work do
       api_model: "Work",
       ark: work.descriptive_metadata.ark,
       batch_ids: work.batches |> Enum.map(& &1.id),
+      behavior: encode_label(work.behavior),
       box_name: work.descriptive_metadata.box_name,
       box_number: work.descriptive_metadata.box_number,
       canonical_link: Path.join([dc_url(), "items", work.id]),

--- a/app/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
+++ b/app/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
@@ -118,6 +118,7 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
   @desc "Schemes for code list table. (Ex: Subjects, MARC relators, prevervation levels, etc)"
   enum :code_list_scheme do
     value(:authority, as: "authority", description: "Authority")
+    value(:behavior, as: "behavior", description: "IIIF Behavior")
     value(:file_set_role, as: "file_set_role", description: "File Set Role")
     value(:library_unit, as: "library_unit", description: "Library Unit")
     value(:license, as: "license", description: "License")

--- a/app/lib/meadow_web/schema/types/data/work_types.ex
+++ b/app/lib/meadow_web/schema/types/data/work_types.ex
@@ -120,6 +120,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     field(:descriptive_metadata, :work_descriptive_metadata)
     field(:work_type, :coded_term)
     field(:visibility, :coded_term)
+    field(:behavior, :coded_term)
     field(:published, :boolean)
 
     field :manifest_url, :string do
@@ -237,6 +238,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     field(:administrative_metadata, :work_administrative_metadata_input)
     field(:descriptive_metadata, :work_descriptive_metadata_input)
     field(:visibility, :coded_term_input)
+    field(:behavior, :coded_term_input)
     field(:published, :boolean)
     field(:collection_id, :id)
   end

--- a/app/priv/graphql/schema.json
+++ b/app/priv/graphql/schema.json
@@ -113,7 +113,18 @@
           "enumValues": null,
           "fields": [
             {
-              "args": [],
+              "args": [
+                {
+                  "defaultValue": "false",
+                  "description": null,
+                  "name": "includeDeprecated",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                }
+              ],
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
@@ -444,7 +455,18 @@
           "enumValues": null,
           "fields": [
             {
-              "args": [],
+              "args": [
+                {
+                  "defaultValue": "false",
+                  "description": null,
+                  "name": "includeDeprecated",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                }
+              ],
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
@@ -567,11 +589,39 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "deprecationReason",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "description",
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "isDeprecated",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
               }
             },
             {
@@ -799,7 +849,18 @@
               }
             },
             {
-              "args": [],
+              "args": [
+                {
+                  "defaultValue": "false",
+                  "description": null,
+                  "name": "includeDeprecated",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  }
+                }
+              ],
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
@@ -2696,6 +2757,12 @@
             },
             {
               "deprecationReason": null,
+              "description": "IIIF Behavior",
+              "isDeprecated": false,
+              "name": "BEHAVIOR"
+            },
+            {
+              "deprecationReason": null,
               "description": "File Set Role",
               "isDeprecated": false,
               "name": "FILE_SET_ROLE"
@@ -3766,6 +3833,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "groupWith",
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
                 "ofType": null
               }
             },
@@ -6071,6 +6150,16 @@
                 {
                   "defaultValue": null,
                   "description": null,
+                  "name": "groupWith",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                {
+                  "defaultValue": null,
+                  "description": null,
                   "name": "id",
                   "type": {
                     "kind": "NON_NULL",
@@ -6430,6 +6519,29 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "NulAuthorityRecord",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "url",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "NullableUrl",
           "possibleTypes": null
         },
         {
@@ -7299,6 +7411,29 @@
               }
             },
             {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "prefix",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "List ingest bucket objects",
+              "isDeprecated": false,
+              "name": "listIngestBucketObjects",
+              "type": {
+                "kind": "OBJECT",
+                "name": "S3Listing",
+                "ofType": null
+              }
+            },
+            {
               "args": [],
               "deprecationReason": null,
               "description": "Get the livebook URL",
@@ -7306,7 +7441,7 @@
               "name": "livebookUrl",
               "type": {
                 "kind": "OBJECT",
-                "name": "Url",
+                "name": "NullableUrl",
                 "ofType": null
               }
             },
@@ -7494,6 +7629,37 @@
               "description": "Get a list of projects",
               "isDeprecated": false,
               "name": "projects",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Project",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [
+                {
+                  "defaultValue": null,
+                  "description": null,
+                  "name": "query",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              ],
+              "deprecationReason": null,
+              "description": "Search for projects by title",
+              "isDeprecated": false,
+              "name": "projectsSearch",
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -7805,6 +7971,191 @@
           "interfaces": [],
           "kind": "OBJECT",
           "name": "RowErrors",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "folders",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "objects",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "S3Object",
+                  "ofType": null
+                }
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "S3Listing",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "eTag",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "key",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "lastModified",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "mimeType",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "owner",
+              "type": {
+                "kind": "OBJECT",
+                "name": "S3Owner",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "size",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "storageClass",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "uri",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "S3Object",
+          "possibleTypes": null
+        },
+        {
+          "description": null,
+          "enumValues": null,
+          "fields": [
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "displayName",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "kind": "OBJECT",
+          "name": "S3Owner",
           "possibleTypes": null
         },
         {
@@ -8327,12 +8678,6 @@
           "enumValues": [
             {
               "deprecationReason": null,
-              "description": "superuser",
-              "isDeprecated": false,
-              "name": "SUPERUSER"
-            },
-            {
-              "deprecationReason": null,
               "description": "administrator",
               "isDeprecated": false,
               "name": "ADMINISTRATOR"
@@ -8348,6 +8693,12 @@
               "description": "manager",
               "isDeprecated": false,
               "name": "MANAGER"
+            },
+            {
+              "deprecationReason": null,
+              "description": "superuser",
+              "isDeprecated": false,
+              "name": "SUPERUSER"
             },
             {
               "deprecationReason": null,
@@ -8451,6 +8802,18 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "WorkAdministrativeMetadata",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "behavior",
+              "type": {
+                "kind": "OBJECT",
+                "name": "CodedTerm",
                 "ofType": null
               }
             },
@@ -10191,6 +10554,16 @@
               "type": {
                 "kind": "INPUT_OBJECT",
                 "name": "WorkAdministrativeMetadataInput",
+                "ofType": null
+              }
+            },
+            {
+              "defaultValue": null,
+              "description": null,
+              "name": "behavior",
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "CodedTermInput",
                 "ofType": null
               }
             },

--- a/app/priv/repo/migrations/20250501161619_add_behavior_to_works.exs
+++ b/app/priv/repo/migrations/20250501161619_add_behavior_to_works.exs
@@ -1,0 +1,10 @@
+defmodule Meadow.Repo.Migrations.AddFieldToWorks do
+  use Ecto.Migration
+
+
+  def change do
+    alter table(:works) do
+      add :behavior, :map, null: true, default: nil
+    end
+  end
+end

--- a/app/priv/repo/seeds/coded_terms/behavior.json
+++ b/app/priv/repo/seeds/coded_terms/behavior.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "individuals",
+    "label": "Individuals"
+  },
+  {
+    "id": "continuous",
+    "label": "Continuous"
+  },
+  {
+    "id": "paged",
+    "label": "Paged"
+  }
+]

--- a/app/test/meadow/data/coded_terms_test.exs
+++ b/app/test/meadow/data/coded_terms_test.exs
@@ -5,6 +5,7 @@ defmodule Meadow.Data.CodedTermsTest do
 
   @schemes [
     "authority",
+    "behavior",
     "file_set_role",
     "library_unit",
     "license",


### PR DESCRIPTION
# Summary 

Adds a `behavior` option to works, corresponding to [IIIF Behavior](https://iiif.io/api/presentation/3.0/#behavior) values.

# Specific Changes in this PR

- adds new `CodedTerms` with the scheme `"behavior"`
- adds new coded terms seeds (see note below)
- adds a `behavior` field to the `Work` type
- updates GraphQL queries and mutations
- adds a dropdown in the Access files tab to select a behavior
 
**Note:**
Though the original issue lists:
- individuals
- continuous
- paged
- facing_pages
- non_paged

as terms to be added, because `facing_pages` and `non_paged` only apply to Canvases and not Manifests, they were not included in the seed file.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [X] Minor
- [ ] Major

# Steps to Test

See example here: https://cwl.dev.rdc.library.northwestern.edu:3001/work/d9199523-afeb-4239-b20f-2a76ef04977c

<img width="1401" alt="image" src="https://github.com/user-attachments/assets/5e7a22a5-abb9-4674-95b7-a7748c0fc40d" />


Will need to incorporate the seed file, so `mix ecto.reset`

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [x] Database Schema changes
  - [x] GraphQL API
  - [x] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [x] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex (**???? maybe**)
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

