### PR TITLE
Add GraphQL routes to get and approve plans

### DIFF
--- a/app/lib/meadow_web/resolvers/plans.ex
+++ b/app/lib/meadow_web/resolvers/plans.ex
@@ -1,0 +1,64 @@
+defmodule MeadowWeb.Resolvers.Data.Plans do
+  @moduledoc """
+  Absinthe resolver for Plan related functionality
+  """
+  alias Meadow.Data.Planner
+
+  def plan(_, %{id: id}, _) do
+    case Planner.get_plan(id) do
+      nil -> {:error, "Plan not found"}
+      plan -> {:ok, plan}
+    end
+  end
+
+  def update_plan_status(_, %{id: id, status: status} = args, %{context: %{current_user: user}}) do
+    case Planner.get_plan(id) do
+      nil ->
+        {:error, "Plan not found"}
+
+      plan ->
+        result =
+          case status do
+            :approved -> Planner.approve_plan(plan, user.username)
+            :rejected -> Planner.reject_plan(plan, Map.get(args, :notes))
+            _ -> {:error, "Invalid status transition"}
+          end
+
+        case result do
+          {:ok, updated_plan} -> {:ok, updated_plan}
+          {:error, changeset} -> {:error, message: "Could not update plan status", details: changeset}
+        end
+    end
+  end
+
+  def plan_changes(_, %{plan_id: plan_id}, _) do
+    {:ok, Planner.list_plan_changes(plan_id)}
+  end
+
+  def plan_change(_, %{id: id}, _) do
+    case Planner.get_plan_change(id) do
+      nil -> {:error, "Plan change not found"}
+      plan_change -> {:ok, plan_change}
+    end
+  end
+
+  def update_plan_change_status(_, %{id: id, status: status} = args, %{context: %{current_user: user}}) do
+    case Planner.get_plan_change(id) do
+      nil ->
+        {:error, "Plan change not found"}
+
+      plan_change ->
+        result =
+          case status do
+            :approved -> Planner.approve_plan_change(plan_change, user.username)
+            :rejected -> Planner.reject_plan_change(plan_change, Map.get(args, :notes))
+            _ -> {:error, "Invalid status transition"}
+          end
+
+        case result do
+          {:ok, updated_change} -> {:ok, updated_change}
+          {:error, changeset} -> {:error, message: "Could not update plan change status", details: changeset}
+        end
+    end
+  end
+end

--- a/app/lib/meadow_web/schema/schema.ex
+++ b/app/lib/meadow_web/schema/schema.ex
@@ -27,6 +27,7 @@ defmodule MeadowWeb.Schema do
   import_types(__MODULE__.Data.CSVMetadataUpdateTypes)
   import_types(__MODULE__.NULAuthorityTypes)
   import_types(__MODULE__.ChatTypes)
+  import_types(__MODULE__.Data.PlanTypes)
 
   query do
     import_fields(:account_queries)
@@ -39,6 +40,7 @@ defmodule MeadowWeb.Schema do
     import_fields(:ingest_queries)
     import_fields(:csv_metadata_update_queries)
     import_fields(:nul_authority_queries)
+    import_fields(:plan_queries)
     import_fields(:preservation_check_queries)
     import_fields(:s3_queries)
     import_fields(:work_queries)
@@ -52,6 +54,7 @@ defmodule MeadowWeb.Schema do
     import_fields(:ingest_mutations)
     import_fields(:csv_metadata_update_mutations)
     import_fields(:nul_authority_mutations)
+    import_fields(:plan_mutations)
     import_fields(:shared_link_mutations)
     import_fields(:work_mutations)
     import_fields(:chat_mutations)

