### PR TITLE
Allow frontend to pass limit to NUL Authority searches, fixes bug in dashboard

### DIFF
--- a/app/assets/js/components/Dashboards/LocalAuthorities/List.jsx
+++ b/app/assets/js/components/Dashboards/LocalAuthorities/List.jsx
@@ -47,6 +47,7 @@ export default function DashboardsLocalAuthoritiesList() {
         variables: {
           authority: "nul-authority",
           query: searchValue,
+          limit: limit,
         },
       });
     } else {
@@ -113,7 +114,7 @@ export default function DashboardsLocalAuthoritiesList() {
   React.useEffect(() => {
     if (!data) return;
     filterValues();
-  }, [data, searchValue]);
+  }, [data, searchValue, limit]);
 
   if (loading || deleteAuthorityLoading || updateLoading) return null;
   if (error) return <Notification isDanger>{error.toString()}</Notification>;

--- a/app/assets/js/components/Work/controlledVocabulary.gql.js
+++ b/app/assets/js/components/Work/controlledVocabulary.gql.js
@@ -1,8 +1,8 @@
 import gql from "graphql-tag";
 
 export const AUTHORITIES_SEARCH = gql`
-  query AuthoritiesSearch($authority: ID!, $query: String!) {
-    authoritiesSearch(authority: $authority, query: $query) {
+  query AuthoritiesSearch($authority: ID!, $query: String!, $limit: Int) {
+    authoritiesSearch(authority: $authority, query: $query, limit: $limit) {
       hint
       id
       label

--- a/app/lib/meadow_web/resolvers/authorities_search.ex
+++ b/app/lib/meadow_web/resolvers/authorities_search.ex
@@ -4,16 +4,22 @@ defmodule MeadowWeb.Resolvers.Data.AuthoritiesSearch do
   alias Meadow.Data.ControlledTerms
 
   def search(
-        %{authority: "nul-authority", query: <<"info:nul/", _::binary-size(36)>> = query},
+        %{authority: "nul-authority", query: <<"info:nul/", _::binary-size(36)>> = query} = args,
         _
       ) do
     case Authoritex.fetch(query) do
       {:ok, %{id: id, label: label, hint: hint}} -> {:ok, [%{id: id, label: label, hint: hint}]}
-      _ -> Authoritex.search("nul-authority", query)
+      _ -> do_search(args)
     end
   end
 
-  def search(%{authority: code, query: query}, _) do
+  def search(args, _), do: do_search(args)
+
+  defp do_search(%{authority: code, query: query, limit: limit}) do
+    Authoritex.search(code, query, limit)
+  end
+
+  defp do_search(%{authority: code, query: query}) do
     Authoritex.search(code, query)
   end
 

--- a/app/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
+++ b/app/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
@@ -36,6 +36,7 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
     field :authorities_search, list_of(:controlled_value) do
       arg(:authority, non_null(:id))
       arg(:query, non_null(:string))
+      arg(:limit, :integer)
       middleware(Middleware.Authenticate)
 
       resolve(&AuthoritiesSearch.search/2)

--- a/app/test/gql/AuthoritiesSearch.gql
+++ b/app/test/gql/AuthoritiesSearch.gql
@@ -1,7 +1,7 @@
 #import "./ControlledValueFields.frag.gql"
 
-query AuthoritiesSearch($authority: ID!, $query: String!) {
-  authoritiesSearch(authority: $authority, query: $query) {
+query AuthoritiesSearch($authority: ID!, $query: String!, $limit: Int) {
+  authoritiesSearch(authority: $authority, query: $query, limit: $limit) {
     ...ControlledValueFields
   }
 }

--- a/app/test/nul/authority_records_test.exs
+++ b/app/test/nul/authority_records_test.exs
@@ -34,6 +34,13 @@ defmodule NUL.AuthorityRecordsTest do
       assert AuthorityRecords.list_authority_records() |> length() == 3
     end
 
+    test "list_authority_records/1 respects limit parameter" do
+      assert AuthorityRecords.list_authority_records(1) |> length() == 1
+      assert AuthorityRecords.list_authority_records(2) |> length() == 2
+      assert AuthorityRecords.list_authority_records(3) |> length() == 3
+      assert AuthorityRecords.list_authority_records(100) |> length() == 3
+    end
+
     test "get_authority_record!/1", %{authority_record: authority_record} do
       assert AuthorityRecords.get_authority_record!(authority_record.id)
 

--- a/app/test/nul/authority_test.exs
+++ b/app/test/nul/authority_test.exs
@@ -89,5 +89,20 @@ defmodule NUL.AuthorityTest do
     test "no results" do
       assert {:ok, []} = Authority.search("M1551ng")
     end
+
+    test "respects limit parameter" do
+      # Search for "Legend" matches 3 records (2 in hint, 1 in label)
+      assert {:ok, results} = Authority.search("Legend", 1)
+      assert length(results) == 1
+
+      assert {:ok, results} = Authority.search("Legend", 2)
+      assert length(results) == 2
+
+      assert {:ok, results} = Authority.search("Legend", 3)
+      assert length(results) == 3
+
+      assert {:ok, results} = Authority.search("Legend", 100)
+      assert length(results) == 3
+    end
   end
 end


### PR DESCRIPTION
# Summary 
Allow frontend to pass limit to NUL Authority searches, fixes bug in dashboard

<img width="1656" height="489" alt="authorities_counts" src="https://github.com/user-attachments/assets/c1c65fde-6f9e-4737-99c9-4df05a841ac0" />

# Specific Changes in this PR
- Updates components, resolvers and tests for selecting counts in the NUL Authorities dashboard

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
- Add NUL authorities and try selecting different counts (I exported from the using the export button in the dashboard on production and imported a 1000 row CSV to test)

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

