### PR TITLE
Handle exceptions in Planner.apply_plan gracefully

### DIFF
--- a/app/lib/meadow/data/planner.ex
+++ b/app/lib/meadow/data/planner.ex
@@ -886,7 +886,11 @@ defmodule Meadow.Data.Planner do
   end
 
   defp apply_single_change(change) do
-    apply_change_to_work(change)
+    try do
+      apply_change_to_work(change)
+    rescue
+      err -> {:error, Exception.message(err)}
+    end
     |> handle_change_result(change)
   end
 

--- a/app/test/meadow/data/planner_test.exs
+++ b/app/test/meadow/data/planner_test.exs
@@ -679,6 +679,22 @@ defmodule Meadow.Data.PlannerTest do
     end
   end
 
+  test "handles exception applying plan", %{plan: plan, work: work} do
+    {:ok, change} =
+      Planner.create_plan_change(%{
+        plan_id: plan.id,
+        work_id: work.id,
+        replace: %{descriptive_metadata: %{title: ["Updated"]}}
+      })
+
+    Planner.approve_plan_change(change)
+    {:ok, plan} = Planner.approve_plan(plan)
+
+    assert {:ok, error_plan} = Planner.apply_plan(plan)
+    assert error_plan.status == :error
+    assert error_plan.error |> String.contains?(~s(cannot load `[\\"Updated\\"]` as type :string))
+  end
+
   describe "apply_plan_change/1" do
     test "applies replace change to work", %{plan: plan} do
       work = work_fixture()


### PR DESCRIPTION
# Summary 
Handle exceptions in Planner.apply_plan gracefully

# Specific Changes in this PR
- Wrap `apply_single_change` in an exception handler
- Add a test

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

