### PR TITLE
Update Elixir, OTP, and Docker build based on current livebook version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,9 @@
 !livebook/**/*
 app/.dockerignore
 app/.elixir_ls
+app/.expert
 app/.git
+app/.lexical
 app/_build
 app/assets/coverage
 app/**/node_modules

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       deploy_env: ${{ steps.set-deploy-env.outputs.result }}
-      container_tag: ${{ steps.set-container-tag.outputs.result }}
+      image_tag: ${{ steps.set-image-tag.outputs.result }}
       meadow_tenant: ${{ steps.set-meadow-prefix.outputs.result }}
     steps:
       - name: Set DEPLOY_ENV from Branch Name
@@ -30,8 +30,8 @@ jobs:
           fi
         env:
           BRANCH: ${{ github.ref }}
-      - name: Set container tag from DEPLOY_ENV
-        id: set-container-tag
+      - name: Set image tag from DEPLOY_ENV
+        id: set-image-tag
         run: |
           if [[ $DEPLOY_ENV == 'production' || $DEPLOY_ENV == 'staging' ]]; then
             echo "result=latest" >> $GITHUB_OUTPUT
@@ -53,7 +53,7 @@ jobs:
       - name: Output Environment Info
         run: |
           echo "Deploying to environment: ${{ steps.set-deploy-env.outputs.result }}"
-          echo "Using container tag: ${{ steps.set-container-tag.outputs.result }}"
+          echo "Using image tag: ${{ steps.set-image-tag.outputs.result }}"
           echo "Using meadow tenant prefix: ${{ steps.set-meadow-prefix.outputs.result }}"
   build:
     if: ${{ !github.event.pull_request && !contains(github.event.head_commit.message, '[no-deploy]') }}
@@ -61,7 +61,7 @@ jobs:
     needs: get-environment
     env:
       DEPLOY_ENV: ${{ needs.get-environment.outputs.deploy_env }}
-      CONTAINER_TAG: ${{ needs.get-environment.outputs.container_tag }}
+      IMAGE_TAG: ${{ needs.get-environment.outputs.image_tag }}
       MEADOW_TENANT: ${{ needs.get-environment.outputs.meadow_tenant }}
     steps:
       - uses: actions/checkout@v2
@@ -73,7 +73,7 @@ jobs:
           SECRETS: ${{ toJSON(secrets) }}
       - name: Extract MEADOW_VERSION from mix.exs
         run: echo "MEADOW_VERSION=$(make app-version)" >> $GITHUB_ENV
-      - run: echo "Building Meadow v${MEADOW_VERSION} as nulib/meadow:${CONTAINER_TAG}"
+      - run: echo "Building Meadow v${MEADOW_VERSION} as nulib/meadow:${IMAGE_TAG}"
       - name: Tag Meadow Release
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
@@ -85,42 +85,45 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
-      - name: Determine container tags
-        id: determine-container-tags
+      - name: Determine image tags
+        id: determine-image-tags
         run: |
           {
             echo "tags<<EOF"
-            echo "${REGISTRY_NAME}/meadow:${CONTAINER_TAG}"
-            if [[ ${CONTAINER_TAG} == "latest" ]]; then
+            echo "${REGISTRY_NAME}/meadow:${IMAGE_TAG}"
+            if [[ ${IMAGE_TAG} == "latest" ]]; then
               echo "${REGISTRY_NAME}/meadow:${MEADOW_VERSION}"
             fi
             echo "EOF"
           } >> $GITHUB_OUTPUT
         env:
           REGISTRY_NAME: ${{ steps.login-ecr.outputs.registry }}
-      - name: Set Meadow Release Name
-        id: meadow-release
-        run: echo "name=meadow-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Set Build Options
+        id: build-options
+        run: |
+          echo "release_name=meadow-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "build_image=$(make build-image)" >> $GITHUB_OUTPUT
+          echo "runtime_image=$(make runtime-image)" >> $GITHUB_OUTPUT
       - uses: docker/build-push-action@v2
         with:
           context: ./app
           push: true
-          tags: ${{ steps.determine-container-tags.outputs.tags }}
+          tags: ${{ steps.determine-image-tags.outputs.tags }}
           build-args: |
