### PR TITLE
Accept image transcriptions through ingest sheet

### DIFF
--- a/app/lib/meadow/data/file_sets.ex
+++ b/app/lib/meadow/data/file_sets.ex
@@ -516,6 +516,28 @@ defmodule Meadow.Data.FileSets do
   end
 
   @doc """
+  Copy annotation content from a source S3 location to the annotation's destination.
+
+  ## Examples
+
+      iex> copy_annotation_content(%FileSetAnnotation{}, "source-bucket", "path/to/source.txt")
+      {:ok, "s3://dest-bucket/path/to/annotation.txt"}
+
+  """
+  def copy_annotation_content(%FileSetAnnotation{} = annotation, source_bucket, source_key) do
+    location = annotation_location(annotation)
+    %URI{host: dest_bucket, path: "/" <> dest_key} = URI.parse(location)
+
+    case ExAws.S3.put_object_copy(dest_bucket, dest_key, source_bucket, source_key,
+           content_type: "text/plain; charset=utf-8"
+         )
+         |> ExAws.request() do
+      {:ok, _} -> {:ok, location}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
   Read annotation content from S3.
 
   ## Examples

--- a/app/test/fixtures/ingest_sheet_transcription.csv
+++ b/app/test/fixtures/ingest_sheet_transcription.csv
@@ -1,0 +1,9 @@
+work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image,structure
+IMAGE,Donohue_001r,Donohue_001_01555,coffee.tif,"Letter, page 1, Dear Sir, recto",A,The label,,transcription.txt
+IMAGE,Donohue_001r,Donohue_001_01556,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P,The label,,
+IMAGE,Donohue_001r,Donohue_001_01557,coffee.tif,"Letter, page 2, If these papers, recto",A,The label,TRUE,
+IMAGE,Donohue_001r,Donohue_001_01558,coffee.tif,"Letter, page 2, If these papers, verso, blank",X,The label,,
+VIDEO,Donohue_002r,Donohue_001_01559,small.m4v,"Photo, man with two children",A,The label,,Donohue_002_01.vtt
+VIDEO,Donohue_002r,Donohue_001_01560,small.m4v,Small Video,A,The label,,
+VIDEO,Donohue_002r,Donohue_001_01561,coffee.tif,"Photo, two children praying",X,The label,,
+VIDEO,Donohue_002r,Donohue_001_01562,details.json,Supplemental information,S,Supplement,,

--- a/app/test/fixtures/transcription.txt
+++ b/app/test/fixtures/transcription.txt
@@ -1,0 +1,1 @@
+This is the transcription for the image!


### PR DESCRIPTION
# Summary 

Allow image transcriptions to come in with ingest sheet if a text file transcription is provided. 

# Specific Changes in this PR

- structure column of ingest sheet can accept a `.txt` transcription filename for access  files belonging to `IMAGE` work types
- See [app/test/fixtures/ingest_sheet_transcription.csv‎](https://github.com/nulib/meadow/pull/5022/files#diff-aca137765338b539d677ce23465036d2a48dc13103c7cc243b956684833efb6d) for example


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- place a transcription file in the ingest bucket/project folder (text only) with .txt extension
- Reference the transcription filename from the structure column of the ingest sheet for an access file set belonging to an IMAGE work type
- Run the ingest
- Verify the file ended up with a transcription

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

