### PR TITLE
Add stats to GraphQL collection result

### DIFF
--- a/app/lib/meadow_web/schema/types/data/collection_types.ex
+++ b/app/lib/meadow_web/schema/types/data/collection_types.ex
@@ -94,7 +94,7 @@ defmodule MeadowWeb.Schema.Data.CollectionTypes do
   # Object Types
   #
 
-  @desc "Fields for a `collection` object "
+  @desc "Fields for a `collection` object"
   object :collection do
     field :id, :id
     field :title, :string
@@ -113,9 +113,26 @@ defmodule MeadowWeb.Schema.Data.CollectionTypes do
 
     field :representative_work, :work
 
+    field :stats, :collection_stats,
+      resolve: fn query, _, _ ->
+        {:ok, Meadow.Data.Collections.get_work_stats(query.id)}
+      end
+
     field :total_works, :integer,
       resolve: fn query, _, _ ->
         Meadow.Data.Collections.get_work_count(query.id)
-      end
+      end do
+      deprecate("Use `stats.total`.")
+    end
+  end
+
+  @desc "Stats for a `collection` object"
+  object :collection_stats do
+    field :published, :integer
+    field :unpublished, :integer
+    field :image, :integer
+    field :audio, :integer
+    field :video, :integer
+    field :total, :integer
   end
 end

--- a/app/test/gql/CollectionFields.frag.gql
+++ b/app/test/gql/CollectionFields.frag.gql
@@ -11,4 +11,12 @@ fragment CollectionFields on Collection {
     id
     representativeImage
   }
+  stats {
+    total
+    published
+    unpublished
+    image
+    audio
+    video
+  }
 }

--- a/app/test/meadow/data/collections_test.exs
+++ b/app/test/meadow/data/collections_test.exs
@@ -80,6 +80,16 @@ defmodule Meadow.Data.CollectionsTest do
       assert {:ok, 2} = Collections.get_work_count(collection.id)
     end
 
+    test "get_work_stats/1", %{collection: collection} do
+      assert counts = Collections.get_work_stats(collection.id)
+      assert counts.total == 2
+      assert counts.published == 0
+      assert counts.unpublished == 2
+      assert counts.image == 2
+      assert counts.audio == 0
+      assert counts.video == 0
+    end
+
     test "remove_works/2", %{collection: collection, works: works} do
       assert length(collection.works) == 2
 

--- a/app/test/meadow_web/schema/query/get_collection_by_id_test.exs
+++ b/app/test/meadow_web/schema/query/get_collection_by_id_test.exs
@@ -18,6 +18,8 @@ defmodule MeadowWeb.Schema.Query.GetCollectionByIdTest do
 
     collection_title = get_in(query_data, [:data, "collection", "title"])
     assert collection_title == collection_fixture.title
+    stats = get_in(query_data, [:data, "collection", "stats"])
+    assert Map.keys(stats) == ~w(audio image published total unpublished video)
   end
 
   test "Should return nil for a non-existent collection" do


### PR DESCRIPTION
# Summary 
Add stats to GraphQL collection result

# Specific Changes in this PR
- Add `Meadow.Data.Collections.get_work_stats/1`
- Add `stats` to the GraphQL `collection` schema with a resolver
- Deprecate `totalWorks` field on `collection` schema
- Update tests

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test

Use graphiql to query both `collections` and `collection` with `stats` included in the result.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [x] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

