### PR TITLE
Add ingest sheet export button to UI

### DIFF
--- a/app/assets/js/components/IngestSheet/List.jsx
+++ b/app/assets/js/components/IngestSheet/List.jsx
@@ -7,7 +7,7 @@ import UIModalDelete from "../UI/Modal/Delete";
 import { toastWrapper } from "@js/services/helpers";
 import UIIconText from "@js/components/UI/IconText";
 import { formatDate, TEMP_USER_FRIENDLY_STATUS } from "@js/services/helpers";
-import { IconAlert, IconTrashCan, IconView } from "@js/components/Icon";
+import { IconAlert, IconDownload, IconTrashCan, IconView } from "@js/components/Icon";
 import IngestSheetStatusTag from "@js/components/IngestSheet/StatusTag";
 import { Notification } from "@nulib/design-system";
 
@@ -48,6 +48,24 @@ const IngestSheetList = ({ project, subscribeToIngestSheetStatusChanges }) => {
     setModalOpen(false);
   };
 
+  const handleExportClick = (sheetId, title) => {
+    const filename = `${title.replace(/[^a-z0-9]/gi, '_').toLowerCase()}.csv`;
+    // Create form and submit to trigger download from S3 presigned URL
+    const form = document.createElement('form');
+    form.method = 'POST';
+    form.action = `/api/export/${filename}`;
+
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    input.name = 'sheet_id';
+    input.value = sheetId;
+
+    form.appendChild(input);
+    document.body.appendChild(form);
+    form.submit();
+    document.body.removeChild(form);
+  };
+
   return (
     <div>
       {project.ingestSheets.length === 0 && (
@@ -86,28 +104,42 @@ const IngestSheetList = ({ project, subscribeToIngestSheetStatusChanges }) => {
                       </IngestSheetStatusTag>
                     </td>
                     <td className="has-text-right">
-                      {["APPROVED", "COMPLETED", "COMPLETED_ERROR"].indexOf(
-                        status
-                      ) > -1 && (
-                        <Link
-                          to={`/project/${project.id}/ingest-sheet/${id}`}
-                          className="button is-light"
-                        >
-                          {<IconView />}{" "}
-                          <span className="is-sr-only">View</span>
-                        </Link>
-                      )}
-                      {["VALID", "ROW_FAIL", "FILE_FAIL", "UPLOADED"].indexOf(
-                        status
-                      ) > -1 && (
-                        <button
-                          className="button is-light"
-                          onClick={(e) => onOpenModal(e, { id, title })}
-                        >
-                          {<IconTrashCan />}{" "}
-                          <span className="is-sr-only">Delete</span>
-                        </button>
-                      )}
+                      <div className="buttons is-right">
+                        {["APPROVED", "COMPLETED", "COMPLETED_ERROR"].indexOf(
+                          status
+                        ) > -1 && (
+                          <Link
+                            to={`/project/${project.id}/ingest-sheet/${id}`}
+                            className="button is-light"
+                          >
+                            {<IconView />}{" "}
+                            <span className="is-sr-only">View</span>
+                          </Link>
+                        )}
+                        {["VALID", "APPROVED", "COMPLETED", "COMPLETED_ERROR", "ROW_FAIL"].indexOf(
+                          status
+                        ) > -1 && (
+                          <button
+                            className="button is-light"
+                            onClick={() => handleExportClick(id, title)}
+                            title="Export to CSV"
+                          >
+                            {<IconDownload />}{" "}
+                            <span className="is-sr-only">Export CSV</span>
+                          </button>
+                        )}
+                        {["VALID", "ROW_FAIL", "FILE_FAIL", "UPLOADED"].indexOf(
+                          status
+                        ) > -1 && (
+                          <button
+                            className="button is-light"
+                            onClick={(e) => onOpenModal(e, { id, title })}
+                          >
+                            {<IconTrashCan />}{" "}
+                            <span className="is-sr-only">Delete</span>
+                          </button>
+                        )}
+                      </div>
                     </td>
                   </tr>
                 )


### PR DESCRIPTION
# Summary 
Adds an ingest sheet export button to UI:

<img width="1094" height="208" alt="SCR-20260106-nltl" src="https://github.com/user-attachments/assets/101e9786-a8ec-4333-a5dc-01e7ffb03236" />


# Specific Changes in this PR
- Updates list component and export controller to download ingest sheets from s3

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

