### PR TITLE
Add schema resources to MCP so agent can have better documentation

### DIFF
--- a/app/lib/meadow/utils/ecto/schema.ex
+++ b/app/lib/meadow/utils/ecto/schema.ex
@@ -1,0 +1,142 @@
+defmodule Meadow.Utils.Ecto.Schema do
+  @moduledoc """
+  Utility functions for working with Ecto schemas, particularly for unrolling the schema into a more
+  human-readable format.
+  """
+
+  alias Meadow.Data.Types
+
+  @schemes %{
+    # Field-specific schemes
+    visibility: "visibility",
+    work_type: "work_type",
+    behavior: "behavior",
+    descriptive_metadata: %{
+      license: "license",
+      rights_statement: "rights_statement",
+      notes: %{type: "note_type"},
+      related_url: %{label: "related_url"}
+    },
+    administrative_metadata: %{
+      library_unit: "library_unit",
+      preservation_level: "preservation_level",
+      status: "status"
+    },
+    # Role schemes
+    contributor: "marc_relator",
+    subject: "subject_role",
+  }
+
+  @doc """
+  Unrolls an Ecto schema into a map of field names to their types, recursively
+
+  ## Options
+
+    * `:read_only` - a list of fields to exclude from the unrolled schema. Can also be a keyword list where
+                  the value is a list of fields to exclude from that field's schema.
+
+  ## Examples
+
+  iex> Meadow.Utils.Ecto.Schema.unroll(MyApp.MySchema)
+  %{
+    field1: "string",
+    field2: "integer",
+    embedded_field: %{
+      subfield1: "string",
+      subfield2: "integer"
+    }
+  }
+
+  iex> Meadow.Utils.Ecto.Schema.unroll(MyApp.MySchema, read_only: [:field1])
+  %{
+    field1: "READ_ONLY",
+    field2: "integer",
+    embedded_field: %{
+      subfield1: "string",
+      subfield2: "integer"
+    }
+  }
+
+  iex> Meadow.Utils.Ecto.Schema.unroll(MyApp.MySchema, read_only: [:embedded_field])
+  %{
+    field1: "string",
+    field2: "integer",
+    embedded_field: %{
+      subfield1: "READ_ONLY",
+      subfield2: "READ_ONLY"
+    }
+  }
+
+  iex> Meadow.Utils.Ecto.Schema.unroll(MyApp.MySchema, read_only: [embedded_field: [:subfield1]])
+  %{
+    field1: "string",
+    field2: "integer",
+    embedded_field: %{
+      subfield1: "READ_ONLY",
+      subfield2: "integer"
+    }
+  }
+  """
+  def unroll(schema, opts \\ []) do
+    opts = Keyword.validate!(opts, read_only: [])
+    unroll_schema(schema, Map.new(opts))
+  end
+
+  defp unroll_schema(schema, opts) do
+    read_only = Map.get(opts, :read_only, [])
+    parents = Map.get(opts, :parents, [])
+    is_read_only = Map.get(opts, :is_read_only, false)
+
+    schema.__schema__(:fields)
+    |> Enum.map(fn field ->
+      is_read_only = Enum.any?([is_read_only, Enum.member?(read_only, field)])
+      unroll_field(schema, field, %{read_only: read_only, parents: parents, is_read_only: is_read_only})
+    end)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.into(%{})
+  end
+
+  defp unroll_field(schema, field, %{read_only: read_only, parents: parents, is_read_only: is_read_only}) do
+    read_only = case Keyword.get(read_only, field) do
+      value when is_list(value) -> value
+      _ -> []
+    end
+
+    case schema.__schema__(:type, field) do
+      {:parameterized, {Ecto.Embedded, %{cardinality: :one, related: related}}} ->
+        {field, unroll_schema(related, %{read_only: read_only, parents: [field | parents], is_read_only: is_read_only})}
+      {:parameterized, {Ecto.Embedded, %{cardinality: :many, related: related}}} ->
+        {field, [unroll_schema(related, %{read_only: read_only, parents: [field | parents], is_read_only: is_read_only})]}
+      {:array, type} ->
+        {field, [unroll_field(type, field, parents)]} |> maybe_read_only(is_read_only)
+      type ->
+        {field, unroll_field(type, field, parents)} |> maybe_read_only(is_read_only)
+    end
+  end
+
+  defp unroll_field(:binary_id, _, _), do: "UUID"
+  defp unroll_field(:utc_datetime, _, _), do: "utc_datetime (second precision)"
+  defp unroll_field(:utc_datetime_usec, _, _), do: "utc_datetime (microsecond precision)"
+  defp unroll_field(Elixir.Ecto.UUID, _, _), do: "UUID"
+  defp unroll_field(Types.EDTFDate, _, _), do: "valid EDTF date string"
+  defp unroll_field(Types.CodedTerm, field, parents), do: unroll_coded_term(field, parents)
+  defp unroll_field(Types.ControlledTerm, _, _), do: %{id: "URI", label: "string"}
+  defp unroll_field(type, _, _), do: to_string(type)
+
+  defp unroll_coded_term(:role, [parent | _]) do
+    case @schemes[parent] do
+      nil -> nil
+      scheme -> %{id: "(valid id for scheme `#{scheme}`)", label: "(valid label for scheme `#{scheme}`)", scheme: scheme}
+    end
+  end
+
+  defp unroll_coded_term(field, parents) do
+    case get_in(@schemes, Enum.reverse([field | parents])) do
+      nil -> nil
+      scheme -> %{id: "(valid id for scheme `#{scheme}`)", label: "(valid label for scheme `#{scheme}`)", scheme: scheme}
+    end
+  end
+
+  defp maybe_read_only({field, _value}, true), do: {field, "READ_ONLY"}
+  defp maybe_read_only({field, value}, false), do: {field, value}
+end

