### PR TITLE
Add Transcription UI.

### DIFF
--- a/app/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
+++ b/app/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
@@ -77,32 +77,55 @@ export function MediaButtons({ fileSet }) {
 }
 
 export function ImageButtons({ iiifServerUrl, fileSet }) {
+  const dispatch = useWorkDispatch();
+  const { isAuthorized } = useIsAuthorized();
+
+  if (!fileSet) return null;
+
   return (
-    <div
-      data-testid="download-image-fileset"
-      className="field has-addons is-flex is-justify-content-flex-end"
-    >
-      <p className="control">
-        <a
-          href={`${iiifServerUrl}${fileSet.id}${IIIF_SIZES.IIIF_FULL_TIFF}`}
-          target="_blank"
-          className="button"
-        >
-          <span className="icon">
-            <IconDownload />
-          </span>{" "}
-          <span>TIF</span>
-        </a>
-      </p>
-      <p className="control">
-        <ImageDownloader
-          imageUrl={`${iiifServerUrl}${fileSet.id}${IIIF_SIZES.IIIF_FULL}`}
-          imageTitle={fileSet.accessionNumber}
-          className="button"
-        >
-          JPG
-        </ImageDownloader>
-      </p>
+    <div className="buttons is-grouped is-right">
+      {!fileSet.group_with &&
+        fileSet.representativeImageUrl &&
+        isAuthorized() && (
+          <a
+            className="button"
+            data-testid="edit-structure-button"
+            onClick={() =>
+              dispatch({
+                type: "toggleTranscriptionModal",
+                fileSetId: fileSet.id,
+              })
+            }
+          >
+            Transcription
+          </a>
+        )}
+      <div
+        data-testid="download-image-fileset"
+        className="field has-addons is-flex is-justify-content-flex-end"
+      >
+        <p className="control">
+          <a
+            href={`${iiifServerUrl}${fileSet.id}${IIIF_SIZES.IIIF_FULL_TIFF}`}
+            target="_blank"
+            className="button"
+          >
+            <span className="icon">
+              <IconDownload />
+            </span>{" "}
+            <span>TIF</span>
+          </a>
+        </p>
+        <p className="control">
+          <ImageDownloader
+            imageUrl={`${iiifServerUrl}${fileSet.id}${IIIF_SIZES.IIIF_FULL}`}
+            imageTitle={fileSet.accessionNumber}
+            className="button"
+          >
+            JPG
+          </ImageDownloader>
+        </p>
+      </div>
     </div>
   );
 }

--- a/app/assets/js/components/Work/Fileset/List.jsx
+++ b/app/assets/js/components/Work/Fileset/List.jsx
@@ -5,6 +5,7 @@ import WorkFilesetDraggable from "@js/components/Work/Fileset/Draggable";
 import WorkTabsStructureWebVTTModal from "@js/components/Work/Tabs/Structure/WebVTTModal";
 import { useWorkState } from "@js/context/work-context";
 import { Droppable } from "react-beautiful-dnd";
+import WorkTabsStructureTranscriptionModal from "../Tabs/Structure/Transcription/Modal";
 
 function SubHead({ children }) {
   return <h3 className="my-4 ml-5 is-size-5">{children}</h3>;
@@ -18,7 +19,10 @@ function WorkFilesetList({
   workImageFilesetId,
   work,
 }) {
-  const { webVttModal } = useWorkState();
+  const { transcriptionModal, webVttModal } = useWorkState();
+
+  const isTranscriptionModalActive = transcriptionModal?.isOpen;
+  const isWebVttModalActive = webVttModal?.isOpen;
 
   const uniqueGroupWithValues = fileSets.access
     .filter((fs) => fs.group_with !== null)
@@ -108,7 +112,10 @@ function WorkFilesetList({
           ))}
         </>
       )}
-      <WorkTabsStructureWebVTTModal isActive={webVttModal?.isOpen} />
+      <WorkTabsStructureTranscriptionModal
+        isActive={isTranscriptionModalActive}
+      />
+      <WorkTabsStructureWebVTTModal isActive={isWebVttModalActive} />
     </>
   );
 }
@@ -124,7 +131,7 @@ WorkFilesetList.propTypes = {
     behavior: PropTypes.shape({
       id: PropTypes.string,
       label: PropTypes.string,
-    })
+    }),
   }),
 };
 

--- a/app/assets/js/components/Work/Fileset/List.test.js
+++ b/app/assets/js/components/Work/Fileset/List.test.js
@@ -6,15 +6,12 @@ import { screen, waitFor } from "@testing-library/react";
 import { CodeListProvider } from "@js/context/code-list-context";
 import React from "react";
 import WorkFilesetList from "@js/components/Work/Fileset/List";
-import { WorkProvider } from "@js/context/work-context";
+import { WorkProvider, defaultState } from "@js/context/work-context";
 import { mockFileSets } from "@js/mock-data/filesets";
 import { mockUser } from "@js/components/Auth/auth.gql.mock";
 import useIsAuthorized from "@js/hooks/useIsAuthorized";
 import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