-            BUILD_IMAGE=hexpm/elixir:1.18.2-erlang-27.3-debian-bookworm-20250224
-            RUNTIME_IMAGE=node:22-bookworm-slim
+            BUILD_IMAGE=${{ steps.build-options.outputs.build_image }}
+            RUNTIME_IMAGE=${{ steps.build-options.outputs.runtime_image }}
             HONEYBADGER_API_KEY=${{ secrets.HONEYBADGER_API_KEY }}
             HONEYBADGER_API_KEY_FRONTEND=${{ secrets.HONEYBADGER_API_KEY_FRONTEND }}
             HONEYBADGER_ENVIRONMENT=${{ env.DEPLOY_ENV }}
             HONEYBADGER_REVISION=${{ github.sha }}
-            RELEASE_NAME=${{ steps.meadow-release.outputs.name }}
+            RELEASE_NAME=${{ steps.build-options.outputs.release_name }}
             MEADOW_TENANT=${{ env.MEADOW_TENANT }}
             MEADOW_VERSION=${{ env.MEADOW_VERSION }}
       - name: Upload Source Maps to Honeybadger
         run: .github/scripts/upload_source_maps.sh
         env:
           DEPLOY_ENV: ${{ env.DEPLOY_ENV }}
-          MEADOW_IMAGE: ${{ steps.login-ecr.outputs.registry }}/meadow:${{ env.CONTAINER_TAG }}
+          MEADOW_IMAGE: ${{ steps.login-ecr.outputs.registry }}/meadow:${{ env.IMAGE_TAG }}
           MEADOW_VERSION: ${{ env.MEADOW_VERSION }}
           HONEYBADGER_API_KEY_FRONTEND: ${{ secrets.HONEYBADGER_API_KEY_FRONTEND }}
           HONEYBADGER_REVISION: ${{ github.sha }}
@@ -149,7 +152,7 @@ jobs:
     needs: get-environment
     env:
       DEPLOY_ENV: ${{ needs.get-environment.outputs.deploy_env }}
-      CONTAINER_TAG: ${{ needs.get-environment.outputs.container_tag }}
+      IMAGE_TAG: ${{ needs.get-environment.outputs.image_tag }}
       MEADOW_TENANT: ${{ needs.get-environment.outputs.meadow_tenant }}
     steps:
       - uses: actions/checkout@v2
