### PR TITLE
Fix bug with file set additions to UI works

### DIFF
--- a/app/lib/meadow/events/ingest_sheets/sheet_updates.ex
+++ b/app/lib/meadow/events/ingest_sheets/sheet_updates.ex
@@ -12,6 +12,8 @@ defmodule Meadow.Events.IngestSheets.SheetUpdates do
 
   on_event(:ingest_sheets, %{}, [{__MODULE__, :handle_notification}], & &1)
 
+  def handle_notification(%{new_record: nil}), do: :noop
+
   def handle_notification(%{name: name, new_record: record}) do
     with_log_metadata module: __MODULE__, id: record.id, name: name do
       Logger.info("Sending notifications for ingest sheet: #{record.id}")

--- a/app/lib/meadow/pipeline/actions/initialize_dispatch.ex
+++ b/app/lib/meadow/pipeline/actions/initialize_dispatch.ex
@@ -52,7 +52,6 @@ defmodule Meadow.Pipeline.Actions.InitializeDispatch do
     end
   end
 
-  defp fixup_progress(%{work: %{ingest_sheet: sheet}}, _attributes) when is_nil(sheet), do: :noop
   defp fixup_progress(%{work: work}, _attributes) when is_nil(work), do: :noop
 
   defp fixup_progress(%{work_id: _work_id, work: %{ingest_sheet_id: ingest_sheet_id}} = file_set, attributes) do


### PR DESCRIPTION
### Summary


Quick bug fix for the add to existing work where adding to a work w/out an existing ingest sheet (UI created work) errored and/or hung in the UI. 

https://app.honeybadger.io/projects/61967/faults/127885925

- **initialize_dispatch.ex** — removed the over-broad guard when is_nil(sheet). That guard was firing for
  any work whose ingest_sheet association preloads as nil (i.e., every UI-created work)
 -  **sheet_updates.ex** — added def `handle_notification(%{new_record: nil}), do: :noop `to silently drop WAL
  DELETE events, which carry a nil new_record. Without this, the crash suppressed the UI notification
  for that event.
 -  **initialize_dispatch_test.exs** — added a new describe block "process/2 appending to a work without
  ingest sheet" that creates the work without ingest_sheet_id (the UI-created scenario),

```

2026-02-27T18:44:47.101Z | ** (BadMapError) expected a map, got: | Link | ** (BadMapError) expected a map, got:
-- | -- | -- | --
  | 2026-02-27T18:44:47.101Z | nil | Link
  | 2026-02-27T18:44:47.101Z | (meadow 10.3.1) lib/meadow/events/ingest_sheets/sheet_updates.ex:16: ex:16: Meadow.Events.IngestSheets.SheetUpdates.handle_notification/1
...
```
fixes https://github.com/nulib/repodev_planning_and_docs/issues/5793