### PR TITLE
Deprecate creator, location, publisher and tell agent not to use them

### DIFF
--- a/app/lib/meadow_web/schema/types/data/work_types.ex
+++ b/app/lib/meadow_web/schema/types/data/work_types.ex
@@ -171,10 +171,18 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
   @desc "`controlled_fields` represents all controlled descriptive metadata fields on a work."
   object :controlled_fields do
     field(:contributor, list_of(:controlled_metadata_entry))
-    field(:creator, list_of(:controlled_metadata_entry))
+
+    field(:creator, list_of(:controlled_metadata_entry)) do
+      deprecate "Creator field is deprecated"
+    end
+
     field(:genre, list_of(:controlled_metadata_entry))
     field(:language, list_of(:controlled_metadata_entry))
-    field(:location, list_of(:controlled_metadata_entry))
+
+    field(:location, list_of(:controlled_metadata_entry)) do
+      deprecate "Location field is deprecated"
+    end
+
     field(:notes, list_of(:note_entry))
     field(:related_url, list_of(:related_url_entry))
     field(:style_period, list_of(:controlled_metadata_entry))
@@ -201,7 +209,11 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     field(:physical_description_material, list_of(:string))
     field(:physical_description_size, list_of(:string))
     field(:provenance, list_of(:string))
-    field(:publisher, list_of(:string))
+
+    field(:publisher, list_of(:string)) do
+      deprecate "Publisher field is deprecated"
+    end
+
     field(:related_material, list_of(:string))
     field(:rights_holder, list_of(:string))
     field(:scope_and_contents, list_of(:string))

--- a/app/priv/python/agent/src/meadow_metadata_agent/prompts.py
+++ b/app/priv/python/agent/src/meadow_metadata_agent/prompts.py
@@ -34,6 +34,8 @@ def agent_prompt_with_plan(plan_id, user_query, context_data):
     
     IMPORTANT: For coded fields (controlled field roles, note types, etc.), the subagent MUST use the 
     codeList query to get the list of valid IDs.
+    
+    IMPORTANT: Do not propose any changes to deprecated fields.
 
     Once the subagent completes, provide a summary of the changes proposed.
     """
@@ -75,6 +77,7 @@ def proposer_prompt():
 
     Important:
     - Always query work data - do not make assumptions
+    - Do not propose changes to deprecated fields
     - Process changes one at a time
     - Check for pending changes after each update to ensure nothing is missed
     - When finished looping, you MUST use the propose_plan tool so that the plan is marked ready


### PR DESCRIPTION
# Summary 
Deprecate creator, location, publisher and tell agent not to use them

# Specific Changes in this PR
- Add deprecation block to deprecated fields
- Instruct agent and subagent not to populate or update deprecated fields

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

