### PR TITLE
Add functions and mutations to accept/reject all pending plan changes

### DIFF
--- a/app/lib/meadow/data/schemas/plan.ex
+++ b/app/lib/meadow/data/schemas/plan.ex
@@ -68,6 +68,15 @@ defmodule Meadow.Data.Schemas.Plan do
   end
 
   @doc """
+  Transition plan to proposed status
+  """
+  def propose(plan) do
+    plan
+    |> cast(%{status: :proposed}, [:status])
+    |> validate_inclusion(:status, @statuses)
+  end
+
+  @doc """
   Transition plan to approved status
 
   ## Example

--- a/app/lib/meadow_web/schema/types/data/plan_types.ex
+++ b/app/lib/meadow_web/schema/types/data/plan_types.ex
@@ -53,6 +53,16 @@ defmodule MeadowWeb.Schema.Data.PlanTypes do
       middleware(Middleware.Authorize, "Editor")
       resolve(&Plans.update_plan_change_status/3)
     end
+
+    @desc "Update all proposed plan change statuses (approve or reject)"
+    field :update_proposed_plan_change_statuses, list_of(:plan_change) do
+      arg(:plan_id, non_null(:id))
+      arg(:status, non_null(:plan_status))
+      arg(:notes, :string)
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Plans.update_proposed_plan_change_statuses/3)
+    end
   end
 
   #

--- a/app/test/gql/UpdateProposedPlanChangeStatuses.gql
+++ b/app/test/gql/UpdateProposedPlanChangeStatuses.gql
@@ -1,0 +1,8 @@
+mutation UpdateProposedPlanChangeStatuses($planId: ID!, $status: PlanStatus!, $notes: String) {
+  updateProposedPlanChangeStatuses(planId: $planId, status: $status, notes: $notes) {
+    id
+    status
+    user
+    notes
+  }
+}

--- a/app/test/meadow_web/schema/mutation/update_proposed_plan_change_statuses_test.exs
+++ b/app/test/meadow_web/schema/mutation/update_proposed_plan_change_statuses_test.exs
@@ -1,0 +1,79 @@
+defmodule MeadowWeb.Schema.Mutation.UpdateProposedPlanChangeStatusesTest do
+  use Meadow.DataCase
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+
+  load_gql(MeadowWeb.Schema, "test/gql/UpdateProposedPlanChangeStatuses.gql")
+
+  setup do
+    plan = plan_fixture()
+
+    plan_changes = [
+      plan_change_fixture(%{plan: plan, replace: %{collection_id: 123}, status: :proposed}),
+      plan_change_fixture(%{plan: plan, replace: %{collection_id: 123}, status: :proposed}),
+      plan_change_fixture(%{plan: plan, replace: %{collection_id: 123}, status: :approved}),
+      plan_change_fixture(%{plan: plan, replace: %{collection_id: 123}, status: :proposed}),
+      plan_change_fixture(%{plan: plan, replace: %{collection_id: 123}, status: :rejected}),
+      plan_change_fixture(%{plan: plan, replace: %{collection_id: 123}, status: :proposed}),
+      plan_change_fixture(%{plan: plan, replace: %{collection_id: 123}, status: :proposed}),
+      plan_change_fixture(%{plan: plan, replace: %{collection_id: 123}, status: :rejected}),
+      plan_change_fixture(%{plan: plan, replace: %{collection_id: 123}, status: :proposed}),
+      plan_change_fixture(%{plan: plan, replace: %{collection_id: 123}, status: :proposed})
+    ]
+
+    {:ok, plan: plan, plan_changes: plan_changes}
+  end
+
+  test "should approve remaining proposed changes in the plan", %{
+    plan: plan,
+    plan_changes: plan_changes
+  } do
+    result =
+      query_gql(
+        variables: %{"planId" => plan.id, "status" => "APPROVED"},
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+
+    response = get_in(query_data, [:data, "updateProposedPlanChangeStatuses"])
+    assert length(response) == length(plan_changes)
+    assert not Enum.any?(response, fn pc -> pc["status"] == "PROPOSED" end)
+    assert Enum.count(response, fn pc -> pc["status"] == "APPROVED" end) == 8
+  end
+
+  test "should reject remaining proposed changes in the plan with notes", %{
+    plan: plan,
+    plan_changes: plan_changes
+  } do
+    result =
+      query_gql(
+        variables: %{
+          "planId" => plan.id,
+          "status" => "REJECTED",
+          "notes" => "Incorrect translation"
+        },
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+
+    response = get_in(query_data, [:data, "updateProposedPlanChangeStatuses"])
+    assert length(response) == length(plan_changes)
+    assert not Enum.any?(response, fn pc -> pc["status"] == "PROPOSED" end)
+    assert Enum.count(response, fn pc -> pc["status"] == "REJECTED" end) == 9
+    assert Enum.count(response, fn pc -> pc["notes"] == "Incorrect translation" end) == 7
+  end
+
+  test "should return error for non-existent plan" do
+    result =
+      query_gql(
+        variables: %{"planId" => Ecto.UUID.generate(), "status" => "APPROVED"},
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+    error = List.first(get_in(query_data, [:errors]))
+    assert error.message == "Plan not found"
+  end
+end


### PR DESCRIPTION
# Summary 

Add functions and mutations to accept/reject all pending plan changes

# Specific Changes in this PR
- Add `Planner.propose_plan/1` to transition a plan to `proposed` status
- Add `Planner.approve_proposed_plan_changes/2` and `Planner.reject_proposed_plan_changes/2`
- Add additional handling to `Planner.approve_plan/2` to make sure both the plan and its changes are in an approvable state

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

It's probably easiest to test this in graphiql, but there are ways to test directly with the `Planner` module as well.

1. Create a plan that matches at least a couple dozen works.
2. Make sure the plan and all its changes are `pending`.
3. Put some real add/delete/replace maps in some (not all) of the changes
    - The GraphQL `planChanges` query should only show you changes that have actual data alterations in them
5. Approve/reject some (not all) individual changes
6. Try to approve the plan. It should fail.
7. Transition the plan to `proposed` status. All of its non-empty changes should also transition to `proposed` automatically.
8. Try to approve the plan again. It should fail with a different message.
9. Use either `Planner.approve_proposed_plan_changes` or the `updateProposedPlanChangeStatuses` GraphQL mutation to approve all remaining non-empty proposed changes.
    - Make sure it left the things you rejected in Step 5 alone
10. Try to approve the plan again. It should succeed this time.

Repeat and mess around with other combinations, and bulk rejections, etc.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

