### PR TITLE
Make sure the GraphQL user actually exists

### DIFF
--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "@absinthe/socket-apollo-link": "^0.2.1",
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",

--- a/app/lib/meadow_web/schema/middleware/authenticate.ex
+++ b/app/lib/meadow_web/schema/middleware/authenticate.ex
@@ -7,7 +7,7 @@ defmodule MeadowWeb.Schema.Middleware.Authenticate do
 
   def call(resolution, _) do
     case resolution.context do
-      %{current_user: _} ->
+      %{current_user: %{id: user_id}} when not is_nil(user_id) ->
         resolution
 
       _ ->

--- a/app/lib/mix/tasks/meadow.ex
+++ b/app/lib/mix/tasks/meadow.ex
@@ -10,11 +10,6 @@ defmodule Mix.Tasks.Meadow.Reset do
     Code.compiler_options(ignore_module_conflict: true)
     Mix.Task.run("app.config")
 
-    if Meadow.Config.use_localstack?() do
-      Mix.Task.run("pipeline.purge")
-      Mix.Task.run("pipeline.setup")
-    end
-
     Mix.Task.run("ecto.rollback", ["--all"])
     Mix.Task.run("ecto.migrate")
     Mix.Task.run("meadow.search.clear")

--- a/app/test/meadow_web/schema/middleware/authenticate_test.exs
+++ b/app/test/meadow_web/schema/middleware/authenticate_test.exs
@@ -16,6 +16,26 @@ defmodule MeadowWeb.Schema.Middleware.AuthenticateTest do
     assert %{current_user: %{id: ^id}} = resolution.context
   end
 
+  test "Authenticate middleware errors when there is an invalid user in the context" do
+    resolution =
+      %Absinthe.Resolution{}
+      |> Map.put(:context, %{current_user: %{}})
+      |> Authenticate.call({})
+
+    assert %{errors: [%{message: "Unauthorized", status: 401}]} = resolution
+    assert %{current_user: %{}} = resolution.context
+  end
+
+  test "Authenticate middleware errors when there is a nil user in the context" do
+    resolution =
+      %Absinthe.Resolution{}
+      |> Map.put(:context, %{current_user: nil})
+      |> Authenticate.call({})
+
+    assert %{errors: [%{message: "Unauthorized", status: 401}]} = resolution
+    assert %{current_user: nil} = resolution.context
+  end
+
   test "Authenticate middleware errors when there is not a current user in the context" do
     resolution =
       %Absinthe.Resolution{}

--- a/app/test/meadow_web/schema/mutation/add_work_to_collection_test.exs
+++ b/app/test/meadow_web/schema/mutation/add_work_to_collection_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.AddWorkToCollectionTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, acync: true
+  use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/AddWorkToCollection.gql")
@@ -29,7 +29,7 @@ defmodule MeadowWeb.Schema.Mutation.AddWorkToCollectionTest do
       result =
         query_gql(
           variables: %{"workId" => work.id, "collectionId" => collection.id},
-          context: %{current_user: %{role: :user}}
+          context: gql_context(%{role: :user})
         )
 
       assert {:ok, %{errors: [%{message: "Forbidden", status: 403}]}} = result

--- a/app/test/meadow_web/schema/mutation/add_works_to_collection_test.exs
+++ b/app/test/meadow_web/schema/mutation/add_works_to_collection_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.AddWorksToCollectionTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, acync: true
+  use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 
   alias Meadow.Data.Collections
