### PR TITLE
Fix code reloading under Phoenix 1.8

### DIFF
--- a/app/config/dev.exs
+++ b/app/config/dev.exs
@@ -34,6 +34,10 @@ if System.get_env("AWS_LOCALSTACK", "false") == "true" do
   end)
 end
 
+config :meadow, MeadowWeb.Endpoint,
+  code_reloader: true,
+  debug_errors: true
+
 # Do not include metadata nor timestamps in development logs
 config :logger, :console,
   format: "$metadata[$level] $message\n",

--- a/app/lib/meadow/config/runtime/dev.ex
+++ b/app/lib/meadow/config/runtime/dev.ex
@@ -31,8 +31,6 @@ defmodule Meadow.Config.Runtime.Dev do
         certfile: Path.join(project_root(), "priv/cert/cert.pem"),
         keyfile: Path.join(project_root(), "priv/cert/key.pem")
       ],
-      debug_errors: false,
-      code_reloader: true,
       check_origin: false,
       watchers: [
         node: [

--- a/app/mix.exs
+++ b/app/mix.exs
@@ -23,6 +23,7 @@ defmodule Meadow.MixProject do
         credo: :test
       ],
       releases: releases(),
+      listeners: [Phoenix.CodeReloader],
       xref: [exclude: [Phoenix.View]]
     ]
   end


### PR DESCRIPTION
# Summary 
Fix code reloading under Phoenix 1.8

# Specific Changes in this PR
- Move code reloading/debug settings from runtime `dev.ex` to compile-time `dev.exs`
- Add `Phoenix.CodeReloaded` to the project listeners

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Run `iex -S mix phx.server` and attempt to do a `recompile`. The code reloader should not freak out at you.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

