### PR TITLE
Configure firewall passkey header

### DIFF
--- a/app/assets/build.js
+++ b/app/assets/build.js
@@ -14,13 +14,12 @@ const deploy = args.includes("--deploy");
 
 const cwd = process.cwd();
 
-const meadowPrefix = [process.env.MEADOW_TENANT] || [process.env.DEV_PREFIX, process.env.DEV_ENV]
+const meadowPrefix = [process.env.MEADOW_TENANT] || [
+  process.env.DEV_PREFIX,
+  process.env.DEV_ENV,
+];
 const elasticsearchIndex = (suffix) =>
-  JSON.stringify(
-    [...meadowPrefix, "dc-v2", suffix]
-      .filter((e) => e)
-      .join("-"),
-  );
+  JSON.stringify([...meadowPrefix, "dc-v2", suffix].filter((e) => e).join("-"));
 
 const define = {
   __HONEYBADGER_API_KEY__: JSON.stringify(

--- a/app/lib/meadow/config/runtime.ex
+++ b/app/lib/meadow/config/runtime.ex
@@ -223,6 +223,9 @@ defmodule Meadow.Config.Runtime do
         ),
       environment: environment(),
       environment_prefix: prefix(),
+      firewall_security_header:
+        get_secret(:firewall, ["security_header"], [])
+        |> Enum.map(fn {k, v} -> {String.to_atom(k), v} end),
       iiif_server_url:
         get_secret(
           :iiif,

--- a/app/lib/meadow/config/secrets.ex
+++ b/app/lib/meadow/config/secrets.ex
@@ -9,6 +9,7 @@ defmodule Meadow.Config.Secrets do
   @config_map %{
     dcapi: "config/dcapi",
     ezid: "infrastructure/ezid",
+    firewall: "infrastructure/firewall",
     iiif: "infrastructure/iiif",
     index: "infrastructure/index",
     inference: "infrastructure/inference",


### PR DESCRIPTION
# Summary 
Have Meadow retrieve the header name/value that will let the AI Agent bypass the firewall to access the MCP endpoint. In the Claude Agent SDK, extra headers are supplied as part of the MCP config, e.g.:

```python
client_options = ClaudeCodeOptions(
    mcp_servers={
        "meadow": {
            "type": "http",
            "url": "https://meadow-ai.rdc-staging.library.northwestern.edu/api/mcp",
            "headers": {
                "authorization": f"Bearer {api_token}",
                firewall_header_name: firewall_header_value
            },
        }
    },
    allowed_tools=["mcp__meadow__graphql"],
    system_prompt="..."
)

```

# Specific Changes in this PR
- Load firewall security header config from Secrets Manager

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Check `Application.get_env(:meadow, :firewall_security_header)` in iex console or Livebook. I've added a dev-environment secret for testing even though there's no firewall to get through.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

