### PR TITLE
Create obsolete terms dashboard

### DIFF
--- a/app/assets/js/components/Dashboards/Authorities/ObsoleteTerms/List.jsx
+++ b/app/assets/js/components/Dashboards/Authorities/ObsoleteTerms/List.jsx
@@ -1,0 +1,110 @@
+import { Button, Notification } from "@nulib/design-system";
+import { GET_OBSOLETE_CONTROLLED_TERMS } from "@js/components/Dashboards/dashboards.gql";
+import { IconImages } from "@js/components/Icon";
+import { useHistory } from "react-router-dom";
+import { useQuery } from "@apollo/client";
+
+import React from "react";
+
+const colHeaders = ["Obsolete Term", "Obsolete Label", "Replacement Term"];
+
+export default function DashboardsObsoleteTermsList() {
+  const history = useHistory();
+  const [authorities, setAuthorities] = React.useState([]);
+  const [limit, setLimit] = React.useState(100);
+
+  // GraphQL
+  const { loading, error, data } = useQuery(GET_OBSOLETE_CONTROLLED_TERMS, {
+    variables: { limit },
+    pollInterval: 10000,
+  });
+
+  const limitOptions = [25, 50, 100, 500];
+
+  function filterValues() {
+    if (!data) return;
+    setAuthorities([...data.obsoleteControlledTerms]);
+  }
+
+  React.useEffect(() => {
+    if (!data) return;
+    filterValues();
+  }, [data, limit]);
+
+  if (loading) return null;
+  if (error) return <Notification isDanger>{error.toString()}</Notification>;
+
+  const handleViewClick = (value) => {
+    history.push("/search", {
+      passedInSearchTerm: `all_controlled_ids:\"${value}\"`,
+    });
+  };
+
+  return (
+    <React.Fragment>
+      <div
+        className="is-flex is-justify-content-flex-end is-align-items-center mb-5"
+        data-testid="obsolete-terms-dashboard-table-options"
+      >
+        <label className="is-flex is-align-items-center columns is-3">
+          <span className="column">Item Count</span>
+          <div className="is-flex is-align-items-center column">
+            {limitOptions.map((option) => {
+              return (
+                <button
+                  key={option}
+                  className={`button ${limit === option ? "is-primary active" : "is-ghost"}`}
+                  onClick={() => setLimit(option)}
+                >
+                  {option}
+                </button>
+              );
+            })}
+          </div>
+        </label>
+      </div>
+
+      <div className="table-container">
+        <table
+          className="table is-striped is-fullwidth"
+          data-testid="obsolete-terms-dashboard-table"
+        >
+          <thead>
+            <tr>
+              {colHeaders.map((col) => (
+                <th key={col}>{col}</th>
+              ))}
+              <th></th>
+            </tr>
+          </thead>
+          <tbody data-testid="obsolete-terms-table-body">
+            {authorities.map((record) => {
+              const { id = "", label = "", replacedBy = "" } = record;
+
+              return (
+                <tr key={id} data-testid="obsolete-terms-row">
+                  <td><a href={id} target="_blank" rel="noopener noreferrer">{id}</a></td>
+                  <td>{label}</td>
+                  <td><a href={replacedBy} target="_blank" rel="noopener noreferrer">{replacedBy}</a></td>
+
+                  <td className="has-text-right is-right mb-0">
+                    <div className="field is-grouped">
+                      <Button
+                        onClick={() => handleViewClick(id)}
+                        isLight
+                        data-testid="button-to-search"
+                        title="View works containing this record"
+                      >
+                        <IconImages />
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </React.Fragment>
+  );
+}

--- a/app/assets/js/components/Dashboards/Authorities/ObsoleteTerms/List.test.jsx
+++ b/app/assets/js/components/Dashboards/Authorities/ObsoleteTerms/List.test.jsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { renderWithRouterApollo } from "@js/services/testing-helpers";
+import { screen, within } from "@testing-library/react";
+import DashboardsObsoleteTermsList from "./List";
+import { getObsoleteTermsMock, getObsoleteTermsSetLimitMock } from "@js/components/Dashboards/dashboards.gql.mock";
+import userEvent from "@testing-library/user-event";
+
+describe("DashboardsObsoleteTermsList component", () => {
+  beforeEach(() => {
+    renderWithRouterApollo(<DashboardsObsoleteTermsList />, {
+      mocks: [
+        getObsoleteTermsMock,
+        getObsoleteTermsSetLimitMock,
+      ],
+    });
+  });
+
+  it("renders", async () => {
+    expect(await screen.findByTestId("obsolete-terms-dashboard-table"));
+  });
+
+  it("renders the correct number of obsolete terms rows", async () => {
+    const rows = await screen.findAllByTestId("obsolete-terms-row");
+    expect(rows).toHaveLength(2);
+  });
+
+  it("renders correct obsolete terms row details", async () => {
+    const td = await screen.findByText(
+      "http://id.authority.org/test/12345",
+    );
+    const row = td.closest("tr");
+    const utils = within(row);
+    expect(utils.getByText(/Obsolete Term 1/i));
+    expect(utils.getByText(/http:\/\/id.authority.org\/test\/67890/i));
+  });
+
+  it("renders correct obsolete terms query limit options", async () => {
+    const options = await screen.findByTestId(
+      "obsolete-terms-dashboard-table-options",
+    );
+
+    const buttons = within(options).getAllByRole("button");
+
+    // expect 4 buttons
+    expect(buttons).toHaveLength(4);
+
+    // expect button text content
+    expect(buttons[0]).toHaveTextContent("25");
+    expect(buttons[1]).toHaveTextContent("50");
+    expect(buttons[2]).toHaveTextContent("100");
+    expect(buttons[3]).toHaveTextContent("500");
+
+    // expect default active button
+    expect(buttons[2]).toHaveClass("active", "is-primary");
+
+    // expect button click and active class change
+    await userEvent.click(buttons[0]);
+    expect(await screen.findByText("25")).toHaveClass("active", "is-primary");
+  });
+});

--- a/app/assets/js/components/Dashboards/Authorities/ObsoleteTerms/TitleBar.jsx
+++ b/app/assets/js/components/Dashboards/Authorities/ObsoleteTerms/TitleBar.jsx
@@ -1,0 +1,21 @@
+import { ActionHeadline, PageTitle } from "@js/components/UI/UI";
+
+import NLogo from "@js/components/northwesternN.svg";
+import React from "react";
+import UIIconText from "@js/components/UI/IconText";
+
+function DashboardsObsoleteTermsTitleBar() {
+  return (
+    <React.Fragment>
+      <ActionHeadline data-testid="obsolete-terms-title-bar">
+        <PageTitle data-testid="obsolete-terms-dashboard-title">
+          <UIIconText icon={<NLogo width="24px" height="24px" />}>
+            Obsolete Controlled Terms Dashboard
+          </UIIconText>
+        </PageTitle>
+      </ActionHeadline>
+    </React.Fragment>
+  );
+}
+
+export default DashboardsObsoleteTermsTitleBar;

--- a/app/assets/js/components/Dashboards/Authorities/ObsoleteTerms/TitleBar.test.js
+++ b/app/assets/js/components/Dashboards/Authorities/ObsoleteTerms/TitleBar.test.js
@@ -1,0 +1,15 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { renderWithRouterApollo } from "@js/services/testing-helpers";
+import DashboardsObsoleteTermsTitleBar from "./TitleBar";
+
+describe("DashboardsObsoleteTermsTitleBar component", () => {
+  beforeEach(() => {
+    renderWithRouterApollo(<DashboardsObsoleteTermsTitleBar />);
+  });
+
+  it("renders component, title and add new button", () => {
+    expect(screen.getByTestId("obsolete-terms-title-bar"));
+    expect(screen.getByTestId("obsolete-terms-dashboard-title"));
+  });
+});

--- a/app/assets/js/components/Dashboards/dashboards.gql.js
+++ b/app/assets/js/components/Dashboards/dashboards.gql.js
@@ -159,3 +159,13 @@ export const UPDATE_NUL_AUTHORITY_RECORD = gql`
     }
   }
 `;
+
+export const GET_OBSOLETE_CONTROLLED_TERMS = gql`
+  query ListObsoleteControlledTerms($limit: Int) {
+    obsoleteControlledTerms(limit: $limit){
+      id
+      label
+      replacedBy
+    }
+  }
+`

--- a/app/assets/js/components/Dashboards/dashboards.gql.mock.js
+++ b/app/assets/js/components/Dashboards/dashboards.gql.mock.js
@@ -7,6 +7,7 @@ import {
   GET_NUL_AUTHORITY_RECORDS,
   UPDATE_NUL_AUTHORITY_RECORD,
   GET_PRESERVATION_CHECKS,
+  GET_OBSOLETE_CONTROLLED_TERMS,
 } from "@js/components/Dashboards/dashboards.gql";
 import { errors as csvMetadataUpdateJobErrors } from "@js/components/Dashboards/Csv/Errors";
 
@@ -143,6 +144,19 @@ export const mockNulAuthorityRecords = [
   },
 ];
 
+export const mockObsoleteTerms = [
+  {
+    id: "http://id.authority.org/test/12345",
+    label: "Obsolete Term 1",
+    replacedBy: "http://id.authority.org/test/67890",
+  },
+  {
+    id: "http://id.authority.org/test/54321",
+    label: "Obsolete Term 2",
+    replacedBy: "http://id.authority.org/test/09876",
+  },
+];
+
 export const deleteNulAuthorityRecordMock = {
   request: {
     query: DELETE_NUL_AUTHORITY_RECORD,
@@ -253,6 +267,34 @@ export const updateNulAuthorityRecordMock = {
   result: {
     data: {
       updateNulAuthorityRecord: mockNulAuthorityRecords[0],
+    },
+  },
+};
+
+export const getObsoleteTermsMock = {
+  request: {
+    query: GET_OBSOLETE_CONTROLLED_TERMS,
+    variables: {
+      limit: 100,
+    },
+  },
+  result: {
+    data: {
+      obsoleteControlledTerms: mockObsoleteTerms,
+    },
+  },
+};
+
+export const getObsoleteTermsSetLimitMock = {
+  request: {
+    query: GET_OBSOLETE_CONTROLLED_TERMS,
+    variables: {
+      limit: 25,
+    },
+  },
+  result: {
+    data: {
+      obsoleteControlledTerms: mockObsoleteTerms,
     },
   },
 };

--- a/app/assets/js/components/Icon/LinkedData.jsx
+++ b/app/assets/js/components/Icon/LinkedData.jsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { FiShare2 } from "react-icons/fi";
+
+export default function IconLinkedData(props) {
+  return <FiShare2 {...props} />;
+}

--- a/app/assets/js/components/Icon/index.js
+++ b/app/assets/js/components/Icon/index.js
@@ -26,6 +26,7 @@ import IconEnter from "@js/components/Icon/Enter";
 import IconExternalLink from "@js/components/Icon/ExternalLink";
 import IconFile from "@js/components/Icon/File";
 import IconImages from "@js/components/Icon/Images";
+import IconLinkedData from "@js/components/Icon/LinkedData";
 import IconList from "@js/components/Icon/List";
 import IconMagic from "@js/components/Icon/Magic";
 import IconMinus from "@js/components/Icon/Minus";
@@ -71,6 +72,7 @@ export {
   IconExternalLink,
   IconFile,
   IconImages,
+  IconLinkedData,
   IconList,
   IconMagic,
   IconMinus,

--- a/app/assets/js/components/UI/Layout/NavBar.jsx
+++ b/app/assets/js/components/UI/Layout/NavBar.jsx
@@ -16,6 +16,7 @@ import { GrDocumentCsv, GrMultiple } from "react-icons/gr";
 import {
   IconChart,
   IconCheck,
+  IconLinkedData,
   IconSearch,
   IconUser,
 } from "@js/components/Icon";
@@ -190,6 +191,13 @@ const UILayoutNavBar = () => {
                         <Link to="/dashboards/nul-local-authorities">
                           <IconText icon={<NLogo width="14px" height="14px" />}>
                             Local Authorities
+                          </IconText>
+                        </Link>
+                      </UILayoutNavDropdownItem>
+                      <UILayoutNavDropdownItem>
+                        <Link to="/dashboards/obsolete-terms">
+                          <IconText icon={<IconLinkedData />}>
+                            Obsolete Controlled Terms
                           </IconText>
                         </Link>
                       </UILayoutNavDropdownItem>

--- a/app/assets/js/screens/Dashboards/Authorities/ObsoleteTerms/List.jsx
+++ b/app/assets/js/screens/Dashboards/Authorities/ObsoleteTerms/List.jsx
@@ -1,0 +1,48 @@
+import React from "react";
+import Layout from "@js/screens/Layout";
+import DashboardsObsoleteTermsList from "@/js/components/Dashboards/Authorities/ObsoleteTerms/List";
+import DashboardsObsoleteTermsTitleBar from "@/js/components/Dashboards/Authorities/ObsoleteTerms/TitleBar"; "@js/components/Dashboards/ObsoleteTerms/TitleBar";
+import { ErrorBoundary } from "react-error-boundary";
+import { Breadcrumbs, FallbackErrorComponent } from "@js/components/UI/UI";
+import useGTM from "@js/hooks/useGTM";
+
+function ScreensDashboardsObsoleteTermsList() {
+  const { loadDataLayer } = useGTM();
+
+  React.useEffect(() => {
+    loadDataLayer({ pageTitle: "Obsolete Controlled Terms Dashboard" });
+  }, []);
+
+  return (
+    <Layout>
+      <section
+        className="section"
+        data-testid="dashboard-obsolete-terms-screen"
+      >
+        <div className="container">
+          <Breadcrumbs
+            items={[
+              {
+                label: "Dashboards",
+                isActive: false,
+              },
+              {
+                label: "Obsolete Controlled Terms",
+                route: "/dashboards/obsolete-terms",
+                isActive: true,
+              },
+            ]}
+          />
+          <ErrorBoundary FallbackComponent={FallbackErrorComponent}>
+            <DashboardsObsoleteTermsTitleBar />
+            <DashboardsObsoleteTermsList />
+          </ErrorBoundary>
+        </div>
+      </section>
+    </Layout>
+  );
+}
+
+ScreensDashboardsObsoleteTermsList.propTypes = {};
+
+export default ScreensDashboardsObsoleteTermsList;

--- a/app/assets/js/screens/Root.jsx
+++ b/app/assets/js/screens/Root.jsx
@@ -23,6 +23,7 @@ import ScreensDashboardsBatchEditList from "@js/screens/Dashboards/BatchEdit/Lis
 import ScreensDashboardsCsvDetails from "@js/screens/Dashboards/Csv/Details";
 import ScreensDashboardsCsvList from "@js/screens/Dashboards/Csv/List";
 import ScreensDashboardsLocalAuthoritiesList from "@js/screens/Dashboards/LocalAuthorities/List";
+import ScreensDashboardsObsoleteTermsList from "./Dashboards/Authorities/ObsoleteTerms/List";
 import ScreensDashboardsPreservationChecksList from "@js/screens/Dashboards/PreservationChecks/List";
 import ScreensDashboardsUsersList from "@js/screens/Dashboards/Users/List";
 import ScreensIngestSheet from "./IngestSheet/IngestSheet";
@@ -65,6 +66,11 @@ export default class Root extends React.Component {
                   exact
                   path="/dashboards/nul-local-authorities"
                   component={ScreensDashboardsLocalAuthoritiesList}
+                />
+                <PrivateRoute
+                  exact
+                  path="/dashboards/obsolete-terms"
+                  component={ScreensDashboardsObsoleteTermsList}
                 />
                 <PrivateRoute
                   exact

--- a/app/lib/meadow/config/runtime.ex
+++ b/app/lib/meadow/config/runtime.ex
@@ -326,6 +326,13 @@ defmodule Meadow.Config.Runtime do
         {
           get_secret(:meadow, ["scheduler", "preservation_check"], "0 2 * * *"),
           {Meadow.Data.PreservationChecks, :start_job, []}
+        },
+        # Expire entries in the controlled terms cache nightly at midnight Central.
+        # Entries older than 2 weeks will be deleted, but no more than 2,500
+        # at a time (to avoid overwhelming downstream authorities on re-fetch).
+        {
+          get_secret(:meadow, ["scheduler", "controlled_terms_expire"], "0 0 * * *"),
+          {Meadow.Data.ControlledTerms, :expire!, [14 * 24 * 60 * 60, [limit: 2_500]]}
         }
       ]
 

--- a/app/lib/meadow_web/resolvers/controlled_vocabulary.ex
+++ b/app/lib/meadow_web/resolvers/controlled_vocabulary.ex
@@ -1,7 +1,7 @@
 defmodule MeadowWeb.Resolvers.Data.ControlledVocabulary do
   @moduledoc "GraphQL Resolvers for Controlled and Coded terms"
 
-  alias Meadow.Data.CodedTerms
+  alias Meadow.Data.{CodedTerms, ControlledTerms}
 
   def code_list(_, %{scheme: scheme}, _) do
     {:ok, CodedTerms.list_coded_terms(scheme)}
@@ -15,5 +15,9 @@ defmodule MeadowWeb.Resolvers.Data.ControlledVocabulary do
       {{:ok, _}, term} ->
         {:ok, term}
     end
+  end
+
+  def obsolete_controlled_terms(_, %{limit: limit}, _) do
+    {:ok, ControlledTerms.list_obsolete_terms(limit)}
   end
 end

--- a/app/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
+++ b/app/lib/meadow_web/schema/types/data/controlled_vocabulary_types.ex
@@ -50,6 +50,13 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
 
       resolve(&GeoNames.place/3)
     end
+
+    @desc "Get a list of obsolete terms in use"
+    field :obsolete_controlled_terms, list_of(:obsolete_term) do
+      arg(:limit, :integer, default_value: 100)
+      middleware(Middleware.Authenticate)
+      resolve(&ControlledVocabulary.obsolete_controlled_terms/3)
+    end
   end
 
   @desc "Search or fetch result"
@@ -57,6 +64,14 @@ defmodule MeadowWeb.Schema.Data.ControlledTermTypes do
     field :id, :id
     field :label, :string
     field :hint, :string
+  end
+
+  @desc "Obsolete controlled term with replacement"
+  object :obsolete_term do
+    field :id, :id
+    field :label, :string
+    field :hint, :string
+    field :replaced_by, :id
   end
 
   @desc "Controlled value associated with a role"

--- a/app/priv/repo/migrations/20260121192529_create_updated_at_index_on_controlled_term_cache.exs
+++ b/app/priv/repo/migrations/20260121192529_create_updated_at_index_on_controlled_term_cache.exs
@@ -1,0 +1,7 @@
+defmodule Meadow.Repo.Migrations.CreateUpdatedAtIndexOnControlledTermCache do
+  use Ecto.Migration
+
+  def change do
+    create(index(:controlled_term_cache, [:updated_at]))
+  end
+end

--- a/app/priv/search/v2/settings/work.json
+++ b/app/priv/search/v2/settings/work.json
@@ -46,6 +46,9 @@
         "search_analyzer": "stopword_analyzer",
         "search_quote_analyzer": "full_analyzer"
       },
+      "all_controlled_ids": {
+        "type": "keyword"
+      },
       "all_controlled_labels": {
         "type": "text",
         "analyzer": "full_analyzer",
@@ -92,6 +95,18 @@
             "search_quote_analyzer": "full_analyzer",
             "copy_to": [
               "all_text"
+            ]
+          }
+        }
+      },
+      {
+        "controlled_term_ids": {
+          "path_match": "^contributor.id$|^creator.id$|^genre.id$|^language.id$|^location.id$|^style_period.id$|^subject.id$|^technique.id$",
+          "match_pattern": "regex",
+          "mapping": {
+            "type": "keyword",
+            "copy_to": [
+              "all_controlled_ids"
             ]
           }
         }

--- a/app/test/meadow/data/controlled_terms_test.exs
+++ b/app/test/meadow/data/controlled_terms_test.exs
@@ -119,10 +119,15 @@ defmodule Meadow.Data.ControlledTermsTest do
     end
 
     test "expire on age and prefix" do
-      assert {2, nil} == ControlledTerms.expire!(200, "mock1:")
+      assert {2, nil} == ControlledTerms.expire!(200, prefix: "mock1:")
       assert {{:ok, :miss}, _} = ControlledTerms.fetch("mock1:result1")
       assert {{:ok, :miss}, _} = ControlledTerms.fetch("mock1:result2")
       assert {{:ok, :db}, _} = ControlledTerms.fetch("mock2:result3")
+    end
+
+    test "expire on age with a limit" do
+      assert {2, nil} == ControlledTerms.expire!(200, limit: 2)
+      assert Repo.aggregate(ControlledTermCache, :count) == 1
     end
   end
 


### PR DESCRIPTION
# Summary 
Create obsolete terms dashboard

# Specific Changes in this PR
- Add `ControlledTerms.list_obsolete_terms/1`
- Add GraphQL query to retrieve obsolete terms
- Create front end dashboard to list obsolete terms with their replacements and search links
- Add `all_controlled_ids` keyword field to work index to find works by controlled ID (not just label) across all controlled fields
- Alter `ControlledTerms.expire!/2` to make the second argument a list of options (`prefix` and `limit`)
- Add a job to the Quantum scheduler to expire cached terms older than 2 weeks every night, with a maximum of 2,500

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

1. Do a full reindex of just the Work schema.
2. Add some obsolete terms to your descriptive metadata across a few different works. You may have to do this manually to avoid the system correcting them to the canonical IDs on the fly. Some good candidate URIs are:
    - http://id.worldcat.org/fast/fst01072793
    - http://id.worldcat.org/fast/fst01205331
    - http://id.worldcat.org/fast/fst01209421
    - http://id.worldcat.org/fast/fst00348231
    - http://vocab.getty.edu/ulan/500452875
    - http://vocab.getty.edu/ulan/500456186
    - http://vocab.getty.edu/ulan/500461126
    - http://vocab.getty.edu/ulan/500031933
  (Note the `fstXXXXXX` formatting of the FAST URIs. The replacement IDs are the same with the `fst` and leading zeroes removed.)
3. Use the new Obsolete Terms dashboard to view obsolete terms and their replacement IDs, and link to the affected works.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [x] GraphQL API
  - [x] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

