### PR TITLE
Make plan proposal part of update_plan_change tool

### DIFF
--- a/app/lib/meadow/data/planner.ex
+++ b/app/lib/meadow/data/planner.ex
@@ -484,6 +484,19 @@ defmodule Meadow.Data.Planner do
   end
 
   @doc """
+  Returns the count of pending plan changes for a plan.
+
+  ## Examples
+
+      iex> count_pending_plan_changes(plan_id)
+      3
+  """
+  def count_pending_plan_changes(plan_id) when is_binary(plan_id) do
+    from(c in PlanChange, where: c.plan_id == ^plan_id and c.status == :pending)
+    |> Repo.aggregate(:count)
+  end
+
+  @doc """
   Returns changes for a plan matching the given criteria.
 
   ## Example Criteria

--- a/lambdas/metadata-agent/prompts.js
+++ b/lambdas/metadata-agent/prompts.js
@@ -67,7 +67,6 @@ export const proposerPrompt = () => `
     - Always query work data; avoid assumptions
     - Skip deprecated fields
     - Process one change at a time and recheck pending list
-    - CRITICAL: After all changes, you MUST call propose_plan so the plan itself is proposed; do not skip
     - Return a summary with counts
     - The id, ark and accession_number fields can never be changed
     - The title and terms_of_use fields are single strings; do not use lists


### PR DESCRIPTION
# Summary 

About 20% of the time, the agent skips proposing the plan, which leaves the UI hanging.

# Specific Changes in this PR

- the plan transition to `:proposed` is now a guaranteed side effect of the last  `update_plan_change` call rather than a separate step the agent has to remember.
- Remove instruction from prompt

# Steps to Test

- Perform several auto edits
- Confirm that the plan gets set to proposed consistently


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

