### PR TITLE
Fix flappy tests (🤞)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,10 +114,11 @@ jobs:
         run: mix credo
         working-directory: app
       - name: Elixir Tests
-        run: mix test || mix test --failed
+        run: mix test || mix test --seed $(cat ${MEADOW_TEST_SAVE_SEED}) --failed
         env:
           AWS_LOCALSTACK: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MEADOW_TEST_SAVE_SEED: ${{ runner.temp }}/MEADOW_TEST_SEED
         working-directory: app
       # - name: Test DB Rollback
       #   run: mix ecto.rollback --all

--- a/app/test/meadow/error_test.exs
+++ b/app/test/meadow/error_test.exs
@@ -1,7 +1,7 @@
 defmodule Meadow.ErrorTest do
   use Honeybadger.Case
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
 
   use Meadow.Utils.Logging
 

--- a/app/test/meadow_ai/metadata_agent_test.exs
+++ b/app/test/meadow_ai/metadata_agent_test.exs
@@ -1,5 +1,5 @@
 defmodule MeadowAI.MetadataAgentTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   describe "init/1" do
     setup do

--- a/app/test/meadow_web/resolvers/geo_names_test.exs
+++ b/app/test/meadow_web/resolvers/geo_names_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Resolvers.Data.GeoNamesTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Meadow.AuthorityCase
   use Meadow.GeoNamesCase
   use Wormwood.GQLCase

--- a/app/test/meadow_web/schema/middleware/authenticate_test.exs
+++ b/app/test/meadow_web/schema/middleware/authenticate_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Middleware.AuthenticateTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
 
   alias MeadowWeb.Schema.Middleware.Authenticate
 

--- a/app/test/meadow_web/schema/middleware/authorize_test.exs
+++ b/app/test/meadow_web/schema/middleware/authorize_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Middleware.AuthorizeTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
 
   alias MeadowWeb.Schema.Middleware.Authorize
 

--- a/app/test/meadow_web/schema/mutation/add_work_to_collection_test.exs
+++ b/app/test/meadow_web/schema/mutation/add_work_to_collection_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.AddWorkToCollectionTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/AddWorkToCollection.gql")

--- a/app/test/meadow_web/schema/mutation/add_works_to_collection_test.exs
+++ b/app/test/meadow_web/schema/mutation/add_works_to_collection_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.AddWorksToCollectionTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   alias Meadow.Data.Collections

--- a/app/test/meadow_web/schema/mutation/batch_delete_test.exs
+++ b/app/test/meadow_web/schema/mutation/batch_delete_test.exs
@@ -1,7 +1,7 @@
 defmodule MeadowWeb.Schema.Mutation.BatchDeleteTest do
   use Meadow.DataCase
   use Meadow.IndexCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
   alias Meadow.Data.Indexer
 

--- a/app/test/meadow_web/schema/mutation/batch_update_test.exs
+++ b/app/test/meadow_web/schema/mutation/batch_update_test.exs
@@ -1,7 +1,7 @@
 defmodule MeadowWeb.Schema.Mutation.BatchUpdateTest do
   use Meadow.DataCase
   use Meadow.IndexCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
   alias Meadow.Data.Indexer
 

--- a/app/test/meadow_web/schema/mutation/create_collection_test.exs
+++ b/app/test/meadow_web/schema/mutation/create_collection_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.CreateCollectionTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/CreateCollection.gql")

--- a/app/test/meadow_web/schema/mutation/create_ingest_sheet_test.exs
+++ b/app/test/meadow_web/schema/mutation/create_ingest_sheet_test.exs
@@ -1,7 +1,7 @@
 defmodule MeadowWeb.Schema.Mutation.CreateSheet do
   use Meadow.DataCase
   use Meadow.S3Case
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/CreateIngestSheet.gql")

--- a/app/test/meadow_web/schema/mutation/create_nul_authority_record.exs
+++ b/app/test/meadow_web/schema/mutation/create_nul_authority_record.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.CreateNULAuthorityRecordTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/CreateNULAuthorityRecord.gql")

--- a/app/test/meadow_web/schema/mutation/create_project_test.exs
+++ b/app/test/meadow_web/schema/mutation/create_project_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.CreateProjectTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   alias Meadow.Ingest.Projects

--- a/app/test/meadow_web/schema/mutation/create_shared_link_test.exs
+++ b/app/test/meadow_web/schema/mutation/create_shared_link_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Resolvers.Data.SharedLinkTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/CreateSharedLink.gql")

