### PR TITLE
Add alt_text and image_caption fields FileSet

### DIFF
--- a/app/lib/meadow/data/schemas/file_set_core_metadata.ex
+++ b/app/lib/meadow/data/schemas/file_set_core_metadata.ex
@@ -12,7 +12,9 @@ defmodule Meadow.Data.Schemas.FileSetCoreMetadata do
     field :original_filename
     field :description
     field :label
+    field :alt_text
     field :digests, :map
+    field :image_caption
     field :mime_type
 
     timestamps()
@@ -21,8 +23,10 @@ defmodule Meadow.Data.Schemas.FileSetCoreMetadata do
   def changeset(metadata, params) do
     metadata
     |> cast(params, [
+      :alt_text,
       :description,
       :digests,
+      :image_caption,
       :label,
       :location,
       :mime_type,

--- a/app/lib/meadow/indexing/v2/file_set.ex
+++ b/app/lib/meadow/indexing/v2/file_set.ex
@@ -9,6 +9,7 @@ defmodule Meadow.Indexing.V2.FileSet do
   def encode(file_set) do
     %{
       accession_number: file_set.accession_number,
+      alt_text: file_set.core_metadata.alt_text,
       api_link: Path.join([api_url(), "file-sets", file_set.id]),
       api_model: "FileSet",
       create_date: file_set.inserted_at,
@@ -18,6 +19,7 @@ defmodule Meadow.Indexing.V2.FileSet do
       extracted_metadata: extracted_metadata(file_set.extracted_metadata),
       group_with: file_set.group_with,
       id: file_set.id,
+      image_caption: file_set.core_metadata.image_caption,
       indexed_at: NaiveDateTime.utc_now(),
       label: file_set.core_metadata.label,
       mime_type: file_set.core_metadata.mime_type,

--- a/app/lib/meadow_web/schema/types/data/file_set_types.ex
+++ b/app/lib/meadow_web/schema/types/data/file_set_types.ex
@@ -78,6 +78,8 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
 
   @desc "Same as `file_set_core_metadata`. This represents all metadata associated with a file_set accepted on creation. It is stored in a single json field."
   input_object :file_set_core_metadata_input do
+    field(:alt_text, :string)
+    field(:image_caption, :string)
     field(:label, :string)
     field(:location, :string)
     field(:original_filename, :string)
@@ -93,6 +95,8 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
 
   @desc "Same as `file_set_core_metadata`. This represents all updatable metadata associated with a file_set. It is stored in a single json field."
   input_object :file_set_core_metadata_update do
+    field(:alt_text, :string)
+    field(:image_caption, :string)
     field(:label, :string)
     field(:description, :string)
   end
@@ -154,6 +158,8 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
 
   @desc "`file_set_core_metadata` represents all metadata associated with a file set object. It is stored in a single json field."
   object :file_set_core_metadata do
+    field(:alt_text, :string)
+    field(:image_caption, :string)
     field(:location, :string)
     field(:label, :string)
     field(:mime_type, :string)

--- a/app/test/gql/FileSetFields.frag.gql
+++ b/app/test/gql/FileSetFields.frag.gql
@@ -16,10 +16,12 @@ fragment FileSetFields on FileSet {
     value
   }
   coreMetadata {
+    altText
     description
     digests {
       md5
     }
+    imageCaption
     label
     location
     originalFilename


### PR DESCRIPTION
# Summary 
Brief high level description of this feature or fix

# Specific Changes in this PR
- Add new fields to to FileSet core metadata
- Add new fields to all `file_set_core_metadata` GraphQL types
- Add new fields to indexer

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- In graphiql, use the `work` query and the `updateFileSet` mutation to read and write the `altText` and `imageCaption` fields within `fileSet.coreMetadata`.
- Make sure changes to those fields show up when accessing the file set through the API

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [x] GraphQL API
  - [x] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

