### PR TITLE
Support configuring a forced user to skip login in dev/test environments

### DIFF
--- a/app/lib/meadow_web/plugs/set_current_user.ex
+++ b/app/lib/meadow_web/plugs/set_current_user.ex
@@ -10,17 +10,39 @@ defmodule MeadowWeb.Plugs.SetCurrentUser do
   def init(opts), do: opts
 
   def call(conn, _) do
+    conn
+    |> check_config_user()
+    |> load_session_user()
+    |> add_absinthe_context()
+  end
+
+  defp add_absinthe_context(%Plug.Conn{assigns: %{current_user: user}} = conn) do
+    token = conn |> Map.get(:req_cookies, %{}) |> Map.get("_meadow_key", "")
+
+    Absinthe.Plug.put_options(conn, context: %{auth_token: token, current_user: user})
+  end
+
+  defp check_config_user(conn) do
+    if Mix.env() in [:dev, :test] do
+      case Application.get_env(:meadow, :force_current_user) do
+        nil -> conn
+        user_id -> Plug.Conn.assign(conn, :current_user, User.find(user_id))
+      end
+    else
+      conn
+    end
+  end
+
+  defp load_session_user(%Plug.Conn{assigns: %{current_user: _user}} = conn), do: conn
+
+  defp load_session_user(conn) do
     user =
       conn
       |> fetch_session
       |> get_session(:current_user)
       |> normalize_role()
 
-    token = conn |> Map.get(:req_cookies, %{}) |> Map.get("_meadow_key", "")
-
-    conn
-    |> Absinthe.Plug.put_options(context: %{auth_token: token, current_user: user})
-    |> Plug.Conn.assign(:current_user, user)
+    Plug.Conn.assign(conn, :current_user, user)
   end
 
   defp normalize_role(%User{role: role} = user) when is_binary(role) do


### PR DESCRIPTION
# Summary 

Support configuring a forced user to skip login in dev/test environments.

**Note:** Only works in dev and test environments. Optimized out in prod.

# Specific Changes in this PR
- Update `SetCurrentUser` plug to read a NetID from `:meadow, :force_current_user` if it exists
- Add tests

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

In `dev.local.exs`:
```
config :meadow, force_current_user: "YOUR_NETID"
```

This should skip the login page entirely and just know you're logged in at all times.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

