### PR TITLE
Add local note indicating AI augmented metadata when proposing plan changes via auto edit

### DIFF
--- a/app/priv/python/agent/src/meadow_metadata_agent/prompts.py
+++ b/app/priv/python/agent/src/meadow_metadata_agent/prompts.py
@@ -58,8 +58,9 @@ def proposer_prompt():
     3. Take the FIRST pending PlanChange
     4. Query the work's metadata via graphql
     5. Propose changes based on the plan prompt and work data
-    6. update_plan_change with the PlanChange id, add/delete/replace data, status 'proposed'
-    7. Repeat
+    6. If you are proposing any metadata changes, add a note indicating AI assistance with current date in ISO format (YYYY-MM-DD)
+    7. update_plan_change with the PlanChange id, add/delete/replace data, status 'proposed'
+    8. Repeat
 
     Rules:
     - Always query work data; avoid assumptions
@@ -68,8 +69,9 @@ def proposer_prompt():
     - After all changes, call propose_plan so the plan itself is proposed; do not skip
     - Return a summary with counts
     - The `id` field can never be changed
-    - The `title` is a single strings; do not use lists
+    - The `title` is a single string; do not use lists
     - Works can only have one rights statement
+    - CRITICAL: When proposing metadata changes for a work, ALWAYS add an AI assistance note with note_type LOCAL_NOTE and content "Some metadata created with the assistance of AI on <YYYY-MM-DD>" using the current date. Do NOT add this note if you are not proposing any other metadata changes (e.g., if the requested field is missing or the change cannot be made)
 
     Controlled term fields (must use authoritiesSearch): contributor (role required, marc_relator), creator (role optional, marc_relator), genre, language, location, subject (role required, subject_role), style_period, technique.
 
@@ -134,6 +136,23 @@ def proposer_prompt():
         }]
       }
     }
+
+    CRITICAL - AI Assistance Note (REQUIRED when proposing metadata changes):
+    When proposing metadata changes (add/replace/delete operations) for a work, you MUST include an AI assistance note with type LOCAL_NOTE:
+    {
+      "descriptive_metadata": {
+        "notes": [{
+          "note": "Some metadata created with the assistance of AI on 2026-01-22",
+          "type": {
+            "id": "LOCAL_NOTE",
+            "scheme": "note_type",
+            "label": "Local Note"
+          }
+        }]
+      }
+    }
+    Use the current date in ISO format (YYYY-MM-DD). Add this note to the "add" section along with other metadata changes.
+    Do NOT add this note if you are not proposing any other metadata changes (e.g., no changes needed, requested field is missing, or change cannot be made).
 
     Example for related_url with label coded term:
     1. Query: codeList(scheme: RELATED_URL_LABEL) { id label scheme }


### PR DESCRIPTION
# Summary 

When auto edit plan changes are proposed, add a local note indicating that metadata is AI augmented. 

# Specific Changes in this PR

- Update prompt to include local note about AI augmented metadata.

# Steps to Test

- Perform an auto edit and verify that the note is present in the plan changes and the metadata once the plan is applied.


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major



# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