@@ -45,7 +45,7 @@ defmodule MeadowWeb.Schema.Mutation.AddWorksToCollectionTest do
       {:ok, result} =
         query_gql(
           variables: %{"workIds" => work_ids, "collectionId" => collection.id},
-          context: %{current_user: %{role: :user}}
+          context: gql_context(%{role: :user})
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result
@@ -63,7 +63,7 @@ defmodule MeadowWeb.Schema.Mutation.AddWorksToCollectionTest do
       {:ok, result} =
         query_gql(
           variables: %{"workIds" => work_ids, "collectionId" => collection.id},
-          context: %{current_user: %{role: :editor}}
+          context: gql_context(%{role: :editor})
         )
 
       assert result.data["addWorksToCollection"]

--- a/app/test/meadow_web/schema/mutation/assume_role_test.exs
+++ b/app/test/meadow_web/schema/mutation/assume_role_test.exs
@@ -28,7 +28,7 @@ defmodule MeadowWeb.Schema.Mutation.AssumeRoleTest do
       {:ok, result} =
         query_gql(
           variables: %{"userRole" => "ADMINISTRATOR"},
-          context: %{current_user: %{username: "abc122", role: :manager}}
+          context: gql_context(%{role: :manager})
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result

--- a/app/test/meadow_web/schema/mutation/batch_delete_test.exs
+++ b/app/test/meadow_web/schema/mutation/batch_delete_test.exs
@@ -38,7 +38,7 @@ defmodule MeadowWeb.Schema.Mutation.BatchDeleteTest do
             "query" => ~s'{"query":{"term":{"workType.id": "IMAGE"}}}',
             "nickname" => "This is a batch delete"
           },
-          context: %{current_user: %{username: "abc123", role: :editor}}
+          context: gql_context(%{role: :editor})
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result
@@ -51,7 +51,7 @@ defmodule MeadowWeb.Schema.Mutation.BatchDeleteTest do
             "query" => ~s'{"query":{"term":{"workType.id": "IMAGE"}}}',
             "nickname" => "This is a batch delete"
           },
-          context: %{current_user: %{username: "abc123", role: :manager}}
+          context: gql_context(%{role: :manager})
         )
 
       assert result.data["batchDelete"]

--- a/app/test/meadow_web/schema/mutation/batch_update_test.exs
+++ b/app/test/meadow_web/schema/mutation/batch_update_test.exs
@@ -123,7 +123,7 @@ defmodule MeadowWeb.Schema.Mutation.BatchUpdateTest do
               }
             }
           },
-          context: %{current_user: %{username: "abc123", role: :user}}
+          context: gql_context(%{role: :user})
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result
@@ -145,7 +145,7 @@ defmodule MeadowWeb.Schema.Mutation.BatchUpdateTest do
               }
             }
           },
-          context: %{current_user: %{username: "abc123", role: :editor}}
+          context: gql_context(%{role: :editor})
         )
 
       assert result.data["batchUpdate"]

--- a/app/test/meadow_web/schema/mutation/create_collection_test.exs
+++ b/app/test/meadow_web/schema/mutation/create_collection_test.exs
@@ -23,7 +23,7 @@ defmodule MeadowWeb.Schema.Mutation.CreateCollectionTest do
       {:ok, result} =
         query_gql(
           variables: %{"title" => "The collection title"},
-          context: %{current_user: %{role: :user}}
+          context: gql_context(%{role: :user})
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result
@@ -33,7 +33,7 @@ defmodule MeadowWeb.Schema.Mutation.CreateCollectionTest do
       {:ok, result} =
         query_gql(
           variables: %{"title" => "The collection title"},
-          context: %{current_user: %{role: :manager}}
+          context: gql_context(%{role: :manager})
         )
 
       assert result.data["createCollection"]

--- a/app/test/meadow_web/schema/mutation/create_ingest_sheet_test.exs
+++ b/app/test/meadow_web/schema/mutation/create_ingest_sheet_test.exs
@@ -59,7 +59,7 @@ defmodule MeadowWeb.Schema.Mutation.CreateSheet do
             "filename" => @sheet_key,
             "projectId" => project.id
           },
-          context: %{current_user: %{role: :user}}
+          context: gql_context(%{role: :user})
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result
@@ -73,7 +73,7 @@ defmodule MeadowWeb.Schema.Mutation.CreateSheet do
             "filename" => @sheet_key,
             "projectId" => project.id
           },
-          context: %{current_user: %{role: :editor}}
+          context: gql_context(%{role: :editor})
         )
 
       assert result.data["createIngestSheet"]

