### PR TITLE
Allow users to refine the proposed plan changes in AI edit

### DIFF
--- a/app/assets/js/components/Plan/Panel/Changes.jsx
+++ b/app/assets/js/components/Plan/Panel/Changes.jsx
@@ -163,10 +163,7 @@ const PlanPanelChanges = ({
               Approved
             </span>
             <hr className="plan-panel-changes--status--divider" />
-            <span
-              data-status={status}
-              data-active={status === "COMPLETED"}
-            >
+            <span data-status={status} data-active={status === "COMPLETED"}>
               Applied
             </span>
           </div>
@@ -232,7 +229,10 @@ const PlanPanelChanges = ({
               <UISkeleton type="text" rows={3} />
             </div>
           )}
-          <PlanPanelChangesDiff proposedChanges={changes?.planChange || {}} />
+          <PlanPanelChangesDiff
+            proposedChanges={changes?.planChange || {}}
+            planChangeId={changes?.planChange?.id}
+          />
         </div>
       )}
     </div>

--- a/app/assets/js/components/Plan/Panel/Diff.jsx
+++ b/app/assets/js/components/Plan/Panel/Diff.jsx
@@ -1,11 +1,16 @@
-import React from "react";
+import React, { useState } from "react";
 import UIControlledTermList from "@js/components/UI/ControlledTerm/List";
+import UIModalDelete from "@js/components/UI/Modal/Delete";
 import {
   toArray,
   toRows,
   isCodedTerm,
-  isNestedCodedTerm,
 } from "@js/components/Plan/Panel/diff-helpers";
