### PR TITLE
Send status_update responses via the chat_response subscription

### DIFF
--- a/app/lib/meadow/application/caches.ex
+++ b/app/lib/meadow/application/caches.ex
@@ -8,6 +8,12 @@ defmodule Meadow.Application.Caches do
     [
       cache_spec(:global_cache, Meadow.Cache),
       cache_spec(
+        :chat_conversation_cache,
+        Meadow.Cache.Chat.Conversations,
+        expiration: Cachex.Spec.expiration(default: :timer.hours(6)),
+        stats: true
+      ),
+      cache_spec(
         :coded_term_cache,
         Meadow.Cache.CodedTerms,
         expiration: Cachex.Spec.expiration(default: :timer.hours(6)),

--- a/app/lib/meadow_web/resolvers/chat.ex
+++ b/app/lib/meadow_web/resolvers/chat.ex
@@ -13,8 +13,8 @@ defmodule MeadowWeb.Resolvers.Chat do
     case Planner.create_plan(%{prompt: prompt, query: query}) do
       {:ok, plan} ->
         # Publish plan_id immediately to frontend with dedicated message type
-        Absinthe.Subscription.publish(
-          MeadowWeb.Endpoint,
+        Cachex.put!(Meadow.Cache.Chat.Conversations, plan.id, conversation_id)
+        Meadow.Notification.publish(
           %{
             conversation_id: conversation_id,
             message: "Plan created with ID: #{plan.id}",
@@ -29,8 +29,7 @@ defmodule MeadowWeb.Resolvers.Chat do
           {:ok, ai_response} = MeadowAI.query(prompt, context: %{query: query, plan_id: plan.id})
 
           # Publish final agent response as chat message
-          Absinthe.Subscription.publish(
-            MeadowWeb.Endpoint,
+          Meadow.Notification.publish(
             %{
               conversation_id: conversation_id,
               message: ai_response,

--- a/app/priv/python/agent/src/meadow_metadata_agent/execute.py
+++ b/app/priv/python/agent/src/meadow_metadata_agent/execute.py
@@ -2,7 +2,7 @@ import json
 from claude_agent_sdk import create_sdk_mcp_server, ClaudeAgentOptions, ClaudeSDKClient, AgentDefinition, ResultMessage
 from .prompts import (agent_prompt, proposer_prompt, system_prompt)
 from .message_handler import emit, emit_message
-from .tools import (make_fetch_iiif_image_tool)
+from .tools import (make_fetch_iiif_image_tool, send_status_update_tool)
 
 async def query_claude(model, prompt, context_json, mcp_url, iiif_server_url, additional_headers={}):
     context_data = json.loads(context_json) if context_json else {}
@@ -36,10 +36,10 @@ async def execute_agent(model, prompt, context_data, mcp_url, iiif_server_url, a
         model=model,
         mcp_servers={
             "meadow": meadow_server_config,
-            "image_fetcher": create_sdk_mcp_server(
+            "agent_tools": create_sdk_mcp_server(
                 name="metadata",
                 version="1.0.0",
-                tools=[make_fetch_iiif_image_tool(additional_headers)]
+                tools=[make_fetch_iiif_image_tool(additional_headers), send_status_update_tool]
             )
         },
         allowed_tools=[
@@ -47,7 +47,8 @@ async def execute_agent(model, prompt, context_data, mcp_url, iiif_server_url, a
             "mcp__meadow__get_plan_changes",
             "mcp__meadow__propose_plan",
             "mcp__meadow__update_plan_change",
-            "mcp__image_fetcher__fetch_iiif_image"
+            "mcp__agent_tools__send_status_update",
+            "mcp__agent_tools__fetch_iiif_image"
         ],
         disallowed_tools=["Bash", "Grep", "Glob"],
         agents={
@@ -59,7 +60,8 @@ async def execute_agent(model, prompt, context_data, mcp_url, iiif_server_url, a
                     "mcp__meadow__get_plan_changes",
                     "mcp__meadow__propose_plan",
                     "mcp__meadow__update_plan_change",
-                    "mcp__image_fetcher__fetch_iiif_image"
+                    "mcp__agent_tools__send_status_update",
+                    "mcp__agent_tools__fetch_iiif_image",
                 ]
             )
         },

--- a/app/priv/python/agent/src/meadow_metadata_agent/prompts.py
+++ b/app/priv/python/agent/src/meadow_metadata_agent/prompts.py
@@ -24,6 +24,10 @@ def agent_prompt_with_plan(plan_id, user_query, context_data):
 
     Context data: {json.dumps(context_data, indent=2)}
 
+    CRITICAL: While processing the plan, you and the subagent MUST provide progress updates using the send_status_update tool.
+    Updates should be short (3-5 words), user-friendly progress messages, suitable for displaying in the UI to update the user on the 
+    progress of the plan.
+
     IMPORTANT: For controlled vocabulary fields like subject headings, creator names, genres, etc.,
     the subagent MUST use the authoritiesSearch GraphQL query to find valid controlled term IDs.
     Never make up or guess term IDs for these fields. 

--- a/app/priv/python/agent/src/meadow_metadata_agent/tools.py
+++ b/app/priv/python/agent/src/meadow_metadata_agent/tools.py
@@ -1,11 +1,50 @@
 # TOOLS
 
 import base64
+import json
 import requests
 from claude_agent_sdk import tool
 from typing import Any
 from urllib import parse
 from .message_handler import emit
+
+@tool(
+    name="send_status_update",
+    description="Sends a status update message for a specific plan",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "plan_id": {
+                "type": "string",
+                "description": "The unique identifier for the plan"
+            },
+            "message": {
+                "type": "string",
+                "description": "The status update message content to send"
+            },
+            "agent": {
+                "type": "string",
+                "description": "Identify yourself as an agent or a sub-agent"
+            }
+        },
+        "required": ["plan_id", "message", "agent"]
+    }
+)
+async def send_status_update_tool(args: dict[str, Any]) -> dict[str, Any]:
+    plan_id = args.get("plan_id")
+    message = args.get("message")
+    agent = args.get("agent")
+    if not message:
+        return {
+            "content": [{"type": "text", "text": "Error: message is required"}]
+        }
+    # Here you would implement the actual sending of the status update to the UI
+    # For this example, we'll just log it
+    payload = json.dumps({"plan_id": plan_id, "agent": agent, "message": message})
+    emit("status_update", payload)
+    return {
+        "content": [{"type": "text", "text": f"Status update sent"}]
+    }
 
 def make_fetch_iiif_image_tool(additional_headers = {}):
     @tool("fetch_iiif_image", "Fetch an image from an IIIF image information URI (ending with 'info.json')", {

--- a/app/test/meadow/application/children_test.exs
+++ b/app/test/meadow/application/children_test.exs
@@ -22,7 +22,7 @@ defmodule Meadow.Application.ChildrenTest do
 
     @tag environment: :test
     test "test processes" do
-      assert Children.specs() |> length() <= 13
+      assert Children.specs() |> length() <= 14
     end
 
     @tag environment: :prod


### PR DESCRIPTION
# Summary 


# Specific Changes in this PR
- Add `send_status_update` MCP tool for subagent to use
- Update `IOHandler` to receive and pass on status messages
- Update prompt to instruct agent and subagent to send status messages

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Do an auto-edit to request a plan on a work. Status messages should come through as bubbles in the main chat area until the front end changes how `chatResponse` messages of type `status_update` are handled.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

