### PR TITLE
Refine Transcription components to have more linear state.

### DIFF
--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Modal.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Modal.jsx
@@ -9,7 +9,7 @@ import { IIIF_SIZES } from "@js/services/global-vars";
 import { toastWrapper } from "@js/services/helpers";
 import { useMutation } from "@apollo/client";
 import { UPDATE_FILE_SET_ANNOTATION } from "@js/components/Work/Tabs/Structure/Transcription/transcription.gql";
-import WorkTabsStructureTranscriptionWorkflow from "./Workflow";
+import WorkTabsStructureTranscriptionWorkflow from "@js/components/Work/Tabs/Structure/Transcription/Workflow";
 
 function WorkTabsStructureTranscriptionModal({ isActive }) {
   const [textArea, setTextArea] = useState();
@@ -109,6 +109,7 @@ function WorkTabsStructureTranscriptionModal({ isActive }) {
             </div>
             <WorkTabsStructureTranscriptionWorkflow
               fileSetId={fileSetId}
+              key={fileSetId}
               workId={workId}
               hasTranscriptionCallback={handleHasTranscriptionCallback}
               isActive={isActive}

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Pane.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Pane.jsx
@@ -3,38 +3,64 @@ import React, { useEffect, useRef } from "react";
 function WorkTabsStructureTranscriptionPane({
   annotation,
   hasTranscriptionCallback,
-  isGenerating,
 }) {
   const textAreaRef = useRef(null);
+  const { content, id, status, type } = annotation;
 
   useEffect(() => {
-    if (annotation?.content) {
-      if (textAreaRef.current) {
-        textAreaRef.current.value = annotation.content;
-        hasTranscriptionCallback(true);
-      }
+    if (!textAreaRef.current) return;
+    if (typeof content === "string") {
+      hasTranscriptionCallback(true);
+      textAreaRef.current.value = content;
       return;
     }
-  }, [annotation, isGenerating]);
-
-  if (isGenerating && !annotation?.content) {
-    return <div>Generating transcription, please wait...</div>;
-  }
+  }, [content]);
 
   return (
-    <textarea
-      className="textarea"
-      data-annotation-id={annotation?.id}
-      data-annotation-type={annotation?.type}
-      id="file-set-transcription-textarea"
-      ref={textAreaRef}
+    <div
+      data-testid="transcription-pane"
+      className="textarea-wrapper"
       style={{
         height: "100%",
-        whiteSpace: "pre-wrap",
-        minWidth: "unset",
-        resize: "none",
+        width: "100%",
+        position: "relative",
+        zIndex: 0,
       }}
-    />
+    >
+      {status === "in_progress" && (
+        <div
+          className="transcription-generating-overlay"
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
+            backgroundColor: "#fff6",
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            zIndex: 1,
+          }}
+        >
+          <span>Generating transcription...</span>
+        </div>
+      )}
+      <textarea
+        className="textarea"
+        data-annotation-id={id}
+        data-annotation-status={status}
+        data-annotation-type={type}
+        id="file-set-transcription-textarea"
+        ref={textAreaRef}
+        style={{
+          height: "100%",
+          whiteSpace: "pre-wrap",
+          minWidth: "unset",
+          resize: "none",
+        }}
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
# Summary 
This resolves some state issues in the transcription workflow by simplifying things and making logic more linear.

 - Removes `isGenerating` declaration in favor of the `annotation?.status` value. If `in_progress`, this effectively lets us know we are generating. Previously we handled this directly from an `onClick` event.
 - Removes `hasTranscription` declaration in favor of the `annotation?.content` value being of type string.
 - Adds a brief `null` rendering while `loading` is occurring. We can swap this out for bouncing loader after merging of `meadow-ai` work.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Test an image work with multiple access files.

Without refreshing, work through each item's transcription workflow. State should be accurate for each item.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

