### PR TITLE
Add MeadowWeb.Schema.Public for use by the MeadowAI agent

### DIFF
--- a/app/lib/meadow_web/mcp/graphql.ex
+++ b/app/lib/meadow_web/mcp/graphql.ex
@@ -39,7 +39,7 @@ defmodule MeadowWeb.MCP.GraphQL do
   end
 
   defp run_query(query, variables, context) do
-    case Absinthe.run(query, MeadowWeb.Schema, variables: variables, context: context) do
+    case Absinthe.run(query, MeadowWeb.Schema.Agent, variables: variables, context: context) do
       {:ok, %{errors: [%{message: reason} | _]}} -> {:error, reason}
       {:ok, %{data: data}} -> {:ok, data}
       {:error, reason} -> {:error, reason}

--- a/app/lib/meadow_web/router.ex
+++ b/app/lib/meadow_web/router.ex
@@ -70,6 +70,13 @@ defmodule MeadowWeb.Router do
       before_send: {Middleware.AssumeRole, :update_user_role}
     )
 
+    forward("/graphiql/agent", Absinthe.Plug.GraphiQL,
+      schema: MeadowWeb.Schema.Agent,
+      interface: :simple,
+      socket: MeadowWeb.UserSocket,
+      before_send: {Middleware.AssumeRole, :update_user_role}
+    )
+
     forward("/graphiql", Absinthe.Plug.GraphiQL,
       schema: MeadowWeb.Schema,
       interface: :simple,

--- a/app/lib/meadow_web/schema/agent.ex
+++ b/app/lib/meadow_web/schema/agent.ex
@@ -1,0 +1,59 @@
+defmodule MeadowWeb.Schema.Agent do
+  @moduledoc """
+  Absinthe Schema for the MeadowAI Agent
+
+  """
+  use Absinthe.Schema
+  import_types(Absinthe.Type.Custom)
+  import_types(MeadowWeb.Schema.Types.Json)
+
+  alias Meadow.Data
+
+  import_types(MeadowWeb.Schema.IngestTypes)
+  import_types(MeadowWeb.Schema.Data.WorkTypes)
+  import_types(MeadowWeb.Schema.Data.CollectionTypes)
+  import_types(MeadowWeb.Schema.Data.ControlledTermTypes)
+  import_types(MeadowWeb.Schema.Data.FileSetTypes)
+  import_types(MeadowWeb.Schema.Data.FieldTypes)
+  import_types(MeadowWeb.Schema.NULAuthorityTypes)
+  import_types(__MODULE__.WorkQueries)
+
+  enum :sort_order do
+    value(:asc)
+    value(:desc)
+  end
+
+  object :status_message do
+    field :message, non_null(:string)
+  end
+
+  object :field do
+    field :header, non_null(:string)
+    field :value, non_null(:string)
+  end
+
+  object :error do
+    field :field, non_null(:string)
+    field :message, non_null(:string)
+  end
+
+  query do
+    import_fields(:collection_queries)
+    import_fields(:controlled_term_queries)
+    import_fields(:field_queries)
+    import_fields(:nul_authority_queries)
+    import_fields(:agent_work_queries)
+  end
+
+  def context(ctx) do
+    loader =
+      Dataloader.new()
+      |> Dataloader.add_source(Data, Data.datasource())
+
+    Map.put(ctx, :loader, loader)
+  end
+
+  def plugins do
+    [Absinthe.Middleware.Dataloader] ++ Absinthe.Plugin.defaults()
+  end
+end

--- a/app/lib/meadow_web/schema/agent/work_queries.ex
+++ b/app/lib/meadow_web/schema/agent/work_queries.ex
@@ -1,0 +1,26 @@
+defmodule MeadowWeb.Schema.Agent.WorkQueries do
+  @moduledoc """
+  Agent subset of work queries
+  """
+  use Absinthe.Schema.Notation
+  alias MeadowWeb.Resolvers.Data
+  alias MeadowWeb.Schema.Middleware
+
+  object :agent_work_queries do
+    @desc "Get a work by id"
+    field :work, :work do
+      arg(:id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      resolve(&Data.work/3)
+    end
+
+    @desc "Get a list of works"
+    field :works, list_of(:work) do
+      arg(:limit, :integer, default_value: 100)
+      arg(:filter, :work_filter)
+      arg(:order, type: :sort_order, default_value: :asc)
+      middleware(Middleware.Authenticate)
+      resolve(&Data.works/3)
+    end
+  end
+end

--- a/app/test/meadow_web/mcp/graphql_test.exs
+++ b/app/test/meadow_web/mcp/graphql_test.exs
@@ -5,23 +5,30 @@ defmodule MeadowWeb.MCP.GraphQLTest do
   describe "GraphQL Tool" do
     setup do
       user = user_fixture()
-      {:ok, %{user: user}}
+      collection = collection_fixture()
+      {:ok, %{user: user, collection: collection}}
     end
 
-    test "execute a simple GraphQL query", %{user: user} do
+    test "execute a simple GraphQL query", %{user: user, collection: collection} do
       query = """
-      query WhoAmi {
-        me {
-          displayName
+      query GetCollection($collectionId: ID!) {
+        collection(collectionId: $collectionId) {
+          id
+          title
         }
       }
       """
 
+      variables = %{"collectionId" => collection.id}
+
       assert {:ok, [{:text, text}]} =
-               call_tool("graphql", %{"query" => query}, current_user: user) |> parse_response()
+               call_tool("graphql", %{"query" => query, "variables" => variables},
+                 current_user: user
+               )
+               |> parse_response()
 
       assert response = Jason.decode!(text)
-      assert get_in(response, ["me", "displayName"]) |> String.contains?(user.display_name)
+      assert get_in(response, ["collection", "title"]) == collection.title
     end
 
     test "execute a GraphQL query with variables", %{user: user} do


### PR DESCRIPTION
- Adds a new, scoped-down GraphQL schema for the agent to use