### PR TITLE
Fix MetadataAgent lambda MCP access

### DIFF
--- a/app/lib/meadow_ai/metadata_agent.ex
+++ b/app/lib/meadow_ai/metadata_agent.ex
@@ -101,7 +101,7 @@ defmodule MeadowAI.MetadataAgent do
         :mcp_url,
         Routes.page_url(MeadowWeb.Endpoint, :index, ["api", "mcp"])
       )
-      |> Keyword.put_new(:graphql_auth_token, token)
+      |> Keyword.put_new(:auth_token, token)
       |> Keyword.put_new(
         :firewall_security_header,
         Application.get_env(:meadow, :firewall_security_header)
@@ -164,7 +164,7 @@ defmodule MeadowAI.MetadataAgent do
       |> Map.put_new(:simple, simple)
 
     auth_header =
-      case opts[:graphql_auth_token] do
+      case opts[:auth_token] do
         nil -> {}
         token -> {"Authorization", "Bearer #{token}"}
       end

--- a/app/lib/meadow_web/plugs/authorize.ex
+++ b/app/lib/meadow_web/plugs/authorize.ex
@@ -1,0 +1,34 @@
+defmodule MeadowWeb.Plugs.Authorize do
+  @moduledoc """
+  A plug to authorize access to certain routes based on user roles.
+  """
+
+  import Meadow.Roles, only: [authorized?: 2]
+  import Plug.Conn
+  require Logger
+
+  def init(opts) do
+    {forward_plug, forward_opts} =
+      case Keyword.get(opts, :forward_to) do
+        {plug, opts} -> {plug, opts}
+        plug -> {plug, []}
+      end
+
+    Keyword.put(opts, :forward_to, {forward_plug, forward_opts})
+  end
+
+  def call(conn, opts) do
+    current_user = conn.assigns[:current_user]
+    required_role = Keyword.get(opts, :require)
+    Logger.debug("Authorizing user #{inspect(current_user)} for role #{inspect(required_role)}")
+
+    if authorized?(current_user, required_role) do
+      {forward_plug, forward_opts} = Keyword.get(opts, :forward_to)
+      forward_plug.call(conn, forward_plug.init(forward_opts))
+    else
+      conn
+      |> send_resp(401, "Unauthorized")
+      |> halt()
+    end
+  end
+end

--- a/app/lib/meadow_web/router.ex
+++ b/app/lib/meadow_web/router.ex
@@ -78,10 +78,14 @@ defmodule MeadowWeb.Router do
       before_send: {Middleware.AssumeRole, :update_user_role}
     )
 
-    forward("/mcp", Anubis.Server.Transport.StreamableHTTP.Plug,
-      server: MeadowWeb.MCP.Server,
-      registry: MeadowWeb.MCP.GlobalRegistry,
-      timeout: 120_000
+    forward("/mcp", MeadowWeb.Plugs.Authorize,
+      require: :editor,
+      forward_to: {
+        Anubis.Server.Transport.StreamableHTTP.Plug,
+        server: MeadowWeb.MCP.Server,
+        registry: MeadowWeb.MCP.GlobalRegistry,
+        timeout: 120_000
+      }
     )
 
     forward("/", Plug.Static,

--- a/app/test/meadow_ai/metadata_agent_test.exs
+++ b/app/test/meadow_ai/metadata_agent_test.exs
@@ -18,7 +18,7 @@ defmodule MeadowAI.MetadataAgentTest do
       assert {:ok, {"test", ^prompt, opts}} = MetadataAgent.query(prompt, test: true, timeout: 1_000)
       assert opts[:test] == true
       assert Keyword.has_key?(opts, :firewall_security_header)
-      assert Keyword.has_key?(opts, :graphql_auth_token)
+      assert Keyword.has_key?(opts, :auth_token)
       assert Keyword.has_key?(opts, :mcp_url)
       assert {:ok, %{request_count: 1, failure_count: 0, last_failure: nil}} = MetadataAgent.status()
 

--- a/app/test/meadow_web/plugs/authorize_test.exs
+++ b/app/test/meadow_web/plugs/authorize_test.exs
@@ -1,0 +1,51 @@
+defmodule MeadowWeb.Plugs.AuthorizeTest do
+  use Meadow.DataCase
+  use MeadowWeb.ConnCase, async: false
+
+  alias MeadowWeb.Plugs.Authorize
+
+  defmodule PassThroughPlug do
+    import Plug.Conn
+
+    def init(opts), do: opts
+
+    def call(conn, opts) do
+      send_resp(conn, 200, "Pass! (with #{inspect(opts)})")
+    end
+  end
+
+  setup do
+    {:ok, %{opts: [require: :editor, forward_to: {PassThroughPlug, [option: "value"]}]}}
+  end
+
+  test "Authorize Plug returns 401 status when user is not logged in", %{opts: opts} do
+    conn =
+      build_conn()
+      |> Authorize.call(opts)
+
+    assert conn.status == 401
+  end
+
+  test "Authorize Plug passes through when current_user is not authorized", %{opts: opts} do
+    user = user_fixture(:user)
+
+    conn =
+      build_conn()
+      |> assign(:current_user, user)
+      |> Authorize.call(opts)
+
+    assert conn.status == 401
+  end
+
+  test "Authorize Plug passes through when current_user is authorized", %{opts: opts} do
+    user = user_fixture(:editor)
+
+    conn =
+      build_conn()
+      |> assign(:current_user, user)
+      |> Authorize.call(opts)
+
+    assert conn.status == 200
+    assert conn.resp_body == "Pass! (with [option: \"value\"])"
+  end
+end

--- a/lambdas/metadata-agent/execute.js
+++ b/lambdas/metadata-agent/execute.js
@@ -4,6 +4,7 @@ import debug from "debug";
 
 const log = debug("metadata-agent:execute");
 const logMessage = debug("metadata-agent:all-messages");
+const logVerbose = debug("metadata-agent:verbose");
 const verboseTools = /^(mcp__meadow__|ReadMcpResource)/;
 
 export async function queryClaude(model, prompt, context, mcp_url, additional_headers) {
@@ -79,8 +80,11 @@ async function executeAgent(model, prompt, contextData, mcp_url, additional_head
     },
     systemPrompt: systemPrompt()
   };
+  logVerbose("Client options:", clientOptions);
 
   const enhancedPrompt = agentPrompt(prompt, contextData);
+  logVerbose("Enhanced prompt:", enhancedPrompt);
+
   const result = await query({
     prompt: enhancedPrompt,
     options: clientOptions,

--- a/lambdas/metadata-agent/index.js
+++ b/lambdas/metadata-agent/index.js
@@ -3,9 +3,9 @@ import debug from "debug";
 
 const log = debug("metadata-agent:index");
 export const handler = async (event) => {
-  const { model, prompt, context, iiif_server_url, mcp_url, additional_headers } = event;
-  log("Received event:", { model, prompt, context, iiif_server_url, mcp_url });
-  const result = await queryClaude(model, prompt, context, mcp_url, iiif_server_url, additional_headers) || {};
+  const { model, prompt, context, mcp_url, additional_headers } = event;
+  log("Received event:", { model, prompt, context, mcp_url });
+  const result = await queryClaude(model, prompt, context, mcp_url, additional_headers) || {};
   log("Query result:", result);
   return { statusCode: 200, body: JSON.stringify(result) };
 };


### PR DESCRIPTION
# Summary 
Require editor or above for MCP access (via Authorize plug)

# Specific Changes in this PR
- Fix agent's JS arguments
- Add Authorize plug
- Wrap MCP plug in Authorize plug

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

