### PR TITLE
UI Implementation of Individual File Set Transfer

### DIFF
--- a/app/assets/js/components/Work/Tabs/Preservation/TransferFileSetsModal.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/TransferFileSetsModal.jsx
@@ -1,35 +1,99 @@
+/** @jsx jsx */
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { useHistory } from "react-router-dom";
 import { Button, Notification } from "@nulib/design-system";
-import { TRANSFER_FILE_SETS } from "@js/components/Work/work.gql.js";
+import { TRANSFER_FILE_SETS_SUBSET } from "@js/components/Work/work.gql.js";
 import { useMutation } from "@apollo/client";
 import { toastWrapper } from "@js/services/helpers";
 import { useForm, FormProvider } from "react-hook-form";
 import Error from "@js/components/UI/Error";
 import classNames from "classnames";
 import UIFormField from "@js/components/UI/Form/Field.jsx";
-import UIInput from "@js/components/UI/Form/Input";
-import { css } from "@emotion/react";
+import UIFormInput from "@js/components/UI/Form/Input";
+import { css, jsx } from "@emotion/react";
 
 const modalCss = css`
   z-index: 100;
+`;
+
+const summaryBox = css`
+  background-color: #f5f5f5;
+  margin-bottom: 1rem;
+`;
+
+const previewBox = css`
+  margin-bottom: 1rem;
+`;
+
+const previewList = css`
+  max-height: 300px;
+  overflow-y: auto;
+`;
+
+const previewItem = css`
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+  padding: 0.5rem;
+  background-color: #fafafa;
+  border-radius: 4px;
+`;
+
+const previewFigure = css`
+  width: 60px;
+  height: 60px;
+  flex-shrink: 0;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 4px;
+  }
+`;
+
+const previewContent = css`
+  flex: 1;
+  min-width: 0;
+`;
+
+const previewFilename = css`
+  font-size: 0.875rem;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const previewRole = css`
+  font-size: 0.75rem;
+  color: #666;
+`;
+
+const radioLabel = css`
+  margin-left: 8px;
 `;
 
 function WorkTabsPreservationTransferFileSetsModal({
   closeModal,
   isVisible,
   fromWorkId,
+  selectedFilesets,
+  work,
 }) {
   const defaultValues = {
-    fromWorkId: null,
+    transferDestination: "existing",
+    accessionNumber: "",
+    newWorkAccessionNumber: "",
+    newWorkTitle: "",
   };
 
-  const [formError, setFormError] = useState();
   const [confirmationInput, setConfirmationInput] = useState("");
   const [confirmationError, setConfirmationError] = useState();
   const [isSubmitted, setIsSubmitted] = useState(false);
-  const [toWorkId, setToWorkId] = useState("");
+  const [transferDestination, setTransferDestination] = useState("existing");
+  const [showPreview, setShowPreview] = useState(false);
 
   const methods = useForm({
     defaultValues: defaultValues,
@@ -38,35 +102,40 @@ function WorkTabsPreservationTransferFileSetsModal({
 
   const history = useHistory();
 
-  const handleToWorkIdChange = (e) => {
-    setToWorkId(e.target.value);
-  };
-
-  const [transferFileSets, { loading, error, data }] = useMutation(
-    TRANSFER_FILE_SETS,
+  const [transferFileSetsSubset, { loading, error, data, reset: resetMutation }] = useMutation(
+    TRANSFER_FILE_SETS_SUBSET,
     {
-      onCompleted({ transferFileSets }) {
+      onCompleted({ transferFileSetsSubset }) {
+        const { transferredFilesetIds, createdWorkId } = transferFileSetsSubset;
+        const targetWorkId =
+          createdWorkId || methods.getValues("accessionNumber");
+
         toastWrapper(
           "is-success",
-          `FileSets transferred successfully to work: ${transferFileSets.id}`
+          `${transferredFilesetIds.length} fileset(s) transferred successfully${
+            createdWorkId ? " to new work" : ""
+          }`,
         );
         resetForm();
-        history.push(`/work/${transferFileSets.id}`);
+
+        // Navigate to the target work (either created or existing)
+        if (createdWorkId) {
+          history.push(`/work/${createdWorkId}`);
+        } else {
+          // For existing work, close the modal and let the user navigate manually
+          closeModal();
+        }
       },
       onError(error) {
         console.error(
-          "error in the transferFileSets GraphQL mutation :>> ",
-          error
+          "error in the transferFileSetsSubset GraphQL mutation :>> ",
+          error,
         );
-        console.error("error MESSAGE", error.message)
-        console.error("graphQL ERRORS", error.graphQLErrors)
-        setFormError(error);
       },
-    }
+    },
   );
 
   const handleSubmit = (data) => {
-    setToWorkId(data.toWorkId);
     setIsSubmitted(true);
     if (confirmationInput !== "I understand") {
       setConfirmationError({
@@ -76,12 +145,35 @@ function WorkTabsPreservationTransferFileSetsModal({
     }
     setConfirmationError(null);
 
-    transferFileSets({
-      variables: {
-        fromWorkId: fromWorkId,
-        toWorkId: data.toWorkId,
-      },
-    });
+    const isCreatingNewWork = transferDestination === "new";
+
+    if (isCreatingNewWork) {
+      // Create new work
+      transferFileSetsSubset({
+        variables: {
+          filesetIds: selectedFilesets,
+          createWork: true,
+          workAttributes: {
+            accessionNumber: data.newWorkAccessionNumber,
+            workType: work.workType.id,
+            descriptiveMetadata: {
+              title: data.newWorkTitle,
+            },
+          },
+          deleteEmptyWorks: true,
+        },
+      });
+    } else {
+      // Transfer to existing work
+      transferFileSetsSubset({
+        variables: {
+          filesetIds: selectedFilesets,
+          createWork: false,
+          accessionNumber: data.accessionNumber,
+          deleteEmptyWorks: true,
+        },
+      });
+    }
   };
 
   const handleCancel = () => {
@@ -91,13 +183,37 @@ function WorkTabsPreservationTransferFileSetsModal({
 
   const resetForm = () => {
     methods.reset();
+    setConfirmationInput("");
+    setTransferDestination("existing");
+    setShowPreview(false);
+    setIsSubmitted(false);
+    setConfirmationError(null);
   };
+
+  // Clear error and reset form when modal opens
+  React.useEffect(() => {
+    if (!isVisible) {
+      // Modal is closing, keep state for next open
+      return;
+    }
+    // Modal is opening, reset form state and clear any GraphQL errors
+    resetForm();
+    if (resetMutation) {
+      resetMutation();
+    }
+  }, [isVisible, resetMutation]);
 
   const handleConfirmationChange = (e) => {
     const value = e.target.value;
     setConfirmationInput(value);
     setConfirmationError(null);
   };
+
+  const selectedFilesetsData = work.fileSets.filter((fs) =>
+    selectedFilesets.includes(fs.id),
+  );
+
+  const remainingFilesetsCount = work.fileSets.length - selectedFilesets.length;
 
   return (
     <div
@@ -114,9 +230,7 @@ function WorkTabsPreservationTransferFileSetsModal({
         >
           <div className="modal-card">
             <header className="modal-card-head">
-              <p className="modal-card-title">
-                Transfer FileSets between Works
-              </p>
+              <p className="modal-card-title">Transfer FileSets</p>
               <button
                 type="button"
                 className="delete"
@@ -127,22 +241,160 @@ function WorkTabsPreservationTransferFileSetsModal({
 
             <section className="modal-card-body">
               {error && <Error error={error} />}
-              <strong>From Work ID:</strong> {fromWorkId}
-              <UIFormField label="To Work ID:">
-                <UIInput
-                  isReactHookForm
-                  onChange={handleToWorkIdChange}
-                  name="toWorkId"
-                  label="To Work ID:"
-                  data-testid="toWorkId"
-                />
-              </UIFormField>
-              <Notification isCentered className="content">
+
+              {/* Transfer Summary */}
+              <div className="box" css={summaryBox}>
+                <p className="mb-2">
+                  <strong>
+                    Transferring {selectedFilesets.length} fileset(s)
+                  </strong>
+                  {remainingFilesetsCount > 0 &&
+                    ` (${remainingFilesetsCount} will remain in current work)`}
+                </p>
+                <p className="mb-2">
+                  <strong>From Work:</strong> {work.accessionNumber}
+                  {work.descriptiveMetadata?.title &&
+                    ` - ${work.descriptiveMetadata.title}`}
+                </p>
+                <p>
+                  <strong>Work Type:</strong>{" "}
+                  {work.workType?.label || work.workType?.id}
+                </p>
+              </div>
+
+              <div className="field mt-4">
+                <label className="checkbox">
+                  <input
+                    type="checkbox"
+                    checked={showPreview}
+                    onChange={(e) => setShowPreview(e.target.checked)}
+                  />
+                  <span css={radioLabel}>
+                    Show preview of selected filesets
+                  </span>
+                </label>
+              </div>
+
+              {/* Preview Section */}
+              {showPreview && (
+                <div className="box" css={previewBox}>
+                  <p className="has-text-weight-bold mb-2">
+                    Selected Filesets:
+                  </p>
+                  <div css={previewList}>
+                    {selectedFilesetsData.map((fs) => (
+                      <div key={fs.id} css={previewItem}>
+                        {fs.representativeImageUrl && (
+                          <figure css={previewFigure}>
+                            <img
+                              src={`${fs.representativeImageUrl}/square/60,/0/default.jpg`}
+                              alt={
+                                fs.coreMetadata?.originalFilename || "Fileset"
+                              }
+                              onError={(e) => {
+                                e.target.src = "/images/placeholder.png";
+                              }}
+                            />
+                          </figure>
+                        )}
+                        <div css={previewContent}>
+                          <p css={previewFilename}>
+                            {fs.coreMetadata?.originalFilename || fs.id}
+                          </p>
+                          <p css={previewRole}>
+                            Role: {fs.role?.id || "N/A"}
+                          </p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <div className="field">
+                <label className="label">Transfer Destination</label>
+                <div className="control">
+                  <label className="radio">
+                    <input
+                      type="radio"
+                      name="transferDestination"
+                      value="existing"
+                      checked={transferDestination === "existing"}
+                      onChange={(e) => setTransferDestination(e.target.value)}
+                    />
+                    <span css={radioLabel}>
+                      Transfer to existing work
+                    </span>
+                  </label>
+                </div>
+                <div className="control">
+                  <label className="radio">
+                    <input
+                      type="radio"
+                      name="transferDestination"
+                      value="new"
+                      checked={transferDestination === "new"}
+                      onChange={(e) => setTransferDestination(e.target.value)}
+                    />
+                    <span css={radioLabel}>Create new work</span>
+                  </label>
+                </div>
+              </div>
+
+              {transferDestination === "existing" ? (
+                <UIFormField label="Target Work Accession Number">
+                  <UIFormInput
+                    isReactHookForm
+                    name="accessionNumber"
+                    label="Target Work Accession Number"
+                    placeholder="Enter accession number"
+                    required
+                    data-testid="accession-number"
+                  />
+                  <p className="help">
+                    Enter the accession number of the work to transfer filesets
+                    to. The work must be of type:{" "}
+                    {work.workType?.label || work.workType?.id}
+                  </p>
+                </UIFormField>
+              ) : (
+                <>
+                  <UIFormField label="New Work Accession Number">
+                    <UIFormInput
+                      isReactHookForm
+                      name="newWorkAccessionNumber"
+                      label="New Work Accession Number"
+                      placeholder="Enter new work accession number"
+                      required
+                      data-testid="new-work-accession-number"
+                    />
+                  </UIFormField>
+                  <UIFormField label="New Work Title">
+                    <UIFormInput
+                      isReactHookForm
+                      name="newWorkTitle"
+                      label="New Work Title"
+                      placeholder="Enter new work title"
+                      data-testid="new-work-title"
+                    />
+                  </UIFormField>
+                  <Notification>
+                    <p>
+                      New work will be created with work type:{" "}
+                      <strong>
+                        {work.workType?.label || work.workType?.id}
+                      </strong>
+                    </p>
+                  </Notification>
+                </>
+              )}
+
+              <Notification isCentered className="content mt-4">
                 <div className="block">
                   <strong>To execute this transfer, type "I understand"</strong>
                 </div>
                 <div>
-                  <UIInput
+                  <UIFormInput
                     isReactHookForm
                     onChange={handleConfirmationChange}
                     name="confirmationText"
@@ -172,11 +424,7 @@ function WorkTabsPreservationTransferFileSetsModal({
               <Button
                 isPrimary
                 type="submit"
-                disabled={
-                  loading ||
-                  toWorkId === "" ||
-                  confirmationInput !== "I understand"
-                }
+                disabled={loading || confirmationInput !== "I understand"}
                 data-testid="submit-button"
               >
                 Transfer FileSets
@@ -193,6 +441,8 @@ WorkTabsPreservationTransferFileSetsModal.propTypes = {
   closeModal: PropTypes.func,
   isVisible: PropTypes.bool,
   fromWorkId: PropTypes.string.isRequired,
+  selectedFilesets: PropTypes.arrayOf(PropTypes.string).isRequired,
+  work: PropTypes.object.isRequired,
 };
 
 export default WorkTabsPreservationTransferFileSetsModal;

--- a/app/assets/js/components/Work/Tabs/Preservation/TransferFileSetsModal.test.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/TransferFileSetsModal.test.jsx
@@ -8,6 +8,7 @@ import { AuthProvider } from "@js/components/Auth/Auth";
 import { mockWork } from "@js/components/Work/work.gql.mock.js";
 import { screen } from "@testing-library/react";
 import { getCurrentUserMock } from "@js/components/Auth/auth.gql.mock";
+import userEvent from "@testing-library/user-event";
 
 let isModalOpen = true;
 
@@ -15,12 +16,19 @@ const handleClose = () => {
   isModalOpen = false;
 };
 
+const selectedFilesets = [
+  mockWork.fileSets[0].id,
+  mockWork.fileSets[1].id,
+];
+
 describe("Transfer file sets to another work modal", () => {
   beforeEach(() => {
     const Wrapped = withReactHookForm(TransferFileSetsModal, {
       closeModal: handleClose,
       isVisible: isModalOpen,
       fromWorkId: mockWork.id,
+      selectedFilesets: selectedFilesets,
+      work: mockWork,
     });
     return renderWithRouterApollo(
       <AuthProvider>
@@ -34,7 +42,75 @@ describe("Transfer file sets to another work modal", () => {
     );
   });
 
-  it("renders fileset form", async () => {
+  it("renders transfer filesets form", async () => {
     expect(await screen.findByTestId("transfer-filesets-form"));
+  });
+
+  it("displays the number of selected filesets", async () => {
+    expect(
+      await screen.findByText(/Transferring 2 fileset\(s\)/)
+    ).toBeInTheDocument();
+  });
+
+  it("displays the source work information", async () => {
+    expect(
+      await screen.findByText(/From Work:/)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Donohue_001/)).toBeInTheDocument();
+  });
+
+  it("shows transfer destination options", async () => {
+    expect(
+      await screen.findByText("Transfer to existing work")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Create new work")).toBeInTheDocument();
+  });
+
+  it("defaults to existing work transfer option", async () => {
+    const existingWorkRadio = await screen.findByDisplayValue("existing");
+    expect(existingWorkRadio).toBeChecked();
+  });
+
+  it("shows accession number field when transferring to existing work", async () => {
+    expect(
+      await screen.findByTestId("accession-number")
+    ).toBeInTheDocument();
+  });
+
+  it("shows new work fields when create new work is selected", async () => {
+    const user = userEvent.setup();
+    const newWorkRadio = await screen.findByDisplayValue("new");
+
+    await user.click(newWorkRadio);
+
+    expect(
+      await screen.findByTestId("new-work-accession-number")
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("new-work-title")).toBeInTheDocument();
+  });
+
+  it("shows preview checkbox", async () => {
+    expect(
+      await screen.findByText("Show preview of selected filesets")
+    ).toBeInTheDocument();
+  });
+
+  it("displays preview when checkbox is checked", async () => {
+    const user = userEvent.setup();
+    const previewText = await screen.findByText(
+      "Show preview of selected filesets"
+    );
+    const previewCheckbox = previewText.closest("label").querySelector("input[type='checkbox']");
+
+    await user.click(previewCheckbox);
+
+    expect(
+      await screen.findByText("Selected Filesets:")
+    ).toBeInTheDocument();
+  });
+
+  it("requires confirmation text to submit", async () => {
+    const submitButton = await screen.findByTestId("submit-button");
+    expect(submitButton).toBeDisabled();
   });
 });

--- a/app/assets/js/components/Work/work.gql.js
+++ b/app/assets/js/components/Work/work.gql.js
@@ -573,6 +573,27 @@ export const TRANSFER_FILE_SETS = gql`
   }
 `;
 
+export const TRANSFER_FILE_SETS_SUBSET = gql`
+  mutation TransferFileSetsSubset(
+    $filesetIds: [ID!]!
+    $createWork: Boolean!
+    $accessionNumber: String
+    $workAttributes: WorkAttributesInput
+    $deleteEmptyWorks: Boolean
+  ) {
+    transferFileSetsSubset(
+      filesetIds: $filesetIds
+      createWork: $createWork
+      accessionNumber: $accessionNumber
+      workAttributes: $workAttributes
+      deleteEmptyWorks: $deleteEmptyWorks
+    ) {
+      transferredFilesetIds
+      createdWorkId
+    }
+  }
+`;
+
 export const WORK_ARCHIVER_ENDPOINT = gql`
   query WorkArchiverEndpoint {
     workArchiverEndpoint {

--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "@absinthe/socket-apollo-link": "^0.2.1",
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",
@@ -4120,15 +4120,6 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.0.1.tgz",
-      "integrity": "sha512-0VpNtO5cNe1/HQWMkl4OdncYK/mv9hnBte0Ew0n6DMzmo3Q3WzDFABHm6LeNTipt5zAyhQ6Ugjiu8aLaEjh1gg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@fortawesome/fontawesome-svg-core": {


### PR DESCRIPTION
# Summary 

This PR adds the ability to select and transfer individual file sets from one work to another (existing or new) while leaving other file sets intact.

# Specific Changes in this PR

**Frontend:**

- **Preservation Tab UI** ([Preservation.jsx](app/assets/js/components/Work/Tabs/Preservation/Preservation.jsx))
  - Added checkbox column with "select all/select some" pattern
  - Individual checkboxes for each fileset row
  - Updated "Transfer File Sets" button to:
    - Display count of selected filesets: "Transfer File Sets (3)"
    - Show Bulma tooltip when disabled: "Select one or more filesets from the table above to transfer"
    - Disabled state when no filesets are selected
    - Styling matches publish button pattern

- **Transfer Modal** ([TransferFileSetsModal.jsx](app/assets/js/components/Work/Tabs/Preservation/TransferFileSetsModal.jsx))
  - Completely redesigned modal to support individual fileset selection
  - **Transfer Summary** section showing:
    - Number of filesets being transferred
    - Number remaining in source work
    - Source work details (accession number, title, work type)
  - **Transfer Destination** radio button options:
    - "Transfer to existing work" - requires target work accession number
    - "Create new work" - requires new accession number and title, automatically uses source work's work type
  - **Preview functionality** with toggle checkbox:
    - IIIF thumbnail images 
    - Fileset filename and role
    - Scrollable list for many filesets
  - Confirmation input ("I understand") before executing transfer
  - Auto-clears errors when modal reopens
  - Styled using Emotion CSS for consistency with codebase patterns

- **GraphQL Mutation** ([work.gql.js](app/assets/js/components/Work/work.gql.js))
  - Added `TRANSFER_FILE_SETS_SUBSET` mutation with support for:
    - Selecting specific filesets by ID
    - Creating new work or transferring to existing work
    - Passing comprehensive work attributes for new work creation
    - Optional deletion of empty source works

**Backend:**

- **Work Type Validation** ([transfer_file_sets.ex](app/lib/meadow/data/works/transfer_file_sets.ex))
  - Added `validate_work_types_match/2` function to prevent transferring filesets between works of different types
  - Integrated validation into `transfer_subset` transaction for existing work transfers
  - Returns clear error message: "Work type mismatch: source work(s) are AUDIO, target work is IMAGE"

**Tests:**

- **TransferFileSetsModal Tests** ([TransferFileSetsModal.test.jsx](app/assets/js/components/Work/Tabs/Preservation/TransferFileSetsModal.test.jsx))
  - Tests for rendering form and selected fileset count display
  - Tests for transfer destination radio button behavior
  - Tests for conditional field display (existing vs new work)
  - Tests for preview functionality
  - Tests for form validation (disabled submit button)



See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Navigate to a work page in Meadow
- click on the Preservation tab
- select all or individual file sets
- click "Transfer file sets" button at bottom and fill out the form.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

