### PR TITLE
Make sure a successful hot_swap always cleans up

### DIFF
--- a/app/lib/meadow/config/runtime.ex
+++ b/app/lib/meadow/config/runtime.ex
@@ -152,19 +152,22 @@ defmodule Meadow.Config.Runtime do
           settings: priv_path("search/v2/settings/work.json"),
           version: 2,
           schemas: [Meadow.Data.Schemas.Work],
-          pipeline: prefix("dc-v2-work-pipeline")
+          pipeline: prefix("dc-v2-work-pipeline"),
+          retain: 1
         },
         %{
           name: prefix("dc-v2-file-set"),
           settings: priv_path("search/v2/settings/file_set.json"),
           version: 2,
-          schemas: [Meadow.Data.Schemas.FileSet]
+          schemas: [Meadow.Data.Schemas.FileSet],
+          retain: 1
         },
         %{
           name: prefix("dc-v2-collection"),
           settings: priv_path("search/v2/settings/collection.json"),
           version: 2,
-          schemas: [Meadow.Data.Schemas.Collection]
+          schemas: [Meadow.Data.Schemas.Collection],
+          retain: 1
         }
       ],
       embedding_model_id: get_secret(:index, ["embedding_model"]),


### PR DESCRIPTION
# Summary 
Clean up old indexes after `reindex_all` (or any `hot_swap`)

# Specific Changes in this PR
- Add a `retain` property to index configs to determine how many to keep
- Add a `clean` method to the chain of methods called after a hot swap
- Work around `synchronize_schema` returning `{:ok, :ok}` instead of just `:ok` (because of the transaction wrapper)
- Write tests to make sure only 1 index is retained for each schema after `reindex_all`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Call `Indexer.reindex_all/0` a bunch of times and make sure you don't end up with a whole bunch of stale indexes. If you want, change the `retain` values in the cluster config and make sure the right number are retained.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

