### PR TITLE
Fix memory allocation error on pyramid TIFF creation

### DIFF
--- a/lambdas/pyramid-tiff/pyramid.js
+++ b/lambdas/pyramid-tiff/pyramid.js
@@ -11,7 +11,8 @@ const createPyramidTiff = (source, dest) => {
       let metadata;
       const transformStream = sharp({
         limitInputPixels: false,
-        sequentialRead: true
+        sequentialRead: true,
+        unlimited: true
       })
       .removeAlpha()
       .resize({


### PR DESCRIPTION
# Summary 

Fix memory allocation error on pyramid TIFF creation.

Terraform only change.

# Specific Changes in this PR
- Add `unlimited: true` to TIFF creation in `pyramid.js`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

