### PR TITLE
Add subscriptions for annotation updates

### DIFF
--- a/app/lib/meadow/config/runtime.ex
+++ b/app/lib/meadow/config/runtime.ex
@@ -94,6 +94,7 @@ defmodule Meadow.Config.Runtime do
       publication: "events",
       subscriptions: ["works", "file_sets", "file_set_annotations", "collections", "ingest_sheets", "projects"],
       modules: [
+        Meadow.Events.FileSets.Annotations,
         Meadow.Events.FileSets.Cleanup,
         Meadow.Events.FileSets.StructuralMetadata,
         Meadow.Events.IngestSheets.SheetUpdates,
@@ -101,7 +102,7 @@ defmodule Meadow.Config.Runtime do
         Meadow.Events.Indexing
       ],
       name: Meadow,
-      slot_name: "meadow_#{prefix()}",
+      slot_name: String.replace("meadow_#{prefix()}", "-", "_"),
       durable_slot: true
 
     host = System.get_env("MEADOW_HOSTNAME", "localhost")

--- a/app/lib/meadow/events/file_sets/annotations.ex
+++ b/app/lib/meadow/events/file_sets/annotations.ex
@@ -1,0 +1,38 @@
+defmodule Meadow.Events.FileSets.Annotations do
+  @moduledoc """
+  Handles events related to annotations for file sets.
+  """
+
+  alias Meadow.Data.Schemas.{FileSet, FileSetAnnotation, Work}
+  alias Meadow.Notification
+  alias Meadow.Repo
+
+  use Meadow.Utils.Logging
+  use WalEx.Event, name: Meadow
+
+  import Ecto.Query, only: [from: 2]
+
+  require Logger
+
+  on_event(:file_set_annotations, %{}, [{__MODULE__, :notify_annotation_subscriptions}], & &1)
+
+  def notify_annotation_subscriptions(%{type: :delete}), do: :ok
+
+  def notify_annotation_subscriptions(%{new_record: %{id: id}, changes: %{status: _}}) do
+    {annotation, file_set_id, work_id} =
+      from(fsa in FileSetAnnotation,
+        where: fsa.id == ^id,
+        join: fs in FileSet,
+        on: fs.id == fsa.file_set_id,
+        join: w in Work,
+        on: w.id == fs.work_id,
+        select: {fsa, fs.id, w.id}
+      )
+      |> Repo.one()
+
+    Notification.publish(annotation, file_set_annotation: file_set_id)
+    Notification.publish(annotation, work_file_set_annotation: work_id)
+  end
+
+  def notify_annotation_subscriptions(_), do: :ok
+end

--- a/app/lib/meadow_web/schema/schema.ex
+++ b/app/lib/meadow_web/schema/schema.ex
@@ -57,6 +57,8 @@ defmodule MeadowWeb.Schema do
 
   subscription do
     import_fields(:ingest_subscriptions)
+    import_fields(:file_set_subscriptions)
+    import_fields(:work_subscriptions)
   end
 
   enum :sort_order do

--- a/app/lib/meadow_web/schema/types/data/file_set_types.ex
+++ b/app/lib/meadow_web/schema/types/data/file_set_types.ex
@@ -92,6 +92,17 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
     end
   end
 
+  object :file_set_subscriptions do
+    @desc "Subscription for file set annotation updates"
+    field :file_set_annotation, :file_set_annotation do
+      arg(:file_set_id, non_null(:id))
+
+      config(fn args, _ ->
+        {:ok, topic: args.file_set_id}
+      end)
+    end
+  end
+
   #
   # Input Object Types
   #

--- a/app/lib/meadow_web/schema/types/data/work_types.ex
+++ b/app/lib/meadow_web/schema/types/data/work_types.ex
@@ -124,6 +124,17 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     end
   end
 
+  object :work_subscriptions do
+    @desc "Subscription for annotation updates for all file sets within a work"
+    field :work_file_set_annotation, :file_set_annotation do
+      arg(:work_id, non_null(:id))
+
+      config(fn args, _ ->
+        {:ok, topic: args.work_id}
+      end)
+    end
+  end
+
   @desc "Result of transferring file sets"
   object :transfer_file_sets_result do
     field(:transferred_fileset_ids, non_null(list_of(:string)))

--- a/app/priv/repo/migrations/20250218041322_create_publication_events.exs
+++ b/app/priv/repo/migrations/20250218041322_create_publication_events.exs
@@ -16,7 +16,7 @@ defmodule Meadow.Repo.Migrations.CreatePublicationEvents do
   def down do
     # Reset REPLICA IDENTITY to default
     Enum.each(@tables, fn table ->
-      execute("ALTER TABLE #{table} REPLICA IDENTITY FULL")
+      execute("ALTER TABLE #{table} REPLICA IDENTITY DEFAULT")
     end)
 
     execute("DROP PUBLICATION IF EXISTS events")

--- a/app/test/gql/FileSetAnnotation.gql
+++ b/app/test/gql/FileSetAnnotation.gql
@@ -1,0 +1,9 @@
+subscription FileSetAnnotation($fileSetId: ID!) {
+  fileSetAnnotation(fileSetId: $fileSetId) {
+    id
+    type
+    language
+    status
+    content
+  }
+}

--- a/app/test/gql/WorkFileSetAnnotation.gql
+++ b/app/test/gql/WorkFileSetAnnotation.gql
@@ -1,0 +1,9 @@
+subscription WorkFileSetAnnotation($workId: ID!) {
+  workFileSetAnnotation(workId: $workId) {
+    id
+    type
+    language
+    status
+    content
+  }
+}

