### PR TITLE
Make diff type tags plain text.

### DIFF
--- a/app/assets/js/components/Plan/Panel/Diff.jsx
+++ b/app/assets/js/components/Plan/Panel/Diff.jsx
@@ -1,4 +1,3 @@
-import { Tag } from "@nulib/design-system";
 import React from "react";
 import UIControlledTermList from "@js/components/UI/ControlledTerm/List";
 import { toArray, toRows } from "@js/components/Plan/Panel/diff-helpers";
@@ -7,33 +6,24 @@ import { toArray, toRows } from "@js/components/Plan/Panel/diff-helpers";
  * Tag indicating the method of change
  */
 const MethodTag = ({ method }) => {
-  let tagProps = {};
   let text = "";
 
   switch (method) {
     case "add":
-      tagProps = { isSuccess: true };
       text = "Add";
       break;
     case "delete":
-      tagProps = { isDanger: true };
       text = "Delete";
       break;
     case "replace":
-      tagProps = { isInfo: true };
       text = "Replace";
       break;
     default:
-      tagProps = {};
       text = "";
       break;
   }
 
-  return (
-    <Tag as="span" {...tagProps}>
-      {text}
-    </Tag>
-  );
+  return <span data-testid="tag">{text}</span>;
 };
 
 /**


### PR DESCRIPTION
# Summary 
This swaps out the `Tag` component in favor of plain text for the Type column values of `Add`, `Replace`, and `Delete`.

<img width="815" height="463" alt="image" src="https://github.com/user-attachments/assets/7916bc7d-bd18-4ed2-bc2e-bdf532aea099" />


# Specific Changes in this PR
- Makes type column plain text

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

