### PR TITLE
Change terminology used for plans and plan changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Meadow supports AI agent-generated plans for batch modifications to works. The s
 - `query`: OpenSearch query string identifying target works
   - Collection query: `"collection.id:abc-123"`
   - Specific works: `"id:(work-id-1 OR work-id-2 OR work-id-3)"`
-- `status`: `:pending`, `:approved`, `:rejected`, `:executed`, or `:error`
+- `status`: `:pending, `:proposed`, `:approved`, `:rejected`, `:completed`, or `:error`
 
 **PlanChanges** - Work-specific modifications
 - `plan_id`: Foreign key to parent plan
@@ -149,10 +149,10 @@ Each PlanChange must specify at least one operation (`add`, `delete`, or `replac
 #### PlanChange payloads
 
 - `add` merges values into existing metadata. For lists (like subjects or notes) the values are appended when they are not already present. Scalar fields (e.g., `title`) are merged according to the context (`:append` for `add`, `:replace` for `replace`).
-- `delete` removes the provided values verbatim. For controlled vocabularies this means the JSON structure must match what is stored in the database (role/term maps). The planner normalizes structs and string-keyed maps automatically when executing changes.
+- `delete` removes the provided values verbatim. For controlled vocabularies this means the JSON structure must match what is stored in the database (role/term maps). The planner normalizes structs and string-keyed maps automatically when applying changes.
 - `replace` overwrites existing values for the provided keys. Use this when the existing content should be replaced entirely instead of appended or removed.
 
-Controlled metadata entries (subjects, creators, contributors, etc.) follow the shape below. For subjects you must supply both the `role` (with at least `id`/`scheme`) and the `term.id`; extra fields such as `label` or `variants` are ignored during execution but can be included when working with structs in IEx:
+Controlled metadata entries (subjects, creators, contributors, etc.) follow the shape below. For subjects you must supply both the `role` (with at least `id`/`scheme`) and the `term.id`; extra fields such as `label` or `variants` are ignored when applying but can be included when working with structs in IEx:
 
 ```elixir
 %{
@@ -241,15 +241,15 @@ change_b = Enum.at(changes, 1)
 })
 ```
 
-**Reviewing and executing:**
+**Reviewing and applying:**
 ```elixir
 # 3. User reviews and approves
 {:ok, _} = Meadow.Data.Planner.approve_plan(plan, "user@example.com")
 {:ok, _} = Meadow.Data.Planner.approve_plan_change(change_a, "user@example.com")
 {:ok, _} = Meadow.Data.Planner.approve_plan_change(change_b, "user@example.com")
 
-# 4. Execute approved changes
-{:ok, executed_plan} = Meadow.Data.Planner.execute_plan(plan)
+# 4. Apply approved changes
+{:ok, completed_plan} = Meadow.Data.Planner.apply_plan(plan)
 ```
 
 ### Doing development on the Meadow Pipeline lambdas

--- a/app/lib/meadow/data/schemas/agent_plan.ex
+++ b/app/lib/meadow/data/schemas/agent_plan.ex
@@ -10,20 +10,20 @@ defmodule Meadow.Data.Schemas.AgentPlan do
   @primary_key {:id, Ecto.UUID, autogenerate: false, read_after_writes: true}
   @timestamps_opts [type: :utc_datetime_usec]
   schema "agent_plans" do
-    field :query, :string
-    field :changeset, :map
-    field :status, Ecto.Enum, values: @statuses, default: :pending
-    field :user, :string
-    field :notes, :string
-    field :executed_at, :utc_datetime_usec
-    field :error, :string
+    field(:query, :string)
+    field(:changeset, :map)
+    field(:status, Ecto.Enum, values: @statuses, default: :pending)
+    field(:user, :string)
+    field(:notes, :string)
+    field(:completed_at, :utc_datetime_usec)
+    field(:error, :string)
     timestamps()
   end
 
   @doc false
   def changeset(agent_plan, attrs) do
     agent_plan
