### PR TITLE
Log transcriber token counts to CloudWatch Logs

### DIFF
--- a/app/config/dev.exs
+++ b/app/config/dev.exs
@@ -22,7 +22,7 @@ if System.get_env("AWS_LOCALSTACK", "false") == "true" do
     },
     mediaconvert_client: MediaConvert.Mock
 
-  [:mediaconvert, :s3, :secretsmanager, :sns, :sqs]
+  [:logs, :mediaconvert, :s3, :secretsmanager, :sns, :sqs]
   |> Enum.each(fn service ->
     config :ex_aws, service,
       scheme: "https://",

--- a/app/config/test.exs
+++ b/app/config/test.exs
@@ -11,7 +11,7 @@ config :ex_aws,
 
 IO.puts("Using localstack services for tests")
 
-[:mediaconvert, :s3, :secretsmanager, :sns, :sqs]
+[:logs, :mediaconvert, :s3, :secretsmanager, :sns, :sqs]
 |> Enum.each(fn service ->
   config :ex_aws, service,
     scheme: "https://",

--- a/app/lib/cloudwatch_logs.ex
+++ b/app/lib/cloudwatch_logs.ex
@@ -1,0 +1,97 @@
+defmodule CloudwatchLogs do
+  @moduledoc """
+  Provides functionality for the AWS Cloudwatch Logs API
+  """
+
+  alias ExAws.Operation.JSON, as: Operation
+
+  @doc """
+  Create a JSON request to create a log stream via the Cloudwatch Logs HTTP API
+  """
+  def create_log_stream(log_group_name, log_stream_name) do
+    request(:post, "CreateLogStream", %{
+      "logGroupName" => log_group_name,
+      "logStreamName" => log_stream_name
+    })
+  end
+
+  @doc """
+  Create a JSON request to delete a log stream via the Cloudwatch Logs HTTP API
+  """
+  def delete_log_stream(log_group_name, log_stream_name) do
+    request(:post, "DeleteLogStream", %{
+      "logGroupName" => log_group_name,
+      "logStreamName" => log_stream_name
+    })
+  end
+
+  @doc """
+  Create a JSON request to describe log streams via the Cloudwatch Logs HTTP API
+  """
+  def describe_log_streams(log_group_name, options \\ []) do
+    data =
+      Map.merge(
+        %{
+          "logGroupName" => log_group_name
+        },
+        camelize_options(options)
+      )
+
+    request(:post, "DescribeLogStreams", data)
+  end
+
+  @doc """
+  Create a JSON request to get log events via the Cloudwatch Logs HTTP API
+  """
+  def get_log_events(log_group_name, log_stream_name, options \\ []) do
+    data =
+      Map.merge(
+        %{
+          "logGroupName" => log_group_name,
+          "logStreamName" => log_stream_name
+        },
+        camelize_options(options)
+      )
+
+    request(:post, "GetLogEvents", data)
+  end
+
+  @doc """
+  Create a JSON request to list log groups via the Cloudwatch Logs HTTP API
+  """
+  def list_log_groups(options \\ []) do
+    request(:post, "DescribeLogGroups", camelize_options(options))
+  end
+
+  @doc """
+  Create a JSON request to put log events via the Cloudwatch Logs HTTP API
+  """
+  def put_log_events(log_group_name, log_stream_name, log_events) do
+    request(:post, "PutLogEvents", %{
+      "logGroupName" => log_group_name,
+      "logStreamName" => log_stream_name,
+      "logEvents" => log_events
+    })
+  end
+
+  defp camelize_options(options) do
+    options
+    |> Enum.map(fn {key, value} ->
+      {Inflex.camelize(key, :lower), value}
+    end)
+    |> Enum.into(%{})
+  end
+
+  defp request(http_method, action, data) do
+    Operation.new(:mediaconvert, %{
+      data: data,
+      headers: [
+        {"x-amz-target", "Logs_20140328.#{action}"},
+        {"content-type", "application/x-amz-json-1.1"}
+      ],
+      http_method: http_method,
+      path: "/",
+      service: :logs
+    })
+  end
+end

--- a/app/lib/meadow/config.ex
+++ b/app/lib/meadow/config.ex
@@ -5,6 +5,12 @@ defmodule Meadow.Config do
 
   @meadow_version Mix.Project.config() |> Keyword.get(:version)
 
+  @doc "Get AI-related configuration"
+  def ai(key, default \\ nil) do
+    Application.get_env(:meadow, :ai, [])
+    |> Keyword.get(key, default)
+  end
+
   @doc "Retrieve the environment specific URL for the Digital Collections website"
   def digital_collections_url do
     Application.get_env(:meadow, :digital_collections_url)

--- a/app/lib/meadow/config/runtime/dev.ex
+++ b/app/lib/meadow/config/runtime/dev.ex
@@ -63,6 +63,19 @@ defmodule Meadow.Config.Runtime.Dev do
         {"*/10 * * * *", {Meadow.Data.PreservationChecks, :start_job, []}}
       ]
 
+    config :meadow, :ai,
+      metrics_log: [
+        group: get_secret(:meadow, ["logging", "log_group"]),
+        region: ExAws.Config.new(:s3)[:region],
+        stream:
+          Path.join([
+            prefix(),
+            "meadow",
+            "metrics",
+            :crypto.strong_rand_bytes(16) |> Base.encode16(case: :lower)
+          ])
+      ]
+
     config :meadow, :sitemaps,
       base_url: "https://dc.library.northwestern.edu/",
       gzip: false,

--- a/app/lib/meadow/config/runtime/test.ex
+++ b/app/lib/meadow/config/runtime/test.ex
@@ -79,6 +79,13 @@ defmodule Meadow.Config.Runtime.Test do
       base_url: "http://localhost:3946/directory-search",
       api_key: "directory-api-key"
 
+    config :meadow, :ai,
+      metrics_log: [
+        group: get_secret(:meadow, ["logging", "log_group"]),
+        region: ExAws.Config.new(:s3)[:region],
+        stream: "meadow/metrics"
+      ]
+
     config :ex_unit,
       assert_receive_timeout: 500
 

--- a/app/test/meadow/utils/aws_test.exs
+++ b/app/test/meadow/utils/aws_test.exs
@@ -7,6 +7,13 @@ defmodule Meadow.Utils.AWSTest do
   @bucket @ingest_bucket
   @random_bucket "nonexistent-#{DateTime.utc_now() |> DateTime.to_unix()}"
 
+  describe "log_metrics/1" do
+    test "log_metrics/1 sends a log to CloudWatch Logs" do
+      message = %{"test_key" => "test_value"}
+      assert {:ok, _response} = AWS.log_metrics(message)
+    end
+  end
+
   describe "create_s3_folder/2" do
     setup do
       on_exit(fn ->

--- a/infrastructure/localstack/environment_config.tf
+++ b/infrastructure/localstack/environment_config.tf
@@ -42,6 +42,10 @@ locals {
         manifest_url      = "http://test-pyramids.s3.localhost.localstack.cloud:4566/public/"
       }
 
+      logging = {
+        log_group = aws_cloudwatch_log_group.meadow_ai_metrics.name
+      }
+
       mediaconvert = {
         queue       = "arn:aws:mediaconvert:::queues/Default"
         role_arn    = "arn:aws:iam:::role/service-role/MediaConvert_Default_Role"

--- a/infrastructure/localstack/main.tf
+++ b/infrastructure/localstack/main.tf
@@ -43,3 +43,7 @@ provider "aws" {
     sts            = var.localstack_endpoint
   }
 }
+
+resource "aws_cloudwatch_log_group" "meadow_ai_metrics" {
+  name = "/nul/meadow"
+}


### PR DESCRIPTION
# Summary 
Log transcriber token counts to CloudWatch Logs

Merging this back into meadow-ai will require some conflict resolution because of the naming changes.

# Specific Changes in this PR
- Cherry-pick metrics logging code from `meadow-ai` branch
- Change some names to avoid polluting `MeadowAI` namespace
- Move metrics logging to `Meadow.Utils.AWS`
- Add token logging to `Meadow.Data.Transcriber`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Run some transcriptions and then check the `/nul/dev-environment` log group for log streams specific to your dev prefix.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

