### PR TITLE
Don't automatically approve the plan when approving remaining changes

### DIFF
--- a/app/lib/meadow_web/mcp/get_plan_changes.ex
+++ b/app/lib/meadow_web/mcp/get_plan_changes.ex
@@ -59,7 +59,6 @@ defmodule MeadowWeb.MCP.GetPlanChanges do
     )
   end
 
-  @impl true
   def name, do: "get_plan_changes"
 
   @impl true

--- a/app/lib/meadow_web/mcp/update_plan_change.ex
+++ b/app/lib/meadow_web/mcp/update_plan_change.ex
@@ -45,28 +45,19 @@ defmodule MeadowWeb.MCP.UpdatePlanChange do
       required: true
     )
 
-    field(:add, :map,
-      description: "Map of values to append to existing work data"
-    )
+    field(:add, :map, description: "Map of values to append to existing work data")
 
-    field(:delete, :map,
-      description: "Map of values to remove from existing work data"
-    )
+    field(:delete, :map, description: "Map of values to remove from existing work data")
 
-    field(:replace, :map,
-      description: "Map of values to fully replace in work data"
-    )
+    field(:replace, :map, description: "Map of values to fully replace in work data")
 
     field(:status, :string,
       description: "Status: pending, proposed, approved, rejected, completed, error"
     )
 
-    field(:notes, :string,
-      description: "Optional notes about this change"
-    )
+    field(:notes, :string, description: "Optional notes about this change")
   end
 
-  @impl true
   def name, do: "update_plan_change"
 
   @impl true


### PR DESCRIPTION
# Summary 
Don't automatically approve the plan when approving remaining changes

# Specific Changes in this PR
- Remove auto-approve logic from update_proposed_plan_change_statuses resolver

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