--- a/app/test/meadow_web/schema/mutation/create_work_test.exs
+++ b/app/test/meadow_web/schema/mutation/create_work_test.exs
@@ -1,7 +1,7 @@
 defmodule MeadowWeb.Schema.Mutation.CreateWorkTest do
   use Meadow.AuthorityCase
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/CreateWork.gql")

--- a/app/test/meadow_web/schema/mutation/delete_collection_test.exs
+++ b/app/test/meadow_web/schema/mutation/delete_collection_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.DeleteCollectionTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/DeleteCollection.gql")

--- a/app/test/meadow_web/schema/mutation/delete_file_set_annotation_test.exs
+++ b/app/test/meadow_web/schema/mutation/delete_file_set_annotation_test.exs
@@ -1,7 +1,7 @@
 defmodule MeadowWeb.Schema.Mutation.DeleteFileSetAnnotationTest do
   use Meadow.DataCase
   use Meadow.S3Case
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   alias Meadow.Data.FileSets

--- a/app/test/meadow_web/schema/mutation/delete_file_set_test.exs
+++ b/app/test/meadow_web/schema/mutation/delete_file_set_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.DeleteFileSetTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   alias Meadow.Data.FileSets

--- a/app/test/meadow_web/schema/mutation/delete_nul_authority_record_test.exs
+++ b/app/test/meadow_web/schema/mutation/delete_nul_authority_record_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.DeleteNULAuthorityRecordTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   alias NUL.AuthorityRecords

--- a/app/test/meadow_web/schema/mutation/ingest_file_set_test.exs
+++ b/app/test/meadow_web/schema/mutation/ingest_file_set_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.IngestFileSetTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Meadow.S3Case
   use Wormwood.GQLCase
 

--- a/app/test/meadow_web/schema/mutation/metadata_update_test.exs
+++ b/app/test/meadow_web/schema/mutation/metadata_update_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.MetadataUpdateTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Meadow.CSVMetadataUpdateCase
   use Wormwood.GQLCase
 

--- a/app/test/meadow_web/schema/mutation/remove_works_from_collection_test.exs
+++ b/app/test/meadow_web/schema/mutation/remove_works_from_collection_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.RemoveWorksFromCollectionTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   alias Meadow.Data.Collections

--- a/app/test/meadow_web/schema/mutation/replace_file_set_test.exs
+++ b/app/test/meadow_web/schema/mutation/replace_file_set_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.ReplaceFileSetTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Meadow.S3Case
   use Wormwood.GQLCase
 

--- a/app/test/meadow_web/schema/mutation/send_chat_message_test.exs
+++ b/app/test/meadow_web/schema/mutation/send_chat_message_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.SendChatMessageTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/SendChatMessage.gql")

--- a/app/test/meadow_web/schema/mutation/set_collection_image_test.exs
+++ b/app/test/meadow_web/schema/mutation/set_collection_image_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.SetCollectionImageTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
   alias Meadow.Data.Collections
 

--- a/app/test/meadow_web/schema/mutation/set_work_image_test.exs
+++ b/app/test/meadow_web/schema/mutation/set_work_image_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.SetWorkImageTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
   alias Meadow.Data.Works
 

--- a/app/test/meadow_web/schema/mutation/transfer_file_sets_test.exs
+++ b/app/test/meadow_web/schema/mutation/transfer_file_sets_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.TransferFileSetsTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/TransferFileSets.gql")
@@ -82,7 +82,7 @@ end
 
 defmodule MeadowWeb.Schema.Mutation.TransferFileSetsTest.Subset do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/TransferFileSetsSubset.gql")

--- a/app/test/meadow_web/schema/mutation/udpate_nul_authority_record.exs
+++ b/app/test/meadow_web/schema/mutation/udpate_nul_authority_record.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.UpdateNULAuthorityRecordTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   alias NUL.AuthorityRecords

--- a/app/test/meadow_web/schema/mutation/update_access_file_order_test.exs
+++ b/app/test/meadow_web/schema/mutation/update_access_file_order_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.UpdateAccessFileOrderTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/UpdateAccessFileOrder.gql")

--- a/app/test/meadow_web/schema/mutation/update_file_set_annotation_test.exs
+++ b/app/test/meadow_web/schema/mutation/update_file_set_annotation_test.exs
@@ -1,7 +1,7 @@
 defmodule MeadowWeb.Schema.Mutation.UpdateFileSetAnnotationTest do
   use Meadow.DataCase
   use Meadow.S3Case
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   alias Meadow.Data.FileSets

