### PR TITLE
Fix shared links index prefix

### DIFF
--- a/app/lib/meadow/config/runtime.ex
+++ b/app/lib/meadow/config/runtime.ex
@@ -251,7 +251,7 @@ defmodule Meadow.Config.Runtime do
       pyramid_tiff_working_dir: System.tmp_dir!(),
       required_checksum_tags: ["computed-md5"],
       checksum_wait_timeout: 3_600_000,
-      shared_links_index: prefix("shared_links"),
+      shared_links_index: index_prefix("shared_links"),
       sitemaps: [
         gzip: true,
         store: Sitemapper.S3Store,


### PR DESCRIPTION
# Summary 
Fix shared links index prefix

# Specific Changes in this PR
- Use `index_prefix` instead of `prefix` when configuring the shared links index

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [x] Other specific instructions/tasks
  - Copy data from wrong shared_links index to right shared_links index?

# Tested/Verified
- [ ] End users/stakeholders