--- a/app/test/meadow_web/schema/mutation/create_nul_authority_record.exs
+++ b/app/test/meadow_web/schema/mutation/create_nul_authority_record.exs
@@ -21,7 +21,7 @@ defmodule MeadowWeb.Schema.Mutation.CreateNULAuthorityRecordTest do
       {:ok, result} =
         query_gql(
           variables: %{"label" => "test label", "hint" => "test hint"},
-          context: %{current_user: %{role: :editor}}
+          context: gql_context(%{role: :editor})
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result
@@ -31,7 +31,7 @@ defmodule MeadowWeb.Schema.Mutation.CreateNULAuthorityRecordTest do
       {:ok, result} =
         query_gql(
           variables: %{"label" => "test label", "hint" => "test hint"},
-          context: %{current_user: %{role: :manager}}
+          context: gql_context(%{role: :manager})
         )
 
       assert result.data["createNULAuthorityRecord"]

--- a/app/test/meadow_web/schema/mutation/create_project_test.exs
+++ b/app/test/meadow_web/schema/mutation/create_project_test.exs
@@ -27,7 +27,7 @@ defmodule MeadowWeb.Schema.Mutation.CreateProjectTest do
       {:ok, result} =
         query_gql(
           variables: %{"title" => "The project title"},
-          context: %{current_user: %{role: :user}}
+          context: gql_context(%{role: :user})
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result
@@ -37,7 +37,7 @@ defmodule MeadowWeb.Schema.Mutation.CreateProjectTest do
       {:ok, result} =
         query_gql(
           variables: %{"title" => "The project title"},
-          context: %{current_user: %{role: :editor}}
+          context: gql_context(%{role: :editor})
         )
 
       assert result.data["createProject"]

--- a/app/test/meadow_web/schema/mutation/create_shared_link_test.exs
+++ b/app/test/meadow_web/schema/mutation/create_shared_link_test.exs
@@ -22,7 +22,7 @@ defmodule MeadowWeb.Resolvers.Data.SharedLinkTest do
       {:ok, result} =
         query_gql(
           variables: %{"workId" => "1234"},
-          context: %{current_user: %{role: :user}}
+          context: gql_context(%{role: :user})
         )
 
       assert result.data["createSharedLink"]

--- a/app/test/meadow_web/schema/mutation/create_work_test.exs
+++ b/app/test/meadow_web/schema/mutation/create_work_test.exs
@@ -68,7 +68,7 @@ defmodule MeadowWeb.Schema.Mutation.CreateWorkTest do
             "workType" => %{"id" => "IMAGE", "scheme" => "WORK_TYPE"},
             "visibility" => %{"id" => "OPEN", "scheme" => "VISIBILITY"}
           },
-          context: %{current_user: %{role: :user}}
+          context: gql_context(%{role: :user})
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result
@@ -85,7 +85,7 @@ defmodule MeadowWeb.Schema.Mutation.CreateWorkTest do
             "workType" => %{"id" => "IMAGE", "scheme" => "WORK_TYPE"},
             "visibility" => %{"id" => "OPEN", "scheme" => "VISIBILITY"}
           },
-          context: %{current_user: %{role: :editor}}
+          context: gql_context(%{role: :editor})
         )
 
       assert result.data["createWork"]

--- a/app/test/meadow_web/schema/mutation/delete_collection_test.exs
+++ b/app/test/meadow_web/schema/mutation/delete_collection_test.exs
@@ -44,7 +44,7 @@ defmodule MeadowWeb.Schema.Mutation.DeleteCollectionTest do
       {:ok, result} =
         query_gql(
           variables: %{"collectionId" => collection_fixture.id},
-          context: %{current_user: %{role: :editor}}
+          context: gql_context(%{role: :editor})
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result
@@ -56,7 +56,7 @@ defmodule MeadowWeb.Schema.Mutation.DeleteCollectionTest do
       {:ok, result} =
         query_gql(
           variables: %{"collectionId" => collection_fixture.id},
-          context: %{current_user: %{role: :manager}}
+          context: gql_context(%{role: :manager})
         )
 
       assert result.data["deleteCollection"]

--- a/app/test/meadow_web/schema/mutation/ingest_file_set_test.exs
+++ b/app/test/meadow_web/schema/mutation/ingest_file_set_test.exs
@@ -50,7 +50,7 @@ defmodule MeadowWeb.Schema.Mutation.IngestFileSetTest do
               "location" => "s3://#{@bucket}/#{@key}"
             }
           },
-          context: %{current_user: %{role: :user}}
+          context: gql_context(%{role: :user})
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result

--- a/app/test/meadow_web/schema/mutation/remove_works_from_collection_test.exs
+++ b/app/test/meadow_web/schema/mutation/remove_works_from_collection_test.exs
@@ -50,7 +50,7 @@ defmodule MeadowWeb.Schema.Mutation.RemoveWorksFromCollectionTest do
             "workIds" => Enum.map(works, & &1.id),
             "collectionId" => collection_fixture.id
           },
-          context: %{current_user: %{role: :user}}
+          context: gql_context(%{role: :user})
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result

--- a/app/test/meadow_web/schema/mutation/replace_file_set_test.exs
+++ b/app/test/meadow_web/schema/mutation/replace_file_set_test.exs
@@ -46,7 +46,7 @@ defmodule MeadowWeb.Schema.Mutation.ReplaceFileSetTest do
               "location" => "s3://#{@bucket}/#{@key}"
             }
           },