--- a/app/lib/meadow/utils/lambda.ex
+++ b/app/lib/meadow/utils/lambda.ex
@@ -179,7 +179,7 @@ defmodule Meadow.Utils.Lambda do
     :continue
   end
 
-  defp handle_output(port, timeout, buffer \\ "", on_log \\ nil) do
+  defp handle_output(port, timeout, buffer, on_log) do
     receive do
       {^port, {:data, {:eol, data}}} ->
         case handle_buffer(buffer <> data, on_log) do

--- a/app/lib/meadow_web/mcp/resources/schemas.ex
+++ b/app/lib/meadow_web/mcp/resources/schemas.ex
@@ -1,0 +1,69 @@
+defmodule MeadowWeb.MCP.Resources.Schemas do
+  @moduledoc false
+
+  defmacro __using__(opts) do
+    uri = Keyword.fetch!(opts, :uri)
+    schema = Keyword.fetch!(opts, :schema)
+    read_only = Keyword.get(opts, :read_only, [])
+
+    quote do
+      use Anubis.Server.Component,
+        type: :resource,
+        mime_type: "application/json",
+        uri: unquote(uri)
+
+      alias Anubis.MCP.Error, as: MCPError
+      alias Anubis.Server.Response
+
+      @impl true
+      def read(%{"uri" => unquote(uri)}, frame) do
+        content = Meadow.Utils.Ecto.Schema.unroll(unquote(schema), read_only: unquote(read_only))
+        response =
+          Response.resource()
+          |> Response.json(content, annotations: [audience: ["assistant"]])
+        {:reply, response, frame}
+      end
+      def read(params, frame), do: {:error, MCPError.resource(:not_found, %{uri: params["uri"]}), frame}
+    end
+  end
+end
+
+defmodule MeadowWeb.MCP.Resources.Schemas.Work do
+  @moduledoc "JSON schema for a Work resource, including field types and structure"
+
+  @ro_descriptive_metadata_fields  [:ark, :box_name, :box_number, :folder_name, :folder_number, :identifier,
+    :legacy_identifier, :terms_of_use, :physical_description_material, :physical_description_size,
+    :provenance, :publisher, :related_material, :rights_holder, :scope_and_contents, :series, :source,
+    :table_of_contents, :inserted_at, :updated_at]
+  @ro_fields [:id, :accession_number, :collection_id, :behavior, :visibility, :published, :inserted_at,
+    :updated_at, :ingest_sheet_id, :representative_file_set_id, :work_type, :administrative_metadata,
+    descriptive_metadata: @ro_descriptive_metadata_fields]
+
+  use MeadowWeb.MCP.Resources.Schemas,
+    uri: "file://schema/work.json",
+    schema: Meadow.Data.Schemas.Work,
+    read_only: @ro_fields
+end
+
+defmodule MeadowWeb.MCP.Resources.Schemas.FileSet do
+  @moduledoc "JSON schema for a FileSet resource, including field types and structure"
+
+  @ro_fields [:id, :inserted_at, :updated_at, :work_id, :extracted_metadata, :derivatives,
+    core_metadata: [:id, :original_filename]]
+
+  use MeadowWeb.MCP.Resources.Schemas,
+    uri: "file://schema/file_set.json",
+    schema: Meadow.Data.Schemas.FileSet,
+    read_only: @ro_fields
+end
+
+defmodule MeadowWeb.MCP.Resources.Schemas.Collection do
+  @moduledoc "JSON schema for a Collection resource, including field types and structure"
+
+  @ro_fields [:id, :representative_work_id, :featured, :published, :visibility, :inserted_at, :updated_at]
+
+  use MeadowWeb.MCP.Resources.Schemas,
+    uri: "file://schema/collection.json",
+    schema: Meadow.Data.Schemas.Collection,
+    read_only: @ro_fields
+end

