### PR TITLE
Move current user assignment out of MCPCase and into test

### DIFF
--- a/app/test/support/mcp_case.ex
+++ b/app/test/support/mcp_case.ex
@@ -7,7 +7,6 @@ defmodule MeadowWeb.MCPCase do
   use ExUnit.CaseTemplate
 
   alias Anubis.Server.{Frame, Handlers}
-  import Meadow.TestHelpers
 
   using do
     quote do
@@ -20,7 +19,8 @@ defmodule MeadowWeb.MCPCase do
   Fetch the list of available MCP tools.
   """
   def list_tools do
-    call_mcp("tools/list")
+    Frame.new()
+    |> call_mcp("tools/list")
     |> Map.update("tools", [], fn tools ->
       Enum.map(tools, fn tool ->
         %{
@@ -36,8 +36,9 @@ defmodule MeadowWeb.MCPCase do
   @doc """
   Call an MCP tool with the given name and parameters.
   """
-  def call_tool(tool, params \\ %{}) do
-    call_mcp("tools/call", %{
+  def call_tool(tool, params, context \\ []) do
+    Frame.new(context)
+    |> call_mcp("tools/call", %{
       "name" => tool,
       "arguments" => params
     })
@@ -59,8 +60,7 @@ defmodule MeadowWeb.MCPCase do
      end)}
   end
 
-  defp call_mcp(method, params \\ %{}) do
-    frame = Frame.new(current_user: user_fixture())
+  defp call_mcp(frame, method, params \\ %{}) do
     request = %{"method" => method, "params" => params}
     {:reply, response, _frame} = Handlers.handle(request, MeadowWeb.MCP.Server, frame)
     response


### PR DESCRIPTION
# Summary 

Move current user assignment out of MCPCase and into test

# Specific Changes in this PR
- Remove user fixture from the `MCPCase` module, replacing it with a context that gets assigned on `call_tool`
- Add user fixture/context to `MCP.GraphQLTest`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

