### PR TITLE
Fix flappy heartbeat notification test

### DIFF
--- a/app/lib/meadow/config.ex
+++ b/app/lib/meadow/config.ex
@@ -120,6 +120,7 @@ defmodule Meadow.Config do
   @doc "Retrieve a list of configured buckets"
   def buckets do
     [
+      derivatives_bucket(),
       ingest_bucket(),
       preservation_bucket(),
       preservation_check_bucket(),

--- a/app/test/meadow/config_test.exs
+++ b/app/test/meadow/config_test.exs
@@ -39,6 +39,7 @@ defmodule Meadow.ConfigTest do
 
   test "buckets/0" do
     [
+      @derivatives_bucket,
       @ingest_bucket,
       @preservation_bucket,
       @upload_bucket,

--- a/app/test/support/bucket_names.ex
+++ b/app/test/support/bucket_names.ex
@@ -12,6 +12,7 @@ defmodule Meadow.BucketNames do
              |> Enum.reject(&is_nil/1)
              |> Enum.join("-")
            end do
+        @derivatives_bucket prefixed.("derivatives")
         @ingest_bucket prefixed.("ingest")
         @preservation_bucket prefixed.("preservation")
         @preservation_check_bucket prefixed.("preservation-checks")


### PR DESCRIPTION
# Summary 
Fix flappy heartbeat notification test

# Specific Changes in this PR
- Change heartbeat notification test intervals from 75/100 to 80/100 to avoid race condition where the 4th 75ms heartbeat (75x4 = 300) hits before the 3rd 100ms heartbeat (100x3 = 300)
- Silence extraneous logging during notification tests
- Add derivatives bucket to S3 Case to avoid extraneous warnings

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