--- a/app/lib/meadow_web/mcp/server.ex
+++ b/app/lib/meadow_web/mcp/server.ex
@@ -1,13 +1,16 @@
 defmodule MeadowWeb.MCP.Server do
   @moduledoc "MeadowWeb.MCP Server definition"
 
-  alias MeadowWeb.MCP.Tools
+  alias MeadowWeb.MCP.{Resources, Tools}
 
   use Anubis.Server,
     name: "meadow-mcp-server",
     version: "0.1.0",
-    capabilities: [:tools]
+    capabilities: [:resources, :tools]
 
+  component(Resources.Schemas.Work)
+  component(Resources.Schemas.FileSet)
+  component(Resources.Schemas.Collection)
   component(Tools.AuthoritySearch)
   component(Tools.GetImage)
   component(Tools.GetWork)

--- a/app/lib/meadow_web/mcp/tools/authority_search.ex
+++ b/app/lib/meadow_web/mcp/tools/authority_search.ex
@@ -3,7 +3,7 @@ defmodule MeadowWeb.MCP.Tools.AuthoritySearch do
   Return a work resource
   """
 
-alias Anubis.MCP.Error, as: MCPError
+  alias Anubis.MCP.Error, as: MCPError
   alias Anubis.Server.Response
   require Logger
 
@@ -26,7 +26,7 @@ alias Anubis.MCP.Error, as: MCPError
     Logger.info("Executing authority search of `#{params.authority_code}` with query: `#{params.query}`")
     case Authoritex.search(params.authority_code, params.query) do
       {:ok, result} ->
-        {:reply, Response.tool() |> Response.json(result), frame}
+        {:reply, Response.tool() |> Response.structured(%{results: result}), frame}
       {:error, "Unknown authority:" <> _} ->
         {:error, MCPError.protocol(:invalid_params, %{error: "Unknown authority", authority_code: params.authority_code}), frame}
       {:error, reason} ->

--- a/app/lib/meadow_web/mcp/tools/get_code_list.ex
+++ b/app/lib/meadow_web/mcp/tools/get_code_list.ex
@@ -26,7 +26,7 @@ defmodule MeadowWeb.MCP.Tools.GetCodeList do
         {:error, MCPError.protocol(:invalid_params, %{error: "Unknown scheme", scheme: params.scheme}), frame}
       code_list ->
         result = Enum.map(code_list, & &1.id)
-        {:reply, Response.tool() |> Response.json(result), frame}
+        {:reply, Response.tool() |> Response.structured(%{results: result}), frame}
     end
   end
 end

--- a/app/lib/meadow_web/mcp/tools/get_image.ex
+++ b/app/lib/meadow_web/mcp/tools/get_image.ex
@@ -12,6 +12,7 @@ defmodule MeadowWeb.MCP.Tools.GetImage do
   alias Meadow.Utils.DCAPI
   require Logger
 
+  @iiif_image_path "full/%5E!1024,1024/0/default.jpg"
   @timeout 600_000
 
   schema do
@@ -26,7 +27,7 @@ defmodule MeadowWeb.MCP.Tools.GetImage do
     uri =
       Meadow.Config.iiif_server_url()
       |> Path.join(file_set_id)
-      |> Path.join("full/!1024,1024/0/default.jpg")
+      |> Path.join(@iiif_image_path)
 
     {:ok, %{token: token}} =
       DCAPI.token(@timeout,

--- a/app/lib/meadow_web/mcp/tools/get_plan_changes.ex
+++ b/app/lib/meadow_web/mcp/tools/get_plan_changes.ex
@@ -73,7 +73,7 @@ defmodule MeadowWeb.MCP.Tools.GetPlanChanges do
           |> Repo.preload(:plan)
           |> Enum.map(&serialize_change/1)
 
-        {:reply, Response.tool() |> Response.json(%{changes: changes}), frame}
+        {:reply, Response.tool() |> Response.structured(%{changes: changes}), frame}
     end
   rescue
     error -> {:error, MCPError.protocol(:internal_error, %{error: inspect(error)}), frame}

--- a/app/lib/meadow_web/mcp/tools/get_work.ex
+++ b/app/lib/meadow_web/mcp/tools/get_work.ex
@@ -20,7 +20,7 @@ defmodule MeadowWeb.MCP.Tools.GetWork do
   def execute(%{work_id: work_id}, frame) do
     case Works.get_work(work_id) |> Repo.preload([:file_sets, :collection]) do
       nil -> {:error, MCPError.resource(:not_found, %{work_id: work_id}), frame}
-      work -> {:reply, Response.tool() |> Response.json(work), frame}
+      work -> {:reply, Response.tool() |> Response.structured(work), frame}
     end
   end
 end

--- a/app/lib/meadow_web/mcp/tools/id_query.ex
+++ b/app/lib/meadow_web/mcp/tools/id_query.ex
@@ -39,7 +39,7 @@ defmodule MeadowWeb.MCP.Tools.IDQuery do
       |> Enum.chunk_every(10)
       |> Enum.flat_map(fn chunk -> fetch_chunk(chunk, slice) end)
 
-    {:reply, Response.tool() |> Response.json(%{ids: ids}), frame}
+    {:reply, Response.tool() |> Response.structured(%{ids: ids}), frame}
   after
     Slice.finish(slice)
   end

--- a/app/lib/meadow_web/mcp/tools/propose_plan.ex
+++ b/app/lib/meadow_web/mcp/tools/propose_plan.ex
@@ -37,7 +37,7 @@ defmodule MeadowWeb.MCP.Tools.ProposePlan do
   defp propose_plan(plan, frame) do
     case Planner.propose_plan(plan) do
       {:ok, updated_plan} ->
-        {:reply, Response.tool() |> Response.json(%{plan: updated_plan}), frame}
+        {:reply, Response.tool() |> Response.structured(%{plan: updated_plan}), frame}
 
       {:error, reason} ->
         {:error, MCPError.execution(reason), frame}

--- a/app/lib/meadow_web/mcp/tools/update_plan_change.ex
+++ b/app/lib/meadow_web/mcp/tools/update_plan_change.ex
@@ -112,7 +112,7 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChange do
          {:ok, updated_change} <- Planner.update_plan_change(change, attrs) do
       updated_change = Repo.preload(updated_change, :plan)
       maybe_auto_propose_plan(updated_change)
-      {:reply, Response.tool() |> Response.json(serialize_change(updated_change)), frame}
+      {:reply, Response.tool() |> Response.structured(serialize_change(updated_change)), frame}
     else
       {:error, reason} ->
         {:error, MCPError.execution(reason), frame}

--- a/app/test/meadow/utils/ecto/schema_test.exs
+++ b/app/test/meadow/utils/ecto/schema_test.exs
@@ -1,0 +1,106 @@
+defmodule Meadow.Utils.Ecto.SchemaTest do
+  use ExUnit.Case, async: true
+
+  alias Meadow.Data.Schemas.{Work, FileSet}
+  alias Meadow.Utils.Ecto.Schema
+
+  describe "unroll(Work)" do
+    setup do
+      {:ok, subject: Schema.unroll(Work)}
+    end
+
+    test "returns a map", %{subject: subject} do
+      assert is_map(subject)
+    end
+
+    test "handles UUID fields", %{subject: subject} do
+      assert subject.id == "UUID"
+    end
+
+    test "handles top-level CodedTerm fields with correct scheme", %{subject: subject} do
+      assert subject.visibility == %{
+        id: "(valid id for scheme `visibility`)",
+        label: "(valid label for scheme `visibility`)",
+        scheme: "visibility"
+      }
+    end
+
+    test "handles DateTime fields", %{subject: subject} do
+      assert subject.inserted_at == "utc_datetime (microsecond precision)"
+    end
+
+    test "handles embedded schemas", %{subject: subject} do
+      assert is_map(subject.administrative_metadata)
+      assert is_map(subject.descriptive_metadata)
+    end
+
+    test "handles simple string fields in embedded schemas", %{subject: subject} do
+      assert subject.descriptive_metadata.title == "string"
+    end
+
+    test "handles CodedTerm fields with correct scheme in embedded schemas", %{subject: subject} do
+      assert subject.descriptive_metadata.license == %{
+        id: "(valid id for scheme `license`)",
+        label: "(valid label for scheme `license`)",
+        scheme: "license"
+      }
+    end
+
+    test "handles single- and multi-value fields in embedded schemas", %{subject: subject} do
+      assert subject.descriptive_metadata.title == "string"
+      assert subject.descriptive_metadata.alternate_title == ["string"]
+    end
+
+    test "handles multi-valued controlled term without role in embedded schemas", %{subject: subject} do
+      assert subject.descriptive_metadata.language == [%{term: %{id: "URI", label: "string"}, role: nil}]
+    end
+
+    test "handles multi-valued controlled term with role in embedded schemas", %{subject: subject} do
+      assert subject.descriptive_metadata.subject == [
+        %{
+          term: %{id: "URI", label: "string"},
+          role: %{
+            id: "(valid id for scheme `subject_role`)",
+            label: "(valid label for scheme `subject_role`)",
+            scheme: "subject_role"
+          }
+        }
+      ]
+    end
+
+    test "handles EDTF date fields in embedded schemas", %{subject: subject} do
+      assert subject.descriptive_metadata.date_created == ["valid EDTF date string"]
+    end
+  end
+
+  describe "unroll(Work) with read_only option" do
+    test "omits specified fields at the top level" do
+      result = Schema.unroll(Work, read_only: [:administrative_metadata, :visibility])
+      Map.get(result, :administrative_metadata)
+      |> Enum.each(fn {_, value} ->
+        assert value == "READ_ONLY"
+      end)
+      assert Map.get(result, :visibility) == "READ_ONLY"
+      assert Map.has_key?(result, :id)
+    end
+
+    test "omits specified fields in embedded schemas" do
+      result = Schema.unroll(Work, read_only: [descriptive_metadata: [:license]])
+      assert Map.has_key?(result, :descriptive_metadata)
+      assert Map.get(result.descriptive_metadata, :license) == "READ_ONLY"
+      assert Map.has_key?(result.descriptive_metadata, :title)
+    end
+  end
+
+  describe "unroll(FileSet)" do
+    setup do
+      {:ok, subject: Schema.unroll(FileSet)}
+    end
+
+    test "handles embedded schemas in FileSet", %{subject: subject} do
+      assert is_map(subject)
+      assert is_map(subject.core_metadata)
+      assert subject.core_metadata.original_filename == "string"
+    end
+  end
+end

--- a/app/test/meadow_web/mcp/tools/authority_search_test.exs
+++ b/app/test/meadow_web/mcp/tools/authority_search_test.exs
@@ -7,7 +7,7 @@ defmodule MeadowWeb.MCP.Tools.AuthoritySearchTest do
       {:ok, [{:text, response} | _]} =
         call_tool("authority_search", %{"authority_code" => "mock", "query" => "test"}) |> parse_response()
 
-      assert result = Jason.decode!(response)
+      assert %{"results" => result} = Jason.decode!(response)
       assert is_list(result)
       assert length(result) == 5
     end

--- a/app/test/meadow_web/mcp/tools/get_code_list_test.exs
+++ b/app/test/meadow_web/mcp/tools/get_code_list_test.exs
@@ -6,7 +6,7 @@ defmodule MeadowWeb.MCP.Tools.GetCodeListTest do
       {:ok, [{:text, response} | _]} =
         call_tool("get_code_list", %{"scheme" => "note_type"}) |> parse_response()
 
-      assert result = Jason.decode!(response)
+      assert %{"results" => result} = Jason.decode!(response)
       assert is_list(result)
       assert Enum.member?(result, "GENERAL_NOTE")
       assert Enum.member?(result, "STATEMENT_OF_RESPONSIBILITY")

--- a/infrastructure/pipeline/start_multi.sh
+++ b/infrastructure/pipeline/start_multi.sh
@@ -40,5 +40,6 @@ backend b
 $BACKENDS"
 
 PIDS+=($TAIL_PID)
+echo " * Logging to $LOGDIR/*.log"
 echo " * Running on http://127.0.0.1:$PORT/ (Press CTRL+C to quit)"
 echo "$CONFIG" | haproxy -f /dev/stdin

--- a/lambdas/metadata-agent/prompts.js
+++ b/lambdas/metadata-agent/prompts.js
@@ -13,170 +13,122 @@ export const agentPrompt = (userQuery, contextData = {}) => {
 };
 
 const agentPromptWithPlan = (planId, userQuery, contextData = {}) => `
-    Use the plan_change_proposer subagent to process plan ${planId} for:
-    ${userQuery}
+  Use the plan_change_proposer subagent to process plan ${planId} for:
+  ${userQuery}
 
-    Subagent must:
-    1. Get all pending PlanChanges for ${planId}
-    2. Read each work's metadata using the get_work tool with the work ID
-    3. Propose metadata changes per the prompt.
-    4. Use the authority_search tool for controlled vocab fields (subject, creator, contributor, genre, 
-        language, location, style_period, technique)
-    5. Use the get_code_list tool to get the valid values for coded fields (role, note type, license, rights statement, 
-        related_url label, library unit, preservation level, status) and use those exact values in updates.
-    6. Update each PlanChange with the proposed changes.
+  Subagent must:
+  1. Get all pending PlanChanges for ${planId}
+  2. Read each work's metadata using the get_work tool with the work ID
+  3. Read the "file://schema/work.json" resource for documented field types and structure
+  4. Propose metadata changes per the prompt.
+  5. Use the authority_search tool for controlled vocab fields (subject, creator, contributor, genre, 
+      language, location, style_period, technique)
+  6. Use the get_code_list tool to get the valid values for coded fields (role, note type, license, rights statement, 
+      related_url label, library unit, preservation level, status) and use those exact values in updates.
+  7. Update each PlanChange with the proposed changes.
 
-    Context: ${JSON.stringify(contextData, null, 2)}
+  Context: ${JSON.stringify(contextData, null, 2)}
 
-    CRITICAL: You and the subagent MUST send 3-5 word, user-friendly progress updates via send_status_update.
+  CRITICAL: You and the subagent MUST send 3-5 word, user-friendly progress updates via send_status_update.
 
-    IMPORTANT: Always use authority_search for controlled terms; never invent IDs. For coded fields (roles, note types, etc.),
-    use get_code_list. Do not touch deprecated fields. NEVER populate the navPlace field (experimental, not ready for use).
+  IMPORTANT: Always use authority_search for controlled terms; never invent IDs. For coded fields (roles, note types, etc.),
+  use get_code_list. Do not touch deprecated fields. NEVER populate the navPlace field (experimental, not ready for use).
 
-    CRITICAL API USAGE:
-    - Works use descriptive_metadata nesting: work.descriptive_metadata.title NOT work.title
-    - Use the get_image tool with the ID of any file set to retrieve its base64 image for analysis.
-    - The work's representative_file_set_id can be used to identify the primary image for the work.
+  CRITICAL API USAGE:
+  - Make sure you follow the retrived schema, e.g., DO NOT invent JSON/nested structures that aren't in the schema; 
+    use the exact structure from the schema resource
+  - Use the get_image tool with the ID of any file set to retrieve its base64 image for analysis.
+  - The work's representative_file_set_id can be used to identify the primary image for the work.
 
-    Finish with a concise summary of proposed changes. Keep the summary focused on the changed fields instead of the plan process itself. Do not mention the subagent or anything related to plan status. Do not include headers or introductory text in the summary.
+  Finish with a concise summary of proposed changes. Keep the summary focused on the changed fields instead of the plan 
+  process itself. Do not mention the subagent or anything related to plan status. Do not include headers or introductory 
+  text in the summary.
 
-    <example summary>
-    Added FAST subject heading for penmanship/cursive handwriting with proper topical role
-    Replaced description field with visual description of the manuscript based on the image.
-    </example summary>
-    `;
+  <example summary>
+  Added FAST subject heading for penmanship/cursive handwriting with proper topical role
+  Replaced description field with visual description of the manuscript based on the image.
+  </example summary>
+`;
 
 const agentPromptWithoutPlan = (userQuery, contextData = {}) => `
-    Use available tools to answer:
-    ${userQuery}
+  Use available tools to answer:
+  ${userQuery}
 
-    Context: ${stringifyContext(contextData)}
+  Context: ${stringifyContext(contextData)}
 
-    Respond with tool results and analysis.
-    `;
-    
+  Respond with tool results and analysis.
+`;
+
 export const proposerPrompt = () => `
-    You are a metadata plan proposer.
+  You are a Meadow metadata proposer. Your sole responsibility is to propose 
+  well-formed, schema-compliant changes to digital collection work records.
 
-    LOOP until no pending changes:
-    1. get_plan_changes(plan_id: <plan_id>, status: "pending")
-    2. If none, stop and return a summary
-    3. Take the FIRST pending PlanChange
-    4. Query the work's metadata via the get_work tool with the work ID
-    5. Propose changes based on the plan prompt and work data
-    6. update_plan_change with the PlanChange id, add/delete/replace data, status 'proposed'
-    7. Repeat
+  ## Authority hierarchy
+  The schema ("file://schema/work.json") is the absolute source of truth for 
+  what fields exist and what operations are valid on them. The plan prompt tells 
+  you *what* to change. The schema tells you *how*. When any instruction — 
+  including the task you were given — conflicts with the schema, follow the schema.
 
-    Rules:
-    - Always query work data; avoid assumptions
-    - Skip deprecated fields
-    - Process one change at a time and recheck pending list
-    - Return a summary with counts
-    - The id, ark and accession_number fields can never be changed
-    - The title and terms_of_use fields are single strings; do not use lists
-    - Works can only have one rights statement
-    - NEVER populate the navPlace field - it is experimental and not ready for use
+  ## Prerequisite: always read the schema first
+  Before proposing any changes, you MUST read "file://schema/work.json". 
+  Do not proceed without it. This is not optional.
 
-    CRITICAL - Valid operations per field type:
-    - Controlled term fields (contributor, creator, genre, language, location, style_period, subject, technique):
-      Use "add" to add new terms. Use "delete" to remove specific existing terms.
-      To replace a term, put the old value in "delete" AND the new value in "add" in the same update.
-      NEVER use "replace" for these fields - it will be ignored.
-    - Coded fields (license, rights_statement) and title and terms_of_use:
-      ONLY use "replace". Never use "add" or "delete" for these fields.
-    - All other fields (description, alternate_title, notes, related_url, date_created, etc.):
-      Use "add" to append new values alongside existing ones (existing values are kept).
-      Use "replace" to overwrite the entire field with new values (existing values are removed).
-      To remove specific items from these fields, use "replace" with only the items you want to keep.
-      To clear a field entirely, use "replace" with an empty array [].
-      NEVER use "delete" for these fields - it will be ignored.
-    - date_created: use simple EDTF strings e.g. ["1985", "2005-06"] - do NOT use {edtf:, humanized:} objects.
-    - Do not suggest changes to administrative_metadata fields
+  ## Process (repeat until no pending changes remain)
+  1. get_plan_changes(plan_id: <plan_id>, status: "pending")
+  2. If none, stop and return a summary with counts
+  3. Take the FIRST pending PlanChange
+  4. Query work metadata via get_work with the work ID
+  5. Propose changes based on the plan prompt and work data, following the field 
+    operation rules below
+  6. update_plan_change with the PlanChange id, add/delete/replace data, 
+    status: "proposed"
+  7. Repeat from step 1
 
-    Controlled term fields (must use the authority_search tool for valid values and the get_code_list tool for valid codes):
-    - contributor (role required, marc_relator scheme)
-    - subject (role required, subject_role scheme)
-    - genre
-    - language
-    - location
-    - style_period
-    - technique
-    - creator (no role)
+  ## Field operation rules
 
-    Requirements:
-    - Always search for controlled term IDs; never invent them
-    - Structure for contributor and subject: {"term": {"id": "controlled-term-id", "label": "Label"}, "role": {"id": "role-id", "scheme": "role-scheme", "label": "Role Label"}}
-    - Structure for other controlled terms: {"term": {"id": "controlled-term-id", "label": "Label"}}
-    - term is an object with id, not a string; role required for subject and contributor
-    - role should never be used for genre, language, location, creator, style_period, and technique
-    - For roles, use the get_code_list tool (scheme: subject_role or marc_relator); use returned ids (e.g., TOPICAL, GEOGRAPHIC, TEMPORAL, pht, art, ctb)
+  These rules are derived from the schema. Apply them mechanically — 
+  do not improvise based on context or instruction.
 
-    Controlled term format in add/replace (for contributor (role required), genre, language, location, subject (role required), style_period, technique, creator:
-    {
-      "descriptive_metadata": {
-        "subject": [{"term": {"id": "http://id.worldcat.org/fast/849374"}, "role": {"id": "TOPICAL", "scheme": "subject_role"}}],
-        "creator": [{"term": {"id": "http://id.loc.gov/authorities/names/n79021164"}}],
-        "contributor": [{"term": {"id": "http://id.loc.gov/authorities/names/n79021164"}, "role": {"id": "pht", "scheme": "marc_relator"}}]
-      }
-    }
+  **Read-only fields**:
+  - Any field whose value is "READ_ONLY" in the schema must never be included in 
+    a proposed change. These fields are informational context only.
+  - NEVER propose changes to read-only fields. Do not include them in add/delete/replace,
+    even if the plan prompt seems to suggest it.
 
-    Add controlled terms by: search for term, lookup role if required, build the nested structure, then call update_plan_change.
+  **Controlled term fields** (contributor, creator, genre, language, location, 
+  style_period, subject, technique):
+  - Add terms: use "add"
+  - Remove terms: use "delete"  
+  - Replace a term: use both "delete" (old value) and "add" (new value) together
+  - NEVER use "replace"
 
-    Coded term fields (must use get_code_list tool for valid codes):
-    - Only use schemes listed in the tool's description
-    - CRITICAL: The "id" field must be the exact URI from the get_code_list tool, NOT a UUID or generated value
-    - CRITICAL: The "scheme" field must be LOWERCASE when used in update_plan_change (e.g., "note_type", not "NOTE_TYPE")
-    - Use the exact "id" value returned (e.g., "http://rightsstatements.org/vocab/InC/1.0/")
-    - For related_url labels, the scheme is related_url (not related_url_label)
+  **Single-valued coded fields** (license, rights_statement):
+  - ONLY use "replace"
+  - NEVER use "add" or "delete"
 
-    Example workflow for rights_statement:
-    1. Query: get_code_list(scheme: "rights_statement")
-    2. Find desired term (e.g., "In Copyright" with id "http://rightsstatements.org/vocab/InC/1.0/")
-    3. Use exact values in update (IMPORTANT: scheme must be lowercase in update):
-    {
-      "descriptive_metadata": {
-        "rights_statement": {
-          "id": "http://rightsstatements.org/vocab/InC/1.0/",
-          "scheme": "rights_statement",
-          "label": "In Copyright"
-        }
-      }
-    }
+  **Single-valued string fields** (title, terms_of_use):
+  - ONLY use "replace"
+  - NEVER use "add" or "delete"
 
-    Example for notes with type coded term:
-    1. Query: get_code_list(scheme: "note_type")
-    2. Find desired type (e.g., "General Note" with id "GENERAL_NOTE")
-    3. Use in update (scheme must be lowercase "note_type"):
-    {
-      "descriptive_metadata": {
-        "notes": [{
-          "note": "This is a general note",
-          "type": {
-            "id": "GENERAL_NOTE",
-            "scheme": "note_type",
-            "label": "General Note"
-          }
-        }]
-      }
-    }
+  **All other fields** (description, alternate_title, notes, related_url, 
+  date_created, etc.):
+  - Append new values: use "add"
+  - Overwrite entire field: use "replace"
+  - Remove specific items: use "replace" with only the items to keep
+  - Clear a field: use "replace" with []
+  - NEVER use "delete"
 
-    Example for related_url with label coded term:
-    1. Query: get_code_list(scheme: "related_url")
-    2. Find desired label (e.g., "Related Information" with id "RELATED_INFORMATION")
-    3. Use in update (scheme must be lowercase "related_url"):
-    {
-      "descriptive_metadata": {
-        "related_url": [{
-          "url": "https://example.org/resource",
-          "label": {
-            "id": "RELATED_INFORMATION",
-            "scheme": "related_url",
-            "label": "Related Information"
-          }
-        }]
-      }
-    }
-    `;
+  **date_created**: use simple EDTF strings — e.g. ["1985", "2005-06"]
+  Do NOT use {edtf:, humanized:} objects.
+
+  ## Controlled term and coded field rules
+  - Fields requiring a role (e.g., subject with topical role): always include it
+  - Fields with role listed as "null" in the schema: do NOT include a role field
+  - Use authority_search to find controlled term IDs — never invent them
+  - Use get_code_list to find valid coded field values — never invent them
+  - Use the correct scheme for each coded field as listed in the schema
+  - Do NOT propose changes to fields not in the schema
+`;
 
 export const systemPrompt = () => `
   Answer questions using only the tools available.
@@ -199,4 +151,4 @@ export const systemPrompt = () => `
   5. For related_url: each entry has a "url" text field and a "label" coded term object (scheme is "related_url")
 
   Do not look for information in the file system or local codebase.
-  `;
+`;


### PR DESCRIPTION
# Summary 
Improve MCP and prompting to help the agent propose more valid metadata

# Specific Changes in this PR
- Add schema resources to MCP so agent can have better documentation
- Move plan proposer prompt from lambda to MCP to promote customization and reduce deployments
- Fix upscaling regression in `get_image` tool

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Test auto-edits with `make pipeline-start` and `USE_SAM_LAMBDAS=true`

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