-    |> cast(attrs, [:query, :changeset, :status, :user, :notes, :executed_at, :error])
+    |> cast(attrs, [:query, :changeset, :status, :user, :notes, :completed_at, :error])
     |> validate_required([:query, :changeset])
     |> validate_inclusion(:status, @statuses)
     |> validate_changeset_format()
@@ -52,7 +52,7 @@ defmodule Meadow.Data.Schemas.AgentPlan do
   """
   def mark_executed(agent_plan) do
     agent_plan
-    |> cast(%{status: :executed, executed_at: DateTime.utc_now()}, [:status, :executed_at])
+    |> cast(%{status: :executed, completed_at: DateTime.utc_now()}, [:status, :completed_at])
     |> validate_inclusion(:status, @statuses)
   end
 

--- a/app/lib/meadow_web/mcp/get_plan_changes.ex
+++ b/app/lib/meadow_web/mcp/get_plan_changes.ex
@@ -18,7 +18,7 @@ defmodule MeadowWeb.MCP.GetPlanChanges do
       # Filter by status
       %{
         plan_id: "plan-uuid",
-        status: "pending"
+        status: "proposed"
       }
 
       # Combine filters
@@ -51,7 +51,7 @@ defmodule MeadowWeb.MCP.GetPlanChanges do
     )
 
     field(:status, :string,
-      description: "Optional status filter: pending, approved, rejected, executed, error"
+      description: "Optional status filter: proposed, approved, rejected, completed, error"
     )
 
     field(:user, :string,
@@ -63,68 +63,68 @@ defmodule MeadowWeb.MCP.GetPlanChanges do
   def name, do: "get_plan_changes"
 
   @impl true
-def execute(%{plan_id: plan_id} = request, frame) do
-  Logger.debug("MCP Server getting PlanChanges for plan: #{plan_id}")
+  def execute(%{plan_id: plan_id} = request, frame) do
+    Logger.debug("MCP Server getting PlanChanges for plan: #{plan_id}")
 
-  case fetch_plan(plan_id) do
-    {:ok, _plan} ->
-      changes =
-        plan_id
-        |> Planner.list_plan_changes(build_criteria(request))
-        |> Repo.preload(:plan)
-        |> Enum.map(&serialize_change/1)
+    case fetch_plan(plan_id) do
+      {:ok, _plan} ->
+        changes =
+          plan_id
+          |> Planner.list_plan_changes(build_criteria(request))
+          |> Repo.preload(:plan)
+          |> Enum.map(&serialize_change/1)
 
-      {:reply, Response.tool() |> Response.json(%{changes: changes}), frame}
+        {:reply, Response.tool() |> Response.json(%{changes: changes}), frame}
 
-    {:error, reason} ->
-      {:error, MCPError.execution(reason), frame}
+      {:error, reason} ->
+        {:error, MCPError.execution(reason), frame}
+    end
   end
-end
 
-defp fetch_plan(plan_id) do
-  case Planner.get_plan(plan_id) do
-    nil -> {:error, "Plan with id #{plan_id} not found"}
-    plan -> {:ok, plan}
+  defp fetch_plan(plan_id) do
+    case Planner.get_plan(plan_id) do
+      nil -> {:error, "Plan with id #{plan_id} not found"}
+      plan -> {:ok, plan}
+    end
   end
-end
 
-defp build_criteria(request) do
-  for {k, v} <- Map.take(request, [:work_id, :status, :user]),
-      not is_nil(v),
-      do: {k, v}
-end
+  defp build_criteria(request) do
+    for {k, v} <- Map.take(request, [:work_id, :status, :user]),
+        not is_nil(v),
+        do: {k, v}
+  end
 
-defp serialize_change(change) do
-  %{
-    id: change.id,
-    plan_id: change.plan_id,
-    work_id: change.work_id,
-    add: change.add,
-    delete: change.delete,
-    replace: change.replace,
-    status: change.status,
-    user: change.user,
-    notes: change.notes,
-    executed_at: change.executed_at,
-    error: change.error,
-    inserted_at: change.inserted_at,
-    updated_at: change.updated_at,
-    plan: serialize_plan(change.plan)
-  }
-end
+  defp serialize_change(change) do
+    %{
+      id: change.id,
+      plan_id: change.plan_id,
+      work_id: change.work_id,
+      add: change.add,
+      delete: change.delete,
+      replace: change.replace,
+      status: change.status,
+      user: change.user,
+      notes: change.notes,
+      completed_at: change.completed_at,
+      error: change.error,
+      inserted_at: change.inserted_at,
+      updated_at: change.updated_at,
+      plan: serialize_plan(change.plan)
+    }
+  end
 
-defp serialize_plan(plan) do
-  %{
-    id: plan.id,
-    prompt: plan.prompt,
-    query: plan.query,
-    status: plan.status,
-    user: plan.user,
-    notes: plan.notes,
-    executed_at: plan.executed_at,
-    error: plan.error,
-    inserted_at: plan.inserted_at,
-    updated_at: plan.updated_at
-  }
-end
+  defp serialize_plan(plan) do
+    %{
+      id: plan.id,
+      prompt: plan.prompt,
+      query: plan.query,
+      status: plan.status,
+      user: plan.user,
+      notes: plan.notes,
+      completed_at: plan.completed_at,
+      error: plan.error,
+      inserted_at: plan.inserted_at,
+      updated_at: plan.updated_at
+    }
+  end
 end

--- a/app/lib/meadow_web/resolvers/plans.ex
+++ b/app/lib/meadow_web/resolvers/plans.ex
@@ -25,8 +25,11 @@ defmodule MeadowWeb.Resolvers.Data.Plans do
           end
 
         case result do
-          {:ok, updated_plan} -> {:ok, updated_plan}
-          {:error, changeset} -> {:error, message: "Could not update plan status", details: changeset}
+          {:ok, updated_plan} ->
+            {:ok, updated_plan}
+
+          {:error, changeset} ->
+            {:error, message: "Could not update plan status", details: changeset}
         end
     end
   end
@@ -42,7 +45,9 @@ defmodule MeadowWeb.Resolvers.Data.Plans do
     end
   end
 
-  def update_plan_change_status(_, %{id: id, status: status} = args, %{context: %{current_user: user}}) do
+  def update_plan_change_status(_, %{id: id, status: status} = args, %{
+        context: %{current_user: user}
+      }) do
     case Planner.get_plan_change(id) do
       nil ->
         {:error, "Plan change not found"}
@@ -56,8 +61,11 @@ defmodule MeadowWeb.Resolvers.Data.Plans do
           end
 
         case result do
-          {:ok, updated_change} -> {:ok, updated_change}
-          {:error, changeset} -> {:error, message: "Could not update plan change status", details: changeset}
+          {:ok, updated_change} ->
+            {:ok, updated_change}
+
+          {:error, changeset} ->
+            {:error, message: "Could not update plan change status", details: changeset}
         end
     end
   end

--- a/app/lib/meadow_web/schema/types/data/plan_types.ex
+++ b/app/lib/meadow_web/schema/types/data/plan_types.ex
@@ -67,7 +67,7 @@ defmodule MeadowWeb.Schema.Data.PlanTypes do
     field(:status, :plan_status)
     field(:user, :string)
     field(:notes, :string)
-    field(:executed_at, :datetime)
+    field(:completed_at, :datetime)
     field(:error, :string)
     field(:inserted_at, :datetime)
     field(:updated_at, :datetime)
@@ -84,7 +84,7 @@ defmodule MeadowWeb.Schema.Data.PlanTypes do
     field(:status, :plan_status)
     field(:user, :string)
     field(:notes, :string)
-    field(:executed_at, :datetime)
+    field(:completed_at, :datetime)
     field(:error, :string)
     field(:inserted_at, :datetime)
     field(:updated_at, :datetime)
@@ -92,10 +92,11 @@ defmodule MeadowWeb.Schema.Data.PlanTypes do
 
   @desc "Plan status values"
   enum :plan_status do
-    value(:pending, as: :pending, description: "Pending review")
-    value(:approved, as: :approved, description: "Approved for execution")
-    value(:rejected, as: :rejected, description: "Rejected, will not be executed")
-    value(:executed, as: :executed, description: "Successfully executed")
-    value(:error, as: :error, description: "Execution failed")
+    value(:pending, as: :pending, description: "Plan created")
+    value(:proposed, as: :proposed, description: "Pending review")
+    value(:approved, as: :approved, description: "Approved, will be applied")
+    value(:rejected, as: :rejected, description: "Rejected, will not be applied")
+    value(:completed, as: :completed, description: "Successfully applied")
+    value(:error, as: :error, description: "Failed to apply")
   end
 end

--- a/app/priv/repo/migrations/20251001031320_create_agent_plans.exs
+++ b/app/priv/repo/migrations/20251001031320_create_agent_plans.exs
@@ -8,7 +8,7 @@ defmodule Meadow.Repo.Migrations.CreateAgentPlans do
       add(:status, :string, null: false, default: "pending")
       add(:user, :string)
       add(:notes, :text)
-      add(:executed_at, :utc_datetime_usec)
+      add(:completed_at, :utc_datetime_usec)
       add(:error, :text)
       timestamps()
     end

--- a/app/priv/repo/migrations/20251001120000_create_plans_and_plan_changes.exs
+++ b/app/priv/repo/migrations/20251001120000_create_plans_and_plan_changes.exs
@@ -3,41 +3,41 @@ defmodule Meadow.Repo.Migrations.CreatePlansAndPlanChanges do
 
   def change do
     create table(:plans, primary_key: false) do
-      add :id, :uuid, primary_key: true, default: fragment("gen_random_uuid()")
-      add :prompt, :text, null: false
-      add :query, :text
-      add :status, :string, null: false, default: "pending"
-      add :user, :string
-      add :notes, :text
-      add :executed_at, :utc_datetime_usec
-      add :error, :text
+      add(:id, :uuid, primary_key: true, default: fragment("gen_random_uuid()"))
+      add(:prompt, :text, null: false)
+      add(:query, :text)
+      add(:status, :string, null: false, default: "pending")
+      add(:user, :string)
+      add(:notes, :text)
+      add(:completed_at, :utc_datetime_usec)
+      add(:error, :text)
       timestamps(type: :utc_datetime_usec)
     end
 
     create table(:plan_changes, primary_key: false) do
-      add :id, :uuid, primary_key: true, default: fragment("gen_random_uuid()")
-      add :plan_id, references(:plans, type: :uuid, on_delete: :delete_all), null: false
-      add :work_id, :uuid, null: false
-      add :changeset, :jsonb
-      add :add, :jsonb
-      add :delete, :jsonb
-      add :replace, :jsonb
-      add :status, :string, null: false, default: "pending"
-      add :user, :string
-      add :notes, :text
-      add :executed_at, :utc_datetime_usec
-      add :error, :text
+      add(:id, :uuid, primary_key: true, default: fragment("gen_random_uuid()"))
+      add(:plan_id, references(:plans, type: :uuid, on_delete: :delete_all), null: false)
+      add(:work_id, :uuid, null: false)
+      add(:changeset, :jsonb)
+      add(:add, :jsonb)
+      add(:delete, :jsonb)
+      add(:replace, :jsonb)
+      add(:status, :string, null: false, default: "pending")
+      add(:user, :string)
+      add(:notes, :text)
+      add(:completed_at, :utc_datetime_usec)
+      add(:error, :text)
       timestamps(type: :utc_datetime_usec)
     end
 
-    create index(:plans, [:status])
-    create index(:plans, [:user])
-    create index(:plans, [:inserted_at])
+    create(index(:plans, [:status]))
+    create(index(:plans, [:user]))
+    create(index(:plans, [:inserted_at]))
 
-    create index(:plan_changes, [:plan_id])
-    create index(:plan_changes, [:work_id])
-    create index(:plan_changes, [:status])
-    create index(:plan_changes, [:user])
-    create index(:plan_changes, [:inserted_at])
+    create(index(:plan_changes, [:plan_id]))
+    create(index(:plan_changes, [:work_id]))
+    create(index(:plan_changes, [:status]))
+    create(index(:plan_changes, [:user]))
+    create(index(:plan_changes, [:inserted_at]))
   end
 end

--- a/app/test/meadow_web/schema/query/get_plan_change_test.exs
+++ b/app/test/meadow_web/schema/query/get_plan_change_test.exs
@@ -17,7 +17,7 @@ defmodule MeadowWeb.Schema.Query.GetPlanChangeTest do
     assert {:ok, query_data} = result
 
     plan_change_status = get_in(query_data, [:data, "planChange", "status"])
-    assert plan_change_status == "PENDING"
+    assert plan_change_status == "PROPOSED"
   end
 
   test "should return nil for a non-existent plan change" do

--- a/app/test/meadow_web/schema/query/get_plan_changes_test.exs
+++ b/app/test/meadow_web/schema/query/get_plan_changes_test.exs
@@ -23,7 +23,7 @@ defmodule MeadowWeb.Schema.Query.GetPlanChangesTest do
 
     first_change = List.first(changes)
     assert first_change["id"] == plan_change.id
-    assert first_change["status"] == "PENDING"
+    assert first_change["status"] == "PROPOSED"
   end
 
   test "should return empty list for plan with no changes" do

--- a/app/test/meadow_web/schema/query/get_plan_test.exs
+++ b/app/test/meadow_web/schema/query/get_plan_test.exs
@@ -17,7 +17,7 @@ defmodule MeadowWeb.Schema.Query.GetPlanTest do
     assert {:ok, query_data} = result
 
     plan_status = get_in(query_data, [:data, "plan", "status"])
-    assert plan_status == "PENDING"
+    assert plan_status == "PROPOSED"
   end
 
   test "should return nil for a non-existent plan" do

--- a/app/test/support/test_helpers.ex
+++ b/app/test/support/test_helpers.ex
@@ -226,14 +226,15 @@ defmodule Meadow.TestHelpers do
 
   def gql_context(user \\ %{}, extra \\ %{}) do
     %{
-      current_user: %{
-        id: "user1",
-        username: "user1",
-        email: "email@example.com",
-        display_name: "User Name",
-        role: :administrator
-      }
-      |> Map.merge(user)
+      current_user:
+        %{
+          id: "user1",
+          username: "user1",
+          email: "email@example.com",
+          display_name: "User Name",
+          role: :administrator
+        }
+        |> Map.merge(user)
     }
     |> Map.merge(extra)
   end
@@ -303,7 +304,7 @@ defmodule Meadow.TestHelpers do
       Enum.into(attrs, %{
         prompt: "Test plan prompt",
         query: "collection.id:test-123",
-        status: :pending
+        status: :proposed
       })
 
     {:ok, plan} =
@@ -323,7 +324,7 @@ defmodule Meadow.TestHelpers do
         plan_id: plan.id,
         work_id: work.id,
         add: %{descriptive_metadata: %{title: "Updated title"}},
-        status: :pending
+        status: :proposed
       })
 
     {:ok, plan_change} =


### PR DESCRIPTION
# Summary 
Change terminology used for plans and plan changes

# Specific Changes in this PR
- add **proposed** status to both `Plan` and `PlanChange` schema
- use **apply** instead of **execute**
- use **completed** instead of **executed**

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Requires re-creating the `plans` and `plan_changes` tables in development:
```shell
mix do ecto.rollback, ecto.migrate
```

After merge, will require re-creating the same tables in the deployed Meadow AI instance, which can be done from Livebook.
```elixir
Meadow.Repo
|> Ecto.Migrator.with_repo(fn repo ->
  Ecto.Migrator.run(repo, :down, step: 1)
  Ecto.Migrator.run(repo, :up, all: true)
end)
```

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [x] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

