### PR TITLE
Render status_update messages in loading screen.

### DIFF
--- a/app/assets/js/components/Plan/Chat/Chat.jsx
+++ b/app/assets/js/components/Plan/Chat/Chat.jsx
@@ -7,7 +7,12 @@ import { v4 as uuidv4 } from "uuid";
 
 const conversationId = uuidv4();
 
-const PlanChat = ({ initialMessages, query, planIdCallback }) => {
+const PlanChat = ({
+  initialMessages,
+  query,
+  planIdCallback,
+  planLoadingMessageCallback,
+}) => {
   const scrollerRef = useRef(null);
   const [messages, setMessages] = useState(initialMessages || []);
   const [isAtBottom, setIsAtBottom] = useState(true);
@@ -61,14 +66,18 @@ const PlanChat = ({ initialMessages, query, planIdCallback }) => {
     if (chatResponseMessage.type === "plan_id")
       planIdCallback(chatResponseMessage.planId);
 
-    setMessages((prev) => [
-      ...prev,
-      {
-        content: chatResponseMessage.message,
-        isUser: false,
-        type: chatResponseMessage.type,
-      },
-    ]);
+    if (chatResponseMessage.type === "status_update")
+      planLoadingMessageCallback(chatResponseMessage.message);
+
+    if (chatResponseMessage.type !== "status_update")
+      setMessages((prev) => [
+        ...prev,
+        {
+          content: chatResponseMessage.message,
+          isUser: false,
+          type: chatResponseMessage.type,
+        },
+      ]);
 
     if (isAtBottom) scrollToBottom(true);
   }, [chatResponseMessage]);

--- a/app/assets/js/components/Plan/Panel/Changes.jsx
+++ b/app/assets/js/components/Plan/Panel/Changes.jsx
@@ -9,7 +9,7 @@ import UILoader from "@js/components/UI/Loader";
 import PlanPanelChangesDiff from "@js/components/Plan/Panel/Diff";
 import { IconCheckAlt, IconMagic } from "@js/components/Icon";
 
-const PlanPanelChanges = ({ plan, changes, id, target }) => {
+const PlanPanelChanges = ({ changes, id, loadingMessage, plan, target }) => {
   const [loading, setLoading] = React.useState(true);
   const [isApproved, setIsApproved] = React.useState(false);
   const [isApplying, setIsApplying] = React.useState(false);
@@ -34,11 +34,14 @@ const PlanPanelChanges = ({ plan, changes, id, target }) => {
         setShowCompleted(false);
         break;
       case "PROPOSED":
-        setLoading(false);
-        setIsApproved(false);
-        setIsApplying(false);
-        setApplyStartedAt(null);
-        setShowCompleted(false);
+        // set timeout to simulate loading
+        setTimeout(() => {
+          setLoading(false);
+          setIsApproved(false);
+          setIsApplying(false);
+          setApplyStartedAt(null);
+          setShowCompleted(false);
+        }, 2000);
         break;
       case "APPROVED":
         setLoading(false);
@@ -112,8 +115,12 @@ const PlanPanelChanges = ({ plan, changes, id, target }) => {
       {loading ? (
         <div className="plan-panel-changes--loading plan-placeholder">
           {target.thumbnails}
-          <p className="is-6">{target.title}</p>
           <UILoader />
+          {loadingMessage && (
+            <span className="plan-panel-changes--loading--message">
+              {loadingMessage}
+            </span>
+          )}
         </div>
       ) : (
         <div className="plan-panel-changes--content">

--- a/app/assets/js/components/Plan/Plan.jsx
+++ b/app/assets/js/components/Plan/Plan.jsx
@@ -8,6 +8,8 @@ import SquircleThumbnail from "@js/components/UI/SquircleThumbnail";
 const Plan = ({ works }) => {
   const query = works.map((work) => `id:(${work.id})`).join(" OR ");
   const [planId, setPlanId] = React.useState(null);
+  const [loadingMessage, setLoadingMessage] =
+    React.useState("Initializing plan");
 
   const hasPlan = Boolean(planId);
 
@@ -48,9 +50,10 @@ const Plan = ({ works }) => {
       <div className="plan-workspace">
         {planId ? (
           <PlanPanelChanges
+            changes={planChanges}
             id={planId}
             plan={plan}
-            changes={planChanges}
+            loadingMessage={loadingMessage}
             target={{
               title: targetTitle,
               thumbnails: targetThumbnails,
@@ -75,6 +78,7 @@ const Plan = ({ works }) => {
           query={query}
           initialMessages={initialMessages}
           planIdCallback={(planId) => setPlanId(planId)}
+          planLoadingMessageCallback={(message) => setLoadingMessage(message)}
         />
       </div>
     </div>

--- a/app/assets/js/screens/Work/Work.jsx
+++ b/app/assets/js/screens/Work/Work.jsx
@@ -90,7 +90,7 @@ const ScreensWork = () => {
     onCompleted({ updateWork }) {
       toastWrapper(
         "is-success",
-        `Work has been ${updateWork.published ? "published" : "unpublished"}`
+        `Work has been ${updateWork.published ? "published" : "unpublished"}`,
       );
     },
   });
@@ -121,7 +121,7 @@ const ScreensWork = () => {
 
   const handleMultiNavClick = (nextWorkIndex) => {
     history.push(
-      `/work/${batchState.editAndViewWorks[nextWorkIndex]}/multi/${nextWorkIndex},${multiTotalItems}`
+      `/work/${batchState.editAndViewWorks[nextWorkIndex]}/multi/${nextWorkIndex},${multiTotalItems}`,
     );
   };
 
@@ -233,7 +233,7 @@ const ScreensWork = () => {
                             onClick={() =>
                               handleFacetLinkClick(
                                 "Collection",
-                                data.work.collection.title
+                                data.work.collection.title,
                               )
                             }
                           >
@@ -249,7 +249,6 @@ const ScreensWork = () => {
           </div>
         </section>
       </ErrorBoundary>
-
       {loading ? (
         <UISkeleton rows={20} />
       ) : (

--- a/app/assets/styles/scss/_plan.scss
+++ b/app/assets/styles/scss/_plan.scss
@@ -28,9 +28,17 @@
 
   &--loading {
     text-align: center;
-    p {
-      margin-bottom: 2rem;
-      font-size: 1.25rem;
+
+    [role="img"] {
+      margin-bottom: 1.618rem !important;
+    }
+
+    &--message {
+      display: block;
+      font-family: $PoppinsBold;
+      font-size: 1rem;
+      color: $nu-purple;
+      margin-top: -0.382rem;
     }
   }
 


### PR DESCRIPTION
# Summary 

This maps messages marked as `status_update` type coming through the subscription to the Loading screen and renders them directly underneath the bouncing loading.

https://github.com/user-attachments/assets/cbf8246c-6a1e-4dfa-88b1-2475a67b7f24


# Specific Changes in this PR
- Outputs `status_update` messages to the loading screen


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

