### PR TITLE
Add experimental feature label to navPlace

### DIFF
--- a/app/assets/js/components/Work/Tabs/About.jsx
+++ b/app/assets/js/components/Work/Tabs/About.jsx
@@ -284,14 +284,19 @@ const WorkTabsAbout = ({ work }) => {
             />
           )}
         </UIAccordion>
-        <UIAccordion testid="geo-metadata-wrapper" title="Geographic Context">
+        <UIAccordion testid="geo-metadata-wrapper" title="Geographic Context (Experimental)">
           {updateWorkLoading ? (
             <Skeleton rows={6} />
           ) : (
-            <WorkTabsAboutGeoNamesNavPlace
-              descriptiveMetadata={descriptiveMetadata}
-              isEditing={isEditing}
-            />
+            <>
+              <div className="notification is-warning is-light mb-4">
+                <strong>Experimental Feature:</strong> This field is experimental and not yet ready for production use. Please do not use it at this time.
+              </div>
+              <WorkTabsAboutGeoNamesNavPlace
+                descriptiveMetadata={descriptiveMetadata}
+                isEditing={isEditing}
+              />
+            </>
           )}
         </UIAccordion>
         <UIAccordion

--- a/app/assets/js/components/Work/Tabs/About/GeoNamesNavPlace.jsx
+++ b/app/assets/js/components/Work/Tabs/About/GeoNamesNavPlace.jsx
@@ -259,7 +259,7 @@ const GeoNamesComboBox = ({
 
   return (
     <>
-      <UIFormField label="GeoNames place">
+      <UIFormField label="GeoNames place (Experimental - Do Not Use)">
         <input
           {...getInputProps({
             className: `input ${hasErrors ? "is-danger" : ""}`,

--- a/app/priv/python/agent/src/meadow_metadata_agent/prompts.py
+++ b/app/priv/python/agent/src/meadow_metadata_agent/prompts.py
@@ -23,8 +23,8 @@ def agent_prompt_with_plan(plan_id, user_query, context_data):
 
     CRITICAL: You and the subagent MUST send 3-5 word, user-friendly progress updates via send_status_update.
 
-    IMPORTANT: Always use authoritiesSearch for controlled terms; never invent IDs. For coded fields (roles, note types, etc.), 
-    use codeList. Do not touch deprecated fields.
+    IMPORTANT: Always use authoritiesSearch for controlled terms; never invent IDs. For coded fields (roles, note types, etc.),
+    use codeList. Do not touch deprecated fields. NEVER populate the navPlace field (experimental, not ready for use).
 
     Finish with a concise summary of proposed changes. Keep the summary focused on the changed fields instead of the plan process itself. Do not mention the subagent or anything related to plan status. Do not include headers or introductory text in the summary.
     
@@ -72,6 +72,7 @@ def proposer_prompt():
     - The `title` is a single string; do not use lists
     - Works can only have one rights statement
     - CRITICAL: When proposing metadata changes for a work, ALWAYS add an AI assistance note with note_type LOCAL_NOTE and content "Some metadata created with the assistance of AI on <YYYY-MM-DD>" using the current date. Do NOT add this note if you are not proposing any other metadata changes (e.g., if the requested field is missing or the change cannot be made)
+    - NEVER populate the navPlace field - it is experimental and not ready for use
 
     Controlled term fields (must use authoritiesSearch): contributor (role required, marc_relator), creator (role optional, marc_relator), genre, language, location, subject (role required, subject_role), style_period, technique.
 


### PR DESCRIPTION
# Summary 

`navPlace` field needs some refinements before it is ready for production use. We don't want to remove it but need to indicate to users not to use it.


<img width="1471" height="327" alt="Screenshot 2026-01-26 at 7 48 02 AM" src="https://github.com/user-attachments/assets/94937c1c-3de2-4e05-9712-cf22052ab6d5" />



# Specific Changes in this PR

- Experimental feature text added to edit form
- Agent instructed not to populate navPlace during auto edit.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Try to edit a work and notice experimental feature text next to Geographic Context

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

