### PR TITLE
Always add CLAUDE_CODE_USE_BEDROCK to Pythonx environment

### DIFF
--- a/app/lib/meadow/config/runtime.ex
+++ b/app/lib/meadow/config/runtime.ex
@@ -317,6 +317,11 @@ defmodule Meadow.Config.Runtime do
         }
       ]
 
+    config :meadow,
+      pythonx_env: %{
+        "CLAUDE_CODE_USE_BEDROCK" => "1"
+      }
+
     Logger.info("Configuring ueberauth for NU SSO")
 
     config :ueberauth, Ueberauth.Strategy.NuSSO,

--- a/app/test/meadow_ai/metadata_agent_test.exs
+++ b/app/test/meadow_ai/metadata_agent_test.exs
@@ -1,0 +1,15 @@
+defmodule MeadowAI.MetadataAgentTest do
+  use ExUnit.Case, async: true
+
+  describe "init/1" do
+    setup do
+      start_supervised!({MeadowAI.MetadataAgent, []})
+      :ok
+    end
+
+    test "properly initializes the Pythonx environment" do
+      {result, _} = Pythonx.eval("import os; os.getenv('CLAUDE_CODE_USE_BEDROCK')", %{})
+      assert Pythonx.decode(result) == "1"
+    end
+  end
+end


### PR DESCRIPTION
# Summary 
Always add `CLAUDE_CODE_USE_BEDROCK=1` to Pythonx environment

# Specific Changes in this PR
- Add pythonx environment to meadow config
- Update pythonx environment on initialization
- Add test to make sure variable is set properly

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

1. Make sure `CLAUDE_CODE_USE_BEDROCK` isn't set in your local environment.
2. `MEADOW_PROCESSES=metadata iex -S mix`
3. `Pythonx.eval("import os; os.getenv('CLAUDE_CODE_USE_BEDROCK')", %{})` and also test some `MeadowAI.MetadataAgent.query/2` calls

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

