### PR TITLE
Show work statistics on collection page

### DIFF
--- a/app/assets/js/components/Collection/Collection.jsx
+++ b/app/assets/js/components/Collection/Collection.jsx
@@ -18,6 +18,7 @@ const Collection = ({ collection }) => {
     findingAidUrl,
     keywords = [],
     totalWorks,
+    stats,
   } = collection;
 
   const handleViewAllWorksClick = () => {
@@ -27,6 +28,12 @@ const Collection = ({ collection }) => {
         value: collection.title,
       },
     });
+  };
+
+  const handleFacetClick = (facetComponentId, facetValue) => {
+    const collectionFacet = `Collection=${encodeURIComponent(JSON.stringify([collection.title]))}`;
+    const additionalFacet = `${facetComponentId}=${encodeURIComponent(JSON.stringify([facetValue]))}`;
+    history.push(`/search?${collectionFacet}&${additionalFacet}`);
   };
 
   return (
@@ -87,6 +94,65 @@ const Collection = ({ collection }) => {
               <strong>Total Works</strong>
             </dt>
             <dd>{totalWorks}</dd>
+            {stats && (
+              <>
+                <dt>
+                  <strong>Work Statistics</strong>
+                </dt>
+                <dd>
+                  <ul>
+                    <li>
+                      <a
+                        onClick={() => handleViewAllWorksClick()}
+                        style={{ cursor: "pointer" }}
+                      >
+                        Total Works ({stats.total})
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        onClick={() => handleFacetClick("Published", false)}
+                        style={{ cursor: "pointer" }}
+                      >
+                        Unpublished ({stats.unpublished})
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        onClick={() => handleFacetClick("Published", true)}
+                        style={{ cursor: "pointer" }}
+                      >
+                        Published ({stats.published})
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        onClick={() => handleFacetClick("WorkType", "Video")}
+                        style={{ cursor: "pointer" }}
+                      >
+                        Video ({stats.video})
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        onClick={() => handleFacetClick("WorkType", "Audio")}
+                        style={{ cursor: "pointer" }}
+                      >
+                        Audio ({stats.audio})
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        onClick={() => handleFacetClick("WorkType", "Image")}
+                        style={{ cursor: "pointer" }}
+                      >
+                        Image ({stats.image})
+                      </a>
+                    </li>
+                  </ul>
+                </dd>
+              </>
+            )}
           </dl>
           {totalWorks > 0 && (
             <div className="pt-3">

--- a/app/assets/js/components/Collection/collection.gql.js
+++ b/app/assets/js/components/Collection/collection.gql.js
@@ -99,6 +99,14 @@ export const GET_COLLECTION = gql`
         id
         representativeImage
       }
+      stats {
+        audio
+        image
+        published
+        total
+        unpublished
+        video
+      }
       title
       totalWorks
       visibility {

--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "@absinthe/socket-apollo-link": "^0.2.1",
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",


### PR DESCRIPTION
# Summary 

Added work statistics display to the collection detail page, showing counts and providing faceted search links for different work types and publication status.

# Specific Changes in this PR

### GraphQL Query (`collection.gql.js`)
- Updated `GET_COLLECTION` query to include the `stats` field
- Stats include: `total`, `published`, `unpublished`, `image`, `audio`, `video`

### Collection Component (`Collection.jsx`)
- Added "Work Statistics" section to collection details
- Each statistic is a clickable link that navigates to faceted search results
- Links include both the Collection facet and the specific stat type facet (e.g., Published, WorkType)
- Facet links use URL parameters in JSON array format: `?Collection=["CollectionName"]&WorkType=["Image"]`
- Links are generated using the existing ReactiveSearch URL parameter pattern
- Stats are retrieved from the GraphQL `stats` field on the collection object

# Steps to Test

- Visit an individual collection page in Meadow
- Verify that it contains work stats
- Verify that the work stats link into faceted searches

<img width="1052" height="842" alt="Screenshot 2025-10-27 at 10 57 23 AM" src="https://github.com/user-attachments/assets/bd6525bb-5b54-4439-92e1-4fcf7132a539" />


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major



# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

