### PR TITLE
Add transcriber bucket access to meadow-uploader on staging

### DIFF
--- a/infrastructure/deploy/upload_user.tf
+++ b/infrastructure/deploy/upload_user.tf
@@ -27,14 +27,17 @@ data "aws_iam_policy_document" "upload_bucket_access" {
       "s3:GetObjectVersion"
     ]
 
-    resources = [
+    resources = concat([
       aws_s3_bucket.meadow_ingest.arn,
       aws_s3_bucket.meadow_uploads.arn,
       aws_s3_bucket.meadow_preservation_checks.arn,
       "${aws_s3_bucket.meadow_ingest.arn}/*",
       "${aws_s3_bucket.meadow_uploads.arn}/*",
       "${aws_s3_bucket.meadow_preservation_checks.arn}/*"
-    ]
+    ], var.transcription_bucket != "" ? [
+      "arn:aws:s3:::${var.transcription_bucket}",
+      "arn:aws:s3:::${var.transcription_bucket}/*"
+    ] : [])
   }
 }
 

--- a/infrastructure/deploy/variables.tf
+++ b/infrastructure/deploy/variables.tf
@@ -138,3 +138,8 @@ variable "livebook_shared_bucket" {
   type    = string
   default = ""
 }
+
+variable "transcription_bucket" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
# Summary 

Add transcriber bucket access to meadow-uploader on staging

*_Terraform already applied._

# Specific Changes in this PR

- Add transcriber bucket access to meadow-uploader on staging


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

meadow-uploader user should have read/upload/delete access to `nul-transcriber` bucket on staging

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