--- a/app/test/meadow_web/schema/mutation/update_file_set_test.exs
+++ b/app/test/meadow_web/schema/mutation/update_file_set_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.UpdateFileSetTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/UpdateFileSet.gql")

--- a/app/test/meadow_web/schema/mutation/update_file_sets_test.exs
+++ b/app/test/meadow_web/schema/mutation/update_file_sets_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.UpdateFileSetsTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/UpdateFileSets.gql")

--- a/app/test/meadow_web/schema/mutation/update_plan_change_status_test.exs
+++ b/app/test/meadow_web/schema/mutation/update_plan_change_status_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.UpdatePlanChangeStatusTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/UpdatePlanChangeStatus.gql")

--- a/app/test/meadow_web/schema/mutation/update_plan_status_test.exs
+++ b/app/test/meadow_web/schema/mutation/update_plan_status_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.UpdatePlanStatusTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/UpdatePlanStatus.gql")

--- a/app/test/meadow_web/schema/mutation/update_project_test.exs
+++ b/app/test/meadow_web/schema/mutation/update_project_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.UpdateProjectTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/UpdateProject.gql")

--- a/app/test/meadow_web/schema/mutation/update_proposed_plan_change_statuses_test.exs
+++ b/app/test/meadow_web/schema/mutation/update_proposed_plan_change_statuses_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.UpdateProposedPlanChangeStatusesTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/UpdateProposedPlanChangeStatuses.gql")

--- a/app/test/meadow_web/schema/mutation/update_work_test.exs
+++ b/app/test/meadow_web/schema/mutation/update_work_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Mutation.UpdateWorkTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   alias Meadow.Data.Works

--- a/app/test/meadow_web/schema/query/action_states_test.exs
+++ b/app/test/meadow_web/schema/query/action_states_test.exs
@@ -1,7 +1,7 @@
 defmodule MeadowWeb.Schema.Query.ActionStatesTest do
   use Meadow.DataCase
   use Meadow.IngestCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
   alias Meadow.Data.ActionStates
   alias Meadow.Pipeline.Actions.{ExtractMimeType, IngestFileSet}