--- a/app/test/meadow_web/schema/subscription/file_set_annotation_status_test.exs
+++ b/app/test/meadow_web/schema/subscription/file_set_annotation_status_test.exs
@@ -1,0 +1,49 @@
+defmodule MeadowWeb.Schema.Subscription.FileSetAnnotationTest do
+  use Meadow.DataCase, sandbox: false
+  use MeadowWeb.SubscriptionCase, async: false
+
+  alias Meadow.Data.FileSets
+
+  @reply_timeout 5000
+
+  load_gql(MeadowWeb.Schema, "test/gql/FileSetAnnotation.gql")
+
+  @moduletag walex: [Meadow.Events.FileSets.Annotations]
+  describe "FileSet annotation subscription" do
+    setup %{socket: socket} do
+      %{file_sets: [file_set | _]} = work_with_file_sets_fixture(1)
+
+      {:ok, annotation} =
+        FileSets.create_annotation(file_set, %{type: "transcription", status: "in_progress"})
+
+      {:ok, s3_location} = FileSets.write_annotation_content(annotation, "Original content")
+      {:ok, annotation} = FileSets.update_annotation(annotation, %{s3_location: s3_location})
+
+      {:ok,
+       %{
+         annotation: annotation,
+         file_set: file_set,
+         ref:
+           subscribe_gql(socket, variables: %{"fileSetId" => file_set.id, context: gql_context()})
+       }}
+    end
+
+    test "receive annotation status updates", %{annotation: annotation, ref: ref} do
+      assert_reply ref, :ok, %{subscriptionId: _subscription_id}, @reply_timeout
+      annotation_id = annotation.id
+      status = "completed"
+      FileSets.update_annotation(annotation, %{status: status})
+
+      assert_push "subscription:data", %{
+        result: %{
+          data: %{
+            "fileSetAnnotation" => %{
+              "id" => ^annotation_id,
+              "status" => ^status
+            }
+          }
+        }
+      }
+    end
+  end
+end

--- a/app/test/meadow_web/schema/subscription/work_file_set_annotation_status_test.exs
+++ b/app/test/meadow_web/schema/subscription/work_file_set_annotation_status_test.exs
@@ -1,0 +1,72 @@
+defmodule MeadowWeb.Schema.Subscription.WorkFileSetAnnotationTest do
+  use Meadow.DataCase
+  use MeadowWeb.SubscriptionCase, async: false
+
+  alias Meadow.Data.FileSets
+
+  @reply_timeout 5000
+
+  load_gql(MeadowWeb.Schema, "test/gql/WorkFileSetAnnotation.gql")
+
+  @moduletag walex: [Meadow.Events.FileSets.Annotations]
+  describe "Work FileSet annotation status subscription" do
+    setup %{socket: socket} do
+      %{file_sets: file_sets} = work = work_with_file_sets_fixture(2)
+
+      annotations =
+        file_sets
+        |> Enum.map(fn fs ->
+          {:ok, annotation} =
+            FileSets.create_annotation(fs, %{type: "transcription", status: "in_progress"})
+
+          {:ok, s3_location} =
+            FileSets.write_annotation_content(annotation, "Original content for " <> fs.id)
+
+          {:ok, annotation} = FileSets.update_annotation(annotation, %{s3_location: s3_location})
+          annotation
+        end)
+
+      {:ok,
+       %{
+         work: work,
+         file_sets: file_sets,
+         annotations: annotations,
+         ref: subscribe_gql(socket, variables: %{"workId" => work.id, context: gql_context()})
+       }}
+    end
+
+    test "receive annotation status updates", %{annotations: [a1, a2], ref: ref} do
+      assert_reply ref, :ok, %{subscriptionId: _subscription_id}, @reply_timeout
+      a1_id = a1.id
+      a2_id = a2.id
+
+      status = "completed"
+      FileSets.update_annotation(a1, %{status: status})
+
+      assert_push "subscription:data", %{
+        result: %{
+          data: %{
+            "workFileSetAnnotation" => %{
+              "id" => ^a1_id,
+              "status" => ^status
+            }
+          }
+        }
+      }
+
+      status = "error"
+      FileSets.update_annotation(a2, %{status: status})
+
+      assert_push "subscription:data", %{
+        result: %{
+          data: %{
+            "workFileSetAnnotation" => %{
+              "id" => ^a2_id,
+              "status" => ^status
+            }
+          }
+        }
+      }
+    end
+  end
+end

--- a/app/test/support/data_case.ex
+++ b/app/test/support/data_case.ex
@@ -46,7 +46,8 @@ defmodule Meadow.DataCase do
 
     on_exit(fn ->
       if not sandbox do
-        for table <- ~w(ark_cache works collections file_sets projects ingest_sheets) do
+        for table <-
+              ~w(ark_cache works collections file_sets file_set_annotations projects ingest_sheets) do
           {:ok, _} = SQL.query(Repo, "TRUNCATE TABLE #{table} CASCADE", [])
         end
       end


### PR DESCRIPTION
# Summary 
Add subscriptions for annotation updates at the Work and FileSet levels

# Specific Changes in this PR
- Add the `fileSetAnnotation` subscription, taking a `fileSetId`
- Add the `workFileSetAnnotation` subscription, taking a `workId`
- Send both work and file set notifications whenever `file_set_annotations.status` changes
- Write tests

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Subscribe to annotation updates for both the file set and its work before you kick off a transcription. Watch for updates.


# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [x] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