--- a/app/lib/meadow_web/schema/types/data/plan_types.ex
+++ b/app/lib/meadow_web/schema/types/data/plan_types.ex
@@ -1,0 +1,101 @@
+defmodule MeadowWeb.Schema.Data.PlanTypes do
+  @moduledoc """
+  Absinthe Schema for Plan functionality
+
+  """
+  use Absinthe.Schema.Notation
+  alias MeadowWeb.Resolvers.Data.Plans
+  alias MeadowWeb.Schema.Middleware
+
+  object :plan_queries do
+    @desc "Get a plan by id"
+    field :plan, :plan do
+      arg(:id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Plans.plan/3)
+    end
+
+    @desc "Get all changes for a plan"
+    field :plan_changes, list_of(:plan_change) do
+      arg(:plan_id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Plans.plan_changes/3)
+    end
+
+    @desc "Get a plan change by id"
+    field :plan_change, :plan_change do
+      arg(:id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Plans.plan_change/3)
+    end
+  end
+
+  object :plan_mutations do
+    @desc "Update plan status (approve or reject)"
+    field :update_plan_status, :plan do
+      arg(:id, non_null(:id))
+      arg(:status, non_null(:plan_status))
+      arg(:notes, :string)
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Plans.update_plan_status/3)
+    end
+
+    @desc "Update plan change status (approve or reject)"
+    field :update_plan_change_status, :plan_change do
+      arg(:id, non_null(:id))
+      arg(:status, non_null(:plan_status))
+      arg(:notes, :string)
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Plans.update_plan_change_status/3)
+    end
+  end
+
+  #
+  # Object Types
+  #
+
+  @desc "Fields for a `plan` object"
+  object :plan do
+    field(:id, :id)
+    field(:prompt, :string)
+    field(:query, :string)
+    field(:status, :plan_status)
+    field(:user, :string)
+    field(:notes, :string)
+    field(:executed_at, :datetime)
+    field(:error, :string)
+    field(:inserted_at, :datetime)
+    field(:updated_at, :datetime)
+  end
+
+  @desc "Fields for a `plan_change` object"
+  object :plan_change do
+    field(:id, :id)
+    field(:plan_id, :id)
+    field(:work_id, :id)
+    field(:add, :json)
+    field(:delete, :json)
+    field(:replace, :json)
+    field(:status, :plan_status)
+    field(:user, :string)
+    field(:notes, :string)
+    field(:executed_at, :datetime)
+    field(:error, :string)
+    field(:inserted_at, :datetime)
+    field(:updated_at, :datetime)
+  end
+
+  @desc "Plan status values"
+  enum :plan_status do
+    value(:pending, as: :pending, description: "Pending review")
+    value(:approved, as: :approved, description: "Approved for execution")
+    value(:rejected, as: :rejected, description: "Rejected, will not be executed")
+    value(:executed, as: :executed, description: "Successfully executed")
+    value(:error, as: :error, description: "Execution failed")
+  end
+end

--- a/app/test/gql/GetPlan.gql
+++ b/app/test/gql/GetPlan.gql
@@ -1,0 +1,10 @@
+query GetPlan($id: ID!) {
+  plan(id: $id) {
+    id
+    prompt
+    query
+    status
+    user
+    notes
+  }
+}

--- a/app/test/gql/GetPlanChange.gql
+++ b/app/test/gql/GetPlanChange.gql
@@ -1,0 +1,11 @@
+query GetPlanChange($id: ID!) {
+  planChange(id: $id) {
+    id
+    planId
+    workId
+    add
+    delete
+    replace
+    status
+  }
+}

--- a/app/test/gql/GetPlanChanges.gql
+++ b/app/test/gql/GetPlanChanges.gql
@@ -1,0 +1,11 @@
+query GetPlanChanges($planId: ID!) {
+  planChanges(planId: $planId) {
+    id
+    planId
+    workId
+    add
+    delete
+    replace
+    status
+  }
+}

--- a/app/test/gql/UpdatePlanChangeStatus.gql
+++ b/app/test/gql/UpdatePlanChangeStatus.gql
@@ -1,0 +1,8 @@
+mutation UpdatePlanChangeStatus($id: ID!, $status: PlanStatus!, $notes: String) {
+  updatePlanChangeStatus(id: $id, status: $status, notes: $notes) {
+    id
+    status
+    user
+    notes
+  }
+}

--- a/app/test/gql/UpdatePlanStatus.gql
+++ b/app/test/gql/UpdatePlanStatus.gql
@@ -1,0 +1,8 @@
+mutation UpdatePlanStatus($id: ID!, $status: PlanStatus!, $notes: String) {
+  updatePlanStatus(id: $id, status: $status, notes: $notes) {
+    id
+    status
+    user
+    notes
+  }
+}