--- a/app/test/meadow_web/schema/query/api_token_test.exs
+++ b/app/test/meadow_web/schema/query/api_token_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.ApiTokenTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   set_gql(

--- a/app/test/meadow_web/schema/query/collections_test.exs
+++ b/app/test/meadow_web/schema/query/collections_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.CollectionsTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/GetCollections.gql")

--- a/app/test/meadow_web/schema/query/controlled_types/authorities_search_test.exs
+++ b/app/test/meadow_web/schema/query/controlled_types/authorities_search_test.exs
@@ -1,7 +1,7 @@
 defmodule MeadowWeb.Schema.Query.AuthoritiesSearchTest do
   use Meadow.AuthorityCase
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   alias NUL.Schemas.AuthorityRecord

--- a/app/test/meadow_web/schema/query/controlled_types/code_list_test.exs
+++ b/app/test/meadow_web/schema/query/controlled_types/code_list_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.CodeListTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/CodeList.gql")

--- a/app/test/meadow_web/schema/query/controlled_types/fetch_coded_term_label_test.exs
+++ b/app/test/meadow_web/schema/query/controlled_types/fetch_coded_term_label_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.FetchCodedTermLabelTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/FetchCodedTermLabel.gql")

--- a/app/test/meadow_web/schema/query/controlled_types/fetch_controlled_term_label_test.exs
+++ b/app/test/meadow_web/schema/query/controlled_types/fetch_controlled_term_label_test.exs
@@ -1,7 +1,7 @@
 defmodule MeadowWeb.Schema.Query.FetchControlledTermLabelTest do
   use Meadow.AuthorityCase
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/FetchControlledTermLabel.gql")

--- a/app/test/meadow_web/schema/query/dcapi_endpoint_test.exs
+++ b/app/test/meadow_web/schema/query/dcapi_endpoint_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.DcapiEndpointTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   set_gql(

--- a/app/test/meadow_web/schema/query/describe_fields_test.exs
+++ b/app/test/meadow_web/schema/query/describe_fields_test.exs
@@ -1,7 +1,7 @@
 defmodule MeadowWeb.Schema.Query.DescribeFieldsTest do
   defmodule All do
     use Meadow.DataCase
-    use MeadowWeb.ConnCase, async: true
+    use MeadowWeb.ConnCase, async: false
     use Wormwood.GQLCase
     load_gql(MeadowWeb.Schema, "test/gql/DescribeFields.gql")
 
@@ -13,7 +13,7 @@ defmodule MeadowWeb.Schema.Query.DescribeFieldsTest do
 
   defmodule ByID do
     use Meadow.DataCase
-    use MeadowWeb.ConnCase, async: true
+    use MeadowWeb.ConnCase, async: false
     use Wormwood.GQLCase
     load_gql(MeadowWeb.Schema, "test/gql/DescribeField.gql")
 

--- a/app/test/meadow_web/schema/query/file_sets_test.exs
+++ b/app/test/meadow_web/schema/query/file_sets_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.FileSetsTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
 
   @query """
   query {

--- a/app/test/meadow_web/schema/query/get_batch_by_id_test.exs
+++ b/app/test/meadow_web/schema/query/get_batch_by_id_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.GetBatchByIdTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/GetBatchById.gql")

--- a/app/test/meadow_web/schema/query/get_batches_test.exs
+++ b/app/test/meadow_web/schema/query/get_batches_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.BatchesTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/GetBatches.gql")

--- a/app/test/meadow_web/schema/query/get_collection_by_id_test.exs
+++ b/app/test/meadow_web/schema/query/get_collection_by_id_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.GetCollectionByIdTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/GetCollectionById.gql")

--- a/app/test/meadow_web/schema/query/get_group_members.exs
+++ b/app/test/meadow_web/schema/query/get_group_members.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.GetGroupMembersTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/GetGroupMembers.gql")

--- a/app/test/meadow_web/schema/query/get_metadata_update_job_by_id_test.exs
+++ b/app/test/meadow_web/schema/query/get_metadata_update_job_by_id_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.GetMetadataUpdateJobByIdTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Meadow.CSVMetadataUpdateCase
   use Wormwood.GQLCase
   alias Meadow.Data.CSV.MetadataUpdateJobs

--- a/app/test/meadow_web/schema/query/get_metadata_update_jobs_test.exs
+++ b/app/test/meadow_web/schema/query/get_metadata_update_jobs_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.GetMetadataUpdateJobsTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
   alias Meadow.Data.CSV.MetadataUpdateJobs
 

--- a/app/test/meadow_web/schema/query/get_nul_authority_record_by_id_test.exs
+++ b/app/test/meadow_web/schema/query/get_nul_authority_record_by_id_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.NULAuthorityRecordByIdTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   alias NUL.AuthorityRecords

--- a/app/test/meadow_web/schema/query/get_nul_authority_records_test.exs
+++ b/app/test/meadow_web/schema/query/get_nul_authority_records_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.NULAuthorityRecordsTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   alias NUL.AuthorityRecords

--- a/app/test/meadow_web/schema/query/get_plan_change_test.exs
+++ b/app/test/meadow_web/schema/query/get_plan_change_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.GetPlanChangeTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/GetPlanChange.gql")

--- a/app/test/meadow_web/schema/query/get_plan_changes_test.exs
+++ b/app/test/meadow_web/schema/query/get_plan_changes_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.GetPlanChangesTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/GetPlanChanges.gql")

--- a/app/test/meadow_web/schema/query/get_plan_test.exs
+++ b/app/test/meadow_web/schema/query/get_plan_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.GetPlanTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/GetPlan.gql")

--- a/app/test/meadow_web/schema/query/get_preservation_checks.exs
+++ b/app/test/meadow_web/schema/query/get_preservation_checks.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.PreservationChecksTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   alias Meadow.Data.PreservationChecks

--- a/app/test/meadow_web/schema/query/ingest_errors_test.exs
+++ b/app/test/meadow_web/schema/query/ingest_errors_test.exs
@@ -1,7 +1,7 @@
 defmodule MeadowWeb.Schema.Query.IngestErrorsTest do
   use Meadow.DataCase
   use Meadow.IngestCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   alias Meadow.Ingest.Rows

--- a/app/test/meadow_web/schema/query/ingest_job_test.exs
+++ b/app/test/meadow_web/schema/query/ingest_job_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.SheetTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
 
   @query """
   query($id: ID!) {

--- a/app/test/meadow_web/schema/query/ingest_sheet_work_count.exs
+++ b/app/test/meadow_web/schema/query/ingest_sheet_work_count.exs
@@ -1,7 +1,7 @@
 defmodule MeadowWeb.Schema.Query.IngestSheetWorkCount do
   use Meadow.DataCase
   use Meadow.IngestCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/IngestSheetWorkCount.gql")

--- a/app/test/meadow_web/schema/query/project_test.exs
+++ b/app/test/meadow_web/schema/query/project_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.ProjectTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
 
   @query """
   query($id: ID!) {

--- a/app/test/meadow_web/schema/query/projects_search_test.exs
+++ b/app/test/meadow_web/schema/query/projects_search_test.exs
@@ -1,7 +1,7 @@
 defmodule MeadowWeb.Schema.Query.ProjectsSearchTest do
   defmodule All do
     use Meadow.DataCase
-    use MeadowWeb.ConnCase, async: true
+    use MeadowWeb.ConnCase, async: false
     use Wormwood.GQLCase
 
     set_gql(MeadowWeb.Schema, """
@@ -30,7 +30,7 @@ defmodule MeadowWeb.Schema.Query.ProjectsSearchTest do
 
   defmodule Search do
     use Meadow.DataCase
-    use MeadowWeb.ConnCase, async: true
+    use MeadowWeb.ConnCase, async: false
     use Wormwood.GQLCase
 
     set_gql(MeadowWeb.Schema, """

--- a/app/test/meadow_web/schema/query/projects_test.exs
+++ b/app/test/meadow_web/schema/query/projects_test.exs
@@ -1,7 +1,7 @@
 defmodule MeadowWeb.Schema.Query.ProjectsTest do
   defmodule All do
     use Meadow.DataCase
-    use MeadowWeb.ConnCase, async: true
+    use MeadowWeb.ConnCase, async: false
     use Wormwood.GQLCase
 
     set_gql(MeadowWeb.Schema, """
@@ -28,7 +28,7 @@ defmodule MeadowWeb.Schema.Query.ProjectsTest do
 
   defmodule Limit do
     use Meadow.DataCase
-    use MeadowWeb.ConnCase, async: true
+    use MeadowWeb.ConnCase, async: false
     use Wormwood.GQLCase
 
     set_gql(MeadowWeb.Schema, """
@@ -56,7 +56,7 @@ defmodule MeadowWeb.Schema.Query.ProjectsTest do
 
   defmodule Order do
     use Meadow.DataCase
-    use MeadowWeb.ConnCase, async: true
+    use MeadowWeb.ConnCase, async: false
     use Wormwood.GQLCase
 
     set_gql(MeadowWeb.Schema, """

--- a/app/test/meadow_web/schema/query/roles_test.exs
+++ b/app/test/meadow_web/schema/query/roles_test.exs
@@ -2,7 +2,7 @@ defmodule MeadowWeb.Schema.Query.RolesTest do
   use Meadow.Constants
 
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/GetRoles.gql")

--- a/app/test/meadow_web/schema/query/s3_objects_test.exs
+++ b/app/test/meadow_web/schema/query/s3_objects_test.exs
@@ -1,7 +1,7 @@
 # defmodule MeadowWeb.Schema.Query.S3ObjectsTest do
 #   use Meadow.DataCase
 #   use Meadow.S3Case
-#   use MeadowWeb.ConnCase, async: true
+#   use MeadowWeb.ConnCase, async: false
 
 #   alias Meadow.Config
 #   alias Meadow.Utils.AWS

--- a/app/test/meadow_web/schema/query/users_test.exs
+++ b/app/test/meadow_web/schema/query/users_test.exs
@@ -2,7 +2,7 @@ defmodule MeadowWeb.Schema.Query.UsersTest do
   use Meadow.Constants
 
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/GetUsers.gql")

--- a/app/test/meadow_web/schema/query/verifiy_file_sets_test.exs
+++ b/app/test/meadow_web/schema/query/verifiy_file_sets_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.VerifyFileSets do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
   load_gql(MeadowWeb.Schema, "test/gql/VerifyFileSets.gql")

--- a/app/test/meadow_web/schema/query/work_test.exs
+++ b/app/test/meadow_web/schema/query/work_test.exs
@@ -1,6 +1,6 @@
 defmodule MeadowWeb.Schema.Query.WorkTest do
   use Meadow.DataCase
-  use MeadowWeb.ConnCase, async: true
+  use MeadowWeb.ConnCase, async: false
 
   @query """
   query($id: ID!) {

--- a/app/test/meadow_web/schema/query/works_test.exs
+++ b/app/test/meadow_web/schema/query/works_test.exs
@@ -1,7 +1,7 @@
 defmodule MeadowWeb.Schema.Query.WorksTest do
   defmodule All do
     use Meadow.DataCase
-    use MeadowWeb.ConnCase, async: true
+    use MeadowWeb.ConnCase, async: false
     use Wormwood.GQLCase
 
     set_gql(MeadowWeb.Schema, """
@@ -26,7 +26,7 @@ defmodule MeadowWeb.Schema.Query.WorksTest do
 
   defmodule Limit do
     use Meadow.DataCase
-    use MeadowWeb.ConnCase, async: true
+    use MeadowWeb.ConnCase, async: false
     use Wormwood.GQLCase
 
     set_gql(MeadowWeb.Schema, """
@@ -55,7 +55,7 @@ defmodule MeadowWeb.Schema.Query.WorksTest do
 
   defmodule TitleMatch do
     use Meadow.DataCase
-    use MeadowWeb.ConnCase, async: true
+    use MeadowWeb.ConnCase, async: false
     use Wormwood.GQLCase
 
     set_gql(MeadowWeb.Schema, """
@@ -92,7 +92,7 @@ defmodule MeadowWeb.Schema.Query.WorksTest do
 
   defmodule RepresentativeImage do
     use Meadow.DataCase
-    use MeadowWeb.ConnCase, async: true
+    use MeadowWeb.ConnCase, async: false
     use Wormwood.GQLCase
     alias Meadow.Data.Works
 

--- a/app/test/support/s3_case.ex
+++ b/app/test/support/s3_case.ex
@@ -8,7 +8,7 @@ defmodule Meadow.S3Case do
 
       defmodule Meadow.FileCheckerTest do
         use Meadow.BucketNames
-  $2use Meadow.S3Case
+        use Meadow.S3Case
 
         @bucket @ingest_bucket
         @key "file_checker_test/path/to/file.tif"

--- a/app/test/support/trace_formatter.ex
+++ b/app/test/support/trace_formatter.ex
@@ -1,0 +1,36 @@
+defmodule TraceFormatter do
+  @moduledoc """
+  An ExUnit formatter that logs the start and end of each test with a timestamp
+  and the test's module and name to a file named `test_trace_seed_<seed>_<timestamp>.log`.
+  The seed is taken from the ExUnit configuration to help correlate logs with test runs.
+  """
+  use GenServer
+
+  def init(_opts) do
+    seed = ExUnit.configuration()[:seed]
+    log_file = File.open!("test_trace_seed_#{seed}_#{:os.system_time(:second)}.log", [:write, :utf8, :delayed_write])
+    {:ok, %{log_file: log_file}}
+  end
+
+  def handle_cast({:test_started, %ExUnit.Test{} = test}, state) do
+    log(state.log_file, "▶", "Starting", test)
+    {:noreply, state}
+  end
+
+  def handle_cast({:test_finished, %ExUnit.Test{} = test}, state) do
+    icon = case test.state do
+      nil -> "✓"
+      {:failed, _} -> "✗"
+      {:skipped, _} -> "➟"
+      {:invalid, _} -> "⚠"
+    end
+    log(state.log_file, icon, "Finished", test)
+    {:noreply, state}
+  end
+
+  def handle_cast(_event, state), do: {:noreply, state}
+
+  defp log(device, icon, message, test) do
+    IO.puts(device, "[#{inspect(self())} #{DateTime.utc_now()}] #{icon} #{message}: #{test.module}.#{test.name}")
+  end
+end


### PR DESCRIPTION
# Summary 
Fix as many flappy tests as possible

# Specific Changes in this PR
- Make all Wormwood.GQLCase tests run synchronously to avoid flappiness.
- Make Meadow.ErrorTest and MeadowAI.MetadataAgentTest synchronous.
- In CI, save the initial test seed so the cleanup run (using `--failed`) can use the same seed. This gives tests that failed strictly due to timing issues (e.g., an async condition that times out) a second change without being so permissive as to let real flappy failures slip through.
- Add a new formatter that saves a detailed log of the start and end of each test and its result to make flappy async tests easier to diagnose.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Run the test suite a few times with different seeds (or just let ExUnit generate one)

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