@@ -166,13 +169,13 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
-      - name: Determine container tags
-        id: determine-container-tags
+      - name: Determine image tags
+        id: determine-image-tags
         run: |
           {
             echo "tags<<EOF"
-            echo "${REGISTRY_NAME}/meadow:livebook-${CONTAINER_TAG}"
-            if [[ ${CONTAINER_TAG} == "latest" ]]; then
+            echo "${REGISTRY_NAME}/meadow:livebook-${IMAGE_TAG}"
+            if [[ ${IMAGE_TAG} == "latest" ]]; then
               echo "${REGISTRY_NAME}/meadow:livebook-${MEADOW_VERSION}"
             fi
             echo "EOF"
@@ -184,7 +187,7 @@ jobs:
           context: .
           file: ./Dockerfile.livebook
           push: true
-          tags: ${{ steps.determine-container-tags.outputs.tags }}
+          tags: ${{ steps.determine-image-tags.outputs.tags }}
   deploy:
     needs: 
       - get-environment
@@ -194,7 +197,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DEPLOY_ENV: ${{ needs.get-environment.outputs.deploy_env }}
-      CONTAINER_TAG: ${{ needs.get-environment.outputs.container_tag }}
+      IMAGE_TAG: ${{ needs.get-environment.outputs.image_tag }}
       MEADOW_TENANT: ${{ needs.get-environment.outputs.meadow_tenant }}
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ AGENT.md
 
 .aws-sam/
 samconfig.*
+livebook/versions

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 nodejs      22.14.0
-erlang      27.3
-elixir      1.18.2-otp-27
+erlang      28.1.1
+elixir      1.19.3-otp-28
 terraform   1.7.4
 aws-sam-cli 1.152.0
 #npm 11.6.0

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,66 @@ SHELL := /bin/bash
 APP_DIR ?= ./app
 LOCALSTACK_DIR ?= ./infrastructure/localstack
 PIPELINE_DIR ?= ./infrastructure/pipeline
+MEADOW_VERSION ?= $(shell $(MAKE) --no-print-directory app-version)
+IMAGE_TAG ?= latest
+VERSIONS_FILE ?= livebook/versions
+ELIXIR_VERSION ?= $(shell . $(VERSIONS_FILE) && echo $${elixir})
+OTP_VERSION ?= $(shell . $(VERSIONS_FILE) && echo $${otp})
+UBUNTU_VERSION ?= $(shell . $(VERSIONS_FILE) && echo $${ubuntu})
+BUILD_IMAGE ?= hexpm/elixir:$(ELIXIR_VERSION)-erlang-$(OTP_VERSION)-ubuntu-$(UBUNTU_VERSION)
+RUNTIME_IMAGE ?= ubuntu:$(UBUNTU_VERSION)
 
 help:
 	@make app-help | sed 's/^make /make app-/'
 	@echo "make ci                    | install all dependencies, start test environment, and run all tests"
 	@make localstack-help | sed 's/^make /make localstack-/'
 	@make pipeline-help   | sed 's/^make /make pipeline-/'
+
+$(VERSIONS_FILE):
+	livebook_version=$$(curl -s https://api.github.com/repos/livebook-dev/livebook/releases | jq -r '[.[] | select(.tag_name != "nightly")][0].tag_name') && \
+	curl -sL -o $@ "https://raw.githubusercontent.com/livebook-dev/livebook/refs/tags/$${livebook_version}/versions"
+
+.tool-versions: $(VERSIONS_FILE)
+	. $(VERSIONS_FILE) && \
+	otp_major="$${otp%%.*}" && \
+	sed -i "s/^erlang .*/erlang      $${otp}/" .tool-versions	&& \
+	sed -i "s/^elixir .*/elixir      $${elixir}-otp-$${otp_major}/" .tool-versions
+
+build-image: $(VERSIONS_FILE)
+	@echo $(BUILD_IMAGE)
+
+runtime-image: $(VERSIONS_FILE)
+	@echo $(RUNTIME_IMAGE)
+
+app-image: $(VERSIONS_FILE)
+app-image: AWS_ACCOUNT_ID ?= $(shell aws sts get-caller-identity --query Account --output text)
+app-image: AWS_REGION ?= us-east-1
+app-image: ECR_REPO ?= $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
+app-image: RELEASE_NAME ?= meadow-$(shell git rev-parse --short HEAD)
+app-image: NODE_VERSION ?= 22
+app-image: MEADOW_TENANT ?= meadow
+app-image:
+	cd app && \
+	docker build \
+		--build-arg HONEYBADGER_API_KEY=$(HONEYBADGER_API_KEY) \
+		--build-arg HONEYBADGER_API_KEY_FRONTEND=$(HONEYBADGER_API_KEY_FRONTEND) \
+		--build-arg HONEYBADGER_ENVIRONMENT=$(HONEYBADGER_ENVIRONMENT) \
+		--build-arg HONEYBADGER_REVISION=$(HONEYBADGER_REVISION) \
+		--build-arg BUILD_IMAGE=$(BUILD_IMAGE) \
+		--build-arg RUNTIME_IMAGE=$(RUNTIME_IMAGE) \
+		--build-arg NODE_VERSION=$(NODE_VERSION) \
+		--build-arg MEADOW_TENANT=$(MEADOW_TENANT) \
+		--build-arg MEADOW_VERSION=$(MEADOW_VERSION) \
+		--tag $(ECR_REPO)/meadow:$(IMAGE_TAG) \
+		--tag $(ECR_REPO)/meadow:$(MEADOW_VERSION) \
+		.
+
+livebook-image:
+	docker build \
+		--tag nulib/meadow:livebook-$(MEADOW_VERSION) \
+		--tag nulib/meadow:livebook-$(IMAGE_TAG) \
+		-f Dockerfile.livebook \
+		.
 
 localstack-%:
 	cd $(LOCALSTACK_DIR) && make $*

--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -1,5 +1,7 @@
 .dockerignore
 .elixir_ls
+.expert
+.lexical
 .git
 _build
 assets/coverage

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,24 +1,23 @@
 ARG BUILD_IMAGE
-ARG RUNTIME_IMAGE
 
 # Install elixir & npm dependencies
 FROM ${BUILD_IMAGE} AS build
 LABEL edu.northwestern.library.app=meadow \
-  edu.northwestern.library.cache=true \
-  edu.northwestern.library.stage=deps
-RUN  mix local.hex --force \
-  && mix local.rebar --force
-ENV NODE_VERSION=22
+      edu.northwestern.library.cache=true \
+      edu.northwestern.library.stage=deps
+ARG NODE_VERSION=22
 ENV NPM_VERSION=11.6.0
 ENV ARCH=x64
-RUN apt update -qq \
- && apt install -y ca-certificates curl git gnupg \
- && mkdir -p /etc/apt/keyrings \
- && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
- && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_VERSION}.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
- && apt update -qq \
- && apt install -y nodejs \
- && npm install -g npm@$NPM_VERSION
+RUN apt update -qq
+RUN apt install -y ca-certificates curl git gnupg
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_VERSION}.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt update -qq
+RUN apt install -y nodejs
+RUN npm install -g npm@$NPM_VERSION
+RUN  mix local.hex --force \
+  && mix local.rebar --force
 ENV MIX_ENV=prod
 COPY . /app
 WORKDIR /app
