### PR TITLE
Delete attached S3 object when annotation record is deleted

### DIFF
--- a/app/lib/meadow/events/file_sets/annotations.ex
+++ b/app/lib/meadow/events/file_sets/annotations.ex
@@ -16,23 +16,35 @@ defmodule Meadow.Events.FileSets.Annotations do
 
   on_event(:file_set_annotations, %{}, [{__MODULE__, :notify_annotation_subscriptions}], & &1)
 
-  def notify_annotation_subscriptions(%{type: :delete}), do: :ok
-
-  def notify_annotation_subscriptions(%{new_record: %{id: id}, changes: %{status: _}}) do
-    {annotation, file_set_id, work_id} =
-      from(fsa in FileSetAnnotation,
-        where: fsa.id == ^id,
-        join: fs in FileSet,
-        on: fs.id == fsa.file_set_id,
-        join: w in Work,
-        on: w.id == fs.work_id,
-        select: {fsa, fs.id, w.id}
-      )
-      |> Repo.one()
-
-    Notification.publish(annotation, file_set_annotation: file_set_id)
-    Notification.publish(annotation, work_file_set_annotation: work_id)
+  def notify_annotation_subscriptions(%{old_record: %{s3_location: s3_object}, type: :delete})
+      when is_binary(s3_object) do
+    Logger.info("Deleting annotation S3 object: #{s3_object}")
+    %{host: bucket, path: "/" <> key} = URI.parse(s3_object)
+    ExAws.S3.delete_object(bucket, key) |> ExAws.request()
   end
 
-  def notify_annotation_subscriptions(_), do: :ok
+  def notify_annotation_subscriptions(%{new_record: %{id: id} = record, changes: %{status: _}}) do
+    from(fsa in FileSetAnnotation,
+      where: fsa.id == ^id,
+      left_join: fs in FileSet,
+      on: fs.id == fsa.file_set_id,
+      left_join: w in Work,
+      on: w.id == fs.work_id,
+      select: {fsa, fs.id, w.id}
+    )
+    |> Repo.one()
+    |> case do
+      nil ->
+        :noop
+
+      {annotation, file_set_id, work_id} ->
+        if not is_nil(file_set_id),
+          do: Notification.publish(annotation, file_set_annotation: file_set_id)
+
+        if not is_nil(work_id),
+          do: Notification.publish(annotation, work_file_set_annotation: work_id)
+    end
+  end
+
+  def notify_annotation_subscriptions(message), do: :ok
 end

--- a/app/test/meadow/events/file_sets/annotations_test.exs
+++ b/app/test/meadow/events/file_sets/annotations_test.exs
@@ -1,0 +1,43 @@
+defmodule Meadow.Events.FileSets.AnnotationsTest do
+  use Meadow.DataCase, async: false
+  use Meadow.S3Case
+
+  alias Meadow.Data.FileSets
+
+  import Assertions
+  import ExUnit.CaptureLog
+  import Meadow.TestHelpers
+
+  @moduletag walex: [Meadow.Events.FileSets.Annotations]
+  describe "Meadow.Events.FileSets.Annotations" do
+    setup do
+      file_set = file_set_fixture()
+
+      {:ok, %{id: id}} =
+        FileSets.create_annotation(file_set, %{type: "transcription", status: "pending"})
+
+      FileSets.update_annotation_content(id, "Some annotation content", language: ["en"])
+
+      {:ok, annotation} =
+        FileSets.get_annotation!(id)
+        |> FileSets.update_annotation(%{status: "completed"})
+
+      {:ok, %{annotation: annotation}}
+    end
+
+    test "deleting an annotation removes its S3 object", %{annotation: annotation} do
+      assert object_exists?(annotation.s3_location) == true
+
+      log =
+        capture_log(fn ->
+          {:ok, _} = FileSets.delete_annotation(annotation)
+
+          assert_async(timeout: 2000) do
+            assert object_exists?(annotation.s3_location) == false
+          end
+        end)
+
+      assert log =~ "Deleting annotation S3 object"
+    end
+  end
+end


### PR DESCRIPTION
# Summary 
Delete attached S3 object when annotation record is deleted

# Specific Changes in this PR
- Update `file_set_annotations` delete listener to delete S3 object
- Add test

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Start Meadow
- Create an annotation
- Open the S3 console and find the annotation file in the derivatives bucket
- Delete the annotation record from the database
- Refresh the bucket and see that the file was deleted

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

