### PR TITLE
Fix bug in coded terms format after user edit of proposed plan changes

### DIFF
--- a/app/assets/js/components/Work/controlledVocabulary.gql.js
+++ b/app/assets/js/components/Work/controlledVocabulary.gql.js
@@ -15,6 +15,7 @@ export const CODE_LIST_QUERY = gql`
     codeList(scheme: $scheme) {
       id
       label
+      scheme
     }
   }
 `;


### PR DESCRIPTION
# Summary 

Noticed that when editing license or rights statement in a proposed plan change, we were losing the `scheme`

# Specific Changes in this PR
- Add scheme to retrieved fields for codeListQuery

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Use auto edit to create a plan with a change to license or rights statement
- Edit the change, approve and apply
- Verify that correct changes are applied

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

