### PR TITLE
Wire up baseline plan UI

### DIFF
--- a/app/assets/__mocks__/@nulib/use-markdown.js
+++ b/app/assets/__mocks__/@nulib/use-markdown.js
@@ -1,0 +1,8 @@
+const React = require("react");
+
+module.exports = {
+  __esModule: true,
+  default: (content) => ({
+    jsx: React.createElement(React.Fragment, null, content),
+  }),
+};

--- a/app/assets/jest.setup.ts
+++ b/app/assets/jest.setup.ts
@@ -2,3 +2,4 @@ import "@testing-library/jest-dom";
 
 jest.setTimeout(10000);
 jest.mock("@js/services/elasticsearch");
+jest.mock("@nulib/use-markdown");

--- a/app/assets/js/components/Plan/Chat/Chat.jsx
+++ b/app/assets/js/components/Plan/Chat/Chat.jsx
@@ -7,9 +7,9 @@ import { v4 as uuidv4 } from "uuid";
 
 const conversationId = uuidv4();
 
-const PlanChat = ({ initialMessage, query }) => {
+const PlanChat = ({ initialMessages, query, planIdCallback }) => {
   const scrollerRef = useRef(null);
-  const [messages, setMessages] = useState([initialMessage]);
+  const [messages, setMessages] = useState(initialMessages || []);
   const [isAtBottom, setIsAtBottom] = useState(true);
 
   const { data: chatResponseMessage, error: subscriptionError } =
@@ -57,10 +57,19 @@ const PlanChat = ({ initialMessage, query }) => {
 
   useEffect(() => {
     if (!chatResponseMessage) return;
+
+    if (chatResponseMessage.type === "plan_id")
+      planIdCallback(chatResponseMessage.planId);
+
     setMessages((prev) => [
       ...prev,
-      { content: chatResponseMessage.message, isUser: false, type: "message" },
+      {
+        content: chatResponseMessage.message,
+        isUser: false,
+        type: chatResponseMessage.type,
+      },
     ]);
+
     if (isAtBottom) scrollToBottom(true);
   }, [chatResponseMessage]);
 

--- a/app/assets/js/components/Plan/Chat/Chat.test.skip.jsx
+++ b/app/assets/js/components/Plan/Chat/Chat.test.skip.jsx
@@ -48,7 +48,7 @@ jest.mock("uuid", () => ({ v4: () => "conv-123" }));
  */
 jest.mock("@js/components/Plan/Chat/Transcript", () => ({
   __esModule: true,
-  default: ({ messages }) => (
+  default: ({ messages = [] }) => (
     <div data-testid="transcript">
       {messages.map((m, i) => (
         <div key={i} data-testid={`msg-${i}`}>

--- a/app/assets/js/components/Plan/Chat/Message.jsx
+++ b/app/assets/js/components/Plan/Chat/Message.jsx
@@ -1,13 +1,16 @@
 import React from "react";
+import useMarkdown from "@nulib/use-markdown";
 
 const PlanChatMessage = ({ content, isUser, type = "message" }) => {
+  const markdown = useMarkdown(content);
+
   return (
     <article
       className="chat-message"
       data-message-user={isUser ? "human" : "ai"}
       data-message-type={type}
     >
-      {content}
+      {markdown.jsx}
     </article>
   );
 };

--- a/app/assets/js/components/Plan/Panel/Changes.jsx
+++ b/app/assets/js/components/Plan/Panel/Changes.jsx
@@ -1,0 +1,52 @@
+import { useQuery } from "@apollo/client";
+import React, { useEffect } from "react";
+import { GET_PLAN, GET_PLAN_CHANGES } from "../plan.gql";
+import UILoader from "../../UI/Loader";
+import PlanPanelChangesDiff from "./Diff";
+
+const PlanPanelChanges = ({ planChanges, planId }) => {
+  const [planLoading, setPlanLoading] = React.useState(false);
+  const [proposedChanges, setProposedChanges] = React.useState({});
+
+  const planPending = useQuery(GET_PLAN, {
+    variables: { id: planId },
+    fetchPolicy: "no-cache",
+  });
+
+  console.log({ planPending });
+  console.log({ planChanges });
+
+  /**
+   * Check if we have any pending changes
+   * If so, keep loading until they are resolved
+   */
+  useEffect(() => {
+    const hasPendingChanges = planPending.data?.plan?.status === "PENDING";
+    setPlanLoading(hasPendingChanges);
+  }, [planPending.data?.plan]);
+
+  /**
+   * When planChanges are updated, check if there are proposed changes
+   * If so, set them to state and stop loading
+   */
+  useEffect(() => {
+    if (planChanges?.planChange) {
+      if (planChanges.planChange.status === "PROPOSED") {
+        setPlanLoading(false);
+        setProposedChanges(planChanges.planChange);
+      }
+    }
+  }, [planChanges?.planChange]);
+
+  return (
+    <div>
+      {planLoading ? (
+        <UILoader />
+      ) : (
+        <PlanPanelChangesDiff proposedChanges={proposedChanges} />
+      )}
+    </div>
+  );
+};
+
+export default PlanPanelChanges;

--- a/app/assets/js/components/Plan/Panel/Diff.jsx
+++ b/app/assets/js/components/Plan/Panel/Diff.jsx
@@ -1,0 +1,55 @@
+import { Button } from "@nulib/design-system";
+import React from "react";
+
+const PlanPanelChangesDiff = ({ proposedChanges }) => {
+  const addEntries = proposedChanges.add
+    ? Object.entries(proposedChanges.add)
+    : [];
+  const deleteEntries = proposedChanges.delete
+    ? Object.entries(proposedChanges.delete)
+    : [];
+  const replaceEntries = proposedChanges.replace
+    ? Object.entries(proposedChanges.replace)
+    : [];
+
+  return (
+    <div>
+      <h3 className="title is-4 mb-3">Proposed Changes</h3>
+      <table className="table is-fullwidth is-striped">
+        <thead>
+          <tr>
+            <th>Status</th>
+            <th>Field</th>
+            <th>Proposed Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {addEntries.map(([field, value]) => (
+            <tr key={`add-${field}`}>
+              <td>Add</td>
+              <td>{field}</td>
+              <td>{JSON.stringify(value)}</td>
+            </tr>
+          ))}
+          {deleteEntries.map(([field, value]) => (
+            <tr key={`delete-${field}`}>
+              <td>Delete</td>
+              <td>{field}</td>
+              <td>{JSON.stringify(value)}</td>
+            </tr>
+          ))}
+          {replaceEntries.map(([field, value]) => (
+            <tr key={`replace-${field}`}>
+              <td>Replace</td>
+              <td>{field}</td>
+              <td>{JSON.stringify(value)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <Button isPrimary={true}>Approve Changes</Button>
+    </div>
+  );
+};
+
+export default PlanPanelChangesDiff;

--- a/app/assets/js/components/Plan/Plan.jsx
+++ b/app/assets/js/components/Plan/Plan.jsx
@@ -1,23 +1,68 @@
 import React from "react";
 import PlanChat from "@js/components/Plan/Chat/Chat";
+import { usePlanChanges } from "@js/hooks/usePlanChanges";
+import PlanPanelChanges from "./Panel/Changes";
 
 const Plan = ({ works }) => {
   const query = works.map((work) => `id:(${work.id})`).join(" OR ");
-  const initialMessageContent =
+  const [planId, setPlanId] = React.useState(null);
+
+  const hasPlan = Boolean(planId);
+
+  const { data: planChanges, error: planChangesError } = usePlanChanges(planId);
+
+  const initialMessages = [
+    `You are editing ${works.length === 1 ? `the _${works[0].workType.label}_ work **${works[0].descriptiveMetadata.title ? works[0].descriptiveMetadata.title : "No title"}**` : `${works.length} works`}.`,
+    `What would you like to modify?`,
+  ].map((content) => ({
+    content,
+    type: "message",
+    isUser: false,
+  }));
+
+  const targetTitle =
     works.length === 1
-      ? `You are editing the ${works[0].workType.label} work ${works[0].descriptiveMetadata.title ? works[0].descriptiveMetadata.title : "No title"}, collection ${works[0]?.collection?.title}, with the accession number ${works[0].accessionNumber}. What would you like to modify?`
-      : `You are editing ${works.length} works. What would you like to modify?`;
+      ? works[0].descriptiveMetadata.title
+      : `${works.length} works`;
+
+  // iterate works and get thumbnails
+  const targetThumbnails = works.map((work) => {
+    const thumbnail = new URL(work.representativeImage);
+    thumbnail.pathname += "/square/100,/0/default.jpg";
+    return thumbnail ? (
+      <img
+        key={work.id}
+        src={thumbnail.toString()}
+        alt={work.descriptiveMetadata.title || "work thumbnail"}
+        className="thumbnail-image"
+      />
+    ) : null;
+  });
 
   return (
-    <div className="box" style={{ margin: "1rem 0" }}>
-      <PlanChat
-        query={query}
-        initialMessage={{
-          content: initialMessageContent,
-          type: "message",
-          isUser: false,
-        }}
-      />
+    <div className="plan box" data-has-plan={hasPlan}>
+      <div className="plan-workspace">
+        {planId ? (
+          <PlanPanelChanges planId={planId} planChanges={planChanges} />
+        ) : (
+          <div className="plan-placeholder">
+            {targetThumbnails}
+            <p className="is-6">{targetTitle}</p>
+            <p className="subtitle is-6 mt-3">
+              Describe the changes you want to make to this work, and an AI
+              assistant will help you make those changes.
+            </p>
+          </div>
+        )}
+      </div>
+      <div className="chat-wrapper">
+        <button> collapse the chat </button>
+        <PlanChat
+          query={query}
+          initialMessages={initialMessages}
+          planIdCallback={(planId) => setPlanId(planId)}
+        />
+      </div>
     </div>
   );
 };

--- a/app/assets/js/components/Plan/plan.gql.js
+++ b/app/assets/js/components/Plan/plan.gql.js
@@ -31,3 +31,40 @@ export const SEND_CHAT_MESSAGE = gql`
     }
   }
 `;
+
+export const PLAN_CHANGES = gql`
+  subscription ($planId: ID!) {
+    planChangesUpdated(planId: $planId) {
+      planId
+      planChange {
+        status
+        add
+        replace
+        delete
+      }
+    }
+  }
+`;
+
+export const GET_PLAN = gql`
+  query plan($id: ID!) {
+    plan(id: $id) {
+      id
+      prompt
+      query
+      status
+    }
+  }
+`;
+
+export const GET_PLAN_CHANGES = gql`
+  query planChanges($planId: ID!) {
+    planChanges(planId: $planId) {
+      id
+      status
+      add
+      delete
+      replace
+    }
+  }
+`;

--- a/app/assets/js/components/UI/Loader.jsx
+++ b/app/assets/js/components/UI/Loader.jsx
@@ -1,0 +1,50 @@
+import React from "react";
+
+const UILoader = () => {
+  const style = {
+    display: "flex",
+    margin: "16px 0",
+  };
+
+  const dotStyle = {
+    width: "16px",
+    height: "16px",
+    margin: "8px 8px",
+    borderRadius: "50%",
+    backgroundColor: "#4e2a84",
+    opacity: 1,
+    animation: "bouncingLoader 0.6s infinite alternate",
+    transform: "translateY(0)",
+  };
+
+  const secondDotStyle = {
+    ...dotStyle,
+    animationDelay: "0.2s",
+  };
+
+  const thirdDotStyle = {
+    ...dotStyle,
+    animationDelay: "0.4s",
+  };
+
+  // define bouncingLoader keyframes
+  const styleSheet = document.styleSheets[0];
+  const keyframes = `
+    @keyframes bouncingLoader {
+      to {
+        background-color: #5091cd;    
+        transform: translateY(-13px);
+      }
+    }`;
+  styleSheet.insertRule(keyframes, styleSheet.cssRules.length);
+
+  return (
+    <div aria-label="loading" data-loading={true} role="status" style={style}>
+      <div style={dotStyle}></div>
+      <div style={secondDotStyle}></div>
+      <div style={thirdDotStyle}></div>
+    </div>
+  );
+};
+
+export default UILoader;

--- a/app/assets/js/hooks/usePlanChanges.js
+++ b/app/assets/js/hooks/usePlanChanges.js
@@ -1,0 +1,16 @@
+import { useSubscription } from "@apollo/client";
+import { PLAN_CHANGES } from "@js/components/Plan/plan.gql";
+
+export function usePlanChanges(planId) {
+  try {
+    const { data, loading, error } = useSubscription(PLAN_CHANGES, {
+      variables: { planId },
+      shouldResubscribe: true,
+      fetchPolicy: "no-cache",
+    });
+
+    return { data: data?.planChangesUpdated, loading, error };
+  } catch (error) {
+    return { data: null, loading: false, error };
+  }
+}

--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -20,6 +20,7 @@
         "@honeybadger-io/js": "^6.12.2",
         "@honeybadger-io/react": "^6.1.7",
         "@nulib/design-system": "^1.5.1",
+        "@nulib/use-markdown": "^0.2.3",
         "@radix-ui/react-dialog": "^1.1.14",
         "@samvera/clover-iiif": "^3.0.2",
         "@samvera/image-downloader": "^1.1.1",

--- a/app/assets/package.json
+++ b/app/assets/package.json
@@ -30,6 +30,7 @@
     "@honeybadger-io/js": "^6.12.2",
     "@honeybadger-io/react": "^6.1.7",
     "@nulib/design-system": "^1.5.1",
+    "@nulib/use-markdown": "^0.2.3",
     "@radix-ui/react-dialog": "^1.1.14",
     "@samvera/clover-iiif": "^3.0.2",
     "@samvera/image-downloader": "^1.1.1",

--- a/app/assets/styles/scss/_plan.scss
+++ b/app/assets/styles/scss/_plan.scss
@@ -1,3 +1,54 @@
+.plan {
+  display: flex;
+  margin: 1rem 0;
+
+  &[data-has-plan="true"] .plan-workspace {
+    width: 61.8%;
+    background: $white;
+  }
+  &[data-has-plan="true"] .chat-wrapper {
+    width: 38.2%;
+    border-color: $light-grey;
+  }
+}
+
+.plan-workspace {
+  width: 38.2%;
+  transition: all 0.618s ease-in-out;
+  background: $background-user-message;
+  border-radius: 0.5rem;
+}
+
+.plan-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: $black;
+  font-size: 1.25rem;
+  padding: 2rem;
+  text-align: center;
+  gap: "1rem";
+
+  img {
+    border-radius: 0.5rem;
+    margin-bottom: 1rem;
+    width: 100px;
+    height: 100px;
+    object-fit: cover;
+  }
+}
+
+.chat-wrapper {
+  width: 61.8%;
+  transition: all 0.618s ease-in-out;
+  padding: 1.25rem 0 1.25rem 1rem;
+  margin-top: -1.25rem;
+  margin-bottom: -1.25rem;
+  border-left: 1px solid transparent;
+}
+
 .chat {
   display: flex;
   flex-direction: column;
@@ -54,25 +105,34 @@
 }
 
 .chat-message {
-  padding: 1rem 1.25rem;
+  padding: 0.75rem 1rem;
   border-radius: 0.5rem;
-  max-width: 61.8%; // golden ratio
+  max-width: 94.444%; // golden ratio
   word-wrap: break-word;
   white-space: pre-wrap;
   font-size: 1rem;
   cursor: text;
   margin-top: 1rem;
 
+  em {
+    font-family: $AkkuratProItalic;
+  }
+
+  strong {
+    font-weight: 400;
+    font-family: $AkkuratProBold;
+  }
+
   &[data-message-user="ai"] {
-    background-color: $light-grey;
-    color: $rich-black-80;
+    background: $light-grey;
+    color: $black;
     align-self: flex-start;
     border-bottom-left-radius: 0;
   }
 
   &[data-message-user="human"] {
-    background-color: $nu-purple-10;
-    color: $nu-purple-120;
+    background: $background-user-message;
+    color: $black;
     align-self: flex-end;
     border-bottom-right-radius: 0;
   }

--- a/app/assets/styles/scss/_variables.scss
+++ b/app/assets/styles/scss/_variables.scss
@@ -51,6 +51,13 @@ $PoppinsBold: "Poppins Bold", $AkkuratProBold, sans-serif;
 $PoppinsExtraBold: "Poppins Extra Bold", $AkkuratProBold, sans-serif;
 $PoppinsExtraLight: "Poppins Extra Light", $AkkuratLight, sans-serif;
 
+$background-user-message: linear-gradient(
+  173deg,
+  $white -38.2%,
+  $nu-purple-10 61.8%,
+  $nu-purple-30 161.8%
+);
+
 // Customize Bulma with these variables
 // Colors
 $primary: $nu-purple;

--- a/app/lib/meadow_ai/python.ex
+++ b/app/lib/meadow_ai/python.ex
@@ -36,8 +36,14 @@ defmodule MeadowAI.Python do
         {:error, :pythonx_init_failed}
     end
   rescue
+    error in RuntimeError ->
+      case error.message do
+        "Python interpreter has already been initialized" -> {:ok, :already_initialized}
+        _ -> {:error, {:initialization_error, error}}
+      end
+
     error ->
-      {:error, {:initialization_error, error}}
+      {:error, {:initialization_exception, error}}
   end
 
   defp initialize_python_environment do

--- a/app/lib/meadow_web/mcp/propose_plan.ex
+++ b/app/lib/meadow_web/mcp/propose_plan.ex
@@ -1,0 +1,39 @@
+defmodule MeadowWeb.MCP.ProposePlan do
+  @moduledoc """
+  MCP tool for changing the status of a Plan to proposed.
+  """
+
+  use Anubis.Server.Component,
+    type: :tool,
+    name: "propose_plan",
+    mime_type: "application/json"
+
+  alias Anubis.MCP.Error, as: MCPError
+  alias Anubis.Server.Response
+  alias Meadow.Data.Planner
+  alias Meadow.Repo
+  require Logger
+
+  schema do
+    field(:plan_id, :string,
+      description: "The UUID of the Plan to update",
+      required: true
+    )
+  end
+
+  def name, do: "propose_plan"
+
+  @impl true
+  def execute(%{plan_id: plan_id} = request, frame) do
+    Logger.debug("MCP Server proposing plan: #{plan_id}")
+
+    plan = Planner.get_plan(plan_id)
+    case Planner.propose_plan(plan) do
+      {:ok, updated_plan} ->
+        {:reply, Response.tool() |> Response.json(%{plan: updated_plan}), frame}
+
+      {:error, reason} ->
+        {:error, MCPError.execution(reason), frame}
+    end
+  end
+end

--- a/app/lib/meadow_web/mcp/server.ex
+++ b/app/lib/meadow_web/mcp/server.ex
@@ -8,8 +8,9 @@ defmodule MeadowWeb.MCP.Server do
     version: "0.1.0",
     capabilities: [:tools]
 
+  component(MCP.GetPlanChanges)
   component(MCP.GraphQL)
   component(MCP.IDQuery)
-  component(MCP.GetPlanChanges)
+  component(MCP.ProposePlan)
   component(MCP.UpdatePlanChange)
 end

--- a/app/priv/python/agent/src/meadow_metadata_agent/execute.py
+++ b/app/priv/python/agent/src/meadow_metadata_agent/execute.py
@@ -1,53 +1,14 @@
 import asyncio
 import json
 from claude_agent_sdk import create_sdk_mcp_server, ClaudeAgentOptions, ClaudeSDKClient, AgentDefinition
+from .prompts import (agent_prompt, proposer_prompt, system_prompt)
 from .tools import (
     fetch_iiif_image_tool
 )
 
 async def query_claude(prompt, context_json, mcp_url, iiif_server_url, graphql_auth_token):
     context_data = json.loads(context_json) if context_json else {}
-
-    # Check if we have a plan_id in context - if so, instruct to use subagent
-    plan_id = context_data.get("plan_id")
-
-    if plan_id:
-        # Build prompt for plan-based workflow
-        enhanced_prompt = f"""
-        Use the plan_change_proposer subagent to process the following plan:
-
-        User query: {prompt}
-
-        Plan ID: {plan_id}
-
-        The plan_change_proposer subagent will:
-        1. Retrieve all pending PlanChanges for plan {plan_id}
-        2. Analyze each work's metadata
-        3. Generate appropriate metadata changes based on your prompt
-        4. Use authoritiesSearch for all controlled vocabulary fields (subject, creator, contributor, genre, language, location, style_period, technique)
-        5. Update each PlanChange with the proposed changes
-
-        Context data: {json.dumps(context_data, indent=2)}
-
-        IMPORTANT: For controlled vocabulary fields like subject headings, creator names, genres, etc.,
-        the subagent MUST use the authoritiesSearch GraphQL query to find valid controlled term IDs.
-        Never make up or guess term IDs for these fields.
-
-        Once the subagent completes, provide a summary of the changes proposed."""
-    else:
-        # Build a more explicit prompt that encourages tool usage
-        enhanced_prompt = f"""
-        Use the available tools to answer the following query:
-
-        User query: {prompt}
-
-        Context data: {json.dumps(context_data, indent=2) if context_data else "None"}
-
-        Please use the appropriate tools to help answer this query. For example:
-        - Before using the `call_graphql_endpoint` tool to query or update data, use it to discover the schema first.
-        - The `fetch_iiif_image` tool can be used to quickly retrieve base64 encoded images by URL. Use the IIIF server URL: {iiif_server_url} and construct the full image URL by appending the file set ID followed by `/full/1000,1000/0/default.jpg`.
-
-        Respond with both tool results and your analysis."""
+    enhanced_prompt = agent_prompt(prompt, context_data)
 
     # Build MCP server config with optional auth headers
     # Use HTTP type since Postman shows it works over HTTP POST
@@ -72,161 +33,25 @@ async def query_claude(prompt, context_json, mcp_url, iiif_server_url, graphql_a
         allowed_tools=[
             "mcp__meadow__graphql",
             "mcp__meadow__get_plan_changes",
+            "mcp__meadow__propose_plan",
             "mcp__meadow__update_plan_change",
             "mcp__image_fetcher__fetch_iiif_image"
         ],
         disallowed_tools=["Bash", "Grep", "Glob"],
         agents={
             "plan_change_proposer": AgentDefinition(
-                description="Proposes metadata changes for works in a plan by analyzing work data and generating appropriate metadata updates",
-                prompt="""You are a metadata change proposer for library catalog works.
-
-Process ALL pending PlanChanges for a plan by following this loop:
-
-LOOP:
-1. Call get_plan_changes(plan_id: <plan_id>, status: "pending") to get pending changes
-2. If no pending changes remain, STOP and return a summary
-3. Take the FIRST pending PlanChange from the list
-4. Query the work's current metadata using the graphql tool
-5. Based on the plan's prompt and the work's data, generate appropriate metadata changes
-6. Call update_plan_change with:
-   - The PlanChange id
-   - The proposed changes in the add/delete/replace fields
-   - Set status to 'proposed'
-7. Go back to step 1 (LOOP)
-
-Continue looping until ALL PlanChanges have been processed (no pending changes remain).
-
-Important:
-- Always query work data - do not make assumptions
-- Process changes one at a time
-- Check for pending changes after each update to ensure nothing is missed
-- Return a summary with the count of changes proposed when complete
-
-CRITICAL - Controlled Term Fields:
-The following fields REQUIRE controlled terms from external authorities and MUST use the authoritiesSearch GraphQL query:
-- contributor (with REQUIRED role from marc_relator)
-- creator (with optional role from marc_relator)
-- genre
-- language
-- location
-- subject (with REQUIRED role from subject_role)
-- style_period
-- technique
-
-For these fields, you MUST:
-1. Use the authoritiesSearch query to find valid controlled term IDs
-2. Never make up or guess term IDs
-3. The data structure MUST be (note that term is an OBJECT with id field):
-   {
-     "term": {"id": "controlled-term-id-from-search"},
-     "role": {"id": "role-id", "scheme": "role-scheme"}
-   }
-
-IMPORTANT STRUCTURE NOTES:
-- "term" MUST be an object with "id" field, NOT a bare string
-- "role" is REQUIRED for subject and contributor fields
-- "role" is optional for creator field
-
-FINDING ROLE VALUES:
-- For subject roles: Query codeList(scheme: SUBJECT_ROLE) to get valid role IDs
-  Common values: "TOPICAL", "GEOGRAPHIC", "TEMPORAL", "GENRE_FORM"
-- For contributor/creator roles: Query codeList(scheme: MARC_RELATOR) to get valid role IDs
-  These are 3-letter codes like "pht" (photographer), "art" (artist), "ctb" (contributor)
-- Always use the exact "id" value returned from the codeList query
-
-Example authoritiesSearch query to find controlled term IDs:
-query {
-  authoritiesSearch(authority: "lcsh", query: "cats") {
-    id
-    label
-    hint
-  }
-}
-
-Example codeList query to get available role codes:
-query {
-  codeList(scheme: MARC_RELATOR) {
-    id
-    label
-  }
-}
-
-query {
-  codeList(scheme: SUBJECT_ROLE) {
-    id
-    label
-  }
-}
-
-Available authorities (use appropriate one for the field type):
-- "lcsh" - Library of Congress Subject Headings (for subject)
-- "lcnaf" - Library of Congress Name Authority (for creator, contributor)
-- "lcgft" - Library of Congress Genre/Form Terms (for genre)
-- "lclang" - Library of Congress Languages (for language)
-- "fast" - FAST terms (alternative for subjects)
-- "fast-personal", "fast-corporate-name", "fast-geographic", "fast-topical", "fast-form" - specific FAST subsets
-- "aat" - Getty AAT (for technique, style_period, genre)
-- "tgn" - Getty TGN (for location)
-- "ulan" - Getty ULAN (for creator, contributor)
-- "geonames" - GeoNames (for location)
-- "homosaurus" - Homosaurus LGBTQ+ vocabulary
-- "nul-authority" - Northwestern local authority (for any field)
-
-The controlled term format in add/replace operations:
-{
-  "descriptive_metadata": {
-    "subject": [
-      {"term": {"id": "http://id.worldcat.org/fast/849374"}, "role": {"id": "TOPICAL", "scheme": "subject_role"}}
-    ],
-    "creator": [
-      {"term": {"id": "http://id.loc.gov/authorities/names/n79021164"}}
-    ],
-    "contributor": [
-      {"term": {"id": "http://id.loc.gov/authorities/names/n79021164"}, "role": {"id": "pht", "scheme": "marc_relator"}}
-    ]
-  }
-}
-
-WORKFLOW FOR ADDING CONTROLLED TERMS:
-1. First, use authoritiesSearch to find the controlled term ID (the "term" value)
-2. If the field requires a role (subject, contributor), query codeList to get valid role IDs
-3. Construct the entry with the correct nested structure:
-   {"term": {"id": "found-term-id"}, "role": {"id": "found-role-id", "scheme": "appropriate-scheme"}}
-4. Use update_plan_change to add the properly structured entry
-
-When adding controlled terms, ALWAYS search first to get the correct IDs!
-""",
+                description="Proposes plan changes for works by analyzing work data and generating appropriate metadata updates",
+                prompt=proposer_prompt(),
                 tools=[
                     "mcp__meadow__graphql",
                     "mcp__meadow__get_plan_changes",
+                    "mcp__meadow__propose_plan",
                     "mcp__meadow__update_plan_change",
                     "mcp__image_fetcher__fetch_iiif_image"
                 ]
             )
         },
-        system_prompt="""
-        Answer questions using only the tools available.
-
-        When a plan_id is present in the context, delegate to the plan_change_proposer subagent
-        to process all pending changes for that plan.
-
-        Use the get_plan_changes tool to get a list of changes planned for a given plan UUID and work UUID.
-
-        CRITICAL: When working with controlled vocabulary fields (subject, creator, contributor, genre,
-        language, location, style_period, technique), you MUST:
-        1. Use the authoritiesSearch GraphQL query to find valid controlled term IDs
-        2. For fields requiring roles (subject, contributor), use codeList query to get valid role IDs:
-           - codeList(scheme: SUBJECT_ROLE) for subject roles
-           - codeList(scheme: MARC_RELATOR) for contributor/creator roles
-        3. Structure the term correctly as an OBJECT: {"term": {"id": "uri"}, "role": {"id": "role", "scheme": "scheme"}}
-        4. Never use bare strings for term values - they must be objects with "id" field
-        5. Include required "role" field for subject and contributor fields
-
-        Never make up or guess term IDs or role IDs - always query for them first.
-
-        Do not look for information in the file system or local codebase.
-        """)
+        system_prompt=system_prompt())
 
     async with ClaudeSDKClient(client_options) as client:
         await client.query(enhanced_prompt)

--- a/app/priv/python/agent/src/meadow_metadata_agent/prompts.py
+++ b/app/priv/python/agent/src/meadow_metadata_agent/prompts.py
@@ -1,0 +1,195 @@
+import json
+
+def agent_prompt(user_query, context_data):
+    plan_id = context_data.get("plan_id")
+    if plan_id:
+        return agent_prompt_with_plan(plan_id, user_query, context_data)
+    else:
+        return agent_prompt_without_plan(user_query, context_data)
+
+def agent_prompt_with_plan(plan_id, user_query, context_data):
+    return f"""
+    Use the plan_change_proposer subagent to process the following plan:
+
+    User query: {user_query}
+
+    Plan ID: {plan_id}
+
+    The plan_change_proposer subagent will:
+    1. Retrieve all pending PlanChanges for plan {plan_id}
+    2. Analyze each work's metadata
+    3. Generate appropriate metadata changes based on your prompt
+    4. Use authoritiesSearch for all controlled vocabulary fields (subject, creator, contributor, genre, language, location, style_period, technique)
+    5. Update each PlanChange with the proposed changes
+
+    Context data: {json.dumps(context_data, indent=2)}
+
+    IMPORTANT: For controlled vocabulary fields like subject headings, creator names, genres, etc.,
+    the subagent MUST use the authoritiesSearch GraphQL query to find valid controlled term IDs.
+    Never make up or guess term IDs for these fields.
+
+    Once the subagent completes, provide a summary of the changes proposed.
+    """
+
+def agent_prompt_without_plan(user_query, context_data):
+    return f"""
+    Use the available tools to answer the following query:
+
+    User query: {user_query}
+
+    Context data: {json.dumps(context_data, indent=2) if context_data else "None"}
+
+    Please use the appropriate tools to help answer this query. For example:
+    - Before using the `call_graphql_endpoint` tool to query or update data, use it to discover the schema first.
+    - The `fetch_iiif_image` tool can be used to quickly retrieve base64 encoded images by URL. Use the IIIF server URL: {iiif_server_url} and construct the full image URL by appending the file set ID followed by `/full/1000,1000/0/default.jpg`.
+
+    Respond with both tool results and your analysis.
+    """
+    
+def proposer_prompt():
+    return """
+    You are a metadata plan proposer for library catalog works.
+
+    Process ALL pending PlanChanges for a plan by following this loop:
+
+    LOOP:
+    1. Call get_plan_changes(plan_id: <plan_id>, status: "pending") to get pending changes
+    2. If no pending changes remain, STOP and return a summary
+    3. Take the FIRST pending PlanChange from the list
+    4. Query the work's current metadata using the graphql tool
+    5. Based on the plan's prompt and the work's data, generate appropriate metadata changes
+    6. Call update_plan_change with:
+      - The PlanChange id
+      - The proposed changes in the add/delete/replace fields
+      - Set status to 'proposed'
+    7. Go back to step 1 (LOOP)
+
+    Continue looping until ALL PlanChanges have been processed (no pending changes remain).
+
+    Important:
+    - Always query work data - do not make assumptions
+    - Process changes one at a time
+    - Check for pending changes after each update to ensure nothing is missed
+    - When finished looping, you MUST use the propose_plan tool so that the plan is marked ready
+      for review by the user. DO NOT SKIP THIS STEP. It is critical that the plan, not just the
+      changes, is set to 'proposed' status.
+    - Return a summary with the count of changes proposed when complete
+
+    CRITICAL - Controlled Term Fields:
+    The following fields REQUIRE controlled terms from external authorities and MUST use the authoritiesSearch GraphQL query:
+    - contributor (with REQUIRED role from marc_relator)
+    - creator (with optional role from marc_relator)
+    - genre
+    - language
+    - location
+    - subject (with REQUIRED role from subject_role)
+    - style_period
+    - technique
+
+    For these fields, you MUST:
+    1. Use the authoritiesSearch query to find valid controlled term IDs
+    2. Never make up or guess term IDs
+    3. The data structure MUST be (note that term is an OBJECT with id field):
+      {
+        "term": {"id": "controlled-term-id-from-search"},
+        "role": {"id": "role-id", "scheme": "role-scheme"}
+      }
+
+    IMPORTANT STRUCTURE NOTES:
+    - "term" MUST be an object with "id" field, NOT a bare string
+    - "role" is REQUIRED for subject and contributor fields
+    - "role" is optional for creator field
+
+    FINDING ROLE VALUES:
+    - For subject roles: Query codeList(scheme: SUBJECT_ROLE) to get valid role IDs
+      Common values: "TOPICAL", "GEOGRAPHIC", "TEMPORAL", "GENRE_FORM"
+    - For contributor/creator roles: Query codeList(scheme: MARC_RELATOR) to get valid role IDs
+      These are 3-letter codes like "pht" (photographer), "art" (artist), "ctb" (contributor)
+    - Always use the exact "id" value returned from the codeList query
+
+    Example authoritiesSearch query to find controlled term IDs:
+    query {
+      authoritiesSearch(authority: "lcsh", query: "cats") {
+        id
+        label
+        hint
+      }
+    }
+
+    Example codeList query to get available role codes:
+    query {
+      codeList(scheme: MARC_RELATOR) {
+        id
+        label
+      }
+    }
+
+    query {
+      codeList(scheme: SUBJECT_ROLE) {
+        id
+        label
+      }
+    }
+
+    Available authorities (use appropriate one for the field type):
+    - "lcsh" - Library of Congress Subject Headings (for subject)
+    - "lcnaf" - Library of Congress Name Authority (for creator, contributor)
+    - "lcgft" - Library of Congress Genre/Form Terms (for genre)
+    - "lclang" - Library of Congress Languages (for language)
+    - "fast" - FAST terms (alternative for subjects)
+    - "fast-personal", "fast-corporate-name", "fast-geographic", "fast-topical", "fast-form" - specific FAST subsets
+    - "aat" - Getty AAT (for technique, style_period, genre)
+    - "tgn" - Getty TGN (for location)
+    - "ulan" - Getty ULAN (for creator, contributor)
+    - "geonames" - GeoNames (for location)
+    - "homosaurus" - Homosaurus LGBTQ+ vocabulary
+    - "nul-authority" - Northwestern local authority (for any field)
+
+    The controlled term format in add/replace operations:
+    {
+      "descriptive_metadata": {
+        "subject": [
+          {"term": {"id": "http://id.worldcat.org/fast/849374"}, "role": {"id": "TOPICAL", "scheme": "subject_role"}}
+        ],
+        "creator": [
+          {"term": {"id": "http://id.loc.gov/authorities/names/n79021164"}}
+        ],
+        "contributor": [
+          {"term": {"id": "http://id.loc.gov/authorities/names/n79021164"}, "role": {"id": "pht", "scheme": "marc_relator"}}
+        ]
+      }
+    }
+
+    WORKFLOW FOR ADDING CONTROLLED TERMS:
+    1. First, use authoritiesSearch to find the controlled term ID (the "term" value)
+    2. If the field requires a role (subject, contributor), query codeList to get valid role IDs
+    3. Construct the entry with the correct nested structure:
+      {"term": {"id": "found-term-id"}, "role": {"id": "found-role-id", "scheme": "appropriate-scheme"}}
+    4. Use update_plan_change to add the properly structured entry
+
+    When adding controlled terms, ALWAYS search first to get the correct IDs!
+    """
+
+def system_prompt():
+    return """
+    Answer questions using only the tools available.
+
+    When a plan_id is present in the context, delegate to the plan_change_proposer subagent
+    to process all pending changes for that plan and propose the plan for user review.
+
+    Use the get_plan_changes tool to get a list of changes planned for a given plan UUID and work UUID.
+
+    CRITICAL: When working with controlled vocabulary fields (subject, creator, contributor, genre,
+    language, location, style_period, technique), you MUST:
+    1. Use the authoritiesSearch GraphQL query to find valid controlled term IDs
+    2. For fields requiring roles (subject, contributor), use codeList query to get valid role IDs:
+        - codeList(scheme: SUBJECT_ROLE) for subject roles
+        - codeList(scheme: MARC_RELATOR) for contributor/creator roles
+    3. Structure the term correctly as an OBJECT: {"term": {"id": "uri"}, "role": {"id": "role", "scheme": "scheme"}}
+    4. Never use bare strings for term values - they must be objects with "id" field
+    5. Include required "role" field for subject and contributor fields
+
+    Never make up or guess term IDs or role IDs - always query for them first.
+
+    Do not look for information in the file system or local codebase.
+    """

--- a/app/priv/python/integration/pyproject.toml
+++ b/app/priv/python/integration/pyproject.toml
@@ -12,4 +12,4 @@ dependencies = [
 reinstall-package = ["meadow-metadata-agent"]
 
 [tool.uv.sources]
-meadow-metadata-agent = { path = "${PRIV_PATH}/python/agent" }
+meadow-metadata-agent = { path = "${PRIV_PATH}/python/agent", editable = true }


### PR DESCRIPTION
# Summary 

This work wires up a _rough_ UI that outputs proposed plan changes to the screen alongside the streaming chat responses. While the UI is awaiting proposed changes, we will render a simple bouncing loader component to signify the the end user that work is being completed by the AI agent in the background. Once proposed changes arrive, they will be rendered in a simple table along with a non-functional `Approve Changes` button. 

<img width="1174" height="687" alt="image" src="https://github.com/user-attachments/assets/2b6b84e0-0a62-43bb-b1e4-48fba5fc4242" />

Along with this work, the markdown chat responses are rendering as relative HTML elements using the `@nulib/use-markdown` dependency.

Brief high level description of this feature or fix

# Specific Changes in this PR
- Renders out markdown chat responses as HTML
- Adds loader for pending changes
- Renders simple table for proposed changes.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

