### PR TITLE
Add 5000ms heartbeat message to Metadata Agent interactions

### DIFF
--- a/app/lib/meadow/notification/heartbeat.ex
+++ b/app/lib/meadow/notification/heartbeat.ex
@@ -1,0 +1,49 @@
+defmodule Meadow.Notification.Heartbeat do
+  @moduledoc """
+  GenServer for sending periodic heartbeat notifications.
+  """
+
+  use GenServer
+  require Logger
+  alias Meadow.Notification
+
+  @default_interval :timer.seconds(5)
+
+  def start(message, info, interval \\ @default_interval) do
+    Logger.info("Starting heartbeat for #{inspect(info)} every #{interval} ms")
+    state = %{message: message, info: info, interval: interval}
+    GenServer.start(__MODULE__, state)
+  end
+
+  def stop(pid) do
+    if Process.alive?(pid) do
+      state = GenServer.call(pid, :get_state)
+      Logger.info("Stopping heartbeat for #{inspect(state.info)}")
+      GenServer.stop(pid)
+    else
+      {:error, :not_open}
+    end
+  end
+
+  @impl true
+  def init(state) do
+    schedule_heartbeat(state.interval)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call(:get_state, _from, state) do
+    {:reply, state, state}
+  end
+
+  @impl true
+  def handle_info(:send_heartbeat, state) do
+    Notification.publish(state.message, state.info)
+    schedule_heartbeat(state.interval)
+    {:noreply, state}
+  end
+
+  defp schedule_heartbeat(interval) do
+    Process.send_after(self(), :send_heartbeat, interval)
+  end
+end

--- a/app/test/meadow/notification_test.exs
+++ b/app/test/meadow/notification_test.exs
@@ -47,4 +47,59 @@ defmodule Meadow.NotificationTest do
       refute_receive {:notify, :test_event, %{data: "test_data"}}, 250
     end
   end
+
+  describe "heartbeat" do
+    setup do
+      pid = self()
+      on_exit(fn -> Notification.unregister(pid) end)
+      {:ok, %{pid: pid}}
+    end
+
+    test "sends periodic heartbeat notifications", %{pid: pid} do
+      Notification.register(pid)
+
+      data = %{
+        "test1" => {:message1, 75},
+        "test2" => {:message2, 100}
+      }
+
+      pids =
+        for {info, {message, interval}} <- data do
+          {:ok, heartbeat_pid} = Meadow.Notification.Heartbeat.start(message, %{test: info}, interval)
+          heartbeat_pid
+        end
+
+      # Collect messages with timestamps as they arrive
+      # We expect 3 of each message type over ~300ms
+      received =
+        for _ <- 1..6 do
+          receive do
+            {:notify, message, %{test: info}} ->
+              {message, info, System.monotonic_time(:millisecond)}
+          after
+            1000 -> flunk("Timeout waiting for heartbeat message")
+          end
+        end
+        |> Enum.group_by(fn {_, info, _} -> info end)
+
+      for {info, {message, expected_interval}} <- data do
+        messages = Map.get(received, info, [])
+        assert length(messages) == 3, "Expected 3 messages for info #{inspect(info)}"
+        timestamps = Enum.map(messages, fn {_, _, ts} -> ts end)
+        intervals =
+          timestamps
+          |> Enum.chunk_every(2, 1, :discard)
+          |> Enum.map(fn [t1, t2] -> t2 - t1 end)
+
+        for interval <- intervals do
+          assert_in_delta interval, expected_interval, 10,
+            "Expected ~#{expected_interval}ms interval for #{inspect(message)} with info #{inspect(info)}, got #{interval}ms"
+        end
+      end
+
+      for pid <- pids do
+        assert :ok = Meadow.Notification.Heartbeat.stop(pid)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Summary 
Add 5000ms heartbeat message to Metadata Agent interactions

# Specific Changes in this PR
- Create `Meadow.Notification.Heartbeat` that will send a given notification at a given period until stopped
- Add 5000ms heartbeat to `MeadowWeb.Resolvers.Chat`

I don't think one heartbeat every 5 seconds will overwhelm the client the way the constant ingest sheet updates did.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

(These instructions are for Brave; other browsers might have slightly different wording in the Dev Tools)

- Open browser Developer Tools
- In the Network tab, filter on **Socket** requests
- Select the `websocket` request where the Initiator is `socket.js`
- Select the **Messages** tab
- Start an Auto Edit conversation
- Watch the Developer Tools window, and see the heartbeat messages come by every 5 seconds
- When the plan is finished and proposed, the heartbeats should stop

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

