### PR TITLE
Allow lambdas to retry

### DIFF
--- a/app/lib/meadow/utils/lambda.ex
+++ b/app/lib/meadow/utils/lambda.ex
@@ -92,7 +92,7 @@ defmodule Meadow.Utils.Lambda do
     Logger.metadata(lambda: lambda)
 
     case ExAws.Lambda.invoke(lambda, payload, %{})
-         |> ExAws.request(http_opts: [receive_timeout: timeout], retries: [max_attempts: 1]) do
+         |> ExAws.request(http_opts: [receive_timeout: timeout]) do
       {:ok, %{"errorType" => _, "errorMessage" => error_message, "trace" => trace}} ->
         Meadow.Error.report(%Meadow.LambdaError{message: error_message}, __MODULE__, [], %{
           lambda: lambda,


### PR DESCRIPTION
# Summary 
Allow lambdas to retry

# Specific Changes in this PR
- Remove retry override from `lambda.ex`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

