### PR TITLE
Allow logged in users to continue without clearing cookies

### DIFF
--- a/app/test/meadow_web/plugs/set_current_user_test.exs
+++ b/app/test/meadow_web/plugs/set_current_user_test.exs
@@ -47,5 +47,38 @@ defmodule MeadowWeb.Plugs.SetCurrentUserTest do
              } ==
                conn.assigns[:current_user]
     end
+
+    test "SetCurrentUser plug handles logged in user roles", %{user: user} do
+      conn =
+        build_conn()
+        |> Plug.Test.init_test_session(
+          current_user: %User{
+            id: user.id,
+            username: user.username,
+            email: user.email,
+            display_name: user.display_name,
+            role: "SuperUser"
+          }
+        )
+        |> SetCurrentUser.call(nil)
+
+      assert %User{
+               username: user.username,
+               email: user.email,
+               id: user.id,
+               display_name: user.display_name,
+               role: :superuser
+             } ==
+               conn.private.absinthe.context.current_user
+
+      assert %User{
+               username: user.username,
+               email: user.email,
+               id: user.id,
+               display_name: user.display_name,
+               role: :superuser
+             } ==
+               conn.assigns[:current_user]
+    end
   end
 end


### PR DESCRIPTION
# Summary 
Allow logged in users to continue without clearing cookies

# Specific Changes in this PR
- Downcase and atomize the role key in the user's session
- Add test for the above
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

