### PR TITLE
Reject untrimmed accession numbers

### DIFF
--- a/app/lib/meadow/data/schemas/file_set.ex
+++ b/app/lib/meadow/data/schemas/file_set.ex
@@ -60,6 +60,7 @@ defmodule Meadow.Data.Schemas.FileSet do
       changeset =
         file_set
         |> cast(rename_core_metadata(params), required_params ++ optional_params)
+        |> validate_trimmed(:accession_number)
         |> prepare_embed(:core_metadata)
         |> cast_embed(:core_metadata)
         |> prepare_embed(:structural_metadata)

--- a/app/lib/meadow/data/schemas/validations.ex
+++ b/app/lib/meadow/data/schemas/validations.ex
@@ -8,6 +8,8 @@ defmodule Meadow.Data.Schemas.Validations do
   If a `cast_embed()` will result in a `nil` value (either on create or
   update), set it to an empty embedded struct instead
   """
+  import Ecto.Changeset
+
   def prepare_embed(%Ecto.Changeset{data: data, params: params} = change, field)
       when is_atom(field) do
     with f <- to_string(field),
@@ -29,6 +31,14 @@ defmodule Meadow.Data.Schemas.Validations do
           Map.put(change, :params, params)
       end
     end
+  end
+
+  def validate_trimmed(%Ecto.Changeset{} = change, field) do
+    validate_change(change, field, fn _, value ->
+      if String.trim(value) == value,
+        do: [],
+        else: [{field, "cannot have leading or trailing spaces"}]
+    end)
   end
 
   defp empty_struct(data, field) do

--- a/app/lib/meadow/data/schemas/work.ex
+++ b/app/lib/meadow/data/schemas/work.ex
@@ -89,6 +89,7 @@ defmodule Meadow.Data.Schemas.Work do
     with {required_params, optional_params} <- changeset_params() do
       work
       |> cast(attrs, required_params ++ optional_params)
+      |> validate_trimmed(:accession_number)
       |> prepare_embed(:administrative_metadata)
       |> prepare_embed(:descriptive_metadata)
       |> cast_embed(:administrative_metadata)

--- a/app/lib/meadow/ingest/validator.ex
+++ b/app/lib/meadow/ingest/validator.ex
@@ -306,7 +306,7 @@ defmodule Meadow.Ingest.Validator do
       nil ->
         if FileSets.accession_exists?(value),
           do: {:error, "file_accession_number", "#{value} already exists in system"},
-          else: :ok
+          else: ensure_trimmed(value, "file_accession_number")
 
       duplicate_rows ->
         with row_list <- duplicate_rows |> Enum.map_join(", ", &to_string/1) do
@@ -321,7 +321,7 @@ defmodule Meadow.Ingest.Validator do
         {:error, "work_accession_number", "#{value} already exists in system"}
 
       false ->
-        :ok
+        ensure_trimmed(value, "work_accession_number")
     end
   end
 
@@ -355,6 +355,12 @@ defmodule Meadow.Ingest.Validator do
 
   defp validate_value(_row, {_field_name, _value}, _context),
     do: :ok
+
+  defp ensure_trimmed(value, field_name) do
+    if String.trim(value) == value,
+      do: :ok,
+      else: {:error, field_name, "cannot have leading or trailing spaces"}
+  end
 
   defp validate_structure_value({:ok, %{body: content}}, value, work_type) do
     extension = Path.extname(value) |> String.downcase()

--- a/app/lib/meadow/utils/changeset_errors.ex
+++ b/app/lib/meadow/utils/changeset_errors.ex
@@ -18,10 +18,10 @@ defmodule Meadow.Utils.ChangesetErrors do
     end
   end
 
-  defp format_value(%{id: value}), do: value
-  defp format_value(%{edtf: value}), do: value
+  defp format_value(%{id: value}), do: format_value(value)
+  defp format_value(%{edtf: value}), do: format_value(value)
   defp format_value(nil), do: nil
-  defp format_value(value) when is_binary(value), do: value
+  defp format_value(""), do: ""
   defp format_value(value), do: inspect(value)
 
   defp format_error({404, _opts}), do: "is an unknown identifier"

--- a/app/test/fixtures/ingest_sheet_accession_with_spaces.csv
+++ b/app/test/fixtures/ingest_sheet_accession_with_spaces.csv
@@ -1,0 +1,9 @@
+work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image,structure
+IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",,
+IMAGE,Donohue_001,Donohue_001_02,coffee.tif,"Letter, page 1, Dear Sir, verso, blank",P,"The label",,
+IMAGE,Donohue_001, Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",TRUE,
+IMAGE,Donohue_001,Donohue_001_04 ,coffee.tif,"Letter, page 2, If these papers, verso, blank",X,"The label",,
+VIDEO,Donohue_002 ,Donohue_002_01,small.m4v,"Photo, man with two children",A,"The label",,Donohue_002_01.vtt
+VIDEO,Donohue_002,Donohue_002_02,small.m4v,Small Video,A,"The label",,
+VIDEO, Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",X,"The label",,
+VIDEO,Donohue_002,Donohue_002_04,details.json,"Supplemental information",S,"Supplement",,

--- a/app/test/meadow/data/csv/metadata_update_jobs_test.exs
+++ b/app/test/meadow/data/csv/metadata_update_jobs_test.exs
@@ -192,7 +192,7 @@ defmodule Meadow.Data.CSV.MetadataUpdateJobsTest do
                %{
                  errors: %{
                    "subject#1" => [
-                     "METAPHORICAL is an invalid coded term for scheme SUBJECT_ROLE"
+                     ~s'"METAPHORICAL" is an invalid coded term for scheme SUBJECT_ROLE'
                    ]
                  },
                  row: 15
@@ -257,22 +257,22 @@ defmodule Meadow.Data.CSV.MetadataUpdateJobsTest do
                %{errors: %{"notes" => ["cannot have a blank id"]}, row: 10},
                %{
                  errors: %{
-                   "contributor#3" => ["nop is an invalid coded term for scheme MARC_RELATOR"]
+                   "contributor#3" => [~s'"nop" is an invalid coded term for scheme MARC_RELATOR']
                  },
                  row: 12
                },
-               %{errors: %{"id" => "NOT_A_UUID is not a valid UUID"}, row: 13},
+               %{errors: %{"id" => ~s'"NOT_A_UUID" is not a valid UUID'}, row: 13},
                %{
                  errors: %{
-                   "date_created" => "[%{edtf: \"bad_date\"}, %{edtf: \"201?\"}] is invalid"
+                   "date_created" => ~s'[%{edtf: "bad_date"}, %{edtf: "201?"}] is invalid'
                  },
                  row: 14
                },
-               %{errors: %{"id" => "0bde5432-0b7b-4f80-98fb-5f7ceff98dee not found"}, row: 18},
+               %{errors: %{"id" => ~s'"0bde5432-0b7b-4f80-98fb-5f7ceff98dee" not found'}, row: 18},
                %{errors: %{"subject#3" => ["can't be blank"]}, row: 21},
-               %{errors: %{"published" => "flase is invalid"}, row: 26},
+               %{errors: %{"published" => ~s'"flase" is invalid'}, row: 26},
                %{errors: %{"id" => "is required"}, row: 28},
-               %{errors: %{"accession_number" => "MISMATCHED_ACCESSION does not match"}, row: 37}
+               %{errors: %{"accession_number" => ~s'"MISMATCHED_ACCESSION" does not match'}, row: 37}
              ]
     end
   end

--- a/app/test/meadow/data/planner_test.exs
+++ b/app/test/meadow/data/planner_test.exs
@@ -533,7 +533,7 @@ defmodule Meadow.Data.PlannerTest do
       }
 
       assert {:error, error_message} = Planner.create_plan_change(attrs)
-      assert error_message == "#{invalid_plan_id} is invalid"
+      assert error_message == ~s'"#{invalid_plan_id}" is invalid'
     end
   end
 
@@ -595,7 +595,7 @@ defmodule Meadow.Data.PlannerTest do
       assert {:error, error_message} =
                Planner.update_plan_change(change, %{plan_id: invalid_plan_id})
 
-      assert error_message == "#{invalid_plan_id} is invalid"
+      assert error_message == ~s'"#{invalid_plan_id}" is invalid'
     end
   end
 

--- a/app/test/meadow/data/schemas/file_set_test.exs
+++ b/app/test/meadow/data/schemas/file_set_test.exs
@@ -60,5 +60,13 @@ defmodule Meadow.Data.Schemas.FileSetTest do
 
       assert log =~ ~r/Ignoring :metadata/
     end
+
+    test "accession number cannot have leading or trailing spaces" do
+      invalid_attrs = Map.put(@valid_attrs, :accession_number, " 12345 ")
+
+      assert changeset = FileSet.changeset(%FileSet{}, invalid_attrs)
+      assert changeset.errors[:accession_number] ==
+        {"cannot have leading or trailing spaces", []}
+    end
   end
 end

--- a/app/test/meadow/data/schemas/work_test.exs
+++ b/app/test/meadow/data/schemas/work_test.exs
@@ -23,5 +23,13 @@ defmodule Meadow.Data.Schemas.WorkTest do
 
       assert {:ok, <<_data::binary-size(16)>>} = Ecto.UUID.dump(work.id)
     end
+
+    test "accession number cannot have leading or trailing spaces", %{attrs: attrs} do
+      invalid_attrs = Map.put(attrs, :accession_number, " 12345 ")
+
+      assert changeset = Work.changeset(%Work{}, invalid_attrs)
+      assert changeset.errors[:accession_number] ==
+        {"cannot have leading or trailing spaces", []}
+    end
   end
 end

--- a/app/test/meadow/ingest/validator_test.exs
+++ b/app/test/meadow/ingest/validator_test.exs
@@ -128,6 +128,18 @@ defmodule Meadow.Ingest.ValidatorTest do
       assert(ingest_sheet.status == "row_fail")
     end
 
+    @tag sheet: "ingest_sheet_accession_with_spaces.csv"
+    test "fails when work or file accession_number isn't trimmed", context do
+      assert(Validator.result(context.sheet.id) == "fail")
+      ingest_sheet = Validator.validate(context.sheet.id)
+
+      assert(ingest_sheet.status == "row_fail")
+      %{ingest_sheet_rows: rows} = Repo.preload(ingest_sheet, :ingest_sheet_rows)
+
+      assert Enum.filter(rows, fn row -> not Enum.empty?(row.errors) end)
+             |> length() == 4
+    end
+
     @tag sheet: "ingest_sheet_work_accession_exists.csv"
     test "fails when work_accession_number already exists", context do
       work_fixture(%{accession_number: "6779"})

--- a/app/test/meadow/utils/changeset_errors_test.exs
+++ b/app/test/meadow/utils/changeset_errors_test.exs
@@ -50,26 +50,26 @@ defmodule Meadow.Utils.ChangesetErrorsTest do
              accession_number: [%{error: "can't be blank", value: ""}],
              administrative_metadata: %{
                preservation_level: [
-                 %{error: "is an invalid coded term for scheme PRESERVATION_LEVEL", value: "nope"}
+                 %{error: "is an invalid coded term for scheme PRESERVATION_LEVEL", value: ~s'"nope"'}
                ]
              },
              descriptive_metadata: %{
                contributor: [
                  %{
-                   term: [%{error: "is an unknown identifier", value: "missing_id_authority:123"}],
+                   term: [%{error: "is an unknown identifier", value: ~s'"missing_id_authority:123"'}],
                    role: [
-                     %{error: "is an invalid coded term for scheme MARC_RELATOR", value: "nop"}
+                     %{error: "is an invalid coded term for scheme MARC_RELATOR", value: ~s'"nop"'}
                    ]
                  }
                ],
-               date_created: [%{error: "is invalid", value: "[\"1899\", \"bad_date\"]"}],
-               genre: [%{term: [%{error: "is from an unknown authority", value: "wrong"}]}, %{}],
+               date_created: [%{error: "is invalid", value: ~s'["1899", "bad_date"]'}],
+               genre: [%{term: [%{error: "is from an unknown authority", value: ~s'"wrong"'}]}, %{}],
                subject: [
                  %{
                    role: [
                      %{
                        error: "is an invalid coded term for scheme SUBJECT_ROLE",
-                       value: "wrong_coded_term_id"
+                       value: ~s'"wrong_coded_term_id"'
                      }
                    ]
                  }
@@ -83,8 +83,8 @@ defmodule Meadow.Utils.ChangesetErrorsTest do
     # date_created: [%{}, %{edtf: %{error: "is invalid", value: "bad_date"}}]
   end
 
-  def assert_all_equal(a, b) when is_list(a), do: MapSet.new(a) == MapSet.new(b)
-  def assert_all_equal(a, b), do: a == b
+  def assert_all_equal(a, b) when is_list(a), do: assert MapSet.new(a) == MapSet.new(b)
+  def assert_all_equal(a, b), do: assert a == b
 
   test "formats errors for human readability", %{changeset: changeset} do
     fields_to_flatten = [:administrative_metadata, :descriptive_metadata]
@@ -94,13 +94,13 @@ defmodule Meadow.Utils.ChangesetErrorsTest do
     expected = %{
       "accession_number" => "can't be blank",
       "contributor" => [
-        "nop is an invalid coded term for scheme MARC_RELATOR",
-        "missing_id_authority:123 is an unknown identifier"
+        ~s'"nop" is an invalid coded term for scheme MARC_RELATOR',
+        ~s'"missing_id_authority:123" is an unknown identifier'
       ],
-      "date_created" => "[\"1899\", \"bad_date\"] is invalid",
-      "genre#1" => ["wrong is from an unknown authority"],
-      "preservation_level" => "nope is an invalid coded term for scheme PRESERVATION_LEVEL",
-      "subject" => ["wrong_coded_term_id is an invalid coded term for scheme SUBJECT_ROLE"]
+      "date_created" => ~s'["1899", "bad_date"] is invalid',
+      "genre#1" => [~s'"wrong" is from an unknown authority'],
+      "preservation_level" => ~s'"nope" is an invalid coded term for scheme PRESERVATION_LEVEL',
+      "subject" => [~s'"wrong_coded_term_id" is an invalid coded term for scheme SUBJECT_ROLE']
     }
 
     for {k, actual_v} <- actual do

--- a/app/test/meadow_web/schema/query/get_metadata_update_job_by_id_test.exs
+++ b/app/test/meadow_web/schema/query/get_metadata_update_job_by_id_test.exs
@@ -62,14 +62,14 @@ defmodule MeadowWeb.Schema.Query.GetMetadataUpdateJobByIdTest do
                    "errors" => [
                      %{
                        "field" => "contributor#3",
-                       "messages" => ["nop is an invalid coded term for scheme MARC_RELATOR"]
+                       "messages" => [~s'"nop" is an invalid coded term for scheme MARC_RELATOR']
                      }
                    ],
                    "row" => 12
                  },
                  %{
                    "errors" => [
-                     %{"field" => "id", "messages" => ["NOT_A_UUID is not a valid UUID"]}
+                     %{"field" => "id", "messages" => [~s'"NOT_A_UUID" is not a valid UUID']}
                    ],
                    "row" => 13
                  },
@@ -77,7 +77,7 @@ defmodule MeadowWeb.Schema.Query.GetMetadataUpdateJobByIdTest do
                    "errors" => [
                      %{
                        "field" => "date_created",
-                       "messages" => ["[%{edtf: \"bad_date\"}, %{edtf: \"201?\"}] is invalid"]
+                       "messages" => [~s'[%{edtf: "bad_date"}, %{edtf: "201?"}] is invalid']
                      }
                    ],
                    "row" => 14
@@ -86,7 +86,7 @@ defmodule MeadowWeb.Schema.Query.GetMetadataUpdateJobByIdTest do
                    "errors" => [
                      %{
                        "field" => "id",
-                       "messages" => ["0bde5432-0b7b-4f80-98fb-5f7ceff98dee not found"]
+                       "messages" => [~s'"0bde5432-0b7b-4f80-98fb-5f7ceff98dee" not found']
                      }
                    ],
                    "row" => 18
@@ -96,7 +96,7 @@ defmodule MeadowWeb.Schema.Query.GetMetadataUpdateJobByIdTest do
                    "row" => 21
                  },
                  %{
-                   "errors" => [%{"field" => "published", "messages" => ["flase is invalid"]}],
+                   "errors" => [%{"field" => "published", "messages" => [~s'"flase" is invalid']}],
                    "row" => 26
                  },
                  %{"errors" => [%{"field" => "id", "messages" => ["is required"]}], "row" => 28},
@@ -104,7 +104,7 @@ defmodule MeadowWeb.Schema.Query.GetMetadataUpdateJobByIdTest do
                    "errors" => [
                      %{
                        "field" => "accession_number",
-                       "messages" => ["MISMATCHED_ACCESSION does not match"]
+                       "messages" => [~s'"MISMATCHED_ACCESSION" does not match']
                      }
                    ],
                    "row" => 37


### PR DESCRIPTION
# Summary 
Reject untrimmed accession numbers

- Resolves nulib/repodev_planning_and_docs#5787
- Closes #5144 

# Specific Changes in this PR
- Reject accession numbers with leading or trailing spaces as invalid
- Wrap binary values in quotes when humanizing errors to make untrimmed strings more obvious
- Update tests to reflect new formatting

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

1. Try and fail to ingest a sheet containing a work and/or fileset with leading or trailing spaces in the accession number.
2. Try and fail to create a work from the UI with leading or trailing spaces in the accession number. (The error for this doesn't look great, but the details are all there in the GraphQL, and it displays the same as when you try to create a work with an already existing accession number, so I think that bit is out of scope for this PR.)
3. Try and fail to create a file set from the UI with leading or trailing spaces in the accession number.
4. Try and fail to import a CSV metadata update with leading or trailing spaces in the accession number.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

