### PR TITLE
Fix flappy FileSet delete test

### DIFF
--- a/app/test/fixtures/test_users.json
+++ b/app/test/fixtures/test_users.json
@@ -4,7 +4,7 @@
     "mail": "TestUser13@example.com",
     "nuAllDisplayName": "Test User13",
     "nuAllSchoolAffiliations": ["lib:staff"],
-    "_role": "manager"
+    "_role": "editor"
   },
   {
     "uid": "aum1701",

--- a/app/test/meadow_web/schema/query/file_sets_test.exs
+++ b/app/test/meadow_web/schema/query/file_sets_test.exs
@@ -45,7 +45,7 @@ defmodule MeadowWeb.Schema.Query.FileSetsTest do
       "file_set_id" => file_set.id
     }
 
-    conn = build_conn() |> auth_user(user_fixture())
+    conn = build_conn() |> auth_user(user_fixture(:editor))
 
     response = post(conn, "/api/graphql", query: @delete_query, variables: input)
 

--- a/app/test/support/test_helpers.ex
+++ b/app/test/support/test_helpers.ex
@@ -16,7 +16,8 @@ defmodule Meadow.TestHelpers do
 
   @test_users %{
     administrator: ~w[auy5400 auk0124 auh7250 aud6389],
-    manager: ~w[aut2418 aum1701 auf2249 aua6615],
+    editor: ~w[aut2418],
+    manager: ~w[aum1701 auf2249 aua6615],
     user: ~w[aup9261 aup6836],
     staff_user: ~w[aup6836],
     faculty_user: ~w[auw7721],


### PR DESCRIPTION
# Summary 
Fix flappy test at `test/meadow_web/schema/query/file_sets_test.exs:41`

# Specific Changes in this PR
- Reassign one of the test users as an editor
- Make sure the file set delete GraphQL test runs as an editor
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

