### PR TITLE
Adjust prompt for concise summaries

### DIFF
--- a/app/priv/python/agent/src/meadow_metadata_agent/prompts.py
+++ b/app/priv/python/agent/src/meadow_metadata_agent/prompts.py
@@ -26,7 +26,12 @@ def agent_prompt_with_plan(plan_id, user_query, context_data):
     IMPORTANT: Always use authoritiesSearch for controlled terms; never invent IDs. For coded fields (roles, note types, etc.), 
     use codeList. Do not touch deprecated fields.
 
-    Finish with a summary of proposed changes.
+    Finish with a concise summary of proposed changes. Keep the summary focused on the changed fields instead of the plan process itself. Do not mention the subagent or anything related to plan status. Do not include headers or introductory text in the summary.
+    
+    <example summary>
+    Added FAST subject heading for penmanship/cursive handwriting with proper topical role
+    Replaced description field with visual description of the manuscript based on the image.
+    </example summary>
     """
 
 def agent_prompt_without_plan(user_query, context_data):


### PR DESCRIPTION
# Summary 

Adjusts the prompt for more concise plan summaries.

Example:

<img width="557" height="386" alt="concise_plan" src="https://github.com/user-attachments/assets/d5e78176-290d-4089-a2f5-599d4f6152ea" />

# Specific Changes in this PR
- Agent prompt change in `prompts.py`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Make a plan! 😀

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

