### PR TITLE
Switchover usage of UIFormSelect `disabled` to `aria-readonly`

### DIFF
--- a/app/assets/js/components/UI/Form/Select.test.js
+++ b/app/assets/js/components/UI/Form/Select.test.js
@@ -21,19 +21,29 @@ describe("Select component", () => {
     expect(renderWithReactHookForm(<UIFormSelect {...props} />));
   });
 
-  it("renders passed through attributes to the input element", () => {
+  it("renders passed through attributes to the select element", () => {
     const { getByTestId } = renderWithReactHookForm(
-      <UIFormSelect {...props} defaultValue={2} disabled />
+      <UIFormSelect {...props} defaultValue={2} data-foo="bar" />,
     );
     const select = getByTestId("select-level");
 
     expect(select.name).toEqual(props.name);
-    expect(select.disabled).toBeTruthy();
+    expect(select.getAttribute("data-foo")).toEqual("bar");
+  });
+
+  it("renders isReadOnly attribute to the select element", () => {
+    const { getByTestId } = renderWithReactHookForm(
+      <UIFormSelect {...props} defaultValue={2} isReadOnly={true} />,
+    );
+    const select = getByTestId("select-level");
+
+    expect(select.name).toEqual(props.name);
+    expect(select.getAttribute("aria-readonly")).toBeTruthy();
   });
 
   it("renders supplied options and a default value", () => {
     const { getByTestId, getByText } = renderWithReactHookForm(
-      <UIFormSelect {...props} defaultValue={2} />
+      <UIFormSelect {...props} defaultValue={2} />,
     );
 
     expect(getByText("Level 1")).toBeInTheDocument();
@@ -46,7 +56,7 @@ describe("Select component", () => {
 
   it("selects different option values correctly", () => {
     const { getByTestId } = renderWithReactHookForm(
-      <UIFormSelect {...props} />
+      <UIFormSelect {...props} />,
     );
     const select = getByTestId("select-level");
     fireEvent.change(select, { target: { value: "3" } });

--- a/app/assets/js/components/Work/Tabs/Preservation/FileSetDropzone.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/FileSetDropzone.jsx
@@ -82,7 +82,7 @@ function WorkTabsPreservationFileSetDropzone({
           <input {...getInputProps()} />
           <p>
             <IconFile className="has-text-grey mr-3" />
-            Drag 'n' drop a file here, or click to select file
+            Drag and drop a file here, or click to select file
           </p>
         </div>
       )}

--- a/app/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/FileSetModal.jsx
@@ -4,7 +4,7 @@ import {
   DialogContent,
   DialogFooter,
   DialogOverlay,
-  DialogTitle
+  DialogTitle,
 } from "@js/components/UI/Dialog/Dialog.styled";
 import { Button, Icon, Notification } from "@nulib/design-system";
 import { FormProvider, useForm } from "react-hook-form";
@@ -12,7 +12,11 @@ import { GET_WORK, INGEST_FILE_SET } from "@js/components/Work/work.gql.js";
 import React, { useState, useEffect } from "react";
 /** @jsx jsx */
 import { css, jsx } from "@emotion/react";
-import { getFileNameFromS3Uri, s3Location, toastWrapper } from "@js/services/helpers";
+import {
+  getFileNameFromS3Uri,
+  s3Location,
+  toastWrapper,
+} from "@js/services/helpers";
 import { useLazyQuery, useMutation } from "@apollo/client";
 
 import Error from "@js/components/UI/Error";
@@ -24,7 +28,7 @@ import WorkTabsPreservationFileSetDropzone from "@js/components/Work/Tabs/Preser
 import WorkTabsPreservationFileSetForm from "@js/components/Work/Tabs/Preservation/FileSetForm";
 import useAcceptedMimeTypes from "@js/hooks/useAcceptedMimeTypes";
 import { useCodeLists } from "@js/context/code-list-context";
-import S3ObjectPicker from "@js/components/Work/Tabs/Preservation/S3ObjectPicker"
+import S3ObjectPicker from "@js/components/Work/Tabs/Preservation/S3ObjectPicker";
 
 function WorkTabsPreservationFileSetModal({
   closeModal,
@@ -62,7 +66,7 @@ function WorkTabsPreservationFileSetModal({
       name: getFileNameFromS3Uri(s3Object.key),
     });
     setS3UploadLocation(s3Object.key);
-    setUploadMethod('s3');
+    setUploadMethod("s3");
   };
 
   useEffect(() => {
@@ -124,12 +128,13 @@ function WorkTabsPreservationFileSetModal({
           original_filename: currentFile.name,
           location: s3UploadLocation,
         },
-      }
-    }
+      },
+    };
     ingestFileSet(mutationInput);
   };
 
   const resetForm = () => {
+    console.log("Resetting form");
     methods.reset(defaultValues);
     setCurrentFile(null);
     setS3UploadLocation(null);
@@ -152,7 +157,7 @@ function WorkTabsPreservationFileSetModal({
 
   const handleSetFile = (file) => {
     setCurrentFile(file);
-    setUploadMethod('dragdrop');
+    setUploadMethod("dragdrop");
     if (file) {
       getPresignedUrl({
         variables: {
@@ -215,7 +220,9 @@ function WorkTabsPreservationFileSetModal({
           {urlError ? (
             <div>
               <section>
-                <Notification isDanger>Error retrieving presigned url</Notification>
+                <Notification isDanger>
+                  Error retrieving presigned url
+                </Notification>
               </section>
             </div>
           ) : (
@@ -239,7 +246,7 @@ function WorkTabsPreservationFileSetModal({
                         options={codeLists?.fileSetRoleData?.codeList}
                         required={!Boolean(watchRole)}
                         showHelper
-                        disabled={Boolean(s3UploadLocation)}
+                        isReadOnly={Boolean(s3UploadLocation)}
                       />
                     </UIFormField>
 
@@ -255,18 +262,18 @@ function WorkTabsPreservationFileSetModal({
                             handleSetFile={handleSetFile}
                             uploadProgress={uploadProgress}
                             workTypeId={workTypeId}
-                            disabled={uploadMethod === 's3'}
+                            disabled={uploadMethod === "s3"}
                           />
                         </div>
 
                         <div className="box">
                           <h3>Option 2: Choose from S3 Ingest Bucket</h3>
                           <S3ObjectPicker
-                            onFiles={console.log} 
+                            onFiles={console.log}
                             onFileSelect={handleSelectS3Object}
                             fileSetRole={watchRole}
                             workTypeId={workTypeId}
-                            disabled={uploadMethod === 'dragdrop'}
+                            disabled={uploadMethod === "dragdrop"}
                           />
                         </div>
                       </>

--- a/app/assets/js/components/Work/Tabs/Preservation/ReplaceFileSet.test.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/ReplaceFileSet.test.jsx
@@ -16,7 +16,15 @@ import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.m
 jest.mock("@js/components/Work/Tabs/Preservation/S3ObjectPicker", () => {
   return function MockS3ObjectPicker({ onFileSelect }) {
     return (
-      <button onClick={() => onFileSelect({ key: "mocked-file.jpg", size: 1000, mimeType: "image/jpeg" })}>
+      <button
+        onClick={() =>
+          onFileSelect({
+            key: "mocked-file.jpg",
+            size: 1000,
+            mimeType: "image/jpeg",
+          })
+        }
+      >
         Select Mocked File
       </button>
     );
@@ -50,10 +58,9 @@ describe("Replace fileset modal", () => {
           getCurrentUserMock,
           ...allCodeListMocks,
         ],
-      }
+      },
     );
   });
-
 
   it("renders replace fileset form", async () => {
     expect(await screen.findByTestId("replace-fileset-form"));
@@ -64,7 +71,11 @@ describe("Replace fileset modal", () => {
   });
 
   it("renders file upload dropzone", async () => {
-    expect(await screen.findByText(/Drag 'n' drop a file here, or click to select file/i));
+    expect(
+      await screen.findByText(
+        /Drag and drop a file here, or click to select file/i,
+      ),
+    );
   });
 
   it("renders label input field", async () => {


### PR DESCRIPTION
# Summary 
This resolves an issue related to our form on the Add fileset modal losing its fileset role value prior submission. I determined that the `disabled` attribute on our Role `select` element was causing the form to deregister the field after a successful upload of a file to S3. To workaround this issue, we now opt for a custom isReadOnly prop which adjusts the select to act similar to a `disabled` attribute in making the element uneditable while retaining  its registration with the React Hook Form for the add fileset modal.

Note: The original issue seems very much an edge case and the recreation is highly dependent on the users' browser and the speed at which the upload to S3 occurs. I could only recreate it in Firefox while using the drag and drop feature with the Add Fileset `dropzone`. 

# Specific Changes in this PR
- Adds `isReadOnly` prop to the UIFormSelect component
- Replaces the `disabled` attribute of fileset role select with `isReadOnly`


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Best tested in Firefox.

- Go to any work. ( work type doesn't seem to matter)
- Go to preservation tab
- Without refreshing, Click add a fileset
  - Select any role (role does not seem matter...)
  - Pull in a file using the drag a drop
  - fill out accession and other fields
  - click ingest file
- Immediately without refreshing, Repeat step 3 above.
  - Role should be retained
  - Ingest should be successful

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

