### PR TITLE
Change publication migration so that it uses the correct (non-superuser) database owner

### DIFF
--- a/app/priv/repo/migrations/20250218041322_create_publication_events.exs
+++ b/app/priv/repo/migrations/20250218041322_create_publication_events.exs
@@ -1,26 +1,24 @@
 defmodule Meadow.Repo.Migrations.CreatePublicationEvents do
   use Ecto.Migration
 
-  def change do
+  @tables ~w(works file_sets collections ingest_sheets projects)
+
+  def up do
     # Create the publication for WAL events
-    execute "CREATE PUBLICATION events FOR ALL TABLES"
+    execute("CREATE PUBLICATION events FOR TABLE #{Enum.join(@tables, ", ")}")
 
     # Set REPLICA IDENTITY FULL for tables we want to track
-    execute "ALTER TABLE works REPLICA IDENTITY FULL"
-    execute "ALTER TABLE file_sets REPLICA IDENTITY FULL"
-    execute "ALTER TABLE collections REPLICA IDENTITY FULL"
-    execute "ALTER TABLE ingest_sheets REPLICA IDENTITY FULL"
-    execute "ALTER TABLE projects REPLICA IDENTITY FULL"
+    Enum.each(@tables, fn table ->
+      execute("ALTER TABLE #{table} REPLICA IDENTITY FULL")
+    end)
   end
 
   def down do
     # Reset REPLICA IDENTITY to default
-    execute "ALTER TABLE works REPLICA IDENTITY DEFAULT"
-    execute "ALTER TABLE file_sets REPLICA IDENTITY DEFAULT"
-    execute "ALTER TABLE collections REPLICA IDENTITY DEFAULT"
-    execute "ALTER TABLE ingest_sheets REPLICA IDENTITY DEFAULT"
-    execute "ALTER TABLE projects REPLICA IDENTITY DEFAULT"
+    Enum.each(@tables, fn table ->
+      execute("ALTER TABLE #{table} REPLICA IDENTITY FULL")
+    end)
 
-    execute "DROP PUBLICATION IF EXISTS events"
+    execute("DROP PUBLICATION IF EXISTS events")
   end
 end


### PR DESCRIPTION
# Summary 
Only superusers can create publications using `FOR ALL TABLES` or `FOR TABLES IN SCHEMA`. Regular database owners have to specify the tables to include in the publication. Additional tables can be added in future migrations with `ALTER PUBLICATION events ADD new_table, other_new_table, ...`

# Specific Changes in this PR
- Change the migration that creates the publication to use specific tables

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Because we don't want to roll back and re-migrate everything that came after this migration, we have to tell `Ecto.Migrator` to roll back and re-apply this one specific migration:

```
[meadow/app] $ MEADOW_PROCESSES=none iex -S mix
iex(1)> [{module, _}|_] = Code.require_file("priv/repo/migrations/20250218041322_create_publication_events.exs")
iex(2)> Ecto.Migrator.down(Repo, 20250218041322, module)
iex(3)> Ecto.Migrator.up(Repo, 20250218041322, module)
```
There will be a warning after the last command. It's safe to ignore it; we knew what it's warning about would happen.

Exit IEx, then fire up Meadow as normal, make a change to a work, and watch the log for indexing messages.

I will apply this change on staging and prod when it's time.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [x] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

