### PR TITLE
Use CLAUDE_CONFIG_DIR instead of HOME to configure Claude

### DIFF
--- a/infrastructure/pipeline/Makefile
+++ b/infrastructure/pipeline/Makefile
@@ -23,6 +23,7 @@ deps: $(LAMBDAS_DIR)/execute-fixity/node_modules
 deps: $(LAMBDAS_DIR)/exif/node_modules 
 deps: $(LAMBDAS_DIR)/frame-extractor/node_modules
 deps: $(LAMBDAS_DIR)/mediainfo/node_modules
+deps: $(LAMBDAS_DIR)/metadata-agent/node_modules
 deps: $(LAMBDAS_DIR)/mime-type/node_modules 
 deps: $(LAMBDAS_DIR)/pyramid-tiff/node_modules
 deps: $(LAMBDAS_DIR)/stream-authorizer/node_modules

--- a/infrastructure/pipeline/template.yaml
+++ b/infrastructure/pipeline/template.yaml
@@ -173,6 +173,7 @@ Resources:
       Environment:
         Variables:
           CLAUDE_CODE_USE_BEDROCK: 1
+          CLAUDE_CONFIG_DIR: /tmp
       Policies:
       - Version: "2012-10-17"
         Statement:

--- a/lambdas/metadata-agent/execute.js
+++ b/lambdas/metadata-agent/execute.js
@@ -40,10 +40,6 @@ async function executeSimple(model, prompt, context) {
 
 async function executeAgent(model, prompt, contextData, mcp_url, iiif_server_url, additional_headers) {
   const clientOptions = {
-    env: {
-      ...process.env,
-      HOME: "/tmp"
-    },
     model,
     mcpServers: {
       "meadow": { type: "http", url: mcp_url, headers: additional_headers }


### PR DESCRIPTION
# Summary 
Brief high level description of this feature or fix

# Specific Changes in this PR
- Set CLAUDE_CONFIG_DIR in pipeline SAM template
- Remove HOME override from metadata agent code
- Add metadata-agent to the pipeline `deps` target

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Terraform changes
  - [ ] Adds/requires new or changed Terraform variables
- [ ] Pipeline configuration changes (requires `mix meadow.pipeline.setup` run)
- [ ] Requires new variable added to `miscellany`
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

