### PR TITLE
Cache replaced terms so they don't get re-fetched all the time

### DIFF
--- a/app/lib/meadow/data/schemas/controlled_term_cache.ex
+++ b/app/lib/meadow/data/schemas/controlled_term_cache.ex
@@ -9,13 +9,14 @@ defmodule Meadow.Data.Schemas.ControlledTermCache do
   schema "controlled_term_cache" do
     field :label, :string
     field :variants, {:array, :string}, default: []
+    field :replaced_by, :string
     timestamps()
   end
 
   @doc false
   def changeset(entry, attrs) do
     entry
-    |> cast(attrs, [:id, :label, :variants])
+    |> cast(attrs, [:id, :label, :variants, :replaced_by])
     |> validate_required([:id, :label])
   end
 end

--- a/app/priv/repo/migrations/20260115223616_add_replaced_by_to_controlled_term_cache.exs
+++ b/app/priv/repo/migrations/20260115223616_add_replaced_by_to_controlled_term_cache.exs
@@ -1,0 +1,11 @@
+defmodule Meadow.Repo.Migrations.AddReplacedByToControlledTermCache do
+  use Ecto.Migration
+
+  def change do
+    alter table(:controlled_term_cache) do
+      add :replaced_by, :string, null: true
+    end
+
+    create index(:controlled_term_cache, [:replaced_by])
+  end
+end


### PR DESCRIPTION
# Summary 
When `Authoritex.fetch(obsolete_id)` returns `{:ok, %{id: replacement_id, ...}}`:
1. The replacement term gets cached with `replaced_by: nil`
2. The obsolete term gets cached with `replaced_by: replacement_id` and the same label/variants
3. Future fetches for the obsolete ID hit the DB cache instead of making HTTP requests

Log output example for a CSV metadata update that includes the obsolete subject: `TOPICAL:http://vocab.getty.edu/ulan/500461126` (note the `replaced_by` value for the record in the db):
```
module=Authoritex.Getty.ULAN id=821509b9-9431-4cb7-b068-0578cfa43274 [warning] http://vocab.getty.edu/ulan/500461126 is obsolete. Fetching replacement term http://vocab.getty.edu/ulan/500125274.
module=Ecto.Adapters.SQL id=821509b9-9431-4cb7-b068-0578cfa43274 [debug] QUERY OK source="controlled_term_cache" db=1.1ms
INSERT INTO "controlled_term_cache" ("id","label","variants","inserted_at","updated_at") VALUES ($1,$2,$3,$4,$5) ON CONFLICT DO NOTHING ["http://vocab.getty.edu/ulan/500125274", "unknown", ["anonymous"], ~N[2026-01-16 15:44:44], ~N[2026-01-16 15:44:44]]
module=Ecto.Adapters.SQL id=821509b9-9431-4cb7-b068-0578cfa43274 [debug] QUERY OK source="controlled_term_cache" db=0.9ms
INSERT INTO "controlled_term_cache" ("id","label","variants","replaced_by","inserted_at","updated_at") VALUES ($1,$2,$3,$4,$5,$6) ON CONFLICT DO NOTHING ["http://vocab.getty.edu/ulan/500461126", "unknown", ["anonymous"], "http://vocab.getty.edu/ulan/500125274", ~N[2026-01-16 15:44:44], ~N[2026-01-16 15:44:44]]
```

# Specific Changes in this PR
- list changes
- list changes
# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
To run the manual integration test: `mix test test/meadow/data/controlled_terms_test.exs --only manual`

Testing manually in `iex`:
```elixir
# Start with: iex -S mix          
# Clear any existing cache for these terms                                   
Meadow.Data.ControlledTerms.clear!("http://vocab.getty.edu/ulan/500461126")  
Meadow.Data.ControlledTerms.clear!("http://vocab.getty.edu/ulan/500125274")  

# First fetch - should show the warning and return :miss                     
Meadow.Data.ControlledTerms.fetch("http://vocab.getty.edu/ulan/500461126")   
# You should see the warning log, then: {{:ok, :miss}, %{id: "http://vocab.getty.edu/ulan/500125274", ...}}                               

# Check both are now cached in DB                                            
alias Meadow.Data.Schemas.ControlledTermCache                                
Meadow.Repo.get(ControlledTermCache, "http://vocab.getty.edu/ulan/500461126")
# Should show: %{id: "..500461126", replaced_by: "..500125274", label: "unknown", ...}                                                              

Meadow.Repo.get(ControlledTermCache, "http://vocab.getty.edu/ulan/500125274")
# Should show: %{id: "..500125274", replaced_by: nil, label: "unknown", ...} 

# Clear ETS to force DB lookup                                               
Cachex.clear!(Meadow.Cache.ControlledTerms)                                  

# Second fetch - should be :db hit with NO warning logged                    
Meadow.Data.ControlledTerms.fetch("http://vocab.getty.edu/ulan/500461126")   
# Should return: {{:ok, :db}, %{id: "..500461126", label: "unknown", ...}}   
```
The key thing to watch for: the second fetch should not log the "is obsolete" warning.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [x] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

