### PR TITLE
NUL Authority bulk update - surface errors and display to users

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,11 @@ You will probably see `Warning: AWS account ID not found for provider`, but this
 
 ```
 cd app
+export AWS_LOCALSTACK=true 
 mix test [test args...]
 ```
 
-**Note:** `mix test` can be run repeatedly without re-provisioning as long as the Docker services are running. If you stop the services, you will need to run Terraform again.
+**Note:** `mix test` can be run repeatedly without re-provisioning as long as the Docker services are running. If you stop the services, you will need to run Terraform again. Also, do not try to run Meadow with `export AWS_LOCALSTACK=true` set.
 
 ### GraphQL API
 

--- a/app/assets/js/components/Dashboards/LocalAuthorities/List.jsx
+++ b/app/assets/js/components/Dashboards/LocalAuthorities/List.jsx
@@ -174,6 +174,7 @@ export default function DashboardsLocalAuthoritiesList() {
           label="NUL search"
           onChange={handleSearchChange}
           value={searchValue}
+          showClearButton={true}
         />
       </SearchBarRow>
 

--- a/app/assets/js/components/UI/Form/Input.jsx
+++ b/app/assets/js/components/UI/Form/Input.jsx
@@ -1,6 +1,21 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { useFormContext } from "react-hook-form";
+import { Button, Icon } from "@nulib/design-system";
+/** @jsx jsx */
+import { css, jsx } from "@emotion/react";
+
+const clearButtonStyles = css`
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none !important;
+  border: none !important;
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+`;
 
 const UIFormInput = ({
   id = "",
@@ -9,19 +24,37 @@ const UIFormInput = ({
   name,
   required,
   type = "text",
+  showClearButton = false,
   ...passedInProps
 }) => {
   let errors = {},
-    register;
+    register,
+    setValue,
+    watch;
 
   if (isReactHookForm) {
     const context = useFormContext();
     errors = context.formState.errors;
     register = context.register;
+    setValue = context.setValue;
+    watch = context.watch;
   }
 
+  const currentValue = isReactHookForm ? watch(name) : passedInProps.value;
+  const shouldShowClear =
+    showClearButton && currentValue && currentValue.length > 0;
+
+  const handleClear = () => {
+    if (isReactHookForm) {
+      setValue(name, "");
+    } else if (passedInProps.onChange) {
+      // For non-react-hook-form usage
+      passedInProps.onChange({ target: { name, value: "" } });
+    }
+  };
+
   return (
-    <>
+    <div>
       <input
         id={id || name}
         name={name}
@@ -30,12 +63,25 @@ const UIFormInput = ({
         className={`input ${errors[name] ? "is-danger" : ""}`}
         {...passedInProps}
       />
+      {shouldShowClear && (
+        <Button
+          type="button"
+          onClick={handleClear}
+          className="clear-button"
+          css={clearButtonStyles}
+          aria-label="Clear input"
+        >
+          <Icon isSmall isText>
+            <Icon.Close />
+          </Icon>
+        </Button>
+      )}
       {errors[name] && (
         <p data-testid="input-errors" className="help is-danger">
           {label || name} field is required
         </p>
       )}
-    </>
+    </div>
   );
 };
 

--- a/app/assets/js/components/UI/Form/Input.test.js
+++ b/app/assets/js/components/UI/Form/Input.test.js
@@ -43,3 +43,94 @@ xit("renders error message when errors", async () => {
   expect(getByTestId("input-errors")).toBeInTheDocument();
   expect(getByText("First name field is required"));
 });
+
+
+it("does not show clear button when showClearButton is false", () => {
+  const { queryByLabelText } = renderWithReactHookForm(
+    <UIInput {...attrs} showClearButton={false} />
+  );
+
+  expect(queryByLabelText("Clear input")).not.toBeInTheDocument();
+});
+
+it("does not show clear button when input is empty", () => {
+  const attrsWithoutValue = { ...attrs, defaultValue: "" };
+  const { queryByLabelText } = renderWithReactHookForm(
+    <UIInput {...attrsWithoutValue} showClearButton={true} />
+  );
+
+  expect(queryByLabelText("Clear input")).not.toBeInTheDocument();
+});
+
+it("shows clear button when showClearButton is true and input has value", () => {
+  const { getByLabelText } = renderWithReactHookForm(
+    <UIInput {...attrs} isReactHookForm={true} showClearButton={true} />,
+    {
+      defaultValues: { tester: "Bob Smith" }  
+    }
+  );
+  
+  expect(getByLabelText("Clear input")).toBeInTheDocument();
+});
+
+it("clears input value when clear button is clicked (React Hook Form)", async () => {
+  const { getByLabelText, getByTestId } = renderWithReactHookForm(
+    <UIInput {...attrs} isReactHookForm={true} showClearButton={true} />,
+    {
+      defaultValues: { tester: "Bob Smith" }
+    }
+  );
+
+  const input = getByTestId("input-element");
+  const clearButton = getByLabelText("Clear input");
+
+  expect(input.value).toEqual("Bob Smith");
+
+  clearButton.click();
+
+  await waitFor(() => {
+    expect(input.value).toEqual("");
+  });
+});
+
+it("clears input value when clear button is clicked (non-React Hook Form)", () => {
+  const mockOnChange = jest.fn();
+  const nonHookFormAttrs = {
+    ...attrs,
+    isReactHookForm: false,
+    onChange: mockOnChange,
+    value: "Bob Smith"
+  };
+
+  const { getByLabelText } = renderWithReactHookForm(
+    <UIInput {...nonHookFormAttrs} showClearButton={true} />
+  );
+
+  const clearButton = getByLabelText("Clear input");
+  clearButton.click();
+
+  expect(mockOnChange).toHaveBeenCalledWith({
+    target: { name: "tester", value: "" }
+  });
+});
+
+it("hides clear button after clearing input", async () => {
+  const { getByLabelText, queryByLabelText, getByTestId } = renderWithReactHookForm(
+    <UIInput {...attrs} isReactHookForm={true} showClearButton={true} />,
+    {
+      defaultValues: { tester: "Bob Smith" }
+    }
+  );
+
+  expect(getByLabelText("Clear input")).toBeInTheDocument();
+
+  getByLabelText("Clear input").click();
+
+  await waitFor(() => {
+    expect(getByTestId("input-element").value).toEqual("");
+  });
+
+  await waitFor(() => {
+    expect(queryByLabelText("Clear input")).not.toBeInTheDocument();
+  });
+});

--- a/app/test/meadow_web/controllers/authority_records_controller_test.exs
+++ b/app/test/meadow_web/controllers/authority_records_controller_test.exs
@@ -86,21 +86,8 @@ defmodule MeadowWeb.AuthorityRecordsControllerTest do
         |> auth_user(user_fixture("TestAdmins"))
         |> post("/api/authority_records/bulk_create", %{records: upload})
 
-      assert response(conn, 400)
-    end
-
-    @tag fixture: "test/fixtures/authority_records/bad_authority_import.csv"
-    test "bad data, w/referer", %{conn: conn, upload: upload} do
-      referer = "https://example.edu/dashboards/nul-local-authorities"
-
-      conn =
-        conn
-        |> auth_user(user_fixture("TestAdmins"))
-        |> put_req_header("referer", referer)
-        |> post("/api/authority_records/bulk_create", %{records: upload})
-
-      assert response(conn, 302)
-      assert [^referer] = get_resp_header(conn, "location")
+      assert body = response(conn, 400)
+      assert body =~ "Invalid CSV format. Expected columns: label, hint"
     end
 
     @tag fixture: "test/fixtures/authority_records/good_authority_import.csv"


### PR DESCRIPTION
# Summary 

Currently when NUL authority bulk update encounters bad data or errors, it throws an internal server error and a blank page is displayed to users with no information about what went wrong.

# Specific Changes in this PR

- Front end/UI:
  - Updated front end to send request using `fetch` and display error responses in modal
  - Handles form resetting/clearing properly now
  - Added clear button (the little 'x') to the search bar (`Input.jsx`) component (defaults to show=false)
- Error conditions surfaced:
  - Create
    - CSV too large (database error)
    - Invalid headers
  - Update
    - Duplicate labels in CSV (marked as status `duplicate_in_batch` in results csv)
    - Label already present in DB (marked as status `label_already_exists` in results csv)
    - Invalid headers
- Also removed the redirect logic as I don't think it's needed at this point (LMK if I'm wrong about that)

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Perform NUL Authorities bulk create/update operations for success and error conditions listed above.
  - CSV's that error should display an error message to the user in the UI
  - CSV's that successfully process will return a csv (download happens automatically) that contains details about the results (created/update, not found, duplicate, error, etc...). Modal should close/clear automatically after successful create/update operation.
- Cancel or "X" button on the modal should now clear the form and stale values should not be shown when the model is subsequently opened
- Authorites search input should allow clearing of contents
- Regression test all bulk actions as most code was refactored

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

