### PR TITLE
Implement plan subscription backend

### DIFF
--- a/app/lib/meadow_web/resolvers/chat.ex
+++ b/app/lib/meadow_web/resolvers/chat.ex
@@ -12,13 +12,13 @@ defmodule MeadowWeb.Resolvers.Chat do
       ) do
     case Planner.create_plan(%{prompt: prompt, query: query}) do
       {:ok, plan} ->
-        # Publish plan_id immediately to frontend
+        # Publish plan_id immediately to frontend with dedicated message type
         Absinthe.Subscription.publish(
           MeadowWeb.Endpoint,
           %{
             conversation_id: conversation_id,
             message: "Plan created with ID: #{plan.id}",
-            type: type,
+            type: "plan_id",
             plan_id: plan.id
           },
           chat_response: "conversation:#{conversation_id}"
@@ -28,13 +28,13 @@ defmodule MeadowWeb.Resolvers.Chat do
         Task.start(fn ->
           {:ok, ai_response} = MeadowAI.query(prompt, context: %{query: query, plan_id: plan.id})
 
-          # Publish final agent response
+          # Publish final agent response as chat message
           Absinthe.Subscription.publish(
             MeadowWeb.Endpoint,
             %{
               conversation_id: conversation_id,
               message: ai_response,
-              type: type,
+              type: "chat",
               plan_id: plan.id
             },
             chat_response: "conversation:#{conversation_id}"

--- a/app/lib/meadow_web/schema/types/chat_types.ex
+++ b/app/lib/meadow_web/schema/types/chat_types.ex
@@ -15,6 +15,14 @@ defmodule MeadowWeb.Schema.ChatTypes do
         {:ok, topic: "conversation:#{args.conversation_id}"}
       end)
     end
+
+    field :plan_changes_updated, :plan_change_update do
+      arg(:plan_id, non_null(:id))
+
+      config(fn args, _ ->
+        {:ok, topic: "plan:#{args.plan_id}"}
+      end)
+    end
   end
 
   object :chat_mutations do
@@ -39,8 +47,14 @@ defmodule MeadowWeb.Schema.ChatTypes do
 
   object :chat_response do
     field(:conversation_id, :id)
-    field(:type, :string, description: "Type of message, e.g. 'chat'")
+    field(:type, :string, description: "Type of message, e.g. 'chat', 'plan_id'")
     field(:message, :string, description: "AI response message")
     field(:plan_id, :id, description: "The ID of the plan created for this chat message")
+  end
+
+  object :plan_change_update do
+    field(:plan_id, non_null(:id), description: "The plan ID")
+    field(:plan_change, :plan_change, description: "The updated plan change")
+    field(:action, non_null(:string), description: "The action that occurred: 'created', 'updated', 'deleted'")
   end
 end


### PR DESCRIPTION
Steps to test:

Start up Meadow in `iex`:

First make a new plan and get the `Plan` and a `PlanChange`:
```elixir
{:ok, plan} = Planner.create_plan(%{prompt: "Add date_created EDTF fields", query: ~s({"query": {"match_all": {}}})})
plan = plan |> Repo.preload(:plan_changes)
plan_change = plan.plan_changes |> hd()

# in this example:
# plan.id "ad94c13e-3b9a-48f0-b850-412cf5071f86"
#
# don't close iex yet, you'll come back after graphiql to update the plan_change
```

In the `graphiql` interface:
```graphql
subscription {
  planChangesUpdated(planId:"ad94c13e-3b9a-48f0-b850-412cf5071f86") {
    planId
    planChange {
      status
      add
      replace
      delete
    }
  }
}
```

Back in `iex`:
```elixir
Planner.update_plan_change(plan_change, %{
  status: :proposed,
  add: %{
    descriptive_metadata: %{
      alternate_title: ["test"]
    }
  }
})
```

The message immediately appear in `graphiql`:
```json
{
  "data": {
    "planChangesUpdated": {
      "planChange": {
        "add": {
          "descriptive_metadata": {
            "alternate_title": [
              "test"
            ]
          }
        },
        "delete": null,
        "replace": null,
        "status": "PROPOSED"
      },
      "planId": "ad94c13e-3b9a-48f0-b850-412cf5071f86"
    }
  }
}
```