### PR TITLE
Add fixity function to Meadow Terraform

### DIFF
--- a/infrastructure/deploy/fixity.tf
+++ b/infrastructure/deploy/fixity.tf
@@ -1,0 +1,16 @@
+resource "aws_cloudformation_stack" "serverless_fixity_solution" {
+  name         = "${local.project}-fixity"
+  template_url = "https://awsi-megs-guidances-us-east-1.s3.amazonaws.com/serverless-fixity-for-digital-preservation-compliance/latest/serverless-fixity-for-digital-preservation-compliance.template"
+  parameters = {
+    # The fixity stack won't deploy without an email address, so we'll give it a black hole address
+    # that we'll unsubscribe manually as soon as the stack finishes deploying
+    Email                 = "fixity-blackhole@mailinator.com"
+    VendorAccountRoleList = ""
+  }
+  capabilities = ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+}
+
+# Reference the state machine created by the CloudFormation stack
+data "aws_sfn_state_machine" "fixity_state_machine" {
+  name = aws_cloudformation_stack.serverless_fixity_solution.outputs.StateMachineName
+}


### PR DESCRIPTION
# Summary 

Update AWS Fixity Checksum solution to latest version and integrate with Meadow infrastructure.

# Specific Changes in this PR
- AWS Serverless Fixity for Digital Preservation Step Function updated to version 1.4.0
- Fixity function code added to Meadow Terraform.
- 
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Verify files uploaded to ingest and uploads buckets get the `computed-md5` and `computed-md5-last-modified` user metadata
- OR verify that ingest still works from w/in Meadow since it requires the above - but **YOU MUST USE NEWLY UPLOADED FILES** so they test the new checksummer.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