+import { IconEdit, IconDelete } from "@js/components/Icon";
+import { UPDATE_PLAN_CHANGE } from "../plan.gql";
+import { Button } from "@nulib/design-system";
+import { useMutation } from "@apollo/client";
+import EditDiffRowForm from "@js/components/Plan/Panel/EditDiffRowForm";
 
 /**
  * Tag indicating the method of change
@@ -54,9 +59,7 @@ const renderNotes = (notes) => {
     <ul>
       {notes.map((note, i) => (
         <li key={i}>
-          {note.type?.label && (
-            <strong>{note.type.label}: </strong>
-          )}
+          {note.type?.label && <strong>{note.type.label}: </strong>}
           {note.note || "—"}
         </li>
       ))}
@@ -74,9 +77,7 @@ const renderRelatedUrls = (urls) => {
     <ul>
       {urls.map((item, i) => (
         <li key={i}>
-          {item.label?.label && (
-            <strong>{item.label.label}: </strong>
-          )}
+          {item.label?.label && <strong>{item.label.label}: </strong>}
           {item.url ? (
             <a href={item.url} target="_blank" rel="noopener noreferrer">
               {item.url}
@@ -118,7 +119,9 @@ const renderGenericValue = (value) => {
       <ul>
         {value.map((v, i) => (
           <li key={i}>
-            {typeof v === "object" ? JSON.stringify(v, null, 0) : String(v)}
+            {typeof v === "object" && v !== null
+              ? v.humanized || v.edtf || JSON.stringify(v, null, 0)
+              : String(v)}
           </li>
         ))}
       </ul>
@@ -129,7 +132,124 @@ const renderGenericValue = (value) => {
   return JSON.stringify(value, null, 0);
 };
 
-const PlanPanelChangesDiff = ({ proposedChanges }) => {
+const PlanPanelChangesDiff = ({ proposedChanges, planChangeId }) => {
+  const [updatePlanChange] = useMutation(UPDATE_PLAN_CHANGE);
+  const [editingRowId, setEditingRowId] = useState(null);
+  const [deletingRowId, setDeletingRowId] = useState(null);
+
+  const isProposed = proposedChanges?.status === "PROPOSED";
+
+  const removeFieldFromProposedChanges = (id) => {
+    const [method, path] = id.split("-");
+
+    const methodChanges = JSON.parse(
+      JSON.stringify(proposedChanges[method] || {}),
+    );
+    const pathSegments = path.split(".");
+    let current = methodChanges;
+
+    for (let i = 0; i < pathSegments.length - 1; i++) {
+      const key = pathSegments[i];
+      if (typeof current[key] === "undefined" || current[key] === null) {
+        return;
+      }
+      current = current[key];
+    }
+
+    const finalKey = pathSegments[pathSegments.length - 1];
+    if (typeof current[finalKey] !== "undefined") {
+      delete current[finalKey];
+    }
+
+    return {
+      ...proposedChanges,
+      [method]: methodChanges,
+    };
+  };
+
+  const formatUpdates = (updatedPlanChangeForMethod) => {
+    return Object.keys(updatedPlanChangeForMethod || {}).length > 0
+      ? JSON.stringify(updatedPlanChangeForMethod)
+      : null;
+  };
+
+  const handleDeletePlanChangeRow = async (id) => {
+    if (!id) {
+      console.error("Cannot delete: id is null or undefined");
+      return;
+    }
+
+    const updatedPlanChange = removeFieldFromProposedChanges(id);
+
+    try {
+      await updatePlanChange({
+        variables: {
+          id: planChangeId,
+          add: formatUpdates(updatedPlanChange.add),
+          replace: formatUpdates(updatedPlanChange.replace),
+          delete: formatUpdates(updatedPlanChange.delete),
+        },
+      });
+    } catch (e) {
+      console.error("Error deleting plan change row:", e);
+    }
+    setDeletingRowId(null);
+  };
+
+  const handleSaveClick = async (changeId, newValue) => {
+    // Parse the changeId to get method and path
+    const [method, path] = changeId.split("-");
+
+    // Update the proposedChanges structure
+    const updatedChanges = JSON.parse(JSON.stringify(proposedChanges));
+
+    // Navigate to the field and update it (path already exists since we're editing an existing row)
+    const pathSegments = path.split(".");
+    let current = updatedChanges[method];
+
+    // Navigate to the parent
+    for (let i = 0; i < pathSegments.length - 1; i++) {
+      current = current[pathSegments[i]];
+    }
+
+    // Update the value, or delete the field if the new value is an empty array
+    const finalSegment = pathSegments[pathSegments.length - 1];
+    if (Array.isArray(newValue) && newValue.length === 0) {
+      delete current[finalSegment];
+    } else {
+      current[finalSegment] = newValue;
+    }
+
+    try {
+      await updatePlanChange({
+        variables: {
+          id: planChangeId,
+          add: updatedChanges.add && formatUpdates(updatedChanges.add),
+          replace:
+            updatedChanges.replace && formatUpdates(updatedChanges.replace),
+          delete: updatedChanges.delete && formatUpdates(updatedChanges.delete),
+        },
+      });
+
+      setEditingRowId(null);
+    } catch (e) {
+      console.error("Error saving plan change:", e);
+    }
+  };
+  const handleCancelClick = () => {
+    setEditingRowId(null);
+  };
+  const handleEditClick = (id) => {
+    setEditingRowId(id);
+  };
+  const handleDeleteClick = (id) => {
+    setDeletingRowId(id);
+  };
+
+  const onCloseModal = () => {
+    setDeletingRowId(null);
+  };
+
   const changes = [
     ...toRows(proposedChanges.add, "add"),
     ...toRows(proposedChanges.delete, "delete"),
@@ -150,6 +270,7 @@ const PlanPanelChangesDiff = ({ proposedChanges }) => {
             <th>Type</th>
             <th>Field</th>
             <th>Proposed Value</th>
+            <th>{isProposed && "Actions"}</th>
           </tr>
         </thead>
         <tbody>
@@ -173,10 +294,47 @@ const PlanPanelChangesDiff = ({ proposedChanges }) => {
                   renderGenericValue(change.value)
                 )}
               </td>
+              <td style={{ whiteSpace: "nowrap" }}>
+                {isProposed && (
+                  <>
+                    {!(Array.isArray(change.value) && change.value.length === 0) && (
+                      <Button
+                        onClick={() => handleEditClick(change.id)}
+                        data-testid="button-edit-plan-change-row"
+                      >
+                        <IconEdit />
+                      </Button>
+                    )}
+                    <Button
+                      onClick={() => handleDeleteClick(change.id)}
+                      data-testid="button-delete-plan-change-row"
+                    >
+                      <IconDelete />
+                    </Button>
+                  </>
+                )}
+              </td>
             </tr>
           ))}
         </tbody>
       </table>
+
+      <EditDiffRowForm
+        change={changes.find((c) => c.id === editingRowId)}
+        isOpen={!!editingRowId}
+        onSave={handleSaveClick}
+        onCancel={handleCancelClick}
+      />
+      <UIModalDelete
+        isOpen={!!deletingRowId}
+        handleClose={onCloseModal}
+        handleConfirm={() => handleDeletePlanChangeRow(deletingRowId)}
+        thingToDeleteLabel={
+          deletingRowId
+            ? `${changes.find((c) => c.id === deletingRowId)?.label || 'this field'} from plan changes`
+            : ''
+        }
+      />
     </>
   );
 };

--- a/app/assets/js/components/Plan/Panel/Diff.test.jsx
+++ b/app/assets/js/components/Plan/Panel/Diff.test.jsx
@@ -11,8 +11,15 @@ const mockIsCodedTerm = jest.fn((path) =>
   path === "descriptive_metadata.license"
 );
 
+jest.mock("@apollo/client", () => ({
+  useMutation: () => [jest.fn()],
+}));
+
 jest.mock("@nulib/design-system", () => ({
   Tag: ({ children }) => <span data-testid="tag">{children}</span>,
+  Button: ({ children, onClick, type, ...rest }) => (
+    <button onClick={onClick} type={type || "button"} {...rest}>{children}</button>
+  ),
 }));
 
 jest.mock("@js/components/UI/ControlledTerm/List", () => {
@@ -20,6 +27,19 @@ jest.mock("@js/components/UI/ControlledTerm/List", () => {
     <div data-testid="ctl" data-title={title} data-count={items?.length ?? 0} />
   );
 });
+
+jest.mock("@js/components/UI/Modal/Delete", () => () => <div data-testid="modal-delete" />);
+
+jest.mock("@js/components/Icon", () => ({
+  IconEdit: () => <span data-testid="icon-edit" />,
+  IconDelete: () => <span data-testid="icon-delete" />,
+}));
+
+jest.mock("../plan.gql", () => ({ UPDATE_PLAN_CHANGE: "UPDATE_PLAN_CHANGE" }));
+
+jest.mock("@js/components/Plan/Panel/EditDiffRowForm", () => () => (
+  <div data-testid="edit-diff-row-form" />
+));
 
 jest.mock("@js/components/Plan/Panel/diff-helpers", () => ({
   toArray: (...args) => mockToArray(...args),

--- a/app/assets/js/components/Plan/Panel/EditDiffRowForm.jsx
+++ b/app/assets/js/components/Plan/Panel/EditDiffRowForm.jsx
@@ -1,0 +1,370 @@
+import {
+  prepFieldArrayItemsForPost,
+  prepEDTFforPost,
+  prepNotes,
+  prepRelatedUrl,
+  prepControlledTermInput,
+  CONTROLLED_METADATA,
+} from "@js/services/metadata";
+import { isCodedTerm, isTextSingle, isTextArray } from "@js/components/Plan/Panel/diff-helpers";
+
+import React from "react";
+import PropTypes from "prop-types";
+import { Button } from "@nulib/design-system";
+import { useForm, FormProvider } from "react-hook-form";
+import UIFormInput from "@js/components/UI/Form/Input";
+import UIFormField from "@js/components/UI/Form/Field";
+import UIFormFieldArray from "@js/components/UI/Form/FieldArray";
+import UIFormSelect from "@js/components/UI/Form/Select";
+import UIFormNote from "@js/components/UI/Form/Note";
+import { IconTrashCan } from "@js/components/Icon";
+import UIFormRelatedURL from "@js/components/UI/Form/RelatedURL";
+import UIFormControlledTermArray from "@js/components/UI/Form/ControlledTermArray";
+import { useCodeLists } from "@js/context/code-list-context";
+
+/** @jsx jsx */
+import { css, jsx } from "@emotion/react";
+
+const noBullets = css`
+  ul {
+    list-style: none;
+    padding-left: 0;
+  }
+`;
+
+const EditDiffRowForm = ({ change, isOpen, onSave, onCancel }) => {
+  const codeLists = useCodeLists();
+
+  const isDeleteMode = change?.method === "delete";
+
+  // For delete mode: track which items remain (user can remove items)
+  const [deleteItems, setDeleteItems] = React.useState(
+    Array.isArray(change?.value) ? change.value : change?.value ? [change.value] : []
+  );
+
+  React.useEffect(() => {
+    setDeleteItems(
+      Array.isArray(change?.value) ? change.value : change?.value ? [change.value] : []
+    );
+  }, [change?.id]);
+
+  const getItemLabel = (item) => {
+    if (item == null) return "—";
+    if (typeof item === "string") return item;
+    if (item.humanized) return item.humanized;
+    if (item.edtf) return item.edtf;
+    if (item.label && typeof item.label === "string") return item.label;
+    if (item.term?.label) return `${item.term.label}${item.role?.label ? ` (${item.role.label})` : ""}`;
+    if (item.note) return `${item.type?.label ? item.type.label + ": " : ""}${item.note}`;
+    if (item.url) return `${item.label?.label ? item.label.label + ": " : ""}${item.url}`;
+    return JSON.stringify(item);
+  };
+
+  const fieldType = {
+    isControlled: change?.controlled,
+    isNestedCoded: change?.nestedCoded,
+    isCoded: isCodedTerm(change?.path),
+    isPlainTextArray: isTextArray(change?.path),
+    isPlainTextSingle: isTextSingle(change?.path),
+  };
+
+  const isSupported = Object.values(fieldType).some(v => v);
+
+  // Get controlled field metadata if applicable
+  const controlledFieldMeta = fieldType.isControlled
+    ? CONTROLLED_METADATA.find((f) => change?.path.endsWith(f.name))
+    : null;
+
+  // Get the form field name for controlled terms (use actual field name, not "values")
+  const controlledFieldName = controlledFieldMeta?.name || "values";
+
+  // Helper to safely get a code list by key
+  const getCodeList = (key) => codeLists[key]?.codeList || [];
+
+  // Convert snake_case field name to camelCase code list key (e.g. rights_statement -> rightsStatementData)
+  const getCodedTermCodeListKey = (fieldName) => {
+    const camel = fieldName.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+    return camel + "Data";
+  };
+
+  const getRoleDropdownOptions = (fieldMeta) => {
+    if (!fieldMeta) return [];
+    if (fieldMeta.scheme === "MARC_RELATOR") {
+      return getCodeList("marcData");
+    } else if (fieldMeta.scheme === "SUBJECT_ROLE") {
+      return getCodeList("subjectRoleData");
+    }
+    return [];
+  };
+
+  // Parser functions for converting values from form data to API format
+  const parsers = {
+    plainTextArray: (data) =>
+      change.path.endsWith("date_created")
+        ? prepEDTFforPost(data.values)
+        : prepFieldArrayItemsForPost(data.values),
+
+    coded: (data) => {
+      const selectedId = data.value;
+      const fieldName = change.path.split(".").pop();
+      const codeListKey = getCodedTermCodeListKey(fieldName);
+      const codeList = getCodeList(codeListKey);
+      const selectedItem = codeList.find((item) => item.id === selectedId);
+
+      if (selectedItem) {
+        return {
+          id: selectedItem.id,
+          label: selectedItem.label,
+          scheme: selectedItem.scheme,
+        };
+      }
+      return change.value; 
+    },
+
+    nestedCoded: (data) => {
+      if (change.path.endsWith("notes")) {
+        return prepNotes(data.values);
+      } else if (change.path.endsWith("related_url")) {
+        return prepRelatedUrl(data.values);
+      }
+      return data.values;
+    },
+
+    controlled: (data) => {
+      const result = prepControlledTermInput(controlledFieldMeta, data[controlledFieldName]);
+      return result.map(item => ({
+        ...item,
+        term: { id: item.term }
+      }));
+    },
+
+    plainTextSingle: (data) => data.value,
+  };
+
+  // Get default values for React Hook Form based on field type
+  const getDefaultValues = () => {
+    if (!change) return {};
+    if (fieldType.isPlainTextArray) {
+      // UIFormFieldArray expects array of { metadataItem: "value" }
+      // date_created may come back from DB as [{ edtf, humanized }] - unwrap to string
+      return {
+        values: change.value.map((v) => ({
+          metadataItem: typeof v === "object" && v.edtf ? v.edtf : v,
+        })),
+      };
+    } else if (fieldType.isCoded) {
+      // Coded terms: just use the id (URL)
+      return { value: change.value?.id || "" };
+    } else if (fieldType.isNestedCoded) {
+      // Nested coded terms (notes, related_url): pass the array as-is
+      return { values: change.value || [] };
+    } else if (fieldType.isControlled) {
+      // Controlled terms: use actual field name
+      return { [controlledFieldName]: change.value || [] };
+    } else {
+      // Single text field
+      return { value: change.value || "" };
+    }
+  };
+
+  const defaultValues = getDefaultValues();
+
+  const methods = useForm({
+    defaultValues: defaultValues,
+  });
+  const { isDirty } = methods.formState;
+
+  React.useEffect(() => {
+    methods.reset(defaultValues);
+  }, [change?.id]);
+
+  // Early return after all hooks
+  if (!change) return null;
+
+  const onSubmit = (data) => {
+    const parserKey = fieldType.isPlainTextArray ? 'plainTextArray'
+      : fieldType.isCoded ? 'coded'
+      : fieldType.isNestedCoded ? 'nestedCoded'
+      : fieldType.isControlled ? 'controlled'
+      : 'plainTextSingle';
+
+    const parsedValue = parsers[parserKey](data);
+
+    onSave(change.id, parsedValue);
+    methods.reset();
+  };
+
+  return (
+    <FormProvider {...methods}>
+      <form
+        name="modal-edit-plan-change"
+        data-testid="modal-edit-plan-change"
+        className={`modal ${isOpen ? "is-active" : ""}`}
+        onSubmit={methods.handleSubmit(onSubmit)}
+        role="form"
+      >
+        <div className="modal-background"></div>
+        <div className="modal-card">
+          <header className="modal-card-head">
+            <p className="modal-card-title">
+              {isDeleteMode ? "Review deletions" : "Edit"} - {change.label}
+            </p>
+            <button
+              className="delete"
+              aria-label="close"
+              type="button"
+              onClick={onCancel}
+            ></button>
+          </header>
+          <section className="modal-card-body">
+            {isDeleteMode ? (
+              <div>
+                {!fieldType.isControlled && (
+                  <div className="notification is-warning mb-3">
+                    <strong>Note:</strong> Deletions are only supported for controlled vocabulary fields. This deletion will have no effect when the plan is approved.
+                  </div>
+                )}
+                <p className="mb-3">Remove items from this deletion, or close to keep as-is.</p>
+                <ul css={noBullets}>
+                  {deleteItems.map((item, index) => (
+                    <li key={index} className="is-flex is-align-items-center mb-2" style={{ gap: '0.5rem' }}>
+                      <span className="is-flex-grow-1">{getItemLabel(item)}</span>
+                      <button
+                        type="button"
+                        className="button is-small is-light"
+                        onClick={() => setDeleteItems(deleteItems.filter((_, i) => i !== index))}
+                      >
+                        <span className="icon"><IconTrashCan /></span>
+                      </button>
+                    </li>
+                  ))}
+                  {deleteItems.length === 0 && (
+                    <p className="has-text-grey">All items removed - saving will remove this field from the plan change.</p>
+                  )}
+                </ul>
+              </div>
+            ) : !isSupported ? (
+              <div className="notification is-warning">
+                <p>
+                  <strong>Editing this field type is not yet supported.</strong>
+                </p>
+                <p>
+                  {fieldType.isControlled && "This is a controlled vocabulary field."}
+                  {fieldType.isNestedCoded &&
+                    " This is a structured field with nested data."}
+                </p>
+                <p className="mt-3">Supported field types:</p>
+                <ul>
+                  <li>• Single-valued text fields (e.g., title)</li>
+                  <li>
+                    • Multi-valued text fields (e.g., description,
+                    alternate_title)
+                  </li>
+                  <li>• Coded term fields (e.g., license, rights_statement)</li>
+                  <li>• Nested coded fields (e.g., notes, related_url)</li>
+                  <li>• Controlled vocabulary fields (e.g., subject, genre, contributor)</li>
+                </ul>
+              </div>
+            ) : fieldType.isPlainTextArray ? (
+              <div css={noBullets}>
+                <UIFormFieldArray
+                  name="values"
+                  label={change.label}
+                  required
+                  isTextarea={true}
+                />
+              </div>
+            ) : fieldType.isCoded ? (
+              <UIFormField label={change.label}>
+                <UIFormSelect
+                  isReactHookForm
+                  name="value"
+                  label={change.label}
+                  showHelper={true}
+                  options={(() => {
+                    const fieldName = change.path.split(".").pop();
+                    return getCodeList(getCodedTermCodeListKey(fieldName));
+                  })()}
+                  defaultValue={change.value ? change.value.id : ""}
+                />
+              </UIFormField>
+            ) : fieldType.isNestedCoded ? (
+              <div css={noBullets}>
+                <UIFormField label={change.label}>
+                  {change.path.endsWith("notes") ? (
+                    <UIFormNote
+                      codeLists={getCodeList("notesData")}
+                      label={change.label}
+                      name="values"
+                    />
+                  ) : change.path.endsWith("related_url") ? (
+                    <UIFormRelatedURL
+                      codeLists={getCodeList("relatedUrlData")}
+                      label={change.label}
+                      name="values"
+                    />
+                  ) : null}
+                </UIFormField>
+              </div>
+            ) : fieldType.isControlled ? (
+              <div css={noBullets}>
+                <UIFormField label={change.label}>
+                  <UIFormControlledTermArray
+                    authorities={getCodeList("authorityData")}
+                    roleDropdownOptions={getRoleDropdownOptions(controlledFieldMeta)}
+                    label={change.label}
+                    name={controlledFieldName}
+                  />
+                </UIFormField>
+              </div>
+            ) : (
+              <UIFormField label="Value" forId="edit-value" required>
+                <UIFormInput
+                  isReactHookForm
+                  required
+                  id="edit-value"
+                  name="value"
+                  label="Value"
+                  placeholder="Enter value"
+                />
+              </UIFormField>
+            )}
+          </section>
+          <footer className="modal-card-foot is-justify-content-flex-end">
+            <Button isText onClick={onCancel} data-testid="cancel-button">
+              Cancel
+            </Button>
+            {isDeleteMode ? (
+              <Button
+                isPrimary
+                type="button"
+                data-testid="submit-button"
+                onClick={() => { onSave(change.id, deleteItems); }}
+              >
+                Save changes
+              </Button>
+            ) : isSupported && (
+              <Button
+                isPrimary
+                type="submit"
+                data-testid="submit-button"
+                disabled={!isDirty}
+              >
+                Save changes
+              </Button>
+            )}
+          </footer>
+        </div>
+      </form>
+    </FormProvider>
+  );
+};
+
+EditDiffRowForm.propTypes = {
+  change: PropTypes.object,
+  isOpen: PropTypes.bool,
+  onSave: PropTypes.func,
+  onCancel: PropTypes.func,
+};
+
+export default EditDiffRowForm;

