### PR TITLE
Stream agent logs to Auto Edit UI

### DIFF
--- a/app/assets/js/components/Plan/Panel/Changes.jsx
+++ b/app/assets/js/components/Plan/Panel/Changes.jsx
@@ -14,6 +14,7 @@ const PlanPanelChanges = ({
   changes,
   id,
   loadingMessage,
+  logs = [],
   plan,
   summary,
   originalPrompt,
@@ -24,23 +25,25 @@ const PlanPanelChanges = ({
   const [isApproved, setIsApproved] = React.useState(false);
   const [isApplying, setIsApplying] = React.useState(false);
   const [applyStartedAt, setApplyStartedAt] = React.useState(null);
+  const [showLogs, setShowLogs] = React.useState(false);
 
   const status = plan?.status || "PENDING";
   const proposedChange = changes?.planChange || null;
   const hasDiffPayload = Boolean(
     proposedChange &&
-      ((proposedChange.add &&
-        typeof proposedChange.add === "object" &&
-        Object.keys(proposedChange.add).length > 0) ||
-        (proposedChange.delete &&
-          typeof proposedChange.delete === "object" &&
-          Object.keys(proposedChange.delete).length > 0) ||
-        (proposedChange.replace &&
-          typeof proposedChange.replace === "object" &&
-          Object.keys(proposedChange.replace).length > 0))
+    ((proposedChange.add &&
+      typeof proposedChange.add === "object" &&
+      Object.keys(proposedChange.add).length > 0) ||
+      (proposedChange.delete &&
+        typeof proposedChange.delete === "object" &&
+        Object.keys(proposedChange.delete).length > 0) ||
+      (proposedChange.replace &&
+        typeof proposedChange.replace === "object" &&
+        Object.keys(proposedChange.replace).length > 0)),
   );
   const effectiveStatus =
-    status === "PENDING" && (proposedChange?.status === "PROPOSED" || hasDiffPayload)
+    status === "PENDING" &&
+    (proposedChange?.status === "PROPOSED" || hasDiffPayload)
       ? "PROPOSED"
       : status;
 
@@ -111,7 +114,13 @@ const PlanPanelChanges = ({
         onCompleted?.(null, "COMPLETED");
       }, 500);
     }
-  }, [effectiveStatus, isApplying, applyStartedAt, onCompleted, originalPrompt]);
+  }, [
+    effectiveStatus,
+    isApplying,
+    applyStartedAt,
+    onCompleted,
+    originalPrompt,
+  ]);
 
   const handleApproveChanges = async () => {
     try {
@@ -172,11 +181,17 @@ const PlanPanelChanges = ({
       ) : (
         <div className="plan-panel-changes--content">
           <div className="plan-panel-changes--status">
-            <span data-status={effectiveStatus} data-active={effectiveStatus === "PROPOSED"}>
+            <span
+              data-status={effectiveStatus}
+              data-active={effectiveStatus === "PROPOSED"}
+            >
               Proposed
             </span>
             <hr className="plan-panel-changes--status--divider" />
-            <span data-status={effectiveStatus} data-active={effectiveStatus === "APPROVED"}>
+            <span
+              data-status={effectiveStatus}
+              data-active={effectiveStatus === "APPROVED"}
+            >
               Approved
             </span>
             <hr className="plan-panel-changes--status--divider" />
@@ -255,6 +270,32 @@ const PlanPanelChanges = ({
           />
         </div>
       )}
+      <div className="plan-panel-changes--logs">
+        <button
+          type="button"
+          onClick={() => setShowLogs((current) => !current)}
+          data-variant="secondary"
+        >
+          {showLogs ? "Hide logs" : "Show logs"}
+          {` (${logs.length})`}
+        </button>
+        {showLogs && (
+          <div
+            className="plan-panel-changes--logs--panel"
+            role="log"
+            aria-live="polite"
+          >
+            {logs.length === 0 && (
+              <span className="plan-panel-changes--logs--empty">
+                Waiting for log output...
+              </span>
+            )}
+            {logs.map((entry, index) => (
+              <pre key={`${index}-${entry}`}>{entry}</pre>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/app/assets/js/components/Plan/Panel/Changes.test.jsx
+++ b/app/assets/js/components/Plan/Panel/Changes.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import PlanPanelChanges from "./Changes";
 
 jest.mock("@apollo/client/react", () => ({
@@ -10,9 +10,7 @@ jest.mock("@js/components/Plan/Panel/Diff", () => () => (
   <div data-testid="diff" />
 ));
 
-jest.mock("@js/components/UI/Loader", () => () => (
-  <div data-testid="loader" />
-));
+jest.mock("@js/components/UI/Loader", () => () => <div data-testid="loader" />);
 
 jest.mock("@js/components/UI/Skeleton", () => ({ rows = 3 }) => (
   <div data-testid="skeleton" data-rows={rows} />
@@ -27,6 +25,7 @@ const baseProps = {
   id: "plan-1",
   plan: { status: "APPROVED" },
   loadingMessage: "Loading",
+  logs: [],
   summary: "Changes summary",
   originalPrompt: "Describe the desired edits",
   target: {
@@ -44,22 +43,36 @@ describe("PlanPanelChanges", () => {
       await screen.findByRole("heading", { name: /prompt/i }),
     ).toBeInTheDocument();
     expect(screen.getByText(baseProps.originalPrompt)).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /summary/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /summary/i }),
+    ).toBeInTheDocument();
     expect(screen.getByText(baseProps.summary)).toBeInTheDocument();
   });
 
   test("shows a skeleton placeholder when the prompt is missing", async () => {
     render(
-      <PlanPanelChanges
-        {...baseProps}
-        originalPrompt={null}
-        summary={null}
-      />,
+      <PlanPanelChanges {...baseProps} originalPrompt={null} summary={null} />,
     );
 
     expect(
       await screen.findByRole("heading", { name: /prompt/i }),
     ).toBeInTheDocument();
     expect(screen.getAllByTestId("skeleton").length).toBeGreaterThan(0);
+  });
+
+  test("toggles the log panel", async () => {
+    render(<PlanPanelChanges {...baseProps} logs={["[info] first log"]} />);
+
+    const showLogsButton = await screen.findByRole("button", {
+      name: /show logs/i,
+    });
+    expect(screen.queryByRole("log")).not.toBeInTheDocument();
+
+    fireEvent.click(showLogsButton);
+    expect(screen.getByRole("log")).toBeInTheDocument();
+    expect(screen.getByText("[info] first log")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /hide logs/i }));
+    expect(screen.queryByRole("log")).not.toBeInTheDocument();
   });
 });

--- a/app/assets/js/components/Plan/Plan.jsx
+++ b/app/assets/js/components/Plan/Plan.jsx
@@ -16,6 +16,7 @@ const Plan = ({ works }) => {
   const [planId, setPlanId] = React.useState(null);
   const [summary, setSummary] = React.useState(null);
   const [originalPrompt, setOriginalPrompt] = React.useState(null);
+  const [agentLogs, setAgentLogs] = React.useState([]);
 
   const [loadingMessage, setLoadingMessage] =
     React.useState("Initializing plan");
@@ -52,6 +53,7 @@ const Plan = ({ works }) => {
 
   const handleSubmitMessage = async (text) => {
     setOriginalPrompt(text);
+    setAgentLogs([]);
     try {
       await sendChatMessage({
         conversationId,
@@ -67,15 +69,24 @@ const Plan = ({ works }) => {
   React.useEffect(() => {
     if (!chatResponseMessage) return;
 
-    if (chatResponseMessage.type === "plan_id")
-      setPlanId(chatResponseMessage.planId);
-
-    if (chatResponseMessage.type === "status_update")
-      setLoadingMessage(chatResponseMessage.message);
-
-    // Capture all non-status messages as the summary (last one wins)
-    if (chatResponseMessage.type !== "status_update" && chatResponseMessage.type !== "plan_id")
-      setSummary(chatResponseMessage.message);
+    switch (chatResponseMessage.type) {
+      case "plan_id":
+        setPlanId(chatResponseMessage.planId);
+        break;
+      case "status_update":
+        setLoadingMessage(chatResponseMessage.message);
+        break;
+      case "agent_log":
+        if (chatResponseMessage.message) {
+          setAgentLogs((current) => [...current, chatResponseMessage.message]);
+        }
+        break;
+      case "chat":
+        setSummary(chatResponseMessage.message);
+        break;
+      default:
+        break;
+    }
   }, [chatResponseMessage]);
 
   // Reset to initial screen when plan is completed
@@ -83,16 +94,23 @@ const Plan = ({ works }) => {
     setPlanId(null);
     setLoadingMessage("Initializing plan");
     setSummary(null);
+    setAgentLogs([]);
 
-    if (!rejectedPrompt){
+    if (!rejectedPrompt) {
       setOriginalPrompt(null);
     }
 
     // Show toast notifications after returning to initial screen
     if (status === "COMPLETED") {
-      toastWrapper("is-success", "Your changes have been applied. Refresh your browser to see the changes.");
+      toastWrapper(
+        "is-success",
+        "Your changes have been applied. Refresh your browser to see the changes.",
+      );
     } else if (status === "REJECTED") {
-      toastWrapper("is-warning", "Your changes have been cancelled. Please adjust your prompt and try again.");
+      toastWrapper(
+        "is-warning",
+        "Your changes have been cancelled. Please adjust your prompt and try again.",
+      );
     } else if (status === "ERROR") {
       toastWrapper("is-danger", "An error occurred. Please try again.");
     }
@@ -107,7 +125,9 @@ const Plan = ({ works }) => {
         {showInitialForm ? (
           <div className="plan-placeholder">
             {targetThumbnails}
-            <p className="is-6" style={{ marginBottom: "4rem" }}>{targetTitle}</p>
+            <p className="is-6" style={{ marginBottom: "4rem" }}>
+              {targetTitle}
+            </p>
             <p className="subtitle is-6">
               Describe the changes you want to make to this work, and an AI
               assistant will help you make those changes.
@@ -125,6 +145,7 @@ const Plan = ({ works }) => {
             plan={plan}
             loadingMessage={loadingMessage}
             summary={summary}
+            logs={agentLogs}
             originalPrompt={originalPrompt}
             target={{
               title: targetTitle,

--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "license": "MIT",
       "dependencies": {
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",
@@ -14642,6 +14642,21 @@
         "object-assign": "^4.1.1"
       }
     },
+    "node_modules/chonky/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "dev": true,
@@ -24409,6 +24424,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/recharts/node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/recharts/node_modules/reselect": {
       "version": "5.1.1",

--- a/app/assets/styles/scss/_plan.scss
+++ b/app/assets/styles/scss/_plan.scss
@@ -182,6 +182,52 @@
       margin-bottom: unset !important;
     }
   }
+
+  &--logs {
+    width: 100%;
+    max-width: 1200px;
+    padding: 0 3rem 2rem;
+
+    button {
+      margin: 0;
+      padding: calc(0.5rem - 1px) 1rem;
+      min-height: 40px;
+      border: 1px solid $rich-black-10;
+      background: $white;
+      color: $rich-black-50;
+      font-size: 1rem;
+      font-family: $AkkuratProRegular;
+      cursor: pointer;
+    }
+
+    &--panel {
+      margin-top: 0.75rem;
+      border: 1px solid $rich-black-10;
+      border-radius: 0.5rem;
+      background: $light-grey;
+      max-height: 320px;
+      overflow: auto;
+      padding: 0.75rem 1rem;
+
+      pre {
+        margin: 0;
+        padding: 0.25rem 0;
+        white-space: pre-wrap;
+        word-break: break-word;
+        font-family:
+          Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        font-size: 0.8333rem;
+        line-height: 1.4;
+      }
+    }
+
+    &--empty {
+      display: block;
+      color: $rich-black-50;
+      font-family: $AkkuratProItalic;
+      margin-bottom: 0.5rem;
+    }
+  }
 }
 
 .plan-placeholder {

--- a/app/lib/meadow/utils/lambda.ex
+++ b/app/lib/meadow/utils/lambda.ex
@@ -56,7 +56,7 @@ defmodule Meadow.Utils.Lambda do
   @spec invoke(config :: lambda_config(), payload :: map(), opts :: keyword()) ::
           {:ok | :error, any()}
   def invoke(config, payload, opts \\ []) do
-    opts = Keyword.validate!(opts, timeout: @timeout, retries: @retries)
+    opts = Keyword.validate!(opts, timeout: @timeout, retries: @retries, on_log: nil)
 
     case config do
       {:local, {script, handler}} -> invoke_local(script, handler, payload, opts)
@@ -95,11 +95,15 @@ defmodule Meadow.Utils.Lambda do
   defp invoke_lambda(lambda, payload, opts) do
     # coveralls-ignore-start
     Logger.metadata(lambda: lambda)
-    request_opts = Enum.reduce(opts, [], fn
-      {:retries, nil}, acc -> acc
-      {:retries, retries}, acc -> [retries: [max_attempts: retries]] ++ acc
-      {:timeout, timeout}, acc -> [http_opts: [receive_timeout: timeout]] ++ acc
-    end)
+
+    request_opts =
+      Enum.reduce(opts, [], fn
+        {:retries, nil}, acc -> acc
+        {:retries, retries}, acc -> [retries: [max_attempts: retries]] ++ acc
+        {:timeout, timeout}, acc -> [http_opts: [receive_timeout: timeout]] ++ acc
+        {:on_log, _on_log}, acc -> acc
+        _, acc -> acc
+      end)
 
     case ExAws.Lambda.invoke(lambda, payload, %{})
          |> ExAws.request(request_opts) do
@@ -135,15 +139,17 @@ defmodule Meadow.Utils.Lambda do
 
     with {_, port} <- find_or_create_port(script, handler),
          data <- Jason.encode!(payload) <> "\n",
-         timeout <- Keyword.get(opts, :timeout) do
+         timeout <- Keyword.get(opts, :timeout),
+         on_log <- Keyword.get(opts, :on_log) do
       send(port, {self(), {:command, data}})
-      handle_output(port, timeout)
+      handle_output(port, timeout, "", on_log)
     end
   end
 
-  defp handle_message(message) do
+  defp handle_message(message, on_log) do
     case ~r"^\[(?<level>.+?)\] (?<message>.+)$" |> Regex.named_captures(message) do
       %{"level" => level, "message" => message} ->
+        maybe_notify_log(on_log, String.to_atom(level), message)
         Logger.log(String.to_atom(level), message)
 
       _ ->
@@ -151,37 +157,38 @@ defmodule Meadow.Utils.Lambda do
     end
   end
 
-  defp handle_buffer("[return] undefined") do
+  defp handle_buffer("[return] undefined", _on_log) do
     Logger.warning("Received undefined response from lambda")
     {:ok, nil}
   end
 
-  defp handle_buffer("[return] " <> value) do
+  defp handle_buffer("[return] " <> value, _on_log) do
     {:ok, Jason.decode!(value)}
   end
 
-  defp handle_buffer("[fatal] " <> message) do
+  defp handle_buffer("[fatal] " <> message, on_log) do
+    maybe_notify_log(on_log, :error, message)
     Logger.error(message)
     {:error, message}
   end
 
-  defp handle_buffer("[debug] ping"), do: :continue
+  defp handle_buffer("[debug] ping", _on_log), do: :continue
 
-  defp handle_buffer(message) do
-    handle_message(message)
+  defp handle_buffer(message, on_log) do
+    handle_message(message, on_log)
     :continue
   end
 
-  defp handle_output(port, timeout, buffer \\ "") do
+  defp handle_output(port, timeout, buffer \\ "", on_log \\ nil) do
     receive do
       {^port, {:data, {:eol, data}}} ->
-        case handle_buffer(buffer <> data) do
-          :continue -> handle_output(port, timeout)
+        case handle_buffer(buffer <> data, on_log) do
+          :continue -> handle_output(port, timeout, "", on_log)
           other -> other
         end
 
       {^port, {:data, {:noeol, data}}} ->
-        handle_output(port, timeout, buffer <> data)
+        handle_output(port, timeout, buffer <> data, on_log)
 
       {^port, {:exit_status, status}} ->
         Logger.error("exit_status: #{status}")
@@ -193,6 +200,18 @@ defmodule Meadow.Utils.Lambda do
         {:error, "Timeout"}
     end
   end
+
+  defp maybe_notify_log(nil, _level, _message), do: :ok
+
+  defp maybe_notify_log(on_log, level, message) when is_function(on_log, 2) do
+    on_log.(level, message)
+  rescue
+    error ->
+      Logger.warning("Lambda on_log callback raised: #{Exception.message(error)}")
+      :ok
+  end
+
+  defp maybe_notify_log(_on_log, _level, _message), do: :ok
 
   defp command_for(script, handler),
     do: [Config.priv_path("nodejs/lambda/index.js"), script, handler] |> Enum.join(" ")

--- a/app/lib/meadow_ai/metadata_agent.ex
+++ b/app/lib/meadow_ai/metadata_agent.ex
@@ -58,7 +58,8 @@ defmodule MeadowAI.MetadataAgent do
           {:error, reason}
       end
     end)
-    |> Task.await(:infinity) # Rely on the earlier timeout
+    # Rely on the earlier timeout
+    |> Task.await(:infinity)
   end
 
   @doc """
@@ -108,12 +109,14 @@ defmodule MeadowAI.MetadataAgent do
       )
 
     Task.Supervisor.start_child(MeadowAI.MetadataAgent.TaskSupervisor, fn ->
-      result = if Keyword.get(opts, :test, false) do
-        :timer.sleep(500)
-        {:ok, {"test", prompt, opts}}
-      else
-        check_prompt_and_execute(prompt, opts)
-      end
+      result =
+        if Keyword.get(opts, :test, false) do
+          :timer.sleep(500)
+          {:ok, {"test", prompt, opts}}
+        else
+          check_prompt_and_execute(prompt, opts)
+        end
+
       send(caller, {:query_result, ref, result})
     end)
 

--- a/app/lib/meadow_web/schema/types/chat_types.ex
+++ b/app/lib/meadow_web/schema/types/chat_types.ex
@@ -28,6 +28,16 @@ defmodule MeadowWeb.Schema.ChatTypes do
 
       resolve(&Resolvers.Chat.send_chat_message/3)
     end
+
+    field :send_agent_log, type: :chat_response do
+      arg(:plan_id, non_null(:id))
+      arg(:message, non_null(:string))
+      arg(:level, :string, default_value: "info")
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+
+      resolve(&Resolvers.Chat.send_agent_log/3)
+    end
   end
 
   object :chat_message do
@@ -39,7 +49,7 @@ defmodule MeadowWeb.Schema.ChatTypes do
 
   object :chat_response do
     field(:conversation_id, :id)
-    field(:type, :string, description: "Type of message, e.g. 'chat', 'plan_id'")
+    field(:type, :string, description: "Type of message, e.g. 'chat', 'plan_id', 'agent_log'")
     field(:message, :string, description: "AI response message")
     field(:plan_id, :id, description: "The ID of the plan created for this chat message")
   end

--- a/app/test/gql/SendAgentLog.gql
+++ b/app/test/gql/SendAgentLog.gql
@@ -1,0 +1,8 @@
+mutation SendAgentLog($planId: ID!, $message: String!, $level: String) {
+  sendAgentLog(planId: $planId, message: $message, level: $level) {
+    conversationId
+    type
+    message
+    planId
+  }
+}

--- a/app/test/meadow_web/schema/mutation/send_agent_log_test.exs
+++ b/app/test/meadow_web/schema/mutation/send_agent_log_test.exs
@@ -1,0 +1,32 @@
+defmodule MeadowWeb.Schema.Mutation.SendAgentLogTest do
+  use Meadow.DataCase
+  use MeadowWeb.ConnCase, async: false
+  use Wormwood.GQLCase
+
+  alias Meadow.Data.Planner
+
+  load_gql(MeadowWeb.Schema, "test/gql/SendAgentLog.gql")
+
+  test "sends an agent log as editor" do
+    {:ok, plan} = Planner.create_plan(%{prompt: "test prompt", query: "id:(test)"})
+    Cachex.put!(Meadow.Cache.Chat.Conversations, plan.id, "test-conversation-123")
+
+    result =
+      query_gql(
+        variables: %{
+          "planId" => plan.id,
+          "message" => "tool_call: mcp__meadow__get_work",
+          "level" => "info"
+        },
+        context: gql_context(%{role: :editor, id: "meadow"})
+      )
+
+    assert {:ok, query_data} = result
+
+    message = get_in(query_data, [:data, "sendAgentLog"])
+    assert message["conversationId"] == "test-conversation-123"
+    assert message["type"] == "agent_log"
+    assert message["message"] == "tool_call: mcp__meadow__get_work"
+    assert message["planId"] == plan.id
+  end
+end

--- a/lambdas/metadata-agent/execute.js
+++ b/lambdas/metadata-agent/execute.js
@@ -6,23 +6,102 @@ const log = debug("metadata-agent:execute");
 const logMessage = debug("metadata-agent:all-messages");
 const logVerbose = debug("metadata-agent:verbose");
 const verboseTools = /^(mcp__meadow__|ReadMcpResource)/;
+const uiLogPrefix = "[agent-log] ";
+const maxPreviewLength = 800;
+const maxStreamedLogs = 250;
+const agentLogMutation = `
+mutation SendAgentLog($planId: ID!, $message: String!, $level: String) {
+  sendAgentLog(planId: $planId, message: $message, level: $level) {
+    conversationId
+  }
+}
+`;
+let reportUiLog = () => {};
 
-export async function queryClaude(model, prompt, context, mcp_url, additional_headers) {
-  if (context?.simple) {
-    return await executeSimple(model, prompt, context);
+function emitAgentLog(message, level = "info") {
+  if (!message) return;
+  console.info(`${uiLogPrefix}${message}`);
+  reportUiLog(message, level);
+}
+
+function preview(value, maxLength = maxPreviewLength) {
+  let text = "";
+
+  if (typeof value === "string") {
+    text = value;
   } else {
-    return await executeAgent(model, prompt, context, mcp_url, additional_headers);
+    try {
+      text = JSON.stringify(value);
+    } catch (_error) {
+      text = String(value);
+    }
+  }
+
+  return text.length > maxLength ? `${text.slice(0, maxLength)}...` : text;
+}
+
+function logToolResults(message) {
+  const blocks = message?.message?.content;
+  if (!Array.isArray(blocks)) return;
+
+  for (const block of blocks) {
+    const isToolResult =
+      block?.type === "tool_result" ||
+      (Object.prototype.hasOwnProperty.call(block || {}, "tool_use_id") &&
+        Object.prototype.hasOwnProperty.call(block || {}, "content"));
+
+    if (isToolResult) {
+      emitAgentLog(`tool_result: ${preview(block.content)}`);
+    }
+  }
+}
+
+export async function queryClaude(
+  model,
+  prompt,
+  context,
+  mcp_url,
+  additional_headers,
+) {
+  const reporter = createLogReporter(context, mcp_url, additional_headers);
+  reportUiLog = reporter.report;
+
+  try {
+    emitAgentLog("metadata-agent invocation started");
+    emitAgentLog(`prompt_length: ${(prompt || "").length}`);
+    emitAgentLog(`model: ${model}`);
+    if (context?.plan_id) emitAgentLog(`plan_id: ${context.plan_id}`);
+
+    if (context?.simple) {
+      return await executeSimple(model, prompt, context);
+    } else {
+      return await executeAgent(
+        model,
+        prompt,
+        context,
+        mcp_url,
+        additional_headers,
+      );
+    }
+  } finally {
+    emitAgentLog("metadata-agent invocation finished");
+    await reporter.flush();
+    reportUiLog = () => {};
   }
 }
 
 function logAssistantMessage(message) {
   for (const block of message.message.content) {
     if ("text" in block) {
+      const text = block.text?.replace(/\s+/g, " ").trim();
+      if (text) emitAgentLog(`assistant: ${preview(text)}`);
       log(block.text);
     } else if ("name" in block) {
       if (verboseTools.test(block.name) && block.input) {
+        emitAgentLog(`tool_call: ${block.name} ${preview(block.input)}`);
         log(`Tool: ${block.name} ${JSON.stringify(block.input)}`);
       } else {
+        emitAgentLog(`tool_call: ${block.name}`);
         log(`Tool: ${block.name}`);
       }
     }
@@ -30,12 +109,16 @@ function logAssistantMessage(message) {
 }
 
 async function processAgentMessages(result) {
+  emitAgentLog("waiting for model output");
   let finalResult = null;
   for await (const message of result) {
     logMessage("Message:", JSON.stringify(message, null, 2));
     if (message.type === "assistant" && message.message?.content) {
       logAssistantMessage(message);
+    } else if (message.type === "user" && message.message?.content) {
+      logToolResults(message);
     } else if (message.type === "result") {
+      emitAgentLog(`completed: ${message.subtype}`);
       log(`Done: ${message.subtype}`);
       finalResult = message;
     }
@@ -44,16 +127,26 @@ async function processAgentMessages(result) {
 }
 
 async function executeSimple(model, prompt, context) {
+  emitAgentLog("mode: simple");
   const enhancedPrompt = `${prompt}\n\nContext: ${JSON.stringify(context, null, 2)}`;
   const result = await query({
     prompt: enhancedPrompt,
     model,
-    systemPrompt: "You are a helpful assistant that responds to user queries. Do not use any tools.",
+    systemPrompt:
+      "You are a helpful assistant that responds to user queries. Do not use any tools.",
   });
   return await processAgentMessages(result);
 }
 
-async function executeAgent(model, prompt, contextData, mcp_url, additional_headers) {
+async function executeAgent(
+  model,
+  prompt,
+  contextData,
+  mcp_url,
+  additional_headers,
+) {
+  emitAgentLog("mode: agent");
+  emitAgentLog("connecting to MCP tools");
   const allowedTools = [
     "mcp__meadow__authority_search",
     "mcp__meadow__get_code_list",
@@ -68,26 +161,131 @@ async function executeAgent(model, prompt, contextData, mcp_url, additional_head
   const clientOptions = {
     model,
     mcpServers: {
-      "meadow": { type: "http", url: mcp_url, headers: additional_headers }
+      meadow: { type: "http", url: mcp_url, headers: additional_headers },
     },
     allowedTools,
     disallowedTools,
     agents: {
-      "plan_change_proposer": {
+      plan_change_proposer: {
         prompt: proposerPrompt(),
         tools: allowedTools,
-      }
+      },
     },
-    systemPrompt: systemPrompt()
+    systemPrompt: systemPrompt(),
   };
   logVerbose("Client options:", clientOptions);
 
   const enhancedPrompt = agentPrompt(prompt, contextData);
   logVerbose("Enhanced prompt:", enhancedPrompt);
 
+  emitAgentLog("sending request to Claude");
   const result = await query({
     prompt: enhancedPrompt,
     options: clientOptions,
   });
   return await processAgentMessages(result);
+}
+
+function createLogReporter(context, mcpUrl, additionalHeaders) {
+  const planId = context?.plan_id;
+  const endpoint = graphQlUrlFromMcpUrl(mcpUrl);
+  if (!planId || !endpoint) {
+    return { report: () => {}, flush: async () => {} };
+  }
+
+  const headers = buildHeaders(additionalHeaders);
+  let pending = Promise.resolve();
+  let sentCount = 0;
+  let sentTruncationNotice = false;
+
+  const report = (message, level = "info") => {
+    let safeMessage = preview(message, 2000);
+    let safeLevel = level;
+
+    if (sentCount >= maxStreamedLogs) {
+      if (sentTruncationNotice) return;
+      safeMessage = "Log stream truncated";
+      safeLevel = "warning";
+      sentTruncationNotice = true;
+    } else {
+      sentCount += 1;
+    }
+
+    pending = pending
+      .then(() =>
+        postAgentLog(endpoint, headers, planId, safeMessage, safeLevel),
+      )
+      .catch((error) => {
+        console.warn("Failed to publish agent log:", error?.message || error);
+        logVerbose("Failed to publish agent log", error);
+      });
+  };
+
+  return {
+    report,
+    flush: async () => {
+      try {
+        await pending;
+      } catch (_error) {
+        // No-op
+      }
+    },
+  };
+}
+
+function graphQlUrlFromMcpUrl(mcpUrl) {
+  if (!mcpUrl) return null;
+  try {
+    const url = new URL(mcpUrl);
+    url.pathname = "/api/graphql";
+    url.search = "";
+    return url.toString();
+  } catch (_error) {
+    return null;
+  }
+}
+
+function buildHeaders(additionalHeaders) {
+  const headers = { "Content-Type": "application/json" };
+  for (const [name, value] of Object.entries(additionalHeaders || {})) {
+    if (!name || value == null || value === "") continue;
+    headers[name] = value;
+  }
+  return headers;
+}
+
+async function postAgentLog(endpoint, headers, planId, message, level) {
+  const body = JSON.stringify({
+    query: agentLogMutation,
+    variables: { planId, message, level },
+  });
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers,
+    body,
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to publish agent log: ${response.status}`);
+  }
+
+  let payload;
+  try {
+    payload = await response.json();
+  } catch (_error) {
+    throw new Error("Failed to parse sendAgentLog response");
+  }
+
+  if (Array.isArray(payload?.errors) && payload.errors.length > 0) {
+    const messages = payload.errors
+      .map((error) => error?.message)
+      .filter(Boolean)
+      .join("; ");
+    throw new Error(messages || "sendAgentLog returned GraphQL errors");
+  }
+
+  if (!payload?.data?.sendAgentLog) {
+    throw new Error("sendAgentLog returned no data");
+  }
 }

--- a/lambdas/metadata-agent/index.js
+++ b/lambdas/metadata-agent/index.js
@@ -5,7 +5,9 @@ const log = debug("metadata-agent:index");
 export const handler = async (event) => {
   const { model, prompt, context, mcp_url, additional_headers } = event;
   log("Received event:", { model, prompt, context, mcp_url });
-  const result = await queryClaude(model, prompt, context, mcp_url, additional_headers) || {};
+  const result =
+    (await queryClaude(model, prompt, context, mcp_url, additional_headers)) ||
+    {};
   log("Query result:", result);
   return { statusCode: 200, body: JSON.stringify(result) };
 };


### PR DESCRIPTION
# Summary 
Adds streaming logs to the Auto Edit UI, they are collapsible and make it clear that `Initializing plan` isn't actually initializing or is stalled for some reason not conveyed by the simple loading message.

<img width="1254" height="675" alt="SCR-20260226-muit" src="https://github.com/user-attachments/assets/115201be-ce5b-42a6-966b-96cdb27220df" />

<img width="1143" height="775" alt="SCR-20260226-mtnj" src="https://github.com/user-attachments/assets/9fcc8bbf-62d8-4625-bb77-0aeb2b1910c0" />

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5795

# Specific Changes in this PR
- list changes
- list changes

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
The Lambdas aren't deployed, so `USE_SAM_LAMBDAS=true` and `make pipeline-start` is necessary.


# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [x] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