@@ -45,10 +44,16 @@ ENV RELEASE_NAME=${RELEASE_NAME}
 RUN mix release --overwrite
 
 # Create runtime image
-FROM ${RUNTIME_IMAGE}
+FROM ${BUILD_IMAGE}
 LABEL edu.northwestern.library.app=meadow \
-edu.northwestern.library.stage=runtime
-RUN apt update -qq && apt install -y curl git jq libssl-dev libncurses5-dev
+      edu.northwestern.library.stage=runtime
+ARG NODE_VERSION=22
+RUN apt update -qq && apt install -y ca-certificates curl git gnupg jq libssl-dev libncurses5-dev \
+  && mkdir -p /etc/apt/keyrings \
+  && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_VERSION}.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+  && apt update -qq \
+  && apt install -y nodejs
 ARG RELEASE_NAME=
 ENV RELEASE_NAME=${RELEASE_NAME}
 ENV LANG=C.UTF-8

--- a/app/Makefile
+++ b/app/Makefile
@@ -49,37 +49,10 @@ deps: deps/.install-stamp
 
 all-deps: deps frontend-deps
 
-container: AWS_ACCOUNT_ID ?= $(shell aws sts get-caller-identity --query Account --output text)
-container: AWS_REGION ?= us-east-1
-container: CONTAINER_TAG ?= latest
-container: ECR_REPO ?= $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
-container: RELEASE_NAME ?= meadow-$(shell git rev-parse --short HEAD)
-container: BUILD_IMAGE ?= hexpm/elixir:1.18.2-erlang-27.3-debian-bookworm-20250224
-container: RUNTIME_IMAGE ?= node:22-bookworm-slim
-container: MEADOW_TENANT ?= meadow
-container: MEADOW_VERSION ?= $(shell make version)
-container:
-	docker build \
-		--build-arg HONEYBADGER_API_KEY=$(HONEYBADGER_API_KEY) \
-		--build-arg HONEYBADGER_API_KEY_FRONTEND=$(HONEYBADGER_API_KEY_FRONTEND) \
-		--build-arg HONEYBADGER_ENVIRONMENT=$(HONEYBADGER_ENVIRONMENT) \
-		--build-arg HONEYBADGER_REVISION=$(HONEYBADGER_REVISION) \
-		--build-arg BUILD_IMAGE=$(BUILD_IMAGE) \
-		--build-arg RUNTIME_IMAGE=$(RUNTIME_IMAGE) \
-		--build-arg MEADOW_TENANT=$(MEADOW_TENANT) \
-		--build-arg MEADOW_VERSION=$(MEADOW_VERSION) \
-		--tag $(ECR_REPO)/meadow:$(CONTAINER_TAG) \
-		--tag $(ECR_REPO)/meadow:$(MEADOW_VERSION) \
-		.
-
-livebook: CONTAINER_TAG ?= latest
-livebook: MEADOW_VERSION ?= $(shell make version)
-livebook:
-	docker build \
-		--tag nulib/meadow:livebook-$(MEADOW_VERSION) \
-		--tag nulib/meadow:livebook-$(CONTAINER_TAG) \
-		-f ../Dockerfile.livebook \
-		..
+images:
+	@echo "Livebook versions: $(LIVEBOOK_VERSIONS)"
+	@echo "Build image: $(BUILD_IMAGE)"
+	@echo "Runtime image: $(RUNTIME_IMAGE)"
 
 compile: deps
 	mix compile


### PR DESCRIPTION
# Summary 
Update Elixir, OTP, and Docker build based on current livebook version
Do not merge until after #5186 

# Specific Changes in this PR
- Update `.tool-versions` based on current livebook release
- Update docker build/runtime images based on current livebook release

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