--- a/app/assets/js/components/Plan/Panel/EditDiffRowForm.test.jsx
+++ b/app/assets/js/components/Plan/Panel/EditDiffRowForm.test.jsx
@@ -1,0 +1,353 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import EditDiffRowForm from "./EditDiffRowForm";
+
+// ---- Mocks ----
+jest.mock("@js/context/code-list-context", () => ({
+  useCodeLists: () => ({
+    licenseData: {
+      codeList: [
+        { id: "http://creativecommons.org/licenses/by/4.0/", label: "CC BY", scheme: "license" },
+      ],
+    },
+    rightsStatementData: {
+      codeList: [
+        { id: "http://rightsstatements.org/vocab/InC/1.0/", label: "In Copyright", scheme: "rights_statement" },
+      ],
+    },
+    authorityData: { codeList: [] },
+    marcData: { codeList: [] },
+    subjectRoleData: { codeList: [] },
+    notesData: { codeList: [] },
+    relatedUrlData: { codeList: [] },
+  }),
+}));
+
+jest.mock("@js/components/Plan/Panel/diff-helpers", () => ({
+  isCodedTerm: (path) =>
+    path === "descriptive_metadata.rights_statement" ||
+    path === "descriptive_metadata.license",
+  isTextSingle: (path) => path === "descriptive_metadata.title",
+  isTextArray: (path) =>
+    path === "descriptive_metadata.description" ||
+    path === "descriptive_metadata.date_created",
+}));
+
+jest.mock("@js/services/metadata", () => ({
+  prepFieldArrayItemsForPost: (values) => values.map((v) => v.metadataItem),
+  prepEDTFforPost: (values) => values.map((v) => v.metadataItem),
+  prepNotes: (v) => v,
+  prepRelatedUrl: (v) => v,
+  prepControlledTermInput: (_meta, values) => values,
+  CONTROLLED_METADATA: [
+    { name: "subject", scheme: "FAST_TOPIC" },
+    { name: "contributor", scheme: "MARC_RELATOR" },
+  ],
+}));
+
+jest.mock("@nulib/design-system", () => ({
+  Button: ({ children, onClick, type, disabled, ...rest }) => (
+    <button onClick={onClick} type={type || "button"} disabled={disabled} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock("@js/components/UI/Form/Input", () => ({ name, placeholder, ...rest }) => (
+  <input name={name} placeholder={placeholder} data-testid={`input-${name}`} {...rest} />
+));
+
+jest.mock("@js/components/UI/Form/Field", () => ({ label, children }) => (
+  <div>
+    <label>{label}</label>
+    {children}
+  </div>
+));
+
+jest.mock("@js/components/UI/Form/FieldArray", () => ({ name, label }) => (
+  <div data-testid={`field-array-${name}`} data-label={label} />
+));
+
+jest.mock("@js/components/UI/Form/Select", () => ({ name, options, defaultValue }) => (
+  <select name={name} data-testid={`select-${name}`} defaultValue={defaultValue}>
+    {(options || []).map((o) => (
+      <option key={o.id} value={o.id}>
+        {o.label}
+      </option>
+    ))}
+  </select>
+));
+
+jest.mock("@js/components/UI/Form/Note", () => () => <div data-testid="form-note" />);
+jest.mock("@js/components/UI/Form/RelatedURL", () => () => <div data-testid="form-related-url" />);
+jest.mock("@js/components/UI/Form/ControlledTermArray", () => ({ name, authorities }) => (
+  <div data-testid={`controlled-term-array-${name}`} data-authority-count={authorities?.length ?? 0} />
+));
+jest.mock("@js/components/Icon", () => ({
+  IconTrashCan: () => <span data-testid="icon-trash" />,
+}));
+
+const noop = jest.fn();
+
+describe("EditDiffRowForm", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test("renders nothing when change is null", () => {
+    const { container } = render(
+      <EditDiffRowForm change={null} isOpen={true} onSave={noop} onCancel={noop} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("renders modal with title for plain text single field", () => {
+    render(
+      <EditDiffRowForm
+        change={{
+          id: "1",
+          method: "replace",
+          path: "descriptive_metadata.title",
+          label: "Title",
+          value: "My Title",
+          controlled: false,
+          nestedCoded: false,
+        }}
+        isOpen={true}
+        onSave={noop}
+        onCancel={noop}
+      />
+    );
+
+    expect(screen.getByText("Edit - Title")).toBeInTheDocument();
+    expect(screen.getByTestId("input-value")).toBeInTheDocument();
+  });
+
+  test("modal is inactive when isOpen is false", () => {
+    render(
+      <EditDiffRowForm
+        change={{
+          id: "1",
+          method: "replace",
+          path: "descriptive_metadata.title",
+          label: "Title",
+          value: "My Title",
+          controlled: false,
+          nestedCoded: false,
+        }}
+        isOpen={false}
+        onSave={noop}
+        onCancel={noop}
+      />
+    );
+
+    expect(screen.getByRole("form")).not.toHaveClass("is-active");
+  });
+
+  test("renders UIFormFieldArray for plain text array field", () => {
+    render(
+      <EditDiffRowForm
+        change={{
+          id: "2",
+          method: "add",
+          path: "descriptive_metadata.description",
+          label: "Description",
+          value: ["One", "Two"],
+          controlled: false,
+          nestedCoded: false,
+        }}
+        isOpen={true}
+        onSave={noop}
+        onCancel={noop}
+      />
+    );
+
+    expect(screen.getByTestId("field-array-values")).toBeInTheDocument();
+  });
+
+  test("renders select with rights_statement options using camelCase code list key", () => {
+    render(
+      <EditDiffRowForm
+        change={{
+          id: "3",
+          method: "replace",
+          path: "descriptive_metadata.rights_statement",
+          label: "Rights Statement",
+          value: { id: "http://rightsstatements.org/vocab/InC/1.0/", label: "In Copyright" },
+          controlled: false,
+          nestedCoded: false,
+        }}
+        isOpen={true}
+        onSave={noop}
+        onCancel={noop}
+      />
+    );
+
+    const select = screen.getByTestId("select-value");
+    expect(select).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "In Copyright" })).toBeInTheDocument();
+  });
+
+  test("renders select with license options", () => {
+    render(
+      <EditDiffRowForm
+        change={{
+          id: "4",
+          method: "replace",
+          path: "descriptive_metadata.license",
+          label: "License",
+          value: { id: "http://creativecommons.org/licenses/by/4.0/", label: "CC BY" },
+          controlled: false,
+          nestedCoded: false,
+        }}
+        isOpen={true}
+        onSave={noop}
+        onCancel={noop}
+      />
+    );
+
+    expect(screen.getByRole("option", { name: "CC BY" })).toBeInTheDocument();
+  });
+
+  test("renders UIFormControlledTermArray for controlled field", () => {
+    render(
+      <EditDiffRowForm
+        change={{
+          id: "5",
+          method: "add",
+          path: "descriptive_metadata.subject",
+          label: "Subject",
+          value: [],
+          controlled: true,
+          nestedCoded: false,
+        }}
+        isOpen={true}
+        onSave={noop}
+        onCancel={noop}
+      />
+    );
+
+    expect(screen.getByTestId("controlled-term-array-subject")).toBeInTheDocument();
+  });
+
+  test("delete mode renders items with remove buttons and warning for non-controlled field", () => {
+    render(
+      <EditDiffRowForm
+        change={{
+          id: "6",
+          method: "delete",
+          path: "descriptive_metadata.description",
+          label: "Description",
+          value: ["Item A", "Item B"],
+          controlled: false,
+          nestedCoded: false,
+        }}
+        isOpen={true}
+        onSave={noop}
+        onCancel={noop}
+      />
+    );
+
+    expect(screen.getByText("Review deletions - Description")).toBeInTheDocument();
+    expect(screen.getByText("Item A")).toBeInTheDocument();
+    expect(screen.getByText("Item B")).toBeInTheDocument();
+    // Warning shown for non-controlled deletes
+    expect(screen.getByText(/Deletions are only supported for controlled vocabulary fields/)).toBeInTheDocument();
+  });
+
+  test("delete mode: removing an item updates the list", () => {
+    render(
+      <EditDiffRowForm
+        change={{
+          id: "7",
+          method: "delete",
+          path: "descriptive_metadata.subject",
+          label: "Subject",
+          value: [
+            { term: { id: "t1", label: "Topic One" } },
+            { term: { id: "t2", label: "Topic Two" } },
+          ],
+          controlled: true,
+          nestedCoded: false,
+        }}
+        isOpen={true}
+        onSave={noop}
+        onCancel={noop}
+      />
+    );
+
+    expect(screen.getByText("Topic One")).toBeInTheDocument();
+    // No warning for controlled field
+    expect(screen.queryByText(/Deletions are only supported/)).not.toBeInTheDocument();
+
+    const trashButtons = screen.getAllByTestId("icon-trash");
+    fireEvent.click(trashButtons[0].closest("button"));
+
+    expect(screen.queryByText("Topic One")).not.toBeInTheDocument();
+    expect(screen.getByText("Topic Two")).toBeInTheDocument();
+  });
+
+  test("delete mode: removing all items shows empty message", () => {
+    render(
+      <EditDiffRowForm
+        change={{
+          id: "8",
+          method: "delete",
+          path: "descriptive_metadata.subject",
+          label: "Subject",
+          value: [{ term: { id: "t1", label: "Only Item" } }],
+          controlled: true,
+          nestedCoded: false,
+        }}
+        isOpen={true}
+        onSave={noop}
+        onCancel={noop}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("icon-trash").closest("button"));
+    expect(screen.getByText(/All items removed/)).toBeInTheDocument();
+  });
+
+  test("calls onCancel when close button clicked", () => {
+    const onCancel = jest.fn();
+    render(
+      <EditDiffRowForm
+        change={{
+          id: "9",
+          method: "replace",
+          path: "descriptive_metadata.title",
+          label: "Title",
+          value: "Hello",
+          controlled: false,
+          nestedCoded: false,
+        }}
+        isOpen={true}
+        onSave={noop}
+        onCancel={onCancel}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("close"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  test("Save changes button is disabled when form is not dirty", () => {
+    render(
+      <EditDiffRowForm
+        change={{
+          id: "10",
+          method: "replace",
+          path: "descriptive_metadata.title",
+          label: "Title",
+          value: "Hello",
+          controlled: false,
+          nestedCoded: false,
+        }}
+        isOpen={true}
+        onSave={noop}
+        onCancel={noop}
+      />
+    );
+
+    expect(screen.getByTestId("submit-button")).toBeDisabled();
+  });
+});

--- a/app/assets/js/components/Plan/Panel/diff-helpers.js
+++ b/app/assets/js/components/Plan/Panel/diff-helpers.js
@@ -3,7 +3,12 @@ import {
   CONTROLLED_TERM_FIELDS,
   CODED_TERM_FIELDS,
   NESTED_CODED_TERM_FIELDS,
+  TEXT_SINGLE_FIELDS,
+  TEXT_ARRAY_FIELDS,
 } from "@js/components/Plan/fields";
+import {
+  CONTROLLED_METADATA,
+} from "@js/services/metadata";
 
 /**
  * Ensure a value is an array
@@ -24,6 +29,16 @@ const isCodedTerm = (path) => CODED_TERM_FIELDS.has(path);
  * Determine if a given dotted path is a nested coded term field
  */
 const isNestedCodedTerm = (path) => NESTED_CODED_TERM_FIELDS.has(path);
+
+/**
+ * Determine if a given dotted path is a single valued text field
+ */
+const isTextSingle = (path) => TEXT_SINGLE_FIELDS.has(path);
+
+/**
+ * Determine if a given dotted path is a multi valued text field
+ */
+const isTextArray = (path) => TEXT_ARRAY_FIELDS.has(path);
 
 /**
  * Lookup a display label from WORK_FIELDS
@@ -126,6 +141,8 @@ export {
   isControlled,
   isCodedTerm,
   isNestedCodedTerm,
+  isTextSingle,
+  isTextArray,
   getFieldLabel,
   toRows,
 };

--- a/app/assets/js/components/Plan/Plan.jsx
+++ b/app/assets/js/components/Plan/Plan.jsx
@@ -14,10 +14,11 @@ const conversationId = uuidv4();
 const Plan = ({ works }) => {
   const query = works.map((work) => `id:(${work.id})`).join(" OR ");
   const [planId, setPlanId] = React.useState(null);
-  const [loadingMessage, setLoadingMessage] =
-    React.useState("Initializing plan");
   const [summary, setSummary] = React.useState(null);
   const [originalPrompt, setOriginalPrompt] = React.useState(null);
+
+  const [loadingMessage, setLoadingMessage] =
+    React.useState("Initializing plan");
 
   const { data: planChanges, error: planChangesError } = usePlanChanges(planId);
   const { data: plan, error: planError } = usePlan(planId);

--- a/app/assets/js/components/Plan/fields.js
+++ b/app/assets/js/components/Plan/fields.js
@@ -78,4 +78,45 @@ export const CODED_TERM_FIELDS = new Set([
 export const NESTED_CODED_TERM_FIELDS = new Set([
   "descriptive_metadata.notes",
   "descriptive_metadata.related_url",
+  "administrative_metadata.library_unit",
+  "administrative_metadata.preservation_level",
+  "administrative_metadata.status",
+  "administrative_metadata.visibility",
+]);
+
+/**
+ * Set of single valued text fields by their dotted paths
+ */
+export const TEXT_SINGLE_FIELDS = new Set([
+  "descriptive_metadata.title",
+  "descriptive_metadata.terms_of_use",
+]);
+
+/**
+ * Set of multi valued text fields by their dotted paths
+ */
+export const TEXT_ARRAY_FIELDS = new Set([
+  "descriptive_metadata.abstract",
+  "descriptive_metadata.alternate_title",
+  "descriptive_metadata.box_name",
+  "descriptive_metadata.box_number",
+  "descriptive_metadata.catalog_key",
+  "descriptive_metadata.caption",
+  "descriptive_metadata.cultural_context",
+  "descriptive_metadata.description",
+  "descriptive_metadata.date_created",
+  "descriptive_metadata.folder_name",
+  "descriptive_metadata.folder_number",
+  "descriptive_metadata.identifier",
+  "descriptive_metadata.keywords",
+  "descriptive_metadata.legacy_identifier",
+  "descriptive_metadata.physical_description_material",
+  "descriptive_metadata.physical_description_size",
+  "descriptive_metadata.provenance",
+  "descriptive_metadata.publisher",
+  "descriptive_metadata.related_material",
+  "descriptive_metadata.scope_and_contents",
+  "descriptive_metadata.series",
+  "descriptive_metadata.source",
+  "descriptive_metadata.table_of_contents",
 ]);

--- a/app/assets/js/components/Plan/plan.gql.js
+++ b/app/assets/js/components/Plan/plan.gql.js
@@ -98,6 +98,31 @@ export const UPDATE_PLAN_CHANGE_STATUS = gql`
   }
 `;
 
+export const UPDATE_PLAN_CHANGE = gql`
+  mutation updatePlanChange(
+    $id: ID!
+    $add: Json
+    $replace: Json
+    $delete: Json
+  ) {
+    updatePlanChange(id: $id, add: $add, replace: $replace, delete: $delete) {
+      id
+      add
+      replace
+      delete
+      status
+    }
+  }
+`;
+
+export const DELETE_PLAN_CHANGE = gql`
+  mutation deletePlanChange($id: ID!) {
+    deletePlanChange(id: $id) {
+      id
+    }
+  }
+`;
+
 export const UPDATE_PROPOSED_PLAN_CHANGE_STATUSES = gql`
   mutation updateProposedPlanChangeStatuses(
     $planId: ID!

--- a/app/assets/js/services/metadata.ts
+++ b/app/assets/js/services/metadata.ts
@@ -348,7 +348,7 @@ export const UNCONTROLLED_MULTI_VALUE_METADATA = [
   SOURCE,
   STATUS,
   TABLE_OF_CONTENTS,
-  TERMS_OF_USE,
+  TERMS_OF_USE, // note: this field is single valued
   VISIBILITY,
 ];
 

--- a/app/lib/meadow/data/enrichment.ex
+++ b/app/lib/meadow/data/enrichment.ex
@@ -1,0 +1,268 @@
+defmodule Meadow.Data.Enrichment do
+  @moduledoc """
+  A module for enriching data objects with additional information, such as labels for controlled terms.
+  """
+  require Logger
+  alias Meadow.Data.{CodedTerms, ControlledTerms}
+
+  @controlled_fields ~w(contributor creator genre language location style_period subject technique)a
+  @coded_fields ~w(license rights_statement)a
+  # Fields with arrays of objects containing coded terms
+  @nested_coded_fields ~w(notes related_url)a
+
+  # Enrichment functions for controlled terms
+
+  def enrich_controlled_terms(attrs) do
+    attrs
+    |> Map.update(:add, nil, &enrich_metadata_section/1)
+    |> Map.update(:delete, nil, &enrich_metadata_section/1)
+    |> Map.update(:replace, nil, &enrich_metadata_section/1)
+  end
+
+  defp enrich_metadata_section(nil), do: nil
+
+  defp enrich_metadata_section(section) when is_map(section) do
+    descriptive_metadata =
+      section
+      |> Map.get(:descriptive_metadata, Map.get(section, "descriptive_metadata"))
+      |> enrich_descriptive_metadata()
+
+    if descriptive_metadata do
+      section
+      |> Map.delete("descriptive_metadata")
+      |> Map.put(:descriptive_metadata, descriptive_metadata)
+    else
+      section
+    end
+  end
+
+  defp enrich_metadata_section(section), do: section
+
+  defp enrich_descriptive_metadata(nil), do: nil
+
+  defp enrich_descriptive_metadata(metadata) when is_map(metadata) do
+    metadata
+    |> enrich_controlled_fields()
+    |> enrich_coded_fields()
+    |> enrich_nested_coded_fields()
+  end
+
+  defp enrich_descriptive_metadata(metadata), do: metadata
+
+  defp enrich_controlled_fields(metadata) do
+    Enum.reduce(@controlled_fields, metadata, fn field, acc ->
+      field_string = Atom.to_string(field)
+
+      case Map.get(acc, field, Map.get(acc, field_string)) do
+        nil ->
+          acc
+
+        values when is_list(values) ->
+          enriched_values = Enum.map(values, &enrich_controlled_term_entry/1)
+
+          acc
+          |> Map.delete(field_string)
+          |> Map.put(field, enriched_values)
+
+        value ->
+          enriched_value = enrich_controlled_term_entry(value)
+
+          acc
+          |> Map.delete(field_string)
+          |> Map.put(field, enriched_value)
+      end
+    end)
+  end
+
+  defp enrich_coded_fields(metadata) do
+    Enum.reduce(@coded_fields, metadata, fn field, acc ->
+      field_string = Atom.to_string(field)
+
+      case Map.get(acc, field, Map.get(acc, field_string)) do
+        nil ->
+          acc
+
+        value when is_map(value) ->
+          enriched_value =
+            value
+            |> atomize_keys()
+            |> enrich_coded_term()
+
+          acc
+          |> Map.delete(field_string)
+          |> Map.put(field, enriched_value)
+
+        _value ->
+          acc
+      end
+    end)
+  end
+
+  defp enrich_nested_coded_fields(metadata) do
+    Enum.reduce(@nested_coded_fields, metadata, fn field, acc ->
+      field_string = Atom.to_string(field)
+
+      case Map.get(acc, field, Map.get(acc, field_string)) do
+        nil ->
+          acc
+
+        values when is_list(values) ->
+          enriched_values = Enum.map(values, &enrich_nested_coded_entry(field, &1))
+
+          acc
+          |> Map.delete(field_string)
+          |> Map.put(field, enriched_values)
+
+        _value ->
+          acc
+      end
+    end)
+  end
+
+  # Enrich notes entries (have a 'type' coded term)
+  defp enrich_nested_coded_entry(:notes, entry) when is_map(entry) do
+    entry
+    |> atomize_keys()
+    |> enrich_note_type()
+  end
+
+  # Enrich related_url entries (have a 'label' coded term)
+  defp enrich_nested_coded_entry(:related_url, entry) when is_map(entry) do
+    entry
+    |> atomize_keys()
+    |> enrich_related_url_label()
+  end
+
+  defp enrich_nested_coded_entry(_field, entry), do: entry
+
+  defp enrich_note_type(%{type: type} = entry) when is_map(type) do
+    enriched_type =
+      type
+      |> atomize_keys()
+      |> enrich_coded_term()
+
+    Map.put(entry, :type, enriched_type)
+  end
+
+  defp enrich_note_type(entry), do: entry
+
+  defp enrich_related_url_label(%{label: label} = entry) when is_map(label) do
+    enriched_label =
+      label
+      |> atomize_keys()
+      |> enrich_coded_term()
+
+    Map.put(entry, :label, enriched_label)
+  end
+
+  defp enrich_related_url_label(entry), do: entry
+
+  defp enrich_controlled_term_entry(entry) when is_map(entry) do
+    entry
+    |> atomize_keys()
+    |> enrich_term()
+    |> enrich_role()
+  end
+
+  defp enrich_controlled_term_entry(entry), do: entry
+
+  defp enrich_term(%{term: term} = entry) when is_map(term) do
+    enriched_term =
+      term
+      |> atomize_keys()
+      |> enrich_term_with_label()
+
+    Map.put(entry, :term, enriched_term)
+  end
+
+  defp enrich_term(entry), do: entry
+
+  defp enrich_term_with_label(%{id: _id, label: label} = term) when not is_nil(label) do
+    # Label already exists, don't overwrite
+    term
+  end
+
+  defp enrich_term_with_label(%{id: id} = term) when is_binary(id) do
+    case ControlledTerms.fetch(id) do
+      {{:ok, _}, %{label: label}} ->
+        Map.put(term, :label, label)
+
+      {:error, reason} ->
+        Logger.warning("Failed to fetch label for controlled term #{id}: #{inspect(reason)}")
+        term
+
+      _ ->
+        term
+    end
+  end
+
+  defp enrich_term_with_label(term), do: term
+
+  defp enrich_role(%{role: role} = entry) when is_map(role) do
+    enriched_role =
+      role
+      |> atomize_keys()
+      |> enrich_role_with_label()
+
+    Map.put(entry, :role, enriched_role)
+  end
+
+  defp enrich_role(entry), do: entry
+
+  defp enrich_role_with_label(%{id: _id, scheme: _scheme, label: label} = role)
+       when not is_nil(label) do
+    # Label already exists, don't overwrite
+    role
+  end
+
+  defp enrich_role_with_label(%{id: id, scheme: scheme} = role)
+       when is_binary(id) and is_binary(scheme) do
+    case CodedTerms.get_coded_term(id, scheme) do
+      {{:ok, _}, %{label: label}} ->
+        Map.put(role, :label, label)
+
+      nil ->
+        Logger.warning("Failed to fetch label for coded term #{id} in scheme #{scheme}")
+        role
+
+      _ ->
+        role
+    end
+  end
+
+  defp enrich_role_with_label(role), do: role
+
+  defp enrich_coded_term(%{id: _id, scheme: _scheme, label: label} = term)
+       when not is_nil(label) do
+    # Label already exists, don't overwrite
+    term
+  end
+
+  defp enrich_coded_term(%{id: id, scheme: scheme} = term)
+       when is_binary(id) and is_binary(scheme) do
+    case CodedTerms.get_coded_term(id, scheme) do
+      {{:ok, _}, %{label: label}} ->
+        Map.put(term, :label, label)
+
+      nil ->
+        Logger.warning("Failed to fetch label for coded term #{id} in scheme #{scheme}")
+        term
+
+      _ ->
+        term
+    end
+  end
+
+  defp enrich_coded_term(term), do: term
+
+  defp atomize_keys(map) when is_map(map) do
+    Map.new(map, fn
+      {key, value} when is_binary(key) -> {String.to_atom(key), value}
+      {key, value} -> {key, value}
+    end)
+  end
+
+  defp atomize_keys(value), do: value
+
+
+end

--- a/app/lib/meadow_web/mcp/update_plan_change.ex
+++ b/app/lib/meadow_web/mcp/update_plan_change.ex
@@ -76,7 +76,7 @@ defmodule MeadowWeb.MCP.UpdatePlanChange do
   alias Anubis.MCP.Error, as: MCPError
   alias Anubis.Server.Response
   alias Meadow.Config
-  alias Meadow.Data.{CodedTerms, ControlledTerms, Planner}
+  alias Meadow.Data.{CodedTerms, Enrichment, Planner}
   alias Meadow.Repo
   require Logger
 
@@ -135,7 +135,7 @@ defmodule MeadowWeb.MCP.UpdatePlanChange do
 
     request
     |> Map.take([:add, :delete, :replace, :status, :notes])
-    |> enrich_controlled_terms()
+    |> Enrichment.enrich_controlled_terms()
     |> inject_ai_note(model)
     |> validate_coded_terms()
   end
@@ -181,288 +181,56 @@ defmodule MeadowWeb.MCP.UpdatePlanChange do
     }
   end
 
-  # Enrichment functions for controlled terms
 
-  defp enrich_controlled_terms(attrs) do
-    attrs
-    |> Map.update(:add, nil, &enrich_metadata_section/1)
-    |> Map.update(:delete, nil, &enrich_metadata_section/1)
-    |> Map.update(:replace, nil, &enrich_metadata_section/1)
-  end
 
-  defp enrich_metadata_section(nil), do: nil
-
-  defp enrich_metadata_section(section) when is_map(section) do
-    descriptive_metadata =
-      section
-      |> Map.get(:descriptive_metadata, Map.get(section, "descriptive_metadata"))
-      |> enrich_descriptive_metadata()
-
-    if descriptive_metadata do
-      section
-      |> Map.delete("descriptive_metadata")
-      |> Map.put(:descriptive_metadata, descriptive_metadata)
-    else
-      section
-    end
-  end
-
-  defp enrich_metadata_section(section), do: section
-
-  defp enrich_descriptive_metadata(nil), do: nil
-
-  defp enrich_descriptive_metadata(metadata) when is_map(metadata) do
-    metadata
-    |> enrich_controlled_fields()
-    |> enrich_coded_fields()
-    |> enrich_nested_coded_fields()
-  end
-
-  defp enrich_descriptive_metadata(metadata), do: metadata
-
-  defp enrich_controlled_fields(metadata) do
-    Enum.reduce(@controlled_fields, metadata, fn field, acc ->
-      field_string = Atom.to_string(field)
-
-      case Map.get(acc, field, Map.get(acc, field_string)) do
-        nil ->
-          acc
-
-        values when is_list(values) ->
-          enriched_values = Enum.map(values, &enrich_controlled_term_entry/1)
-
-          acc
-          |> Map.delete(field_string)
-          |> Map.put(field, enriched_values)
-
-        value ->
-          enriched_value = enrich_controlled_term_entry(value)
-
-          acc
-          |> Map.delete(field_string)
-          |> Map.put(field, enriched_value)
-      end
+  defp has_metadata_changes?(attrs) do
+    Enum.any?([:add, :delete, :replace], fn key ->
+      val = Map.get(attrs, key)
+      not is_nil(val) and val != %{}
     end)
   end
 
-  defp enrich_coded_fields(metadata) do
-    Enum.reduce(@coded_fields, metadata, fn field, acc ->
-      field_string = Atom.to_string(field)
-
-      case Map.get(acc, field, Map.get(acc, field_string)) do
-        nil ->
-          acc
-
-        value when is_map(value) ->
-          enriched_value =
-            value
-            |> atomize_keys()
-            |> enrich_coded_term()
-
-          acc
-          |> Map.delete(field_string)
-          |> Map.put(field, enriched_value)
-
-        _value ->
-          acc
-      end
-    end)
-  end
-
-  defp enrich_nested_coded_fields(metadata) do
-    Enum.reduce(@nested_coded_fields, metadata, fn field, acc ->
-      field_string = Atom.to_string(field)
-
-      case Map.get(acc, field, Map.get(acc, field_string)) do
-        nil ->
-          acc
-
-        values when is_list(values) ->
-          enriched_values = Enum.map(values, &enrich_nested_coded_entry(field, &1))
-
-          acc
-          |> Map.delete(field_string)
-          |> Map.put(field, enriched_values)
-
-        _value ->
-          acc
-      end
-    end)
-  end
-
-  # Enrich notes entries (have a 'type' coded term)
-  defp enrich_nested_coded_entry(:notes, entry) when is_map(entry) do
-    entry
-    |> atomize_keys()
-    |> enrich_note_type()
-  end
-
-  # Enrich related_url entries (have a 'label' coded term)
-  defp enrich_nested_coded_entry(:related_url, entry) when is_map(entry) do
-    entry
-    |> atomize_keys()
-    |> enrich_related_url_label()
-  end
-
-  defp enrich_nested_coded_entry(_field, entry), do: entry
-
-  defp enrich_note_type(%{type: type} = entry) when is_map(type) do
-    enriched_type =
-      type
-      |> atomize_keys()
-      |> enrich_coded_term()
-
-    Map.put(entry, :type, enriched_type)
-  end
-
-  defp enrich_note_type(entry), do: entry
-
-  defp enrich_related_url_label(%{label: label} = entry) when is_map(label) do
-    enriched_label =
-      label
-      |> atomize_keys()
-      |> enrich_coded_term()
-
-    Map.put(entry, :label, enriched_label)
-  end
-
-  defp enrich_related_url_label(entry), do: entry
-
-  defp enrich_controlled_term_entry(entry) when is_map(entry) do
-    entry
-    |> atomize_keys()
-    |> enrich_term()
-    |> enrich_role()
-  end
-
-  defp enrich_controlled_term_entry(entry), do: entry
-
-  defp enrich_term(%{term: term} = entry) when is_map(term) do
-    enriched_term =
-      term
-      |> atomize_keys()
-      |> enrich_term_with_label()
-
-    Map.put(entry, :term, enriched_term)
-  end
-
-  defp enrich_term(entry), do: entry
-
-  defp enrich_term_with_label(%{id: _id, label: label} = term) when not is_nil(label) do
-    # Label already exists, don't overwrite
-    term
-  end
-
-  defp enrich_term_with_label(%{id: id} = term) when is_binary(id) do
-    case ControlledTerms.fetch(id) do
-      {{:ok, _}, %{label: label}} ->
-        Map.put(term, :label, label)
-
-      {:error, reason} ->
-        Logger.warning("Failed to fetch label for controlled term #{id}: #{inspect(reason)}")
-        term
-
-      _ ->
-        term
-    end
-  end
-
-  defp enrich_term_with_label(term), do: term
-
-  defp enrich_role(%{role: role} = entry) when is_map(role) do
-    enriched_role =
-      role
-      |> atomize_keys()
-      |> enrich_role_with_label()
-
-    Map.put(entry, :role, enriched_role)
-  end
-
-  defp enrich_role(entry), do: entry
-
-  defp enrich_role_with_label(%{id: _id, scheme: _scheme, label: label} = role)
-       when not is_nil(label) do
-    # Label already exists, don't overwrite
-    role
-  end
-
-  defp enrich_role_with_label(%{id: id, scheme: scheme} = role)
-       when is_binary(id) and is_binary(scheme) do
-    case CodedTerms.get_coded_term(id, scheme) do
-      {{:ok, _}, %{label: label}} ->
-        Map.put(role, :label, label)
-
-      nil ->
-        Logger.warning("Failed to fetch label for coded term #{id} in scheme #{scheme}")
-        role
-
-      _ ->
-        role
-    end
-  end
-
-  defp enrich_role_with_label(role), do: role
-
-  defp enrich_coded_term(%{id: _id, scheme: _scheme, label: label} = term)
-       when not is_nil(label) do
-    # Label already exists, don't overwrite
-    term
-  end
-
-  defp enrich_coded_term(%{id: id, scheme: scheme} = term)
-       when is_binary(id) and is_binary(scheme) do
-    case CodedTerms.get_coded_term(id, scheme) do
-      {{:ok, _}, %{label: label}} ->
-        Map.put(term, :label, label)
-
-      nil ->
-        Logger.warning("Failed to fetch label for coded term #{id} in scheme #{scheme}")
-        term
-
-      _ ->
-        term
-    end
-  end
-
-  defp enrich_coded_term(term), do: term
-
-  defp atomize_keys(map) when is_map(map) do
-    Map.new(map, fn
-      {key, value} when is_binary(key) -> {String.to_atom(key), value}
-      {key, value} -> {key, value}
-    end)
-  end
-
-  defp atomize_keys(value), do: value
-
-  defp inject_ai_note(attrs, model) when is_map(attrs) do
+  defp build_ai_note(model) do
     current_date = Date.utc_today() |> Date.to_iso8601()
 
-    note_text = case model do
-      nil -> "Some metadata created with the assistance of AI on #{current_date}"
-      model_id -> "Some metadata created with the assistance of AI (#{model_id}) on #{current_date}"
-    end
+    note_text =
+      case model do
+        nil -> "Some metadata created with the assistance of AI on #{current_date}"
+        model_id -> "Some metadata created with the assistance of AI (#{model_id}) on #{current_date}"
+      end
 
-    ai_note = %{
-      note: note_text,
-      type: %{
-        id: "LOCAL_NOTE",
-        scheme: "note_type",
-        label: "Local Note"
-      }
-    }
-
-    add_section = Map.get(attrs, :add) || %{}
-    descriptive_metadata = Map.get(add_section, :descriptive_metadata) || %{}
-    existing_notes = Map.get(descriptive_metadata, :notes, [])
-
-    updated_descriptive_metadata = Map.put(descriptive_metadata, :notes, existing_notes ++ [ai_note])
-    updated_add_section = Map.put(add_section, :descriptive_metadata, updated_descriptive_metadata)
-
-    Map.put(attrs, :add, updated_add_section)
+    %{note: note_text, type: %{id: "LOCAL_NOTE", scheme: "note_type", label: "Local Note"}}
   end
 
-  defp inject_ai_note(attrs, _model), do: attrs
+  defp inject_ai_note(attrs, _model) when not is_map(attrs), do: attrs
+
+  defp inject_ai_note(attrs, model) do
+    if has_metadata_changes?(attrs) do
+      do_inject_ai_note(attrs, build_ai_note(model))
+    else
+      attrs
+    end
+  end
+
+  defp do_inject_ai_note(attrs, ai_note) do
+    replace_section = Map.get(attrs, :replace) || %{}
+    replace_metadata = Map.get(replace_section, :descriptive_metadata) || %{}
+
+    case Map.fetch(replace_metadata, :notes) do
+      {:ok, replace_notes} ->
+        updated_replace_metadata = Map.put(replace_metadata, :notes, replace_notes ++ [ai_note])
+        updated_replace_section = Map.put(replace_section, :descriptive_metadata, updated_replace_metadata)
+        Map.put(attrs, :replace, updated_replace_section)
+
+      :error ->
+        add_section = Map.get(attrs, :add) || %{}
+        descriptive_metadata = Map.get(add_section, :descriptive_metadata) || %{}
+        existing_notes = Map.get(descriptive_metadata, :notes, [])
+        updated_descriptive_metadata = Map.put(descriptive_metadata, :notes, existing_notes ++ [ai_note])
+        updated_add_section = Map.put(add_section, :descriptive_metadata, updated_descriptive_metadata)
+        Map.put(attrs, :add, updated_add_section)
+    end
+  end
 
   # Validation functions for coded terms
 

--- a/app/lib/meadow_web/schema/types/data/plan_types.ex
+++ b/app/lib/meadow_web/schema/types/data/plan_types.ex
@@ -54,6 +54,17 @@ defmodule MeadowWeb.Schema.Data.PlanTypes do
       resolve(&Plans.update_plan_change_status/3)
     end
 
+    @desc "Update plan change content (add, replace, delete)"
+    field :update_plan_change, :plan_change do
+      arg(:id, non_null(:id))
+      arg(:add, :json)
+      arg(:replace, :json)
+      arg(:delete, :json)
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Plans.update_plan_change/3)
+    end
+
     @desc "Update all proposed plan change statuses (approve or reject)"
     field :update_proposed_plan_change_statuses, list_of(:plan_change) do
       arg(:plan_id, non_null(:id))
@@ -70,6 +81,14 @@ defmodule MeadowWeb.Schema.Data.PlanTypes do
       middleware(Middleware.Authenticate)
       middleware(Middleware.Authorize, "Editor")
       resolve(&Plans.apply_plan/3)
+    end
+
+    @desc "Delete a plan change"
+    field :delete_plan_change, :plan_change do
+      arg(:plan_change_id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Plans.delete_plan_change/3)
     end
   end
 

--- a/lambdas/metadata-agent/prompts.js
+++ b/lambdas/metadata-agent/prompts.js
@@ -69,17 +69,33 @@ export const proposerPrompt = () => `
     - Process one change at a time and recheck pending list
     - After all changes, call propose_plan so the plan itself is proposed; do not skip
     - Return a summary with counts
-    - The \`id\` field can never be changed
-    - The \`title\` is a single string; do not use lists
+    - The id, ark and accession_number fields can never be changed
+    - The title and terms_of_use fields are single strings; do not use lists
     - Works can only have one rights statement
     - NEVER populate the navPlace field - it is experimental and not ready for use
 
-    Controlled term fields (must use authoritiesSearch): contributor (role required, marc_relator), creator (role optional, marc_relator), genre, language, location, subject (role required, subject_role), style_period, technique.
+    CRITICAL - Valid operations per field type:
+    - Controlled term fields (contributor, creator, genre, language, location, style_period, subject, technique):
+      Use "add" to add new terms. Use "delete" to remove specific existing terms.
+      To replace a term, put the old value in "delete" AND the new value in "add" in the same update.
+      NEVER use "replace" for these fields - it will be ignored.
+    - Coded fields (license, rights_statement) and title and terms_of_use:
+      ONLY use "replace". Never use "add" or "delete" for these fields.
+    - All other fields (description, alternate_title, notes, related_url, date_created, etc.):
+      Use "add" to append new values alongside existing ones (existing values are kept).
+      Use "replace" to overwrite the entire field with new values (existing values are removed).
+      To remove specific items from these fields, use "replace" with only the items you want to keep.
+      To clear a field entirely, use "replace" with an empty array [].
+      NEVER use "delete" for these fields - it will be ignored.
+    - date_created: use simple EDTF strings e.g. ["1985", "2005-06"] - do NOT use {edtf:, humanized:} objects.
+    - Do not suggest changes to administrative_metadata fields
+
+    Controlled term fields (must use authoritiesSearch): contributor (role required, marc_relator), subject (role required, subject_role), genre, language, location, creator, style_period, technique.
 
     Requirements:
     - Always search for controlled term IDs; never invent them
     - Structure: {"term": {"id": "controlled-term-id", "label": "Label"}, "role": {"id": "role-id", "scheme": "role-scheme", "label": "Role Label"}}
-    - term is an object with id, not a string; role required for subject and contributor, optional for creator
+    - term is an object with id, not a string; role required for subject and contributor
     - For roles, query codeList(scheme: SUBJECT_ROLE or MARC_RELATOR); use returned ids (e.g., TOPICAL, GEOGRAPHIC, TEMPORAL, GENRE_FORM, pht, art, ctb)
 
     Examples:
@@ -88,7 +104,7 @@ export const proposerPrompt = () => `
 
     Authorities: lcsh (subject), lcnaf (creator/contributor), lcgft (genre), lclang (language), fast/fast-* subsets (subject), aat (technique/style_period/genre), tgn or geonames (location), ulan (creator/contributor), homosaurus (LGBTQ+), nul-authority (any field).
 
-    Controlled term format in add/replace:
+    Controlled term format in add/replace (for contributor (role required), genre, language, location, subject (role required), style_period, technique, creator:
     {
       "descriptive_metadata": {
         "subject": [{"term": {"id": "http://id.worldcat.org/fast/849374"}, "role": {"id": "TOPICAL", "scheme": "subject_role"}}],


### PR DESCRIPTION
# Summary 

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5788
fixes https://github.com/nulib/repodev_planning_and_docs/issues/5791
fixes https://github.com/nulib/repodev_planning_and_docs/issues/5792


Users can only reject or approve an entire plan. We need to give them the ability to refine the changes.

# Specific Changes in this PR

- Added `EditDiffRowForm` modal component for editing plan changes, supporting plain text (single/multi), coded terms, nested coded fields, and controlled vocabulary fields
- Follow patterns established for single work and batch edit
- Delete mode shows read-only item list with per-item removal; warns when field type doesn't support deletion
- Extracted `Meadow.Data.Enrichment` module shared between MCP server and GraphQL mutation path so controlled term labels are resolved on save
- Fixed AI note injection when agent proposes `replace: {notes: []} ` - note now appended to the replace array instead of being overwritten
- Skip AI note injection entirely when there are no metadata changes (status-only updates)
- Updated agent prompt with explicit rules on valid operations per field type
- Added tests for `EditDiffRowForm` 
- Various prompt tweaks to encourage it to supply valid data for field types

# Steps to Test

- Use auto edit to suggest changes
- Modify those changes before approving

<img width="1113" height="799" alt="Screenshot 2026-02-17 at 6 18 33 AM" src="https://github.com/user-attachments/assets/4acd7d4b-9971-4541-bb5a-e81e1a88d60e" />


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major



# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

