### PR TITLE
Change runtime locale from en_US.UTF-8 to C.UTF-8

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -48,7 +48,7 @@ FROM ${RUNTIME_IMAGE}
 LABEL edu.northwestern.library.app=meadow \
   edu.northwestern.library.stage=runtime
 RUN apt update -qq && apt install -y curl jq libssl-dev libncurses5-dev
-ENV LANG=en_US.UTF-8
+ENV LANG=C.UTF-8
 EXPOSE 4000 4369
 COPY --from=build /app/_build/prod/rel/meadow /app
 WORKDIR /app


### PR DESCRIPTION
# Summary 
Update runtime locale to avoid Erlang warning

# Specific Changes in this PR
- Change runtime locale from en_US.UTF-8 to C.UTF-8
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