-          context: %{current_user: %{role: :user}}
+          context: gql_context(%{role: :user})
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result

--- a/app/test/meadow_web/schema/mutation/set_collection_image_test.exs
+++ b/app/test/meadow_web/schema/mutation/set_collection_image_test.exs
@@ -68,7 +68,7 @@ defmodule MeadowWeb.Schema.Mutation.SetCollectionImageTest do
             "collection_id" => collection.id,
             "work_id" => work.id
           },
-          context: %{current_user: %{role: :editor}}
+          context: gql_context(%{role: :editor})
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result
@@ -84,7 +84,7 @@ defmodule MeadowWeb.Schema.Mutation.SetCollectionImageTest do
             "collection_id" => collection.id,
             "work_id" => work.id
           },
-          context: %{current_user: %{role: :manager}}
+          context: gql_context(%{role: :manager})
         )
 
       assert result.data["setCollectionImage"]
@@ -107,7 +107,7 @@ defmodule MeadowWeb.Schema.Mutation.SetCollectionImageTest do
             "collection_id" => collection.id,
             "work_id" => nil
           },
-          context: %{current_user: %{role: :manager}}
+          context: gql_context(%{role: :manager})
         )
 
       assert result.data["setCollectionImage"]

--- a/app/test/meadow_web/schema/mutation/set_user_role_test.exs
+++ b/app/test/meadow_web/schema/mutation/set_user_role_test.exs
@@ -19,7 +19,7 @@ defmodule MeadowWeb.Schema.Mutation.SetUserRoleTest do
       {:ok, result} =
         query_gql(
           variables: %{"userId" => user.id, "userRole" => "ADMINISTRATOR"},
-          context: %{current_user: %{username: "abc122", role: :administrator}}
+          context: gql_context(%{role: :administrator})
         )
 
       assert %{data: %{"setUserRole" => %{"message" => message}}} = result
@@ -33,7 +33,7 @@ defmodule MeadowWeb.Schema.Mutation.SetUserRoleTest do
       {:ok, result} =
         query_gql(
           variables: %{"userId" => user.id, "userRole" => "ADMINISTRATOR"},
-          context: %{current_user: %{username: "abc122", role: :manager}}
+          context: gql_context(%{role: :manager})
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result

--- a/app/test/meadow_web/schema/mutation/set_work_image_test.exs
+++ b/app/test/meadow_web/schema/mutation/set_work_image_test.exs
@@ -47,7 +47,7 @@ defmodule MeadowWeb.Schema.Mutation.SetWorkImageTest do
             "work_id" => work.id,
             "file_set_id" => expected_file_set.id
           },
-          context: %{current_user: %{role: :user}}
+          context: gql_context(%{role: :user})
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result
@@ -63,7 +63,7 @@ defmodule MeadowWeb.Schema.Mutation.SetWorkImageTest do
             "work_id" => work.id,
             "file_set_id" => expected_file_set.id
           },
-          context: %{current_user: %{role: :editor}}
+          context: gql_context(%{role: :editor})
         )
 
       assert result.data["setWorkImage"]

--- a/app/test/meadow_web/schema/mutation/transfer_file_sets_test.exs
+++ b/app/test/meadow_web/schema/mutation/transfer_file_sets_test.exs
@@ -72,7 +72,7 @@ defmodule MeadowWeb.Schema.Mutation.TransferFileSetsTest do
       result =
         query_gql(
           variables: %{"fromWorkId" => work.id, "toWorkId" => work2.id},
-          context: %{current_user: %{role: :user}}
+          context: gql_context(%{role: :user})
         )
 
       assert {:ok, %{errors: [%{message: "Forbidden", status: 403}]}} = result
@@ -249,7 +249,7 @@ defmodule MeadowWeb.Schema.Mutation.TransferFileSetsTest.Subset do
               "workType" => "IMAGE"
             }
           },
-          context: %{current_user: %{role: :user}}
+          context: gql_context(%{role: :user})
         )
 
       assert {:ok, %{errors: [%{message: "Forbidden", status: 403}]}} = result
@@ -270,7 +270,7 @@ defmodule MeadowWeb.Schema.Mutation.TransferFileSetsTest.Subset do
               "visibility" => %{"id" => "OPEN", "scheme" => "VISIBILITY"}
             }
           },
