### PR TITLE
Add delete transcription functionality

### DIFF
--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/transcription.gql.js
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/transcription.gql.js
@@ -61,3 +61,12 @@ export const UPDATE_FILE_SET_ANNOTATION = gql`
     }
   }
 `;
+
+export const DELETE_FILE_SET_ANNOTATION = gql`
+  mutation deleteFileSetAnnotation($annotationId: ID!) {
+    deleteFileSetAnnotation(annotationId: $annotationId) {
+      id
+      fileSetId
+    }
+  }
+`;

--- a/app/lib/meadow_web/resolvers/data.ex
+++ b/app/lib/meadow_web/resolvers/data.ex
@@ -181,6 +181,25 @@ defmodule MeadowWeb.Resolvers.Data do
     end
   end
 
+  def delete_file_set_annotation(_, args, _) do
+    case FileSets.get_annotation(args[:annotation_id]) do
+      nil ->
+        {:error, message: "Annotation not found"}
+
+      annotation ->
+        case FileSets.delete_annotation(annotation) do
+          {:ok, annotation} ->
+            {:ok, annotation}
+
+          {:error, %Ecto.Changeset{} = changeset} ->
+            {:error, message: "Could not delete annotation", details: ChangesetErrors.humanize_errors(changeset)}
+
+          {:error, reason} ->
+            {:error, message: "Could not delete annotation", details: inspect(reason)}
+        end
+    end
+  end
+
   defp maybe_add_opt(opts, _key, nil), do: opts
   defp maybe_add_opt(opts, key, value), do: Keyword.put(opts, key, value)
 

--- a/app/lib/meadow_web/schema/types/data/file_set_types.ex
+++ b/app/lib/meadow_web/schema/types/data/file_set_types.ex
@@ -90,6 +90,14 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
       middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Data.update_file_set_annotation/3)
     end
+
+    @desc "Delete a FileSet annotation"
+    field :delete_file_set_annotation, :file_set_annotation do
+      arg(:annotation_id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Resolvers.Data.delete_file_set_annotation/3)
+    end
   end
 
   object :file_set_subscriptions do

--- a/app/mix.exs
+++ b/app/mix.exs
@@ -1,7 +1,7 @@
 defmodule Meadow.MixProject do
   use Mix.Project
 
-  @app_version "9.11.1"
+  @app_version "9.12.0"
 
   def project do
     [

--- a/app/test/gql/DeleteFileSetAnnotation.gql
+++ b/app/test/gql/DeleteFileSetAnnotation.gql
@@ -1,0 +1,10 @@
+mutation (
+  $annotationId: ID!
+) {
+  deleteFileSetAnnotation(
+    annotationId: $annotationId
+  ) {
+    id
+    fileSetId
+  }
+}

--- a/app/test/meadow_web/schema/mutation/delete_file_set_annotation_test.exs
+++ b/app/test/meadow_web/schema/mutation/delete_file_set_annotation_test.exs
@@ -1,0 +1,49 @@
+defmodule MeadowWeb.Schema.Mutation.DeleteFileSetAnnotationTest do
+  use Meadow.DataCase
+  use Meadow.S3Case
+  use MeadowWeb.ConnCase, async: true
+  use Wormwood.GQLCase
+
+  alias Meadow.Data.FileSets
+
+  load_gql(MeadowWeb.Schema, "test/gql/DeleteFileSetAnnotation.gql")
+
+  setup do
+    file_set = file_set_fixture()
+    {:ok, annotation} = FileSets.create_annotation(file_set, %{type: "transcription", status: "completed"})
+    {:ok, s3_location} = FileSets.write_annotation_content(annotation, "Original content")
+    {:ok, annotation} = FileSets.update_annotation(annotation, %{s3_location: s3_location})
+
+    {:ok, annotation: annotation, file_set: file_set}
+  end
+
+  test "deletes annotation", %{annotation: annotation, file_set: file_set} do
+    result =
+      query_gql(
+        variables: %{
+          "annotationId" => annotation.id
+        },
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+    deleted_id = get_in(query_data, [:data, "deleteFileSetAnnotation", "id"])
+    assert deleted_id == annotation.id
+
+    # Verify annotation is actually deleted
+    assert [] = FileSets.list_annotations(file_set)
+  end
+
+  test "returns error for non-existent annotation" do
+    result =
+      query_gql(
+        variables: %{
+          "annotationId" => "00000000-0000-0000-0000-000000000000"
+        },
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+    assert [%{message: "Annotation not found"}] = query_data[:errors]
+  end
+end


### PR DESCRIPTION
# Summary 

Add ability to delete transcription. 


# Specific Changes in this PR

- Add delete transcription functionality to GraphQL schema and resolver
- Add delete button + confirmation to UI transcription modal


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test

- Generate a file set transcription in the UI
- From the transcription modal, click the button on the lower left to delete the transcription
- Verify that it's deleted and can be regenerated 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [x] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

