### PR TITLE
Fix bug in transcription note

### DIFF
--- a/app/lib/meadow/data/file_sets.ex
+++ b/app/lib/meadow/data/file_sets.ex
@@ -631,7 +631,12 @@ defmodule Meadow.Data.FileSets do
           type: %{id: "LOCAL_NOTE", scheme: "note_type", label: "Local Note"}
         }
 
-        existing_notes = get_in(work, [Access.key(:descriptive_metadata), Access.key(:notes)]) || []
+        existing_notes =
+          (get_in(work, [Access.key(:descriptive_metadata), Access.key(:notes)]) || [])
+          |> Enum.map(fn
+            %_{} = struct -> Map.from_struct(struct)
+            map when is_map(map) -> map
+          end)
 
         updated_metadata = %{
           descriptive_metadata: %{

--- a/app/lib/meadow/data/transcriber.ex
+++ b/app/lib/meadow/data/transcriber.ex
@@ -14,7 +14,7 @@ defmodule Meadow.Data.Transcriber do
   require Logger
 
   @default_max_tokens 64_000
-  @image_variant "full/^!2048,2048/0/default.jpg"
+  @image_variant "full/!2048,2048/0/default.jpg"
   @default_model "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
   @image_request_headers [{"Accept", "image/jpeg"}]
   @image_request_opts [redirect: true, receive_timeout: 30_000, raw: true]


### PR DESCRIPTION
# Summary 

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5775

Transcription notes throwing this error in if there are existing notes

```
[error] Task #PID<0.4757.0> started from #PID<0.4747.0> terminating
** (Ecto.CastError) expected params to be a :map, got: `%Meadow.Data.Schemas.NoteEntry{note: "Transcription generated for Tawani_B01F16_donut_01 by AI on 2026-01-26", type: %{id: "LOCAL_NOTE", label: "Local Note", scheme: "note_type"}}`
    (ecto 3.13.5) lib/ecto/changeset.ex:767: Ecto.Changeset.cast/4
    (meadow 10.2.1) lib/meadow/data/schemas/note_entry.ex:18: Meadow.Data.Schemas.NoteEntry.changeset/2
    (ecto 3.13.5) lib/ecto/changeset.ex:1413: anonymous fn/4 in Ecto.Changeset.on_cast_default/2
    (ecto 3.13.5) lib/ecto/changeset/relation.ex:131: Ecto.Changeset.Relation.do_cast/7
    (ecto 3.13.5) lib/ecto/changeset/relation.ex:367: Ecto.Changeset.Relation.map_changes/11
    (ecto 3.13.5) lib/ecto/changeset/relation.ex:112: Ecto.Changeset.Relation.cast/5
    (ecto 3.13.5) lib/ecto/changeset.ex:1329: Ecto.Changeset.cast_relation/4
    (meadow 10.2.1) lib/meadow/data/schemas/work_descriptive_metadata.ex:106: Meadow.Data.Schemas.WorkDescriptiveMetadata.changeset/2
    (ecto 3.13.5) lib/ecto/changeset.ex:1413: anonymous fn/4 in Ecto.Changeset.on_cast_default/2
    (ecto 3.13.5) lib/ecto/changeset/relation.ex:143: Ecto.Changeset.Relation.do_cast/7
    (ecto 3.13.5) lib/ecto/changeset/relation.ex:346: Ecto.Changeset.Relation.single_change/5
    (ecto 3.13.5) lib/ecto/changeset/relation.ex:112: Ecto.Changeset.Relation.cast/5
    (ecto 3.13.5) lib/ecto/changeset.ex:1329: Ecto.Changeset.cast_relation/4
    (meadow 10.2.1) lib/meadow/data/schemas/work.ex:123: Meadow.Data.Schemas.Work.update_changeset/2
    (meadow 10.2.1) lib/meadow/data/works.ex:290: Meadow.Data.Works.update_work/2
    (meadow 10.2.1) lib/meadow/data/file_sets.ex:609: Meadow.Data.FileSets.process_transcription/2
    (elixir 1.18.2) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
Function: #Function<4.57238172/0 in Meadow.Data.FileSets.transcribe_file_set/2>
    Args: []
```

# Specific Changes in this PR

-  ensure all items in `existing_notes` are plain maps (not structs) before appending the new note, since the changeset expects plain maps.
- Remove caret (^) from transcriber's IIIF request 


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Generate a transcription and verify that it gets notes - both works with and without existing notes

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

