### PR TITLE
Make bulk size dynamic based on byte size to avoid OpenSearch request body limits

### DIFF
--- a/app/assets/js/components/Dashboards/LocalAuthorities/ModalBulkAdd.jsx
+++ b/app/assets/js/components/Dashboards/LocalAuthorities/ModalBulkAdd.jsx
@@ -92,6 +92,7 @@ function DashboardsLocalAuthoritiesModalBulkAdd({
                   />
                   <span className="ml-2">Bulk Add</span>
                 </label>
+                {/* 
                 <label className="radio">
                   <input
                     type="radio"
@@ -102,6 +103,7 @@ function DashboardsLocalAuthoritiesModalBulkAdd({
                   />
                   <span className="ml-2">Bulk Update</span>
                 </label>
+                */}
               </div>
             </div>
 

--- a/app/assets/js/components/Dashboards/LocalAuthorities/ModalBulkAdd.test.js
+++ b/app/assets/js/components/Dashboards/LocalAuthorities/ModalBulkAdd.test.js
@@ -25,7 +25,7 @@ describe("DashboardsLocalAuthoritiesModalBulkAdd component", () => {
     expect(screen.getByTestId("submit-button"));
     expect(screen.getByTestId("cancel-button"));
     expect(screen.getByTestId("bulk-add-radio"));
-    expect(screen.getByTestId("bulk-update-radio"));
+    // expect(screen.getByTestId("bulk-update-radio"));
   });
 
   it("calls the Cancel callback function", async () => {
@@ -36,39 +36,39 @@ describe("DashboardsLocalAuthoritiesModalBulkAdd component", () => {
 
   it("has 'Bulk Add' selected by default", () => {
     const bulkAddRadio = screen.getByTestId("bulk-add-radio");
-    const bulkUpdateRadio = screen.getByTestId("bulk-update-radio");
+    // const bulkUpdateRadio = screen.getByTestId("bulk-update-radio");
     
     expect(bulkAddRadio).toBeChecked();
-    expect(bulkUpdateRadio).not.toBeChecked();
+    // expect(bulkUpdateRadio).not.toBeChecked();
   });
 
-  it("changes form action when 'Bulk Update' is selected", async () => {
-    const user = userEvent.setup();
-    const bulkUpdateRadio = screen.getByTestId("bulk-update-radio");
+  // it("changes form action when 'Bulk Update' is selected", async () => {
+  //   const user = userEvent.setup();
+  //   const bulkUpdateRadio = screen.getByTestId("bulk-update-radio");
     
-    const form = screen.getByRole("form");
-    expect(form.getAttribute("action")).toBe("/api/authority_records/bulk_create");
+  //   const form = screen.getByRole("form");
+  //   expect(form.getAttribute("action")).toBe("/api/authority_records/bulk_create");
     
-    await user.click(bulkUpdateRadio);
+  //   await user.click(bulkUpdateRadio);
     
-    expect(form.getAttribute("action")).toBe("/api/authority_records/bulk_update");
-  });
+  //   expect(form.getAttribute("action")).toBe("/api/authority_records/bulk_update");
+  // });
 
-  it("changes form action when switching between options", async () => {
-    const user = userEvent.setup();
-    const bulkAddRadio = screen.getByTestId("bulk-add-radio");
-    const bulkUpdateRadio = screen.getByTestId("bulk-update-radio");
-    const form = screen.getByRole("form");
+  // it("changes form action when switching between options", async () => {
+  //   const user = userEvent.setup();
+  //   const bulkAddRadio = screen.getByTestId("bulk-add-radio");
+  //   const bulkUpdateRadio = screen.getByTestId("bulk-update-radio");
+  //   const form = screen.getByRole("form");
     
-    // Initial state
-    expect(form.getAttribute("action")).toBe("/api/authority_records/bulk_create");
+  //   // Initial state
+  //   expect(form.getAttribute("action")).toBe("/api/authority_records/bulk_create");
     
-    // Switch to update
-    await user.click(bulkUpdateRadio);
-    expect(form.getAttribute("action")).toBe("/api/authority_records/bulk_update");
+  //   // Switch to update
+  //   await user.click(bulkUpdateRadio);
+  //   expect(form.getAttribute("action")).toBe("/api/authority_records/bulk_update");
     
-    // Switch back to add
-    await user.click(bulkAddRadio);
-    expect(form.getAttribute("action")).toBe("/api/authority_records/bulk_create");
-  });
+  //   // Switch back to add
+  //   await user.click(bulkAddRadio);
+  //   expect(form.getAttribute("action")).toBe("/api/authority_records/bulk_create");
+  // });
 });

--- a/app/lib/meadow/config/runtime.ex
+++ b/app/lib/meadow/config/runtime.ex
@@ -143,7 +143,8 @@ defmodule Meadow.Config.Runtime do
         timeout: 20_000,
         recv_timeout: 90_000
       ],
-      bulk_page_size: 200,
+      bulk_page_size: 1_000,
+      bulk_request_limit: 1024 * 1024 * 1024 * 10,
       bulk_wait_interval: 500,
       indexes: [
         %{

--- a/app/lib/meadow/search/config.ex
+++ b/app/lib/meadow/search/config.ex
@@ -96,6 +96,11 @@ defmodule Meadow.Search.Config do
     |> Keyword.get(:bulk_page_size)
   end
 
+  def bulk_request_limit do
+    Application.get_env(:meadow, Meadow.Search.Cluster)
+    |> Keyword.get(:bulk_request_limit)
+  end
+
   def bulk_wait_interval do
     Application.get_env(:meadow, Meadow.Search.Cluster)
     |> Keyword.get(:bulk_wait_interval)

--- a/app/test/meadow/data/schemas/types/controlled_term_test.exs
+++ b/app/test/meadow/data/schemas/types/controlled_term_test.exs
@@ -35,7 +35,7 @@ defmodule Meadow.Data.Types.ControlledTermTest do
     test "load function" do
       assert ControlledTerm.load(@controlled_term.id) == {:ok, @controlled_term}
 
-      assert ControlledTerm.load(1234) == {:ok, %{id: @controlled_term.id, label: "", variants: []}}
+      assert ControlledTerm.load("bad-id") == {:ok, %{id: "bad-id", label: "", variants: []}}
     end
   end
 

--- a/app/test/meadow/search/bulk_test.exs
+++ b/app/test/meadow/search/bulk_test.exs
@@ -8,6 +8,8 @@ defmodule Meadow.Search.BulkTest do
   alias Meadow.Search.{Bulk, Document, Index}
   alias Meadow.Search.Config, as: SearchConfig
 
+  import ExUnit.CaptureLog
+
   @target_version 2
   @target_index SearchConfig.alias_for(Work, @target_version)
 
@@ -41,5 +43,39 @@ defmodule Meadow.Search.BulkTest do
     Index.refresh(@target_index)
 
     assert indexed_doc_count(Work, @target_version) == {:ok, work_count + 1}
+  end
+
+  describe "large document bulks" do
+    setup do
+      cluster_config = Application.get_env(:meadow, Meadow.Search.Cluster)
+      updated_config = Keyword.put(cluster_config, :bulk_request_limit, 2_500)
+      Application.put_env(:meadow, Meadow.Search.Cluster, updated_config)
+
+      on_exit(fn ->
+        Application.put_env(:meadow, Meadow.Search.Cluster, cluster_config)
+      end)
+    end
+
+    test "upload/2 with large documents", %{work_count: work_count} do
+      assert indexed_doc_count(Work, @target_version) == {:ok, work_count}
+
+      document_1 =
+        work_fixture()
+        |> Repo.preload(Work.required_index_preloads())
+        |> Document.encode(@target_version)
+
+      document_2 =
+        work_fixture()
+        |> Repo.preload(Work.required_index_preloads())
+        |> Document.encode(@target_version)
+
+      assert capture_log(fn ->
+        Bulk.upload([document_1, document_2], @target_index)
+      end) =~ "Uploading 1 document ("
+
+      Index.refresh(@target_index)
+
+      assert indexed_doc_count(Work, @target_version) == {:ok, work_count + 2}
+    end
   end
 end


### PR DESCRIPTION
# Summary 
Make bulk size dynamic based on byte size to avoid OpenSearch request body limits. Temporarily disable NUL authorities bulk update feature in frontend.

# Specific Changes in this PR
- Adjust bulk page size default
- Splits bulk indexing requests that go above the size limit dynamically

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

