### PR TITLE
URI encode IIIF image dimensions in transcriber

### DIFF
--- a/app/lib/meadow/data/transcriber.ex
+++ b/app/lib/meadow/data/transcriber.ex
@@ -14,7 +14,7 @@ defmodule Meadow.Data.Transcriber do
   require Logger
 
   @default_max_tokens 64_000
-  @image_variant "full/!2048,2048/0/default.jpg"
+  @image_variant "full/^!2048,2048/0/default.jpg"
   @default_model "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
   @image_request_headers [{"Accept", "image/jpeg"}]
   @image_request_opts [redirect: true, receive_timeout: 30_000, raw: true]
@@ -348,6 +348,7 @@ defmodule Meadow.Data.Transcriber do
     base_url
     |> ensure_trailing_slash()
     |> Kernel.<>(@image_variant)
+    |> URI.encode()
   end
 
   defp ensure_trailing_slash(url) do


### PR DESCRIPTION
# Summary 

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5780

Calls to get the IIIF image for the transcriber can fail with errors if upscaling is required.

# Specific Changes in this PR

- Use the caret (^) to allow image upscaling
- URI encode IIIF image request in Transcriber module

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Transcribe image

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

