### PR TITLE
Support invoking the same lambda simultaneously in local mode

### DIFF
--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "license": "MIT",
       "dependencies": {
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",
@@ -14739,6 +14739,21 @@
         "object-assign": "^4.1.1"
       }
     },
+    "node_modules/chonky/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "dev": true,
@@ -24506,6 +24521,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/recharts/node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/recharts/node_modules/reselect": {
       "version": "5.1.1",

--- a/infrastructure/pipeline/Makefile
+++ b/infrastructure/pipeline/Makefile
@@ -2,6 +2,7 @@ LAMBDAS_DIR ?= ../../lambdas
 SAM_PORT ?= 3005
 SAM_HOST ?= 0.0.0.0
 PIPELINE_LOG_DIR := $(shell mktemp -d)
+PIPELINE_THREADS ?= 4
 
 .PHONY: help layers build start clean
 
@@ -40,7 +41,7 @@ build: layers
 	sam build --use-container --cached
 
 start: deps layers
-	sam local start-lambda --warm-containers=LAZY -p 3005
+	./start_multi.sh $(SAM_PORT) $(PIPELINE_THREADS)
 
 clean:
 	rm -rf .aws-sam $(LAMBDAS_DIR)/*/node_modules && \

--- a/infrastructure/pipeline/start_multi.sh
+++ b/infrastructure/pipeline/start_multi.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+BACKENDS=""
+PORT=${1:-3005}
+COUNT=${2:-1}
+PIDS=()
+LOGDIR=$(mktemp -d)
+
+for p in $(seq 3015 $((3015 + COUNT - 1))); do
+  sam local start-lambda --warm-containers=LAZY -p $p >"$LOGDIR/$p.log" 2>&1 &
+  PIDS+=($!)
+  BACKENDS="$BACKENDS
+  server s$p 127.0.0.1:$p";
+done;
+trap 'kill "${PIDS[@]}" 2>/dev/null' EXIT
+
+for p in $(seq 3015 $((3015 + COUNT - 1))); do
+  while ! grep -q "Press CTRL+C to quit" "$LOGDIR/$p.log" 2>/dev/null; do
+    sleep 0.1
+  done
+done
+echo "All $COUNT backends ready"
+tail -f -q -n 0 "$LOGDIR"/*.log &
+TAIL_PID=$!
+
+LAMBDA_TIMEOUT=$(yq '.Resources.metadataAgent.Properties.Timeout' < template.yaml)
+TIMEOUT="$((LAMBDA_TIMEOUT + 5))s"
+CONFIG="defaults
+  mode tcp
+  timeout connect 5s
+  timeout client $TIMEOUT
+  timeout server $TIMEOUT
+
+frontend f
+  bind *:$PORT
+  default_backend b
+
+backend b
+  balance roundrobin
+$BACKENDS"
+
+PIDS+=($TAIL_PID)
+echo " * Running on http://127.0.0.1:$PORT/ (Press CTRL+C to quit)"
+echo "$CONFIG" | haproxy -f /dev/stdin


### PR DESCRIPTION
# Summary 
Support invoking the same lambda simultaneously in local mode

# Specific Changes in this PR
- On `make pipeline-start`, start multiple instances of the local pipeline on different ports, with a round-robin proxy running on port 3005

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- `make pipeline-start`
- `USE_SAM_LAMBDAS iex -S mix phx.server`
- Try simultaneous auto-edits

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

