### PR TITLE
Adjust chat form submit button.

### DIFF
--- a/app/assets/js/components/Icon/Enter.jsx
+++ b/app/assets/js/components/Icon/Enter.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { FaLevelUpAlt } from "react-icons/fa";
+
+export default function IconEnter(props) {
+  return (
+    <FaLevelUpAlt
+      {...props}
+      style={{
+        transform: "rotate(90deg) scaleY(-1)",
+      }}
+    />
+  );
+}

--- a/app/assets/js/components/Icon/Reply.jsx
+++ b/app/assets/js/components/Icon/Reply.jsx
@@ -1,6 +1,0 @@
-import React from "react";
-import { FaReply } from "react-icons/fa";
-
-export default function IconReply(props) {
-  return <FaReply {...props} />;
-}

--- a/app/assets/js/components/Icon/index.js
+++ b/app/assets/js/components/Icon/index.js
@@ -22,6 +22,7 @@ import IconCsv from "@js/components/Icon/Csv";
 import IconDelete from "@js/components/Icon/Delete";
 import IconDownload from "@js/components/Icon/Download";
 import IconEdit from "@js/components/Icon/Edit";
+import IconEnter from "@js/components/Icon/Enter";
 import IconExternalLink from "@js/components/Icon/ExternalLink";
 import IconFile from "@js/components/Icon/File";
 import IconImages from "@js/components/Icon/Images";
@@ -31,7 +32,6 @@ import IconMinus from "@js/components/Icon/Minus";
 import IconPlay from "@js/components/Icon/Play";
 import IconProjects from "@js/components/Icon/Projects";
 import IconReplace from "@js/components/Icon/Replace";
-import IconReply from "@js/components/Icon/Reply";
 import IconSearch from "@js/components/Icon/Search";
 import IconSort from "@js/components/Icon/Sort";
 import IconSortDown from "@js/components/Icon/SortDown";
@@ -67,6 +67,7 @@ export {
   IconDelete,
   IconDownload,
   IconEdit,
+  IconEnter,
   IconExternalLink,
   IconFile,
   IconImages,
@@ -76,7 +77,6 @@ export {
   IconPlay,
   IconProjects,
   IconReplace,
-  IconReply,
   IconSearch,
   IconSort,
   IconSortDown,

--- a/app/assets/js/components/Plan/Chat/Form.jsx
+++ b/app/assets/js/components/Plan/Chat/Form.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { IconArrowDown, IconList, IconReply } from "@js/components/Icon";
+import { IconArrowDown, IconEnter, IconList } from "@js/components/Icon";
 import PlanChatAutoTextArea from "@js/components/Plan/Chat/AutoTextArea";
 import { recipes } from "@js/components/Plan/recipes";
 
@@ -93,7 +93,7 @@ const PlanChatForm = ({
           />
 
           <button
-            className="button is-primary is-flex is-uppercase"
+            className="button is-primary is-flex"
             style={{
               gap: "0.5rem",
               alignItems: "center",
@@ -102,8 +102,9 @@ const PlanChatForm = ({
               right: "1rem",
             }}
             type="submit"
+            name="submit"
           >
-            Reply <IconReply />
+            Submit <IconEnter />
           </button>
         </div>
       </div>

--- a/app/assets/js/components/Plan/Chat/Form.test.jsx
+++ b/app/assets/js/components/Plan/Chat/Form.test.jsx
@@ -18,7 +18,7 @@ jest.mock("@js/components/Icon", () => ({
   __esModule: true,
   IconArrowDown: () => <span data-testid="icon-down" />,
   IconList: () => <span data-testid="icon-list" />,
-  IconReply: () => <span data-testid="icon-reply" />,
+  IconEnter: () => <span data-testid="icon-enter" />,
 }));
 
 /**
@@ -44,7 +44,7 @@ describe("PlanChatForm", () => {
     );
 
     expect(screen.getByTestId("msg-input")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /reply/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /submit/i })).toBeInTheDocument();
   });
 
   test("renders 'scroll to bottom' button when showScrollButton=true and calls handler", async () => {
@@ -105,7 +105,7 @@ describe("PlanChatForm", () => {
     );
 
     const input = screen.getByTestId("msg-input");
-    const submit = screen.getByRole("button", { name: /reply/i });
+    const submit = screen.getByRole("button", { name: /submit/i });
 
     await userEvent.type(input, "   Hello world   ");
     await userEvent.click(submit);
@@ -127,7 +127,7 @@ describe("PlanChatForm", () => {
     );
 
     const input = screen.getByTestId("msg-input");
-    const submit = screen.getByRole("button", { name: /reply/i });
+    const submit = screen.getByRole("button", { name: /submit/i });
 
     await userEvent.type(input, "     ");
     await userEvent.click(submit);
@@ -142,7 +142,7 @@ describe("PlanChatForm", () => {
     );
 
     const input = screen.getByTestId("msg-input");
-    const submit = screen.getByRole("button", { name: /reply/i });
+    const submit = screen.getByRole("button", { name: /submit/i });
 
     await userEvent.type(input, "Hello!");
     await userEvent.click(submit);
@@ -252,7 +252,9 @@ describe("PlanChatForm", () => {
     await userEvent.click(recipesButton);
 
     // Click on second recipe - use fireEvent to avoid triggering document mousedown
-    const recipe = screen.getByText(/Add, update, or replace subject headings/i);
+    const recipe = screen.getByText(
+      /Add, update, or replace subject headings/i,
+    );
     fireEvent.click(recipe);
 
     // Input should be populated with the recipe text
@@ -281,7 +283,7 @@ describe("PlanChatForm", () => {
       name: /show recipe prompts/i,
     });
     const input = screen.getByTestId("msg-input");
-    const submitButton = screen.getByRole("button", { name: /reply/i });
+    const submitButton = screen.getByRole("button", { name: /submit/i });
 
     // Show recipes and select one - use fireEvent to avoid triggering document mousedown
     await userEvent.click(recipesButton);


### PR DESCRIPTION
# Summary 
This simply adjusts the chat form submit button by adjusting button value to "Submit" and using an ENTER icon. 

<img width="733" height="83" alt="image" src="https://github.com/user-attachments/assets/6afe32cf-a024-40a8-8329-8c24f818313f" />


# Specific Changes in this PR

- Adjust reply button

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

