### PR TITLE
Make the BearerAuth plug more resilient

### DIFF
--- a/app/test/meadow_web/plugs/bearer_auth_test.exs
+++ b/app/test/meadow_web/plugs/bearer_auth_test.exs
@@ -1,0 +1,58 @@
+defmodule MeadowWeb.Plugs.BearerAuthTest do
+  use MeadowWeb.ConnCase, async: false
+
+  alias Meadow.Utils.DCAPI
+  alias MeadowWeb.Plugs.BearerAuth
+
+  describe "BearerAuth Plug" do
+    setup %{conn: conn, ttl: ttl, claims: claims} do
+      conn =
+        case ttl do
+          nil ->
+            conn
+          ttl ->
+            {:ok, %{token: token}} = DCAPI.token(ttl, claims)
+            put_req_header(conn, "authorization", "Bearer #{token}")
+        end
+        |> Plug.Test.init_test_session(%{})
+        |> BearerAuth.call([])
+
+      {:ok, %{conn: conn}}
+    end
+
+    @tag ttl: 300, claims: [scopes: ["read:Public", "read:Published", "meadow:MCP"]]
+    test "sets a session user when the token has meadow scopes", %{conn: conn} do
+      assert conn |> fetch_session() |> get_session(:current_user)
+    end
+
+    @tag ttl: 300, claims: [scopes: ["read:Public", "read:Published"], is_superuser: true]
+    test "sets a session user when the token is a superuser", %{conn: conn} do
+      assert conn |> fetch_session() |> get_session(:current_user)
+    end
+
+    @tag ttl: 300, claims: [scopes: ["read:Public", "read:Published"]]
+    test "does not set a session user when the token is not a superuser and does not have meadow scopes", %{conn: conn} do
+      refute conn |> fetch_session() |> get_session(:current_user)
+    end
+
+    @tag ttl: -30, claims: [scopes: ["read:Public", "read:Published"], is_superuser: true]
+    test "does not set a session user when the token is expired", %{conn: conn} do
+      refute conn |> fetch_session() |> get_session(:current_user)
+    end
+
+    @tag ttl: nil, claims: nil
+    test "does not set a session user when no Authorization header is present", %{conn: conn} do
+      refute conn |> fetch_session() |> get_session(:current_user)
+    end
+
+    @tag ttl: nil, claims: nil
+    test "does not set a session user when the token is invalid" do
+      conn =
+        build_conn()
+        |> Plug.Test.init_test_session(%{})
+        |> put_req_header("authorization", "Bearer INVALID_TOKEN")
+        |> BearerAuth.call([])
+      refute conn |> fetch_session() |> get_session(:current_user)
+    end
+  end
+end


### PR DESCRIPTION
# Summary 
Make BearerAuth plug handle expired tokens more gracefully

# Specific Changes in this PR
- Only add the user to the session if a token is present with `isSuperuser` flag _or_ one or more `meadow:` scopes
- Allow the conn to pass through no matter what, so the consequences of having no user happen downstream
- Add tests for the plug

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Start Meadow
- Using Postman, create a new HTTP MCP request to your dev machine's `/api/mcp` endpoint and try to **Connect** with various Bearer auth tokens (instructions on how to generate them in Meadow included)
  - Bearer auth with a `meadow:` scope (200 / success):
      ```elixir
      Meadow.Utils.DCAPI.token(300, scopes: ["read:Public", "read:Published", "meadow:MCP"])
      ```
  - Bearer auth with valid superuser token (200 / success):
      ```elixir
      Meadow.Utils.DCAPI.token(300, scopes: ["read:Public", "read:Published"], is_superuser: true)
      ```
  - Bearer auth with valid token that isn't a superuser (401):
      ```elixir
      Meadow.Utils.DCAPI.token(300, scopes: ["read:Public", "read:Published"])
      ```
  - Bearer auth with expired token (401):
      ```elixir
      Meadow.Utils.DCAPI.token(-30, scopes: ["read:Public", "read:Published"], is_superuser: true)
      ```
  - Bearer auth with an invalid token (401):
      ```elixir
      "invalid.token.value"
      ```
- Don't forget to disconnect (the icon to the left of the **Run** button) after successful connections – once the session is initiated, it doesn't re-auth to run each request


# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

