### PR TITLE
Set ManifestDurationFormat to FLOATING_POINT for audio transcodes

### DIFF
--- a/app/lib/media_convert/audio_template.ex
+++ b/app/lib/media_convert/audio_template.ex
@@ -44,6 +44,7 @@ defmodule MediaConvert.AudioTemplate do
             Name: "HLS",
             OutputGroupSettings: %{
               HlsGroupSettings: %{
+                ManifestDurationFormat: "FLOATING_POINT",
                 MinSegmentLength: 0,
                 SegmentControl: "SEGMENTED_FILES",
                 SegmentLength: 2

--- a/app/test/media_convert/audio_template_test.exs
+++ b/app/test/media_convert/audio_template_test.exs
@@ -23,6 +23,7 @@ defmodule MediaConvert.AudioTemplateTest do
           Name: "HLS",
           OutputGroupSettings: %{
             HlsGroupSettings: %{
+              ManifestDurationFormat: "FLOATING_POINT",
               MinSegmentLength: 0,
               SegmentControl: "SEGMENTED_FILES",
               SegmentLength: 2,


### PR DESCRIPTION
# Summary 
- Set ManifestDurationFormat to FLOATING_POINT for audio transcodes
- Fixes downstream playlist timecode bug

<img width="1298" height="707" alt="SCR-20251219-khzx" src="https://github.com/user-attachments/assets/4e6da1d2-e30c-4f82-b1b0-1aa20dc3ca68" />


# Specific Changes in this PR
- Add config value to `app/lib/media_convert/audio_template.ex`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