-          context: %{current_user: %{role: :editor}}
+          context: gql_context(%{role: :editor})
         )
 
       assert {:ok, %{data: %{"transfer_file_sets_subset" => _}}} = result

--- a/app/test/meadow_web/schema/mutation/udpate_nul_authority_record.exs
+++ b/app/test/meadow_web/schema/mutation/udpate_nul_authority_record.exs
@@ -37,7 +37,7 @@ defmodule MeadowWeb.Schema.Mutation.UpdateNULAuthorityRecordTest do
             "label" => "test label",
             "hint" => "test hint"
           },
-          context: %{current_user: %{role: :editor}}
+          context: gql_context(%{role: :editor})
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result
@@ -54,7 +54,7 @@ defmodule MeadowWeb.Schema.Mutation.UpdateNULAuthorityRecordTest do
             "label" => "test label",
             "hint" => "test hint"
           },
-          context: %{current_user: %{role: :manager}}
+          context: gql_context(%{role: :manager})
         )
 
       assert result.data["updateNULAuthorityRecord"]

--- a/app/test/meadow_web/schema/mutation/update_access_file_order_test.exs
+++ b/app/test/meadow_web/schema/mutation/update_access_file_order_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.UpdateAccessFileOrderTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, acync: true
+  use MeadowWeb.ConnCase, async: true
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/UpdateAccessFileOrder.gql")
@@ -73,7 +73,7 @@ defmodule MeadowWeb.Schema.Mutation.UpdateAccessFileOrderTest do
       result =
         query_gql(
           variables: %{"workId" => work.id, "fileSetIds" => Enum.reverse(file_set_ids)},
-          context: %{current_user: %{role: :user}}
+          context: gql_context(%{role: :user})
         )
 
       assert {:ok, %{errors: [%{message: "Forbidden", status: 403}]}} = result

--- a/app/test/meadow_web/schema/mutation/update_project_test.exs
+++ b/app/test/meadow_web/schema/mutation/update_project_test.exs
@@ -35,7 +35,7 @@ defmodule MeadowWeb.Schema.Mutation.UpdateProjectTest do
             "id" => project.id,
             "title" => "The New Title"
           },
-          context: %{current_user: %{role: :user}}
+          context: gql_context(%{role: :user})
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result
@@ -50,7 +50,7 @@ defmodule MeadowWeb.Schema.Mutation.UpdateProjectTest do
             "id" => project.id,
             "title" => "The New Title"
           },
-          context: %{current_user: %{role: :editor}}
+          context: gql_context(%{role: :editor})
         )
 
       assert result.data["updateProject"]

--- a/app/test/meadow_web/schema/mutation/update_work_test.exs
+++ b/app/test/meadow_web/schema/mutation/update_work_test.exs
@@ -44,7 +44,7 @@ defmodule MeadowWeb.Schema.Mutation.UpdateWorkTest do
             "collection_id" => collection.id,
             "descriptive_metadata" => %{"title" => "Something"}
           },
-          context: %{current_user: %{role: :user}}
+          context: gql_context(%{role: :user})
         )
 
       assert %{errors: [%{message: "Forbidden", status: 403}]} = result
@@ -61,7 +61,7 @@ defmodule MeadowWeb.Schema.Mutation.UpdateWorkTest do
             "collection_id" => collection.id,
             "descriptive_metadata" => %{"title" => "Something"}
           },
-          context: %{current_user: %{role: :editor}}
+          context: gql_context(%{role: :editor})
         )
 
       assert result.data["updateWork"]

--- a/app/test/support/test_helpers.ex
+++ b/app/test/support/test_helpers.ex
@@ -224,16 +224,18 @@ defmodule Meadow.TestHelpers do
     file_set
   end
 
-  def gql_context(extra \\ %{}) do
-    extra
-    |> Map.merge(%{
+  def gql_context(user \\ %{}, extra \\ %{}) do
+    %{
       current_user: %{
+        id: "user1",
         username: "user1",
         email: "email@example.com",
         display_name: "User Name",
         role: :administrator
       }
-    })
+      |> Map.merge(user)
+    }
+    |> Map.merge(extra)
   end
 
   def logged?(string, :warn, pattern),


### PR DESCRIPTION
# Summary 
Make sure the GraphQL user actually exists

# Specific Changes in this PR
- Update `MeadowWeb.Schema.Middleware.Authenticate` to tighten up the user check
- Add tests for empty (`%{}`) and `nil` users
- Update existing GQL tests to make sure they have users that will pass

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

