### PR TITLE
Title should always be a replace in auto edit to avoid creating arrays

### DIFF
--- a/app/test/meadow/data/planner_test.exs
+++ b/app/test/meadow/data/planner_test.exs
@@ -847,6 +847,25 @@ defmodule Meadow.Data.PlannerTest do
       assert humanized != nil
     end
 
+    test "applies add change to single-valued title field using replace mode", %{plan: plan} do
+      work = work_fixture(%{descriptive_metadata: %{title: "Original Title"}})
+
+      {:ok, change} =
+        Planner.create_plan_change(%{
+          plan_id: plan.id,
+          work_id: work.id,
+          add: %{descriptive_metadata: %{title: "Updated Title"}},
+          status: :approved
+        })
+
+      assert {:ok, completed_change} = Planner.apply_plan_change(change)
+      assert completed_change.status == :completed
+
+      updated_work = Repo.get!(Meadow.Data.Schemas.Work, work.id)
+
+      assert updated_work.descriptive_metadata.title == "Updated Title"
+    end
+
     test "marks error when work not found", %{plan: plan} do
       fake_work_id = Ecto.UUID.generate()
 


### PR DESCRIPTION
# Summary 

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5777

Sometimes the proposed change for the `title` can be a `ADD` (seems to depend a bit on prompting), which tries to apply the change as a list, and then errors.

```
{
    "data": {
        "applyPlan": {
            "__typename": "Plan",
            "completedAt": null,
            "error": "\"cannot load `[nil, \\\"Coffee\\\"]` as type :string for field `title` in schema Meadow.Data.Schemas.WorkDescriptiveMetadata\"",
            "id": "8061eabe-3a8c-4e2b-ac50-b2b12865e7de",
            "status": "ERROR"
        }
    }
}
```


# Specific Changes in this PR

- In the planner, handle title the same way coded terms are handled to avoid creating arrays



# Steps to Test

- On a work with no title, use auto edit to add a title (Usually a prompt like "Add title 'Coffee cup" will work but sometimes you have to try it a couple times to get an ADD rather than a REPLACE)
- Verify that the changes can be successfully approved and applied


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major



# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