-import {
-  mockWork,
-  mockWork2
-} from "../work.gql.mock";
+import { mockWork, mockWork2 } from "../work.gql.mock";
 
 jest.mock("@js/hooks/useIsAuthorized");
 useIsAuthorized.mockReturnValue({
@@ -26,7 +23,7 @@ describe("WorkFilesetList component", () => {
   it("renders a draggable list component if re-ordering the list", async () => {
     renderWithRouterApollo(
       <CodeListProvider>
-        <WorkProvider>
+        <WorkProvider initialState={{ ...defaultState, work: mockWork }}>
           {withReactBeautifulDND(WorkFilesetList, {
             fileSets: { access: mockFileSets, auxiliary: [] },
             isReordering: true,
@@ -35,7 +32,7 @@ describe("WorkFilesetList component", () => {
       </CodeListProvider>,
       {
         mocks: allCodeListMocks,
-      }
+      },
     );
     await waitFor(() => {
       expect(screen.getByTestId("fileset-draggable-list"));
@@ -45,7 +42,7 @@ describe("WorkFilesetList component", () => {
   it("renders a non-draggable list if not-reordering", async () => {
     renderWithRouterApollo(
       <CodeListProvider>
-        <WorkProvider>
+        <WorkProvider initialState={{ ...defaultState, work: mockWork }}>
           {withReactBeautifulDND(WorkFilesetList, {
             fileSets: { access: mockFileSets, auxiliary: [] },
           })}
@@ -53,7 +50,7 @@ describe("WorkFilesetList component", () => {
       </CodeListProvider>,
       {
         mocks: allCodeListMocks,
-      }
+      },
     );
     await waitFor(() => {
       expect(screen.getByTestId("fileset-list"));
@@ -63,7 +60,7 @@ describe("WorkFilesetList component", () => {
   it("renders the correct number of list elements", async () => {
     renderWithRouterApollo(
       <CodeListProvider>
-        <WorkProvider>
+        <WorkProvider initialState={{ ...defaultState, work: mockWork }}>
           {withReactBeautifulDND(WorkFilesetList, {
             fileSets: { access: mockFileSets, auxiliary: [] },
           })}
@@ -71,7 +68,7 @@ describe("WorkFilesetList component", () => {
       </CodeListProvider>,
       {
         mocks: allCodeListMocks,
-      }
+      },
     );
     await waitFor(() => {
       expect(screen.getAllByTestId("fileset-item")).toHaveLength(4);

--- a/app/assets/js/components/Work/Fileset/ListItem.jsx
+++ b/app/assets/js/components/Work/Fileset/ListItem.jsx
@@ -4,7 +4,7 @@ import { useWorkDispatch, useWorkState } from "@js/context/work-context";
 
 import AuthDisplayAuthorized from "@js/components/Auth/DisplayAuthorized";
 import PropTypes from "prop-types";
-import React, { useContext } from "react";
+import React from "react";
 import { Tag } from "@nulib/design-system";
 import UIFormField from "@js/components/UI/Form/Field";
 import UIFormInput from "@js/components/UI/Form/Input";

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Modal.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Modal.jsx
@@ -1,0 +1,140 @@
+import React, { useContext, useEffect, useState } from "react";
+import PropTypes from "prop-types";
+import CloverImage from "@samvera/clover-iiif/image";
+import { Button } from "@nulib/design-system";
+import classNames from "classnames";
+import { useWorkDispatch, useWorkState } from "@js/context/work-context";
+import { IIIFContext } from "@js/components/IIIF/IIIFProvider";
+import { IIIF_SIZES } from "@js/services/global-vars";
+import { toastWrapper } from "@js/services/helpers";
+import { useMutation } from "@apollo/client";
+import { UPDATE_FILE_SET_ANNOTATION } from "@js/components/Work/Tabs/Structure/Transcription/transcription.gql";
+import WorkTabsStructureTranscriptionWorkflow from "./Workflow";
+
+function WorkTabsStructureTranscriptionModal({ isActive }) {
+  const [textArea, setTextArea] = useState();
+
+  const dispatch = useWorkDispatch();
+  const iiifServerUrl = useContext(IIIFContext);
+  const {
+    transcriptionModal: { fileSetId },
+    work: { id: workId },
+  } = useWorkState();
+
+  const iiifImageUrl = `${iiifServerUrl}${fileSetId}${IIIF_SIZES.IIIF_FULL}`;
+
+  const [updateFileSetAnnotation] = useMutation(UPDATE_FILE_SET_ANNOTATION);
+
+  useEffect(() => {
+    const textAreaElement = document.getElementById(
+      "file-set-transcription-textarea",
+    );
+    setTextArea(textAreaElement);
+  }, [isActive]);
+
+  const handleClose = () => {
+    dispatch({
+      type: "toggleTranscriptionModal",
+      fileSetId: null,
+    });
+  };
+
+  const handleSaveTranscription = () => {
+    const annotationContent = textArea?.value || "";
+    const annotationId = textArea?.getAttribute("data-annotation-id");
+
+    updateFileSetAnnotation({
+      variables: {
+        annotationId: annotationId,
+        content: annotationContent,
+      },
+      onCompleted: () => {
+        handleClose();
+        toastWrapper("is-success", "Transcription successfully saved");
+      },
+      onError: (error) => {
+        toastWrapper(
+          "is-danger",
+          "Error saving transcription: " + error.message,
+        );
+      },
+    });
+  };
+
+  const handleHasTranscriptionCallback = () => {
+    const textAreaElement = document.getElementById(
+      "file-set-transcription-textarea",
+    );
+    setTextArea(textAreaElement);
+  };
+
+  const hasTextArea = Boolean(textArea);
+
+  return (
+    <div className={classNames(["modal"], { "is-active": isActive })}>
+      <div className="modal-background" />
+      <div className="modal-card" style={{ width: "90%", maxWidth: "1344px" }}>
+        <header className="modal-card-head">
+          <p className="modal-card-title">Transcription</p>
+          <button
+            type="button"
+            className="delete"
+            aria-label="close"
+            onClick={handleClose}
+          />
+        </header>
+
+        <section className="modal-card-body">
+          <div
+            className="is-flex is-justify-content-space-between"
+            style={{ gap: "1rem" }}
+          >
+            <div style={{ width: "50%", flexShrink: 0 }}>
+              <div
+                className="box"
+                style={{
+                  height: "400px",
+                  padding: 0,
+                  position: "relative",
+                  zIndex: 0,
+                }}
+              >
+                <CloverImage
+                  src={iiifImageUrl || ""}
+                  openSeadragonConfig={{
+                    showNavigator: false,
+                  }}
+                />
+              </div>
+            </div>
+            <WorkTabsStructureTranscriptionWorkflow
+              fileSetId={fileSetId}
+              workId={workId}
+              hasTranscriptionCallback={handleHasTranscriptionCallback}
+              isActive={isActive}
+            />
+          </div>
+        </section>
+
+        <footer className="modal-card-foot buttons is-justify-content-space-between">
+          <div className="is-flex is-justify-content-flex-end is-flex-grow-1">
+            <Button onClick={handleClose}>Cancel</Button>
+            <Button
+              isPrimary
+              disabled={!hasTextArea}
+              onClick={handleSaveTranscription}
+            >
+              Save
+            </Button>
+          </div>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+WorkTabsStructureTranscriptionModal.propTypes = {
+  isActive: PropTypes.bool,
+};
+
+export default WorkTabsStructureTranscriptionModal;

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Modal.test.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Modal.test.jsx
@@ -1,0 +1,200 @@
+// js/components/Work/Tabs/Structure/Transcription/Modal.test.jsx
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MockedProvider } from "@apollo/client/testing";
+import { IIIFContext } from "@js/components/IIIF/IIIFProvider";
+import { useWorkDispatch, useWorkState } from "@js/context/work-context";
+import { toastWrapper } from "@js/services/helpers";
+import WorkTabsStructureTranscriptionModal from "./Modal";
+import { UPDATE_FILE_SET_ANNOTATION } from "./transcription.gql";
+
+// --- Mocks ---
+
+// Simple stub for CloverImage
+jest.mock("@samvera/clover-iiif/image", () => {
+  const React = require("react");
+  return function CloverImageStub(props) {
+    return <img data-testid="clover-image" src={props.src} alt="" />;
+  };
+});
+
+// Simple stub for Button
+jest.mock("@nulib/design-system", () => {
+  const React = require("react");
+  return {
+    Button: ({ children, ...props }) => <button {...props}>{children}</button>,
+  };
+});
+
+// Work context hooks
+jest.mock("@js/context/work-context", () => ({
+  useWorkDispatch: jest.fn(),
+  useWorkState: jest.fn(),
+}));
+
+// toast wrapper
+jest.mock("@js/services/helpers", () => ({
+  toastWrapper: jest.fn(),
+}));
+
+// Mock Workflow so it renders the textarea the modal is looking for
+jest.mock("./Workflow", () => {
+  const React = require("react");
+  return function MockWorkflow() {
+    return (
+      <textarea
+        id="file-set-transcription-textarea"
+        data-annotation-id="ann-1"
+        data-annotation-type="transcription"
+        defaultValue="Existing transcription"
+      />
+    );
+  };
+});
+
+describe("WorkTabsStructureTranscriptionModal", () => {
+  let mockDispatch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockDispatch = jest.fn();
+    useWorkDispatch.mockReturnValue(mockDispatch);
+    useWorkState.mockReturnValue({
+      transcriptionModal: { fileSetId: "fs-123" },
+      work: { id: "work-456" },
+    });
+  });
+
+  const renderModal = ({ isActive = true, mocks = [] } = {}) => {
+    return render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <IIIFContext.Provider value="https://iiif.example/">
+          <WorkTabsStructureTranscriptionModal isActive={isActive} />
+        </IIIFContext.Provider>
+      </MockedProvider>,
+    );
+  };
+
+  it("renders an active modal with IIIF image", () => {
+    renderModal();
+
+    const image = screen.getByTestId("clover-image");
+    expect(image).toBeInTheDocument();
+    // Just sanity-check the prefix; full URL includes IIIF_SIZES
+    expect(image.getAttribute("src")).toContain("https://iiif.example/");
+    expect(image.getAttribute("src")).toContain("fs-123");
+  });
+
+  it("disables Save when textarea is not yet found", async () => {
+    // The effect that finds the textarea runs after mount, so on first paint
+    // Save may be disabled. We can at least assert it's a button and becomes
+    // enabled once the textarea exists.
+    renderModal();
+
+    const saveButton = await screen.findByRole("button", { name: /save/i });
+    // After the effect + mock Workflow render, it should be enabled:
+    await waitFor(() => expect(saveButton).not.toBeDisabled());
+  });
+
+  it("calls mutation and closes modal on successful save", async () => {
+    const mutationMocks = [
+      {
+        request: {
+          query: UPDATE_FILE_SET_ANNOTATION,
+          variables: {
+            annotationId: "ann-1",
+            content: "Existing transcription",
+          },
+        },
+        result: {
+          data: {
+            updateFileSetAnnotation: {
+              id: "ann-1",
+              content: "Existing transcription",
+            },
+          },
+        },
+      },
+    ];
+
+    renderModal({ mocks: mutationMocks });
+
+    const saveButton = await screen.findByRole("button", { name: /save/i });
+
+    // Wait until textarea is found and Save enabled
+    await waitFor(() => expect(saveButton).not.toBeDisabled());
+
+    fireEvent.click(saveButton);
+
+    // Wait for mutation + onCompleted to propagate
+    await waitFor(() => {
+      expect(toastWrapper).toHaveBeenCalledWith(
+        "is-success",
+        "Transcription successfully saved",
+      );
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: "toggleTranscriptionModal",
+      fileSetId: null,
+    });
+  });
+
+  it("shows error toast when mutation fails", async () => {
+    const mutationMocks = [
+      {
+        request: {
+          query: UPDATE_FILE_SET_ANNOTATION,
+          variables: {
+            annotationId: "ann-1",
+            content: "Existing transcription",
+          },
+        },
+        error: new Error("Boom"),
+      },
+    ];
+
+    renderModal({ mocks: mutationMocks });
+
+    const saveButton = await screen.findByRole("button", { name: /save/i });
+    await waitFor(() => expect(saveButton).not.toBeDisabled());
+
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(toastWrapper).toHaveBeenCalledWith(
+        "is-danger",
+        "Error saving transcription: Boom",
+      );
+    });
+
+    // Modal should NOT auto-close on error
+    expect(mockDispatch).not.toHaveBeenCalledWith({
+      type: "toggleTranscriptionModal",
+      fileSetId: null,
+    });
+  });
+
+  it("closes modal when clicking close icon and Cancel button", async () => {
+    renderModal();
+
+    const closeIcon = screen.getByLabelText(/close/i);
+    fireEvent.click(closeIcon);
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: "toggleTranscriptionModal",
+      fileSetId: null,
+    });
+
+    mockDispatch.mockClear();
+
+    const cancelButton = await screen.findByRole("button", { name: /cancel/i });
+    fireEvent.click(cancelButton);
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: "toggleTranscriptionModal",
+      fileSetId: null,
+    });
+  });
+});

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Pane.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Pane.jsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useRef } from "react";
+
+function WorkTabsStructureTranscriptionPane({
+  annotation,
+  hasTranscriptionCallback,
+  isGenerating,
+}) {
+  const textAreaRef = useRef(null);
+
+  useEffect(() => {
+    if (annotation?.content) {
+      if (textAreaRef.current) {
+        textAreaRef.current.value = annotation.content;
+        hasTranscriptionCallback(true);
+      }
+      return;
+    }
+  }, [annotation, isGenerating]);
+
+  if (isGenerating && !annotation?.content) {
+    return <div>Generating transcription, please wait...</div>;
+  }
+
+  return (
+    <textarea
+      className="textarea"
+      data-annotation-id={annotation?.id}
+      data-annotation-type={annotation?.type}
+      id="file-set-transcription-textarea"
+      ref={textAreaRef}
+      style={{
+        height: "100%",
+        whiteSpace: "pre-wrap",
+        minWidth: "unset",
+        resize: "none",
+      }}
+    />
+  );
+}
+
+export default WorkTabsStructureTranscriptionPane;

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Pane.test.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Pane.test.jsx
@@ -1,0 +1,105 @@
+// WorkTabsStructureTranscriptionPane.test.js
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import WorkTabsStructureTranscriptionPane from "./Pane";
+
+describe("WorkTabsStructureTranscriptionPane", () => {
+  it("renders a textarea with annotation content and calls callback", () => {
+    const hasTranscriptionCallback = jest.fn();
+    const annotation = {
+      id: "ann-1",
+      type: "transcription",
+      content: "This is the transcription.",
+    };
+
+    render(
+      <WorkTabsStructureTranscriptionPane
+        annotation={annotation}
+        hasTranscriptionCallback={hasTranscriptionCallback}
+        isGenerating={false}
+      />,
+    );
+
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toBeInTheDocument();
+    expect(textarea).toHaveValue("This is the transcription.");
+    expect(textarea).toHaveAttribute("data-annotation-id", "ann-1");
+    expect(textarea).toHaveAttribute("data-annotation-type", "transcription");
+
+    expect(hasTranscriptionCallback).toHaveBeenCalledTimes(1);
+    expect(hasTranscriptionCallback).toHaveBeenCalledWith(true);
+  });
+
+  it("shows generating message when isGenerating and no annotation content", () => {
+    const hasTranscriptionCallback = jest.fn();
+    const annotation = {
+      id: "ann-2",
+      type: "transcription",
+      content: null,
+    };
+
+    render(
+      <WorkTabsStructureTranscriptionPane
+        annotation={annotation}
+        hasTranscriptionCallback={hasTranscriptionCallback}
+        isGenerating={true}
+      />,
+    );
+
+    expect(
+      screen.getByText("Generating transcription, please wait..."),
+    ).toBeInTheDocument();
+
+    // No textarea when generating with no content
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+
+    // Should not yet have called the callback
+    expect(hasTranscriptionCallback).not.toHaveBeenCalled();
+  });
+
+  it("switches from generating state to showing textarea when content arrives", () => {
+    const hasTranscriptionCallback = jest.fn();
+
+    const initialAnnotation = {
+      id: "ann-3",
+      type: "transcription",
+      content: null,
+    };
+
+    const { rerender } = render(
+      <WorkTabsStructureTranscriptionPane
+        annotation={initialAnnotation}
+        hasTranscriptionCallback={hasTranscriptionCallback}
+        isGenerating={true}
+      />,
+    );
+
+    // Initially: generating message
+    expect(
+      screen.getByText("Generating transcription, please wait..."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(hasTranscriptionCallback).not.toHaveBeenCalled();
+
+    // Now simulate "transcription finished" – annotation gains content
+    const updatedAnnotation = {
+      ...initialAnnotation,
+      content: "Final generated transcription",
+    };
+
+    rerender(
+      <WorkTabsStructureTranscriptionPane
+        annotation={updatedAnnotation}
+        hasTranscriptionCallback={hasTranscriptionCallback}
+        isGenerating={false}
+      />,
+    );
+
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toBeInTheDocument();
+    expect(textarea).toHaveValue("Final generated transcription");
+
+    expect(hasTranscriptionCallback).toHaveBeenCalledTimes(1);
+    expect(hasTranscriptionCallback).toHaveBeenCalledWith(true);
+  });
+});

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Workflow.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Workflow.jsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from "react";
+import { Button } from "@nulib/design-system";
+import WorkTabsStructureTranscriptionPane from "@js/components/Work/Tabs/Structure/Transcription/Pane";
+import { TRANSCRIBE_FILE_SET } from "@js/components/Work/Tabs/Structure/Transcription/transcription.gql";
+import { useMutation, useQuery } from "@apollo/client";
+import { useFileSetAnnotation } from "@js/hooks/useFileSetAnnotation";
+import { toastWrapper } from "@js/services/helpers";
+
+import { GET_WORK } from "@js/components/Work/work.gql";
+
+function WorkTabsStructureTranscriptionWorkflow({
+  fileSetId,
+  isActive,
+  workId,
+  hasTranscriptionCallback,
+}) {
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  const { data } = useFileSetAnnotation(fileSetId);
+
+  const { data: { work } = {}, refetch } = useQuery(GET_WORK, {
+    variables: { id: workId },
+  });
+
+  const [transcribeFileSet] = useMutation(TRANSCRIBE_FILE_SET);
+
+  const fileSet = work?.fileSets?.find((fs) => fs.id === fileSetId);
+  const annotation =
+    data?.fileSetAnnotation?.status === "completed"
+      ? data?.fileSetAnnotation
+      : fileSet?.annotations?.find(
+          (annotation) => annotation.type === "transcription",
+        );
+
+  const hasTranscription = Boolean(annotation);
+
+  useEffect(() => {
+    if (hasTranscription) setIsGenerating(false);
+  }, [hasTranscription]);
+
+  useEffect(() => {
+    if (isActive) {
+      refetch();
+    }
+  }, [isActive]);
+
+  const handleStartTranscription = () => {
+    if (!fileSet?.id) return;
+
+    transcribeFileSet({
+      variables: {
+        fileSetId: fileSet.id,
+      },
+      onCompleted: () => {
+        toastWrapper("is-success", "Generating transcription");
+        setIsGenerating(true);
+      },
+      refetchQueries: [
+        {
+          query: GET_WORK,
+          variables: { id: workId },
+        },
+      ],
+      awaitRefetchQueries: true,
+    });
+  };
+
+  return (
+    <div
+      data-generating={isGenerating}
+      data-annotation={annotation?.id}
+      style={{
+        width: "50%",
+        flexGrow: 1,
+        flexShrink: 1,
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      {isGenerating || hasTranscription ? (
+        <WorkTabsStructureTranscriptionPane
+          annotation={annotation}
+          hasTranscriptionCallback={hasTranscriptionCallback}
+          isGenerating={isGenerating}
+        />
+      ) : (
+        <Button
+          isPrimary
+          isLowercase
+          onClick={handleStartTranscription}
+          style={{ gap: "0.5rem" }}
+        >
+          Generate Transcription
+        </Button>
+      )}
+    </div>
+  );
+}
+
+export default WorkTabsStructureTranscriptionWorkflow;

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Workflow.test.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Workflow.test.jsx
@@ -1,0 +1,229 @@
+// js/components/Work/Tabs/Structure/Transcription/Workflow.test.jsx
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MockedProvider } from "@apollo/client/testing";
+
+import WorkTabsStructureTranscriptionWorkflow from "./Workflow";
+import { TRANSCRIBE_FILE_SET } from "@js/components/Work/Tabs/Structure/Transcription/transcription.gql";
+import { GET_WORK } from "@js/components/Work/work.gql";
+import { useFileSetAnnotation } from "@js/hooks/useFileSetAnnotation";
+import { toastWrapper } from "@js/services/helpers";
+
+// ---- Mocks ----
+
+// UseFileSetAnnotation hook
+jest.mock("@js/hooks/useFileSetAnnotation", () => ({
+  useFileSetAnnotation: jest.fn(),
+}));
+
+// toast wrapper
+jest.mock("@js/services/helpers", () => ({
+  toastWrapper: jest.fn(),
+}));
+
+// Design-system Button → simple <button>
+jest.mock("@nulib/design-system", () => {
+  const React = require("react");
+  return {
+    Button: ({ children, ...props }) => <button {...props}>{children}</button>,
+  };
+});
+
+// Pane component → simple div so we can assert props
+jest.mock("@js/components/Work/Tabs/Structure/Transcription/Pane", () => {
+  const React = require("react");
+  return function MockPane({ annotation, isGenerating }) {
+    return (
+      <div
+        data-testid="transcription-pane"
+        data-annotation-id={annotation?.id || ""}
+        data-is-generating={isGenerating ? "true" : "false"}
+      />
+    );
+  };
+});
+
+describe("WorkTabsStructureTranscriptionWorkflow", () => {
+  const fileSetId = "fs-123";
+  const workId = "work-456";
+
+  const baseWork = {
+    id: workId,
+    fileSets: [
+      {
+        id: fileSetId,
+        annotations: [],
+        __typename: "FileSet",
+      },
+    ],
+    __typename: "Work",
+  };
+
+  // Helper to render with Apollo mocks
+  const renderWorkflow = ({ mocks, hookData, isActive = true } = {}) => {
+    // Default: no fileSet annotation from hook
+    useFileSetAnnotation.mockReturnValue(
+      hookData || { data: { fileSetAnnotation: null } },
+    );
+
+    return render(
+      <MockedProvider mocks={mocks || []} addTypename={false}>
+        <WorkTabsStructureTranscriptionWorkflow
+          fileSetId={fileSetId}
+          workId={workId}
+          isActive={isActive}
+          hasTranscriptionCallback={jest.fn()}
+        />
+      </MockedProvider>,
+    );
+  };
+
+  it("renders the Generate Transcription button when there is no annotation", async () => {
+    const workMocks = [
+      {
+        request: {
+          query: GET_WORK,
+          variables: { id: workId },
+        },
+        result: {
+          data: {
+            work: baseWork,
+          },
+        },
+      },
+      // extra mocks in case refetch is triggered
+      {
+        request: {
+          query: GET_WORK,
+          variables: { id: workId },
+        },
+        result: {
+          data: {
+            work: baseWork,
+          },
+        },
+      },
+    ];
+
+    renderWorkflow({ mocks: workMocks });
+
+    const button = await screen.findByRole("button", {
+      name: /generate transcription/i,
+    });
+
+    expect(button).toBeInTheDocument();
+  });
+
+  it("calls TRANSCRIBE_FILE_SET and shows generating state + toast when button is clicked", async () => {
+    const workMocks = [
+      // initial GET_WORK
+      {
+        request: {
+          query: GET_WORK,
+          variables: { id: workId },
+        },
+        result: {
+          data: {
+            work: baseWork,
+          },
+        },
+      },
+      // refetch (effect or refetchQueries)
+      {
+        request: {
+          query: GET_WORK,
+          variables: { id: workId },
+        },
+        result: {
+          data: {
+            work: baseWork,
+          },
+        },
+      },
+      // mutation: TRANSCRIBE_FILE_SET
+      {
+        request: {
+          query: TRANSCRIBE_FILE_SET,
+          variables: { fileSetId },
+        },
+        result: {
+          data: {
+            transcribeFileSet: {
+              id: fileSetId,
+            },
+          },
+        },
+      },
+    ];
+
+    renderWorkflow({ mocks: workMocks });
+
+    const button = await screen.findByRole("button", {
+      name: /generate transcription/i,
+    });
+
+    fireEvent.click(button);
+
+    // onCompleted should trigger toast + setIsGenerating(true)
+    await waitFor(() => {
+      expect(toastWrapper).toHaveBeenCalledWith(
+        "is-success",
+        "Generating transcription",
+      );
+    });
+
+    const wrapper = screen.getByTestId("transcription-pane").parentElement;
+    // the top-level div has data-generating attribute
+    expect(wrapper).toHaveAttribute("data-generating", "true");
+  });
+
+  it("renders Pane when an annotation already exists (hasTranscription=true)", async () => {
+    const completedAnnotation = {
+      id: "ann-1",
+      status: "completed",
+      type: "transcription",
+      content: "Hello world",
+      __typename: "Annotation",
+    };
+
+    const workMocks = [
+      {
+        request: {
+          query: GET_WORK,
+          variables: { id: workId },
+        },
+        result: {
+          data: {
+            work: {
+              ...baseWork,
+              fileSets: [
+                {
+                  id: fileSetId,
+                  annotations: [completedAnnotation],
+                },
+              ],
+            },
+          },
+        },
+      },
+    ];
+
+    const hookData = {
+      data: {
+        fileSetAnnotation: completedAnnotation,
+      },
+    };
+
+    renderWorkflow({ mocks: workMocks, hookData });
+
+    const pane = await screen.findByTestId("transcription-pane");
+    expect(pane).toBeInTheDocument();
+    expect(pane).toHaveAttribute("data-annotation-id", "ann-1");
+    expect(pane).toHaveAttribute("data-is-generating", "false");
+
+    // No "Generate Transcription" button when we already have an annotation
+    expect(
+      screen.queryByRole("button", { name: /generate transcription/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/transcription.gql.js
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/transcription.gql.js
@@ -1,0 +1,63 @@
+import gql from "graphql-tag";
+
+export const FILE_SET_ANNOTATION = gql`
+  subscription fileSetAnnotation($fileSetId: ID!) {
+    fileSetAnnotation(fileSetId: $fileSetId) {
+      content
+      fileSetId
+      id
+      insertedAt
+      language
+      model
+      s3Location
+      status
+      type
+      updatedAt
+    }
+  }
+`;
+
+export const WORK_FILE_SET_ANNOTATION = gql`
+  subscription workFileSetAnnotation($workId: ID!) {
+    workFileSetAnnotation(workId: $workId) {
+      fileSetAnnotation {
+        status
+        fileSetId
+      }
+    }
+  }
+`;
+
+export const TRANSCRIBE_FILE_SET = gql`
+  mutation transcribeFileSet(
+    $fileSetId: ID!
+    $language: [String]
+    $model: String
+  ) {
+    transcribeFileSet(
+      fileSetId: $fileSetId
+      language: $language
+      model: $model
+    ) {
+      id
+      status
+    }
+  }
+`;
+
+export const UPDATE_FILE_SET_ANNOTATION = gql`
+  mutation updateFileSetAnnotation($annotationId: ID!, $content: String!) {
+    updateFileSetAnnotation(annotationId: $annotationId, content: $content) {
+      content
+      fileSetId
+      id
+      insertedAt
+      language
+      model
+      s3Location
+      status
+      type
+      updatedAt
+    }
+  }
+`;

--- a/app/assets/js/components/Work/Work.test.js
+++ b/app/assets/js/components/Work/Work.test.js
@@ -16,7 +16,7 @@ import {
   getCollectionMock,
   getCollectionsMock,
 } from "@js/components/Collection/collection.gql.mock";
-import { WorkProvider } from "@js/context/work-context";
+import { WorkProvider, defaultState } from "@js/context/work-context";
 
 jest.mock("@js/services/get-api-response-headers");
 
@@ -54,7 +54,7 @@ jest.mock("@samvera/clover-iiif/viewer", () => {
 describe("Work component", () => {
   beforeEach(() => {
     renderWithRouterApollo(
-      <WorkProvider>
+      <WorkProvider initialState={{ ...defaultState, work: mockWork }}>
         <Work work={mockWork} />
       </WorkProvider>,
       { mocks },

--- a/app/assets/js/components/Work/work.gql.js
+++ b/app/assets/js/components/Work/work.gql.js
@@ -246,6 +246,13 @@ export const GET_WORK = gql`
       fileSets {
         id
         accessionNumber
+        annotations {
+          id
+          type
+          status
+          language
+          content
+        }
         coreMetadata {
           altText
           description
@@ -314,6 +321,13 @@ export const GET_WORKS = gql`
         role {
           id
           label
+        }
+        annotations {
+          id
+          type
+          status
+          language
+          content
         }
         accessionNumber
         coreMetadata {

--- a/app/assets/js/context/work-context.js
+++ b/app/assets/js/context/work-context.js
@@ -3,9 +3,13 @@ import React from "react";
 const WorkStateContext = React.createContext();
 const WorkDispatchContext = React.createContext();
 
-const defaultState = {
+export const defaultState = {
   activeMediaFileSet: null,
   dcApiToken: null,
+  transcriptionModal: {
+    fileSetId: null,
+    isOpen: false,
+  },
   webVttModal: {
     fileSetId: null,
     isOpen: false,
@@ -16,6 +20,15 @@ const defaultState = {
 
 function workReducer(state, action) {
   switch (action.type) {
+    case "toggleTranscriptionModal": {
+      return {
+        ...state,
+        transcriptionModal: {
+          fileSetId: action.fileSetId,
+          isOpen: Boolean(action.fileSetId),
+        },
+      };
+    }
     case "toggleWebVttModal": {
       return {
         ...state,

--- a/app/assets/js/hooks/useFileSetAnnotation.js
+++ b/app/assets/js/hooks/useFileSetAnnotation.js
@@ -1,0 +1,16 @@
+import { useSubscription } from "@apollo/client";
+import { FILE_SET_ANNOTATION } from "@js/components/Work/Tabs/Structure/Transcription/transcription.gql";
+
+export function useFileSetAnnotation(fileSetId) {
+  try {
+    const { data, loading, error } = useSubscription(FILE_SET_ANNOTATION, {
+      variables: { fileSetId },
+      shouldResubscribe: true,
+      fetchPolicy: "no-cache",
+    });
+
+    return { data, loading, error };
+  } catch (error) {
+    return { data: null, loading: false, error };
+  }
+}

--- a/app/assets/js/hooks/useWorkFileSetAnnotation.js
+++ b/app/assets/js/hooks/useWorkFileSetAnnotation.js
@@ -1,0 +1,16 @@
+import { useSubscription } from "@apollo/client";
+import { WORK_FILE_SET_ANNOTATION } from "@js/components/Work/Tabs/Structure/Transcription/transcription.gql";
+
+export function useWorkFileSetAnnotation(workId) {
+  try {
+    const { data, loading, error } = useSubscription(WORK_FILE_SET_ANNOTATION, {
+      variables: { workId },
+      shouldResubscribe: true,
+      fetchPolicy: "no-cache",
+    });
+
+    return { data, loading, error };
+  } catch (error) {
+    return { data: null, loading: false, error };
+  }
+}

--- a/app/assets/js/screens/Work/Work.jsx
+++ b/app/assets/js/screens/Work/Work.jsx
@@ -22,7 +22,7 @@ import UISkeleton from "@js/components/UI/Skeleton";
 import Work from "@js/components/Work/Work";
 import WorkHeaderButtons from "@js/components/Work/HeaderButtons";
 import WorkMultiEditBar from "@js/components/Work/MultiEditBar";
-import { WorkProvider } from "@js/context/work-context";
+import { WorkProvider, defaultState } from "@js/context/work-context";
 import WorkPublicLinkNotification from "@js/components/Work/PublicLinkNotification";
 import WorkSharedLinkNotification from "@js/components/Work/SharedLinkNotification";
 import WorkTagsList from "@js/components/Work/TagsList";
@@ -90,7 +90,7 @@ const ScreensWork = () => {
     onCompleted({ updateWork }) {
       toastWrapper(
         "is-success",
-        `Work has been ${updateWork.published ? "published" : "unpublished"}`
+        `Work has been ${updateWork.published ? "published" : "unpublished"}`,
       );
     },
   });
@@ -121,7 +121,7 @@ const ScreensWork = () => {
 
   const handleMultiNavClick = (nextWorkIndex) => {
     history.push(
-      `/work/${batchState.editAndViewWorks[nextWorkIndex]}/multi/${nextWorkIndex},${multiTotalItems}`
+      `/work/${batchState.editAndViewWorks[nextWorkIndex]}/multi/${nextWorkIndex},${multiTotalItems}`,
     );
   };
 
@@ -233,7 +233,7 @@ const ScreensWork = () => {
                             onClick={() =>
                               handleFacetLinkClick(
                                 "Collection",
-                                data.work.collection.title
+                                data.work.collection.title,
                               )
                             }
                           >
@@ -254,7 +254,7 @@ const ScreensWork = () => {
         <UISkeleton rows={20} />
       ) : (
         <ErrorBoundary FallbackComponent={FallbackErrorComponent}>
-          <WorkProvider>
+          <WorkProvider initialState={{ ...defaultState, work: data.work }}>
             <Work work={data.work} key={data.work.id} />
           </WorkProvider>
         </ErrorBoundary>

--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "@absinthe/socket-apollo-link": "^0.2.1",
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",
@@ -608,32 +608,32 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.931.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.931.0.tgz",
-      "integrity": "sha512-p+ZSRvmylk/pNImGDvLt3lOkILOexNcYvsCjvN2TR9X8RvxvPURISVp2qdGKdwUr/zkshteg1x/30GYlcTKs5g==",
+      "version": "3.932.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.932.0.tgz",
+      "integrity": "sha512-qrlbJ3W5QR3Gzz2S+yaItH8ZhX7vaeA4j4fDAi8+0FmsVhXOfBbomWr+JO1wk/YojZMdyLfmfYRHrJvAQsLFVw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.931.0",
-        "@aws-sdk/credential-provider-node": "3.931.0",
+        "@aws-sdk/core": "3.932.0",
+        "@aws-sdk/credential-provider-node": "3.932.0",
         "@aws-sdk/middleware-bucket-endpoint": "3.930.0",
         "@aws-sdk/middleware-expect-continue": "3.930.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.931.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.932.0",
         "@aws-sdk/middleware-host-header": "3.930.0",
         "@aws-sdk/middleware-location-constraint": "3.930.0",
         "@aws-sdk/middleware-logger": "3.930.0",
         "@aws-sdk/middleware-recursion-detection": "3.930.0",
-        "@aws-sdk/middleware-sdk-s3": "3.931.0",
+        "@aws-sdk/middleware-sdk-s3": "3.932.0",
         "@aws-sdk/middleware-ssec": "3.930.0",
-        "@aws-sdk/middleware-user-agent": "3.931.0",
+        "@aws-sdk/middleware-user-agent": "3.932.0",
         "@aws-sdk/region-config-resolver": "3.930.0",
-        "@aws-sdk/signature-v4-multi-region": "3.931.0",
+        "@aws-sdk/signature-v4-multi-region": "3.932.0",
         "@aws-sdk/types": "3.930.0",
         "@aws-sdk/util-endpoints": "3.930.0",
         "@aws-sdk/util-user-agent-browser": "3.930.0",
-        "@aws-sdk/util-user-agent-node": "3.931.0",
+        "@aws-sdk/util-user-agent-node": "3.932.0",
         "@smithy/config-resolver": "^4.4.3",
         "@smithy/core": "^3.18.2",
         "@smithy/eventstream-serde-browser": "^4.2.5",
@@ -674,23 +674,23 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.931.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.931.0.tgz",
-      "integrity": "sha512-GM/CARsIUQGEspM9VhZaftFVXnNtFNUUXjpM1ePO4CHk1J/VFvXcsQr3SHWIs0F4Ll6pvy5LpcRlWW5pK7T4aQ==",
+      "version": "3.932.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.932.0.tgz",
+      "integrity": "sha512-XHqHa5iv2OQsKoM2tUQXs7EAyryploC00Wg0XSFra/KAKqyGizUb5XxXsGlyqhebB29Wqur+zwiRwNmejmN0+Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.931.0",
+        "@aws-sdk/core": "3.932.0",
         "@aws-sdk/middleware-host-header": "3.930.0",
         "@aws-sdk/middleware-logger": "3.930.0",
         "@aws-sdk/middleware-recursion-detection": "3.930.0",
-        "@aws-sdk/middleware-user-agent": "3.931.0",
+        "@aws-sdk/middleware-user-agent": "3.932.0",
         "@aws-sdk/region-config-resolver": "3.930.0",
         "@aws-sdk/types": "3.930.0",
         "@aws-sdk/util-endpoints": "3.930.0",
         "@aws-sdk/util-user-agent-browser": "3.930.0",
-        "@aws-sdk/util-user-agent-node": "3.931.0",
+        "@aws-sdk/util-user-agent-node": "3.932.0",
         "@smithy/config-resolver": "^4.4.3",
         "@smithy/core": "^3.18.2",
         "@smithy/fetch-http-handler": "^5.3.6",
@@ -723,9 +723,9 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.931.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.931.0.tgz",
-      "integrity": "sha512-l/b6AQbto4TuXL2FIm7Z+tbVjrp0LN7ESm97Sf3nneB0vjKtB6R0TS/IySzCYMgyOC3Hxz+Ka34HJXZk9eXTFw==",
+      "version": "3.932.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
+      "integrity": "sha512-AS8gypYQCbNojwgjvZGkJocC2CoEICDx9ZJ15ILsv+MlcCVLtUJSRSx3VzJOUY2EEIaGLRrPNlIqyn/9/fySvA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.930.0",
@@ -747,12 +747,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.931.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.931.0.tgz",
-      "integrity": "sha512-dTNBpkKXyBdcpEjyfgkE/EFU/0NRoukLs+Pj0S8K1Dg216J9uIijpi6CaBBN+HvnaTlEItm2tzXiJpPVI+TqHQ==",
+      "version": "3.932.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.932.0.tgz",
+      "integrity": "sha512-ozge/c7NdHUDyHqro6+P5oHt8wfKSUBN+olttiVfBe9Mw3wBMpPa3gQ0pZnG+gwBkKskBuip2bMR16tqYvUSEA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.931.0",
+        "@aws-sdk/core": "3.932.0",
         "@aws-sdk/types": "3.930.0",
         "@smithy/property-provider": "^4.2.5",
         "@smithy/types": "^4.9.0",
@@ -763,12 +763,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.931.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.931.0.tgz",
-      "integrity": "sha512-7Ge26fhMDn51BTbHgopx5+uOl4I47k15BDzYc4YT6zyjS99uycYNCA7zB500DGTTn2HK27ZDTyAyhTKZGxRxbA==",
+      "version": "3.932.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.932.0.tgz",
+      "integrity": "sha512-b6N9Nnlg8JInQwzBkUq5spNaXssM3h3zLxGzpPrnw0nHSIWPJPTbZzA5Ca285fcDUFuKP+qf3qkuqlAjGOdWhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.931.0",
+        "@aws-sdk/core": "3.932.0",
         "@aws-sdk/types": "3.930.0",
         "@smithy/fetch-http-handler": "^5.3.6",
         "@smithy/node-http-handler": "^4.4.5",
@@ -784,18 +784,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.931.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.931.0.tgz",
-      "integrity": "sha512-uzicpP7IHBxvAMjwGdmeke2bGTxjsKCSW7N48zuv0t0d56hmGHfcZIK5p4ry2OBJxzScp182OUAdAEG8wuSuuA==",
+      "version": "3.932.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.932.0.tgz",
+      "integrity": "sha512-ZBjSAXVGy7danZRHCRMJQ7sBkG1Dz39thYlvTiUaf9BKZ+8ymeiFhuTeV1OkWUBBnY0ki2dVZJvboTqfINhNxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.931.0",
-        "@aws-sdk/credential-provider-env": "3.931.0",
-        "@aws-sdk/credential-provider-http": "3.931.0",
-        "@aws-sdk/credential-provider-process": "3.931.0",
-        "@aws-sdk/credential-provider-sso": "3.931.0",
-        "@aws-sdk/credential-provider-web-identity": "3.931.0",
-        "@aws-sdk/nested-clients": "3.931.0",
+        "@aws-sdk/core": "3.932.0",
+        "@aws-sdk/credential-provider-env": "3.932.0",
+        "@aws-sdk/credential-provider-http": "3.932.0",
+        "@aws-sdk/credential-provider-process": "3.932.0",
+        "@aws-sdk/credential-provider-sso": "3.932.0",
+        "@aws-sdk/credential-provider-web-identity": "3.932.0",
+        "@aws-sdk/nested-clients": "3.932.0",
         "@aws-sdk/types": "3.930.0",
         "@smithy/credential-provider-imds": "^4.2.5",
         "@smithy/property-provider": "^4.2.5",
@@ -808,17 +808,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.931.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.931.0.tgz",
-      "integrity": "sha512-eO8mfWNHz0dyYdVfPLVzmqXaSA3agZF/XvBO9/fRU90zCb8lKlXfgUmghGW7LhDkiv2v5uuizUiag7GsKoIcJw==",
+      "version": "3.932.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.932.0.tgz",
+      "integrity": "sha512-SEG9t2taBT86qe3gTunfrK8BxT710GVLGepvHr+X5Pw+qW225iNRaGN0zJH+ZE/j91tcW9wOaIoWnURkhR5wIg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.931.0",
-        "@aws-sdk/credential-provider-http": "3.931.0",
-        "@aws-sdk/credential-provider-ini": "3.931.0",
-        "@aws-sdk/credential-provider-process": "3.931.0",
-        "@aws-sdk/credential-provider-sso": "3.931.0",
-        "@aws-sdk/credential-provider-web-identity": "3.931.0",
+        "@aws-sdk/credential-provider-env": "3.932.0",
+        "@aws-sdk/credential-provider-http": "3.932.0",
+        "@aws-sdk/credential-provider-ini": "3.932.0",
+        "@aws-sdk/credential-provider-process": "3.932.0",
+        "@aws-sdk/credential-provider-sso": "3.932.0",
+        "@aws-sdk/credential-provider-web-identity": "3.932.0",
         "@aws-sdk/types": "3.930.0",
         "@smithy/credential-provider-imds": "^4.2.5",
         "@smithy/property-provider": "^4.2.5",
@@ -831,12 +831,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.931.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.931.0.tgz",
-      "integrity": "sha512-8Mu9r+5BUKqmKSI/WYHl5o4GeoonEb51RmoLEqG6431Uz4Y8C6gzAT69yjOJ+MwoWQ2Os37OZLOTv7SgxyOgrQ==",
+      "version": "3.932.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.932.0.tgz",
+      "integrity": "sha512-BodZYKvT4p/Dkm28Ql/FhDdS1+p51bcZeMMu2TRtU8PoMDHnVDhHz27zASEKSZwmhvquxHrZHB0IGuVqjZUtSQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.931.0",
+        "@aws-sdk/core": "3.932.0",
         "@aws-sdk/types": "3.930.0",
         "@smithy/property-provider": "^4.2.5",
         "@smithy/shared-ini-file-loader": "^4.4.0",
@@ -848,14 +848,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.931.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.931.0.tgz",
-      "integrity": "sha512-FP31lfMgNMDG4ZDX4NUZ+uoHWn76etcG8UWEgzZb4YOPV4M8a7gwU95iD+RBaK4lV3KvwH2tu68Hmne1qQpFqQ==",
+      "version": "3.932.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.932.0.tgz",
+      "integrity": "sha512-XYmkv+ltBjjmPZ6AmR1ZQZkQfD0uzG61M18/Lif3HAGxyg3dmod0aWx9aL6lj9SvxAGqzscrx5j4PkgLqjZruw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.931.0",
-        "@aws-sdk/core": "3.931.0",
-        "@aws-sdk/token-providers": "3.931.0",
+        "@aws-sdk/client-sso": "3.932.0",
+        "@aws-sdk/core": "3.932.0",
+        "@aws-sdk/token-providers": "3.932.0",
         "@aws-sdk/types": "3.930.0",
         "@smithy/property-provider": "^4.2.5",
         "@smithy/shared-ini-file-loader": "^4.4.0",
@@ -867,13 +867,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.931.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.931.0.tgz",
-      "integrity": "sha512-hfX0Buw2+ie0FBiSFMmnXfugQc9fO0KvEojnNnzhk4utlWjZobMcUprOQ/VKUueg0Kga1b1xu8gEP6g1aEh3zw==",
+      "version": "3.932.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.932.0.tgz",
+      "integrity": "sha512-Yw/hYNnC1KHuVIQF9PkLXbuKN7ljx70OSbJYDRufllQvej3kRwNcqQSnzI1M4KaObccqKaE6srg22DqpPy9p8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.931.0",
-        "@aws-sdk/nested-clients": "3.931.0",
+        "@aws-sdk/core": "3.932.0",
+        "@aws-sdk/nested-clients": "3.932.0",
         "@aws-sdk/types": "3.930.0",
         "@smithy/property-provider": "^4.2.5",
         "@smithy/shared-ini-file-loader": "^4.4.0",
@@ -918,15 +918,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.931.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.931.0.tgz",
-      "integrity": "sha512-eYWwUKeEommCrrm0Ro6fGDwVO0x2bL3niOmSnHIlIdpu7ruzAGaphj+2MekCxaSPORzkZ3yheHUzV45D8Qj63A==",
+      "version": "3.932.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.932.0.tgz",
+      "integrity": "sha512-hyvRz/XS/0HTHp9/Ld1mKwpOi7bZu5olI42+T112rkCTbt1bewkygzEl4oflY4H7cKMamQusYoL0yBUD/QSEvA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "3.931.0",
+        "@aws-sdk/core": "3.932.0",
         "@aws-sdk/types": "3.930.0",
         "@smithy/is-array-buffer": "^4.2.0",
         "@smithy/node-config-provider": "^4.3.5",
@@ -1001,12 +1001,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.931.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.931.0.tgz",
-      "integrity": "sha512-uWF78ht8Wgxljn6y0cEcIWfbeTVnJ0cE1Gha9ScCqscmuBCpHuFMSd/p53w3whoDhpQL3ln9mOyY3tfST/NUQA==",
+      "version": "3.932.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.932.0.tgz",
+      "integrity": "sha512-bYMHxqQzseaAP9Z5qLI918z5AtbAnZRRtFi3POb4FLZyreBMgCgBNaPkIhdgywnkqaydTWvbMBX4s9f4gUwlTw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.931.0",
+        "@aws-sdk/core": "3.932.0",
         "@aws-sdk/types": "3.930.0",
         "@aws-sdk/util-arn-parser": "3.893.0",
         "@smithy/core": "^3.18.2",
@@ -1040,12 +1040,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.931.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.931.0.tgz",
-      "integrity": "sha512-Ftd+f3+y5KNYKzLXaGknwJ9hCkFWshi5C9TLLsz+fEohWc1FvIKU7MlXTeFms2eN76TTVHuG8N2otaujl6CuHg==",
+      "version": "3.932.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.932.0.tgz",
+      "integrity": "sha512-9BGTbJyA/4PTdwQWE9hAFIJGpsYkyEW20WON3i15aDqo5oRZwZmqaVageOD57YYqG8JDJjvcwKyDdR4cc38dvg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.931.0",
+        "@aws-sdk/core": "3.932.0",
         "@aws-sdk/types": "3.930.0",
         "@aws-sdk/util-endpoints": "3.930.0",
         "@smithy/core": "^3.18.2",
@@ -1058,23 +1058,23 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.931.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.931.0.tgz",
-      "integrity": "sha512-6/dXrX2nWgiWdHxooEtmKpOErms4+79AQawEvhhxpLPpa+tixl4i/MSFgHk9sjkGv5a1/P3DbnedpZWl+2wMOg==",
+      "version": "3.932.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.932.0.tgz",
+      "integrity": "sha512-E2ucBfiXSpxZflHTf3UFbVwao4+7v7ctAeg8SWuglc1UMqMlpwMFFgWiSONtsf0SR3+ZDoWGATyCXOfDWerJuw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.931.0",
+        "@aws-sdk/core": "3.932.0",
         "@aws-sdk/middleware-host-header": "3.930.0",
         "@aws-sdk/middleware-logger": "3.930.0",
         "@aws-sdk/middleware-recursion-detection": "3.930.0",
-        "@aws-sdk/middleware-user-agent": "3.931.0",
+        "@aws-sdk/middleware-user-agent": "3.932.0",
         "@aws-sdk/region-config-resolver": "3.930.0",
         "@aws-sdk/types": "3.930.0",
         "@aws-sdk/util-endpoints": "3.930.0",
         "@aws-sdk/util-user-agent-browser": "3.930.0",
-        "@aws-sdk/util-user-agent-node": "3.931.0",
+        "@aws-sdk/util-user-agent-node": "3.932.0",
         "@smithy/config-resolver": "^4.4.3",
         "@smithy/core": "^3.18.2",
         "@smithy/fetch-http-handler": "^5.3.6",
@@ -1123,12 +1123,12 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.931.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.931.0.tgz",
-      "integrity": "sha512-EGYYDSSk7k1xbSHtb8MfEMILf5achdNnnsYKgFk0+Oul3tPQ4xUmOt5qRP6sOO3/LQHF37gBYHUF9OSA/+uVCw==",
+      "version": "3.932.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.932.0.tgz",
+      "integrity": "sha512-NCIRJvoRc9246RZHIusY1+n/neeG2yGhBGdKhghmrNdM+mLLN6Ii7CKFZjx3DhxtpHMpl1HWLTMhdVrGwP2upw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.931.0",
+        "@aws-sdk/middleware-sdk-s3": "3.932.0",
         "@aws-sdk/types": "3.930.0",
         "@smithy/protocol-http": "^5.3.5",
         "@smithy/signature-v4": "^5.3.5",
@@ -1140,13 +1140,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.931.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.931.0.tgz",
-      "integrity": "sha512-dr+02X9oxqmXG0856odFJ7wAXy12pr/tq2Zg+IS0TDThFvgtvx4yChkpqmc89wGoW+Aly47JPfPUXh0IMpGzIg==",
+      "version": "3.932.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.932.0.tgz",
+      "integrity": "sha512-43u82ulVuHK4zWhcSPyuPS18l0LNHi3QJQ1YtP2MfP8bPf5a6hMYp5e3lUr9oTDEWcpwBYtOW0m1DVmoU/3veA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.931.0",
-        "@aws-sdk/nested-clients": "3.931.0",
+        "@aws-sdk/core": "3.932.0",
+        "@aws-sdk/nested-clients": "3.932.0",
         "@aws-sdk/types": "3.930.0",
         "@smithy/property-provider": "^4.2.5",
         "@smithy/shared-ini-file-loader": "^4.4.0",
@@ -1221,12 +1221,12 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.931.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.931.0.tgz",
-      "integrity": "sha512-j5if01rt7JCGYDVXck39V7IUyKAN73vKUPzmu+jp1apU3Q0lLSTZA/HCfL2HkMUKVLE67ibjKb+NCoEg0QhujA==",
+      "version": "3.932.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.932.0.tgz",
+      "integrity": "sha512-/kC6cscHrZL74TrZtgiIL5jJNbVsw9duGGPurmaVgoCbP7NnxyaSWEurbNV3VPNPhNE3bV3g4Ci+odq+AlsYQg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.931.0",
+        "@aws-sdk/middleware-user-agent": "3.932.0",
         "@aws-sdk/types": "3.930.0",
         "@smithy/node-config-provider": "^4.3.5",
         "@smithy/types": "^4.9.0",
@@ -3330,40 +3330,6 @@
         "into-stream": "^6.0.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
-      "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
@@ -4617,7 +4583,11 @@
         "@graphql-codegen/plugin-helpers": "^6.0.0",
         "@graphql-codegen/visitor-plugin-common": "6.1.2",
         "@graphql-tools/utils": "^10.0.0",
+        "auto-bind": "~4.0.0",
         "tslib": "~2.6.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -4672,7 +4642,11 @@
         "@graphql-codegen/plugin-helpers": "^6.0.0",
         "@graphql-codegen/visitor-plugin-common": "6.1.2",
         "auto-bind": "~4.0.0",
+        "change-case-all": "1.0.15",
         "tslib": "~2.6.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -7139,19 +7113,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.10.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -10324,6 +10285,19 @@
         "react": ">=16.13.1"
       }
     },
+    "node_modules/@samvera/clover-iiif/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@samvera/image-downloader": {
       "version": "1.1.6",
       "license": "ISC",
@@ -10415,12 +10389,12 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.18.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.3.tgz",
-      "integrity": "sha512-qqpNskkbHOSfrbFbjhYj5o8VMXO26fvN1K/+HbCzUNlTuxgNcPRouUDNm+7D6CkN244WG7aK533Ne18UtJEgAA==",
+      "version": "3.18.4",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.4.tgz",
+      "integrity": "sha512-o5tMqPZILBvvROfC8vC+dSVnWJl9a0u9ax1i1+Bq8515eYjUJqqk5XjjEsDLoeL5dSqGSh6WGdVx1eJ1E/Nwhw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.5",
+        "@smithy/middleware-serde": "^4.2.6",
         "@smithy/protocol-http": "^5.3.5",
         "@smithy/types": "^4.9.0",
         "@smithy/util-base64": "^4.3.0",
@@ -10635,13 +10609,13 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.10.tgz",
-      "integrity": "sha512-SoAag3QnWBFoXjwa1jenEThkzJYClidZUyqsLKwWZ8kOlZBwehrLBp4ygVDjNEM2a2AamCQ2FBA/HuzKJ/LiTA==",
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.11.tgz",
+      "integrity": "sha512-eJXq9VJzEer1W7EQh3HY2PDJdEcEUnv6sKuNt4eVjyeNWcQFS4KmnY+CKkYOIR6tSqarn6bjjCqg1UB+8UJiPQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.18.3",
-        "@smithy/middleware-serde": "^4.2.5",
+        "@smithy/core": "^3.18.4",
+        "@smithy/middleware-serde": "^4.2.6",
         "@smithy/node-config-provider": "^4.3.5",
         "@smithy/shared-ini-file-loader": "^4.4.0",
         "@smithy/types": "^4.9.0",
@@ -10654,15 +10628,15 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.10.tgz",
-      "integrity": "sha512-6fOwX34gXxcqKa3bsG0mR0arc2Cw4ddOS6tp3RgUD2yoTrDTbQ2aVADnDjhUuxaiDZN2iilxndgGDhnpL/XvJA==",
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.11.tgz",
+      "integrity": "sha512-EL5OQHvFOKneJVRgzRW4lU7yidSwp/vRJOe542bHgExN3KNThr1rlg0iE4k4SnA+ohC+qlUxoK+smKeAYPzfAQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.5",
         "@smithy/protocol-http": "^5.3.5",
         "@smithy/service-error-classification": "^4.2.5",
-        "@smithy/smithy-client": "^4.9.6",
+        "@smithy/smithy-client": "^4.9.7",
         "@smithy/types": "^4.9.0",
         "@smithy/util-middleware": "^4.2.5",
         "@smithy/util-retry": "^4.2.5",
@@ -10674,9 +10648,9 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.5.tgz",
-      "integrity": "sha512-La1ldWTJTZ5NqQyPqnCNeH9B+zjFhrNoQIL1jTh4zuqXRlmXhxYHhMtI1/92OlnoAtp6JoN7kzuwhWoXrBwPqg==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.6.tgz",
+      "integrity": "sha512-VkLoE/z7e2g8pirwisLz8XJWedUSY8my/qrp81VmAdyrhi94T+riBfwP+AOEEFR9rFTSonC/5D2eWNmFabHyGQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.5",
@@ -10829,13 +10803,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.9.6",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.6.tgz",
-      "integrity": "sha512-hGz42hggqReicRRZUvrKDQiAmoJnx1Q+XfAJnYAGu544gOfxQCAC3hGGD7+Px2gEUUxB/kKtQV7LOtBRNyxteQ==",
+      "version": "4.9.7",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.7.tgz",
+      "integrity": "sha512-pskaE4kg0P9xNQWihfqlTMyxyFR3CH6Sr6keHYghgyqqDXzjl2QJg5lAzuVe/LzZiOzcbcVtxKYi1/fZPt/3DA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.18.3",
-        "@smithy/middleware-endpoint": "^4.3.10",
+        "@smithy/core": "^3.18.4",
+        "@smithy/middleware-endpoint": "^4.3.11",
         "@smithy/middleware-stack": "^4.2.5",
         "@smithy/protocol-http": "^5.3.5",
         "@smithy/types": "^4.9.0",
@@ -10936,13 +10910,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.9.tgz",
-      "integrity": "sha512-Bh5bU40BgdkXE2BcaNazhNtEXi1TC0S+1d84vUwv5srWfvbeRNUKFzwKQgC6p6MXPvEgw+9+HdX3pOwT6ut5aw==",
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.10.tgz",
+      "integrity": "sha512-3iA3JVO1VLrP21FsZZpMCeF93aqP3uIOMvymAT3qHIJz2YlgDeRvNUspFwCNqd/j3qqILQJGtsVQnJZICh/9YA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.5",
-        "@smithy/smithy-client": "^4.9.6",
+        "@smithy/smithy-client": "^4.9.7",
         "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
@@ -10951,16 +10925,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.12.tgz",
-      "integrity": "sha512-EHZwe1E9Q7umImIyCKQg/Cm+S+7rjXxCRvfGmKifqwYvn7M8M4ZcowwUOQzvuuxUUmdzCkqL0Eq0z1m74Pq6pw==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.13.tgz",
+      "integrity": "sha512-PTc6IpnpSGASuzZAgyUtaVfOFpU0jBD2mcGwrgDuHf7PlFgt5TIPxCYBDbFQs06jxgeV3kd/d/sok1pzV0nJRg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.4.3",
         "@smithy/credential-provider-imds": "^4.2.5",
         "@smithy/node-config-provider": "^4.3.5",
         "@smithy/property-provider": "^4.2.5",
-        "@smithy/smithy-client": "^4.9.6",
+        "@smithy/smithy-client": "^4.9.7",
         "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
@@ -11393,17 +11367,6 @@
       "version": "1.0.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
@@ -11906,188 +11869,6 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
-    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-android-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
@@ -12114,65 +11895,6 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "^0.2.11"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/@webassemblyjs/ast": {
@@ -13192,17 +12914,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bluebird": {
@@ -16271,14 +15982,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/filesize": {
       "version": "6.4.0",
       "license": "BSD-3-Clause",
@@ -16622,21 +16325,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -22189,14 +21877,6 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/nan": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
-      "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/nanoid": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
@@ -26865,17 +26545,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "dev": true,
@@ -27156,26 +26825,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/watchpack-chokidar2/node_modules/fsevents": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-      "deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1"
-      },
-      "engines": {
-        "node": ">= 4.0"
       }
     },
     "node_modules/watchpack-chokidar2/node_modules/glob-parent": {


### PR DESCRIPTION
# Summary 

This adds a Transcription workflow for Access file sets that are images. This follows a rather linear workflow.

Note: This seems to work very well on both handwritten and print material. It does seem to want to always provide some `content` in an annotation even if text is not preset. We may want to refine the prompt to avoid this and direct it that its okay for a an empty string to be the value.

1) Transcription button will not show until the file set has a representative image URL

<img width="1380" height="729" alt="image" src="https://github.com/user-attachments/assets/fd76139c-61b5-470b-b160-88f8db72f2ba" />

2) Once image is processed and IIIF'd, user can click the Transcription button to open the modal.

<img width="1373" height="726" alt="image" src="https://github.com/user-attachments/assets/3a2ebdc0-7352-4410-84f3-c3f415477adb" />

3) The Clover Image component will render alongside a Generate Transcription button. 

<img width="1312" height="636" alt="image" src="https://github.com/user-attachments/assets/03aa2477-9bbd-43b2-b7e1-85ce6724e242" />

4) Clicking the Generate Transcription button will send the mutation to transcribe to image.

<img width="1318" height="646" alt="image" src="https://github.com/user-attachments/assets/246d7423-b030-4b0f-8c08-93698be5f139" />

5) A subscription will watch the file set for annotations coming downstream which will populate into a textarea when available.

<img width="1321" height="645" alt="image" src="https://github.com/user-attachments/assets/dd25f2a8-872b-41d1-b4c0-d9064119c87b" />

6) At this point the Annoation is saved. The user can then further modify the textarea content and save again.

<img width="1314" height="629" alt="image" src="https://github.com/user-attachments/assets/8d6a6ab8-8a24-44a9-b8dc-b2468e319004" />

# Specific Changes in this PR
- Add Transcription UI

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test

Follow steps above on any item with text.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