--- a/app/test/meadow_web/schema/mutation/update_plan_change_status_test.exs
+++ b/app/test/meadow_web/schema/mutation/update_plan_change_status_test.exs
@@ -1,0 +1,55 @@
+defmodule MeadowWeb.Schema.Mutation.UpdatePlanChangeStatusTest do
+  use Meadow.DataCase
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+
+  load_gql(MeadowWeb.Schema, "test/gql/UpdatePlanChangeStatus.gql")
+
+  test "should approve a plan change" do
+    plan_change = plan_change_fixture()
+
+    result =
+      query_gql(
+        variables: %{"id" => plan_change.id, "status" => "APPROVED"},
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+
+    response = get_in(query_data, [:data, "updatePlanChangeStatus", "status"])
+    assert response == "APPROVED"
+
+    user = get_in(query_data, [:data, "updatePlanChangeStatus", "user"])
+    assert user != nil
+  end
+
+  test "should reject a plan change with notes" do
+    plan_change = plan_change_fixture()
+
+    result =
+      query_gql(
+        variables: %{"id" => plan_change.id, "status" => "REJECTED", "notes" => "Incorrect translation"},
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+
+    response = get_in(query_data, [:data, "updatePlanChangeStatus", "status"])
+    assert response == "REJECTED"
+
+    notes = get_in(query_data, [:data, "updatePlanChangeStatus", "notes"])
+    assert notes == "Incorrect translation"
+  end
+
+  test "should return error for non-existent plan change" do
+    result =
+      query_gql(
+        variables: %{"id" => Ecto.UUID.generate(), "status" => "APPROVED"},
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+    error = List.first(get_in(query_data, [:errors]))
+    assert error.message == "Plan change not found"
+  end
+end

--- a/app/test/meadow_web/schema/mutation/update_plan_status_test.exs
+++ b/app/test/meadow_web/schema/mutation/update_plan_status_test.exs
@@ -1,0 +1,55 @@
+defmodule MeadowWeb.Schema.Mutation.UpdatePlanStatusTest do
+  use Meadow.DataCase
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+
+  load_gql(MeadowWeb.Schema, "test/gql/UpdatePlanStatus.gql")
+
+  test "should approve a plan" do
+    plan = plan_fixture()
+
+    result =
+      query_gql(
+        variables: %{"id" => plan.id, "status" => "APPROVED"},
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+
+    response = get_in(query_data, [:data, "updatePlanStatus", "status"])
+    assert response == "APPROVED"
+
+    user = get_in(query_data, [:data, "updatePlanStatus", "user"])
+    assert user != nil
+  end
+
+  test "should reject a plan with notes" do
+    plan = plan_fixture()
+
+    result =
+      query_gql(
+        variables: %{"id" => plan.id, "status" => "REJECTED", "notes" => "Not needed"},
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+
+    response = get_in(query_data, [:data, "updatePlanStatus", "status"])
+    assert response == "REJECTED"
+
+    notes = get_in(query_data, [:data, "updatePlanStatus", "notes"])
+    assert notes == "Not needed"
+  end
+
+  test "should return error for non-existent plan" do
+    result =
+      query_gql(
+        variables: %{"id" => Ecto.UUID.generate(), "status" => "APPROVED"},
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+    error = List.first(get_in(query_data, [:errors]))
+    assert error.message == "Plan not found"
+  end
+end

--- a/app/test/meadow_web/schema/query/get_plan_change_test.exs
+++ b/app/test/meadow_web/schema/query/get_plan_change_test.exs
@@ -1,0 +1,27 @@
+defmodule MeadowWeb.Schema.Query.GetPlanChangeTest do
+  use Meadow.DataCase
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+
+  load_gql(MeadowWeb.Schema, "test/gql/GetPlanChange.gql")
+
+  test "should be a valid query" do
+    plan_change = plan_change_fixture()
+
+    result =
+      query_gql(
+        variables: %{"id" => plan_change.id},
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+
+    plan_change_status = get_in(query_data, [:data, "planChange", "status"])
+    assert plan_change_status == "PENDING"
+  end
+
+  test "should return nil for a non-existent plan change" do
+    result = query_gql(variables: %{"id" => Ecto.UUID.generate()}, context: gql_context())
+    assert {:ok, %{data: %{"planChange" => nil}}} = result
+  end
+end

--- a/app/test/meadow_web/schema/query/get_plan_changes_test.exs
+++ b/app/test/meadow_web/schema/query/get_plan_changes_test.exs
@@ -1,0 +1,42 @@
+defmodule MeadowWeb.Schema.Query.GetPlanChangesTest do
+  use Meadow.DataCase
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+
+  load_gql(MeadowWeb.Schema, "test/gql/GetPlanChanges.gql")
+
+  test "should be a valid query" do
+    plan = plan_fixture()
+    plan_change = plan_change_fixture(%{plan: plan})
+
+    result =
+      query_gql(
+        variables: %{"planId" => plan.id},
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+
+    changes = get_in(query_data, [:data, "planChanges"])
+    assert is_list(changes)
+    assert length(changes) == 1
+
+    first_change = List.first(changes)
+    assert first_change["id"] == plan_change.id
+    assert first_change["status"] == "PENDING"
+  end
+
+  test "should return empty list for plan with no changes" do
+    plan = plan_fixture()
+
+    result =
+      query_gql(
+        variables: %{"planId" => plan.id},
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+    changes = get_in(query_data, [:data, "planChanges"])
+    assert changes == []
+  end
+end

--- a/app/test/meadow_web/schema/query/get_plan_test.exs
+++ b/app/test/meadow_web/schema/query/get_plan_test.exs
@@ -1,0 +1,27 @@
+defmodule MeadowWeb.Schema.Query.GetPlanTest do
+  use Meadow.DataCase
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+
+  load_gql(MeadowWeb.Schema, "test/gql/GetPlan.gql")
+
+  test "should be a valid query" do
+    plan = plan_fixture()
+
+    result =
+      query_gql(
+        variables: %{"id" => plan.id},
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+
+    plan_status = get_in(query_data, [:data, "plan", "status"])
+    assert plan_status == "PENDING"
+  end
+
+  test "should return nil for a non-existent plan" do
+    result = query_gql(variables: %{"id" => Ecto.UUID.generate()}, context: gql_context())
+    assert {:ok, %{data: %{"plan" => nil}}} = result
+  end
+end

--- a/app/test/support/test_helpers.ex
+++ b/app/test/support/test_helpers.ex
@@ -4,7 +4,7 @@ defmodule Meadow.TestHelpers do
 
   """
   alias Meadow.Accounts.User
-  alias Meadow.Data.Schemas.{Batch, Collection, FileSet, Work}
+  alias Meadow.Data.Schemas.{Batch, Collection, FileSet, Plan, PlanChange, Work}
   alias Meadow.Data.Works
   alias Meadow.Ingest.Validator
   alias Meadow.Ingest.Schemas.{Project, Sheet}
@@ -296,5 +296,41 @@ defmodule Meadow.TestHelpers do
     |> :rand.uniform()
     |> Kernel.+(min)
     |> Integer.to_string(36)
+  end
+
+  def plan_fixture(attrs \\ %{}) do
+    attrs =
+      Enum.into(attrs, %{
+        prompt: "Test plan prompt",
+        query: "collection.id:test-123",
+        status: :pending
+      })
+
+    {:ok, plan} =
+      %Plan{}
+      |> Plan.changeset(attrs)
+      |> Repo.insert()
+
+    plan
+  end
+
+  def plan_change_fixture(attrs \\ %{}) do
+    plan = attrs[:plan] || plan_fixture()
+    work = attrs[:work] || work_fixture()
+
+    attrs =
+      Enum.into(attrs, %{
+        plan_id: plan.id,
+        work_id: work.id,
+        add: %{descriptive_metadata: %{title: "Updated title"}},
+        status: :pending
+      })
+
+    {:ok, plan_change} =
+      %PlanChange{}
+      |> PlanChange.changeset(attrs)
+      |> Repo.insert()
+
+    plan_change
   end
 end


### PR DESCRIPTION
# Summary 

Users need to be able to retrieve plans and plan changes and approve/apply plans

# Specific Changes in this PR

## Add GraphQL API for Plan Management

This PR adds GraphQL queries and mutations to support the AI agent planning workflow, allowing users to review and approve/reject plans and individual plan changes.

### New Endpoints

**Queries:**
- `plan(id)` - Get a plan by ID
- `planChanges(planId)` - Get all changes for a plan
- `planChange(id)` - Get a single plan change by ID

**Mutations:**
- `updatePlanStatus(id, status, notes)` - Approve or reject a plan
- `updatePlanChangeStatus(id, status, notes)` - Approve or reject an individual plan change

### Changes Made

- Created `PlanTypes` GraphQL schema with `Plan` and `PlanChange` objects
- Created `Plans` resolver module with all query/mutation handlers
- Added test fixtures (`plan_fixture`, `plan_change_fixture`) to `TestHelpers`
- Added comprehensive test coverage for all new endpoints
- All endpoints require authentication and Editor role authorization

**Note that some routes are fully functional but applying the actual plan is waiting for other in progress work to be fully operational.**


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test

Create a plan and plan change in IEX (use an existing work id in your system)
```
# Create a plan
{:ok, plan} = Meadow.Data.Planner.create_plan(%{
  prompt: "Add lorem ipsum descriptions to works",
  query: "id:4f055a50-b268-4d92-84a5-17c8c8b12ceb"
})

# Create a plan change for the existing work
{:ok, plan_change} = Meadow.Data.Planner.create_plan_change(%{
  plan_id: plan.id,
  work_id: "4f055a50-b268-4d92-84a5-17c8c8b12ceb",
  add: %{
    descriptive_metadata: %{
      description: ["lorem ipsum"]
    }
  }
})
```


Go to GraphiQL and test the above queries and mutations. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [x] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

