### PR TITLE
Get rid of all compiler warnings

### DIFF
--- a/app/lib/meadow/data/transcriber.ex
+++ b/app/lib/meadow/data/transcriber.ex
@@ -207,7 +207,7 @@ defmodule Meadow.Data.Transcriber do
     }
   end
 
-  defp default_prompt(file_set_id) do
+  defp default_prompt(_file_set_id) do
     """
     Use the provide_exact_transcription tool to provide a FULL and EXACT text transcription for this image without any preamble, explanation, excision, truncation, abbreviation, or summarization. Include every column, heading, caption, and any other legible text exactly as it appears. Also detect the language(s) used in the text. Never abbreviate the transcription with bracketed text or summary information. ALWAYS TRANSCRIBE THE TEXT IN FULL!!! You have a massive 64K output token limit so there is NO EXCUSE for omitting any text. If the text is very long, you MUST still provide it ALL without omission. Preserve line breaks when they clarify structure and keep the original order (top-to-bottom, left-to-right).
     """

--- a/app/lib/meadow/events/file_sets/annotations.ex
+++ b/app/lib/meadow/events/file_sets/annotations.ex
@@ -23,7 +23,7 @@ defmodule Meadow.Events.FileSets.Annotations do
     ExAws.S3.delete_object(bucket, key) |> ExAws.request()
   end
 
-  def notify_annotation_subscriptions(%{new_record: %{id: id} = record, changes: %{status: _}}) do
+  def notify_annotation_subscriptions(%{new_record: %{id: id}, changes: %{status: _}}) do
     from(fsa in FileSetAnnotation,
       where: fsa.id == ^id,
       left_join: fs in FileSet,
@@ -46,5 +46,5 @@ defmodule Meadow.Events.FileSets.Annotations do
     end
   end
 
-  def notify_annotation_subscriptions(message), do: :ok
+  def notify_annotation_subscriptions(_), do: :ok
 end

--- a/app/lib/meadow/ingest/validator.ex
+++ b/app/lib/meadow/ingest/validator.ex
@@ -361,6 +361,14 @@ defmodule Meadow.Ingest.Validator do
     validate_structure_extension(extension, work_type, content, value)
   end
 
+  defp validate_structure_value({:error, {:http_error, 404, _}}, value, _work_type) do
+    {:error, "structure", "Structure file #{value} not found in the ingest bucket"}
+  end
+
+  defp validate_structure_value({:error, other}, value, _work_type) do
+    {:error, "structure", "The following error occurred validating #{value}: #{inspect(other)}"}
+  end
+
   defp validate_structure_extension(".txt", "IMAGE", _content, _value), do: :ok
 
   defp validate_structure_extension(".vtt", work_type, content, value)
@@ -381,14 +389,6 @@ defmodule Meadow.Ingest.Validator do
 
   defp validate_structure_extension(extension, work_type, _content, _value) do
     {:error, "structure", "Invalid structure file extension #{extension} for work type #{work_type}"}
-  end
-
-  defp validate_structure_value({:error, {:http_error, 404, _}}, value, _work_type) do
-    {:error, "structure", "Structure file #{value} not found in the ingest bucket"}
-  end
-
-  defp validate_structure_value({:error, other}, value, _work_type) do
-    {:error, "structure", "The following error occurred validating #{value}: #{inspect(other)}"}
   end
 
   defp validate_row(%Row{state: "pending"} = row, context) do

--- a/app/lib/meadow_web.ex
+++ b/app/lib/meadow_web.ex
@@ -19,7 +19,10 @@ defmodule MeadowWeb do
 
   def controller do
     quote do
-      use Phoenix.Controller, namespace: MeadowWeb
+      use Phoenix.Controller,
+        formats: [html: "View", json: "View"]
+
+      plug :put_layout, html: {MeadowWeb.LayoutView, :app}
 
       import Plug.Conn
       use Gettext, backend: MeadowWeb.GetText


### PR DESCRIPTION
# Summary 
Get rid of all compiler warnings

# Specific Changes in this PR
- Update `MeadowWeb.controller/0` to the Phoenix 1.7+ format
- Reorder functions in `Meadow.Ingest.Validator` so that functions with the same name and arity are together
- Remove or _underscore-ize unused variables

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

