### PR TITLE
Update plan change validation, allow MCP file read access.

### DIFF
--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "license": "MIT",
       "dependencies": {
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",
@@ -14642,6 +14642,21 @@
         "object-assign": "^4.1.1"
       }
     },
+    "node_modules/chonky/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "dev": true,
@@ -24409,6 +24424,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/recharts/node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/recharts/node_modules/reselect": {
       "version": "5.1.1",

--- a/app/lib/meadow_web/mcp/tools/authority_search.ex
+++ b/app/lib/meadow_web/mcp/tools/authority_search.ex
@@ -13,24 +13,45 @@ defmodule MeadowWeb.MCP.Tools.AuthoritySearch do
     description: "Search an authority for a term matching the provided query."
 
   schema do
-    field :query, :string, required: true,
+    field(:query, :string,
+      required: true,
       description: "The search query to send to the authority (e.g. 'Shakespeare')"
+    )
 
-    field :authority_code, :required,
+    field(:authority_code, :required,
       description: "The code for the authority to search (e.g. 'lcsh')",
       enum: Authoritex.authorities() |> Enum.map(fn {_, code, _} -> code end)
+    )
   end
 
   @impl true
   def execute(params, frame) do
-    Logger.info("Executing authority search of `#{params.authority_code}` with query: `#{params.query}`")
+    Logger.info(
+      "Executing authority search of `#{params.authority_code}` with query: `#{params.query}`"
+    )
+
     case Authoritex.search(params.authority_code, params.query) do
       {:ok, result} ->
         {:reply, Response.tool() |> Response.structured(%{results: result}), frame}
+
       {:error, "Unknown authority:" <> _} ->
-        {:error, MCPError.protocol(:invalid_params, %{error: "Unknown authority", authority_code: params.authority_code}), frame}
+        {:error,
+         MCPError.protocol(:invalid_params, %{
+           error: "Unknown authority",
+           authority_code: params.authority_code
+         }), frame}
+
       {:error, reason} ->
-        {:error, MCPError.protocol(:internal_error, %{error: reason}), frame}
+        {:error, MCPError.protocol(:internal_error, %{error: error_message(reason)}), frame}
     end
   end
+
+  defp error_message(reason) when is_binary(reason), do: reason
+  defp error_message(reason) when is_atom(reason), do: Atom.to_string(reason)
+
+  defp error_message(%_{} = reason) do
+    if Exception.exception?(reason), do: Exception.message(reason), else: inspect(reason)
+  end
+
+  defp error_message(reason), do: inspect(reason)
 end

--- a/app/lib/meadow_web/mcp/tools/update_plan_change.ex
+++ b/app/lib/meadow_web/mcp/tools/update_plan_change.ex
@@ -76,13 +76,12 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChange do
   alias Anubis.Server.Response
   alias Meadow.Config
   alias Meadow.Data.{CodedTerms, Enrichment, Planner}
+  alias Meadow.Data.Schemas.WorkDescriptiveMetadata
+  alias Meadow.Data.Types
   alias Meadow.Repo
   require Logger
 
-  @controlled_fields ~w(contributor creator genre language location style_period subject technique)a
-  @coded_fields ~w(license rights_statement)a
-  # Fields with arrays of objects containing coded terms
-  @nested_coded_fields ~w(notes related_url)a
+  @ai_note_prefix "Some metadata created with the assistance of AI"
 
   schema do
     field(:id, :string,
@@ -108,17 +107,18 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChange do
     Logger.debug("MCP Server updating PlanChange: #{id}")
 
     with {:ok, change} <- fetch_plan_change(id),
-         {:ok, attrs} <- build_attrs_result(request),
+         {:ok, attrs} <- build_attrs_result(request, change),
          {:ok, updated_change} <- Planner.update_plan_change(change, attrs) do
       updated_change = Repo.preload(updated_change, :plan)
       maybe_auto_propose_plan(updated_change)
       {:reply, Response.tool() |> Response.structured(serialize_change(updated_change)), frame}
     else
       {:error, reason} ->
-        {:error, MCPError.execution(reason), frame}
+        {:error, MCPError.execution(error_message(reason)), frame}
     end
   rescue
-    error -> {:error, MCPError.execution(error), frame}
+    error ->
+      {:error, MCPError.execution(error_message(error)), frame}
   end
 
   defp maybe_auto_propose_plan(%{status: :proposed, plan_id: plan_id, plan: %{status: :pending}}) do
@@ -144,18 +144,19 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChange do
     end
   end
 
-  defp build_attrs(request) do
+  defp build_attrs(request, change) do
     model = Config.ai(:model)
 
     request
     |> Map.take([:add, :delete, :replace, :status, :notes])
     |> Enrichment.enrich_controlled_terms()
-    |> inject_ai_note(model)
+    |> validate_schema_conformance()
+    |> inject_ai_note(model, change)
     |> validate_coded_terms()
   end
 
-  defp build_attrs_result(request) do
-    case build_attrs(request) do
+  defp build_attrs_result(request, change) do
+    case build_attrs(request, change) do
       {:error, _} = error -> error
       attrs -> {:ok, attrs}
     end
@@ -195,8 +196,6 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChange do
     }
   end
 
-
-
   defp has_metadata_changes?(attrs) do
     Enum.any?([:add, :delete, :replace], fn key ->
       val = Map.get(attrs, key)
@@ -209,44 +208,557 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChange do
 
     note_text =
       case model do
-        nil -> "Some metadata created with the assistance of AI on #{current_date}"
-        model_id -> "Some metadata created with the assistance of AI (#{model_id}) on #{current_date}"
+        nil ->
+          "#{@ai_note_prefix} on #{current_date}"
+
+        model_id ->
+          "#{@ai_note_prefix} (#{model_id}) on #{current_date}"
       end
 
     %{note: note_text, type: %{id: "LOCAL_NOTE", scheme: "note_type", label: "Local Note"}}
   end
 
-  defp inject_ai_note(attrs, _model) when not is_map(attrs), do: attrs
+  defp inject_ai_note(attrs, _model, _change) when not is_map(attrs), do: attrs
 
-  defp inject_ai_note(attrs, model) do
+  defp inject_ai_note(attrs, model, change) do
     if has_metadata_changes?(attrs) do
-      do_inject_ai_note(attrs, build_ai_note(model))
+      ai_note = build_ai_note(model)
+
+      updated_attrs =
+        if ai_note_already_present?(attrs, change, ai_note),
+          do: attrs,
+          else: do_inject_ai_note(attrs, ai_note)
+
+      normalize_ai_notes(updated_attrs)
     else
       attrs
     end
   end
 
+  defp ai_note_already_present?(attrs, change, ai_note) do
+    [
+      Map.get(attrs, :add),
+      Map.get(attrs, :replace),
+      Map.get(change || %{}, :add),
+      Map.get(change || %{}, :replace)
+    ]
+    |> Enum.flat_map(&section_notes/1)
+    |> Enum.any?(&same_ai_note?(&1, ai_note))
+  end
+
+  defp section_notes(section) when is_map(section) do
+    case metadata_section(section) do
+      metadata when is_map(metadata) ->
+        case map_value(metadata, :notes) do
+          notes when is_list(notes) -> notes
+          _ -> []
+        end
+
+      _ ->
+        []
+    end
+  end
+
+  defp section_notes(_section), do: []
+
+  defp same_ai_note?(entry, _ai_note) when is_map(entry) do
+    entry_note = map_value(entry, :note)
+    entry_type = map_value(entry, :type)
+
+    is_binary(entry_note) and
+      String.starts_with?(entry_note, @ai_note_prefix) and
+      is_map(entry_type) and
+      map_value(entry_type, :id) == "LOCAL_NOTE" and
+      map_value(entry_type, :scheme) == "note_type"
+  end
+
+  defp same_ai_note?(_entry, _ai_note), do: false
+
   defp do_inject_ai_note(attrs, ai_note) do
     replace_section = Map.get(attrs, :replace) || %{}
     replace_metadata = Map.get(replace_section, :descriptive_metadata) || %{}
 
-    case Map.fetch(replace_metadata, :notes) do
-      {:ok, replace_notes} ->
-        updated_replace_metadata = Map.put(replace_metadata, :notes, replace_notes ++ [ai_note])
-        updated_replace_section = Map.put(replace_section, :descriptive_metadata, updated_replace_metadata)
+    case map_value(replace_metadata, :notes) do
+      replace_notes when is_list(replace_notes) ->
+        updated_replace_metadata =
+          Map.put(replace_metadata, :notes, append_unique_ai_note(replace_notes, ai_note))
+
+        updated_replace_section =
+          Map.put(replace_section, :descriptive_metadata, updated_replace_metadata)
+
         Map.put(attrs, :replace, updated_replace_section)
 
-      :error ->
+      _ ->
         add_section = Map.get(attrs, :add) || %{}
         descriptive_metadata = Map.get(add_section, :descriptive_metadata) || %{}
-        existing_notes = Map.get(descriptive_metadata, :notes, [])
-        updated_descriptive_metadata = Map.put(descriptive_metadata, :notes, existing_notes ++ [ai_note])
-        updated_add_section = Map.put(add_section, :descriptive_metadata, updated_descriptive_metadata)
+        existing_notes = map_value(descriptive_metadata, :notes) || []
+
+        updated_descriptive_metadata =
+          Map.put(descriptive_metadata, :notes, append_unique_ai_note(existing_notes, ai_note))
+
+        updated_add_section =
+          Map.put(add_section, :descriptive_metadata, updated_descriptive_metadata)
+
         Map.put(attrs, :add, updated_add_section)
     end
   end
 
+  defp append_unique_ai_note(notes, ai_note) when is_list(notes) do
+    if Enum.any?(notes, &same_ai_note?(&1, ai_note)) do
+      notes
+    else
+      notes ++ [ai_note]
+    end
+  end
+
+  defp normalize_ai_notes(attrs) when is_map(attrs) do
+    attrs
+    |> normalize_ai_notes_for_operation(:replace)
+    |> normalize_ai_notes_for_operation(:add)
+  end
+
+  defp normalize_ai_notes(attrs), do: attrs
+
+  defp normalize_ai_notes_for_operation(attrs, operation) do
+    case Map.get(attrs, operation) do
+      section when is_map(section) ->
+        metadata = Map.get(section, :descriptive_metadata) || %{}
+        notes = map_value(metadata, :notes)
+
+        if is_list(notes) do
+          normalized_notes = dedupe_ai_notes(notes)
+          updated_metadata = Map.put(metadata, :notes, normalized_notes)
+          updated_section = Map.put(section, :descriptive_metadata, updated_metadata)
+          Map.put(attrs, operation, updated_section)
+        else
+          attrs
+        end
+
+      _ ->
+        attrs
+    end
+  end
+
+  defp dedupe_ai_notes(notes) do
+    notes
+    |> Enum.reduce({[], false}, fn note, {acc, seen_ai_note?} ->
+      if same_ai_note?(note, nil) do
+        if seen_ai_note? do
+          {acc, true}
+        else
+          {[note | acc], true}
+        end
+      else
+        {[note | acc], seen_ai_note?}
+      end
+    end)
+    |> elem(0)
+    |> Enum.reverse()
+  end
+
   # Validation functions for coded terms
+
+  defp validate_schema_conformance({:error, _} = error), do: error
+
+  defp validate_schema_conformance(attrs) when is_map(attrs) do
+    with :ok <- validate_operation_schema(attrs, :add),
+         :ok <- validate_operation_schema(attrs, :delete),
+         :ok <- validate_operation_schema(attrs, :replace) do
+      attrs
+    else
+      {:error, message} -> {:error, message}
+    end
+  end
+
+  defp validate_operation_schema(attrs, operation) do
+    case Map.get(attrs, operation) do
+      nil ->
+        :ok
+
+      operation_section when is_map(operation_section) ->
+        validate_descriptive_metadata_schema(operation_section, operation)
+
+      _ ->
+        {:error, "Operation '#{operation}' must be an object/map"}
+    end
+  end
+
+  defp validate_descriptive_metadata_schema(section, operation) do
+    case metadata_section(section) do
+      nil ->
+        :ok
+
+      metadata when is_map(metadata) ->
+        with :ok <- validate_metadata_changeset(metadata, operation) do
+          validate_metadata_fields(metadata, operation)
+        end
+
+      _ ->
+        {:error, "'#{operation}.descriptive_metadata' must be an object/map"}
+    end
+  end
+
+  defp validate_metadata_changeset(metadata, operation) do
+    normalized_metadata =
+      metadata
+      |> metadata_for_changeset_validation()
+      |> stringify_map_keys()
+
+    changeset = WorkDescriptiveMetadata.changeset(%WorkDescriptiveMetadata{}, normalized_metadata)
+
+    if changeset.valid? do
+      :ok
+    else
+      {:error,
+       "Invalid '#{operation}.descriptive_metadata': #{format_changeset_errors(changeset)}"}
+    end
+  end
+
+  # Controlled-term type casting performs authority resolution. We validate
+  # controlled metadata entries separately (shape/role) and allow lookup failures
+  # to pass through without rejecting the entire tool call.
+  defp metadata_for_changeset_validation(metadata) when is_map(metadata) do
+    Enum.reduce(controlled_fields(), metadata, fn field, acc ->
+      acc
+      |> Map.delete(field)
+      |> Map.delete(Atom.to_string(field))
+    end)
+  end
+
+  defp metadata_for_changeset_validation(metadata), do: metadata
+
+  defp format_changeset_errors(changeset) do
+    changeset
+    |> Ecto.Changeset.traverse_errors(fn {msg, opts} ->
+      msg
+      |> format_changeset_error_message()
+      |> interpolate_changeset_error_opts(opts)
+    end)
+    |> inspect()
+  end
+
+  defp format_changeset_error_message(message) when is_binary(message), do: message
+  defp format_changeset_error_message(message), do: format_changeset_error_value(message)
+
+  defp interpolate_changeset_error_opts(message, opts)
+       when is_binary(message) and is_list(opts) do
+    Enum.reduce(opts, message, fn {key, value}, acc ->
+      String.replace(
+        acc,
+        "%{#{format_changeset_error_key(key)}}",
+        format_changeset_error_value(value)
+      )
+    end)
+  end
+
+  defp interpolate_changeset_error_opts(message, _opts), do: message
+
+  defp format_changeset_error_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp format_changeset_error_key(key) when is_binary(key), do: key
+  defp format_changeset_error_key(key), do: inspect(key)
+
+  defp format_changeset_error_value(value) when is_binary(value), do: value
+
+  defp format_changeset_error_value(value) when is_atom(value) or is_number(value),
+    do: to_string(value)
+
+  defp format_changeset_error_value(value), do: inspect(value)
+
+  # Ecto.Changeset.cast/4 rejects mixed atom/string keys in one params map.
+  # Enrichment may atomize some controlled fields while others remain strings.
+  # Normalize to string keys before schema validation.
+  defp stringify_map_keys(map) when is_map(map) do
+    Enum.reduce(map, %{}, fn {key, value}, acc ->
+      normalized_key =
+        case key do
+          atom when is_atom(atom) -> Atom.to_string(atom)
+          other -> other
+        end
+
+      Map.put(acc, normalized_key, stringify_map_keys(value))
+    end)
+  end
+
+  defp stringify_map_keys(list) when is_list(list), do: Enum.map(list, &stringify_map_keys/1)
+  defp stringify_map_keys(value), do: value
+
+  defp validate_metadata_fields(metadata, operation) do
+    metadata
+    |> Enum.reduce_while(:ok, fn {raw_field, value}, :ok ->
+      field_path = "#{operation}.descriptive_metadata.#{field_name(raw_field)}"
+
+      with {:ok, field} <- normalize_field(raw_field, field_path),
+           :ok <- validate_allowed_field(field, field_path),
+           :ok <- validate_field_operation(field, operation, field_path),
+           :ok <- validate_field_value(field, value, field_path) do
+        {:cont, :ok}
+      else
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp normalize_field(field, _path) when is_atom(field), do: {:ok, field}
+
+  defp normalize_field(field, path) when is_binary(field) do
+    try do
+      {:ok, String.to_existing_atom(field)}
+    rescue
+      ArgumentError ->
+        {:error, "Unknown field '#{field}' in '#{path}'"}
+    end
+  end
+
+  defp normalize_field(field, path),
+    do: {:error, "Invalid field key '#{inspect(field)}' in '#{path}'"}
+
+  defp validate_allowed_field(field, path) do
+    if allowed_descriptive_field?(field) do
+      :ok
+    else
+      {:error, "Field '#{field}' is not allowed in '#{path}'"}
+    end
+  end
+
+  defp validate_field_operation(field, operation, path) do
+    cond do
+      operation == :delete and not controlled_field?(field) ->
+        {:error, "'#{path}' cannot use delete. Only controlled fields support delete operations."}
+
+      operation == :replace and controlled_field?(field) ->
+        {:error, "'#{path}' cannot use replace. Controlled fields must use add/delete."}
+
+      operation in [:add, :delete] and replace_only_field?(field) ->
+        {:error, "'#{path}' must use replace and cannot use #{operation}."}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_field_value(field, value, path) do
+    cond do
+      single_value_string_field?(field) ->
+        validate_plain_string_field(value, path)
+
+      controlled_field?(field) ->
+        validate_controlled_field_entries(field, value, path)
+
+      coded_field?(field) ->
+        validate_coded_object(value, path)
+
+      nested_coded_field?(field) ->
+        validate_nested_coded_entries(field, value, path)
+
+      date_field?(field) ->
+        validate_date_field_values(value, path)
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_plain_string_field(value, path) when is_binary(value) do
+    if json_blob_string?(value) do
+      {:error, "'#{path}' must be plain text, not a JSON-serialized object/array string"}
+    else
+      :ok
+    end
+  end
+
+  defp validate_plain_string_field(_value, path),
+    do: {:error, "'#{path}' must be a plain string value"}
+
+  defp validate_controlled_field_entries(field, values, path) when is_list(values) do
+    values
+    |> Enum.with_index()
+    |> Enum.reduce_while(:ok, fn {entry, index}, :ok ->
+      entry_path = "#{path}[#{index}]"
+
+      with :ok <- validate_controlled_entry_shape(entry, entry_path),
+           :ok <- validate_controlled_entry_role(field, entry, entry_path) do
+        {:cont, :ok}
+      else
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp validate_controlled_field_entries(_field, _values, path),
+    do: {:error, "'#{path}' must be an array of controlled-term entries"}
+
+  defp validate_controlled_entry_shape(entry, path) when is_map(entry) do
+    case map_value(entry, :term) do
+      term when is_map(term) ->
+        case map_value(term, :id) do
+          id when is_binary(id) and byte_size(id) > 0 ->
+            :ok
+
+          _ ->
+            {:error, "'#{path}.term.id' must be a non-empty string"}
+        end
+
+      _ ->
+        {:error, "'#{path}.term' must be an object with an 'id' string"}
+    end
+  end
+
+  defp validate_controlled_entry_shape(_entry, path),
+    do: {:error, "'#{path}' must be an object containing at least a term.id"}
+
+  defp validate_controlled_entry_role(field, entry, path) do
+    role = map_value(entry, :role)
+
+    cond do
+      role_required_field?(field) and is_nil(role) ->
+        {:error, "'#{path}.role' is required for #{field}"}
+
+      role_optional_field?(field) and is_nil(role) ->
+        :ok
+
+      not role_required_field?(field) and
+        not role_optional_field?(field) and
+          not is_nil(role) ->
+        {:error, "'#{path}.role' must be omitted for #{field}"}
+
+      is_nil(role) ->
+        :ok
+
+      true ->
+        with :ok <- validate_coded_object(role, "#{path}.role"),
+             :ok <- validate_role_scheme(field, role, "#{path}.role") do
+          :ok
+        end
+    end
+  end
+
+  defp validate_role_scheme(field, role, path) do
+    expected_scheme =
+      case field do
+        :subject -> "subject_role"
+        :contributor -> "marc_relator"
+        _ -> nil
+      end
+
+    if is_nil(expected_scheme) do
+      :ok
+    else
+      case map_value(role, :scheme) do
+        ^expected_scheme -> :ok
+        _ -> {:error, "'#{path}.scheme' must be '#{expected_scheme}' for #{field}"}
+      end
+    end
+  end
+
+  defp validate_nested_coded_entries(:notes, values, path) when is_list(values) do
+    values
+    |> Enum.with_index()
+    |> Enum.reduce_while(:ok, fn {entry, index}, :ok ->
+      entry_path = "#{path}[#{index}]"
+
+      with true <- is_map(entry) or {:error, "'#{entry_path}' must be an object"},
+           note when is_binary(note) <-
+             map_value(entry, :note) || {:error, "'#{entry_path}.note' must be a string"},
+           true <-
+             byte_size(String.trim(note)) > 0 or
+               {:error, "'#{entry_path}.note' must not be empty"},
+           :ok <- validate_coded_object(map_value(entry, :type), "#{entry_path}.type"),
+           :ok <-
+             validate_coded_scheme(map_value(entry, :type), "note_type", "#{entry_path}.type") do
+        {:cont, :ok}
+      else
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp validate_nested_coded_entries(:related_url, values, path) when is_list(values) do
+    values
+    |> Enum.with_index()
+    |> Enum.reduce_while(:ok, fn {entry, index}, :ok ->
+      entry_path = "#{path}[#{index}]"
+
+      with true <- is_map(entry) or {:error, "'#{entry_path}' must be an object"},
+           url when is_binary(url) <-
+             map_value(entry, :url) || {:error, "'#{entry_path}.url' must be a string"},
+           true <-
+             byte_size(String.trim(url)) > 0 or {:error, "'#{entry_path}.url' must not be empty"},
+           :ok <- validate_coded_object(map_value(entry, :label), "#{entry_path}.label"),
+           :ok <-
+             validate_coded_scheme(map_value(entry, :label), "related_url", "#{entry_path}.label") do
+        {:cont, :ok}
+      else
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp validate_nested_coded_entries(field, values, path) when is_list(values) do
+    if nested_coded_field?(field) do
+      :ok
+    else
+      {:error, "'#{path}' must be an array of objects"}
+    end
+  end
+
+  defp validate_nested_coded_entries(_field, _values, path),
+    do: {:error, "'#{path}' must be an array of objects"}
+
+  defp validate_date_field_values(values, path) when is_list(values) do
+    values
+    |> Enum.with_index()
+    |> Enum.reduce_while(:ok, fn {value, index}, :ok ->
+      if is_binary(value) and byte_size(String.trim(value)) > 0 do
+        {:cont, :ok}
+      else
+        {:halt, {:error, "'#{path}[#{index}]' must be a non-empty EDTF date string"}}
+      end
+    end)
+  end
+
+  defp validate_date_field_values(_values, path),
+    do: {:error, "'#{path}' must be an array of EDTF date strings"}
+
+  defp validate_coded_object(value, path) when is_map(value) do
+    case {map_value(value, :id), map_value(value, :scheme)} do
+      {id, scheme} when is_binary(id) and is_binary(scheme) and id != "" and scheme != "" ->
+        :ok
+
+      _ ->
+        {:error, "'#{path}' must contain non-empty string id and scheme"}
+    end
+  end
+
+  defp validate_coded_object(_value, path),
+    do: {:error, "'#{path}' must be an object with id and scheme"}
+
+  defp validate_coded_scheme(value, expected_scheme, path) do
+    case map_value(value, :scheme) do
+      ^expected_scheme -> :ok
+      _ -> {:error, "'#{path}.scheme' must be '#{expected_scheme}'"}
+    end
+  end
+
+  defp json_blob_string?(value) when is_binary(value) do
+    case Jason.decode(String.trim(value)) do
+      {:ok, decoded} when is_map(decoded) or is_list(decoded) -> true
+      _ -> false
+    end
+  end
+
+  defp metadata_section(section) when is_map(section),
+    do: Map.get(section, :descriptive_metadata) || Map.get(section, "descriptive_metadata")
+
+  defp metadata_section(_section), do: nil
+
+  defp map_value(map, key) when is_map(map),
+    do: Map.get(map, key) || Map.get(map, Atom.to_string(key))
+
+  defp map_value(_map, _key), do: nil
+
+  defp field_name(field) when is_atom(field), do: Atom.to_string(field)
+  defp field_name(field) when is_binary(field), do: field
+  defp field_name(field), do: inspect(field)
 
   defp validate_coded_terms({:error, _} = error), do: error
 
@@ -267,7 +779,7 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChange do
   end
 
   defp validate_coded_terms_in_section(section, path) when is_map(section) do
-    case Map.get(section, :descriptive_metadata) do
+    case metadata_section(section) do
       nil ->
         :ok
 
@@ -283,7 +795,7 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChange do
 
   # Validate direct coded fields (license, rights_statement)
   defp validate_direct_coded_fields(metadata, path) do
-    Enum.reduce_while(@coded_fields, :ok, fn field, :ok ->
+    Enum.reduce_while(coded_fields(), :ok, fn field, :ok ->
       validate_single_coded_field(metadata, field, path)
     end)
   end
@@ -304,7 +816,7 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChange do
 
   # Validate role coded terms in controlled fields
   defp validate_role_coded_terms(metadata, path) do
-    Enum.reduce_while(@controlled_fields, :ok, fn field, :ok ->
+    Enum.reduce_while(controlled_fields(), :ok, fn field, :ok ->
       validate_controlled_field_roles(metadata, field, path)
     end)
   end
@@ -344,7 +856,7 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChange do
 
   # Validate nested coded fields (notes, related_url)
   defp validate_nested_coded_fields(metadata, path) do
-    Enum.reduce_while(@nested_coded_fields, :ok, fn field, :ok ->
+    Enum.reduce_while(nested_coded_fields(), :ok, fn field, :ok ->
       validate_nested_coded_field_values(metadata, field, path)
     end)
   end
@@ -460,4 +972,85 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChange do
 
     base_msg <> label_info <> suggestions
   end
+
+  defp error_message(%{message: message}) when is_binary(message), do: message
+  defp error_message(%_{} = exception), do: Exception.message(exception)
+  defp error_message(message) when is_binary(message), do: message
+  defp error_message(other), do: inspect(other)
+
+  defp allowed_descriptive_field?(field), do: field in allowed_descriptive_fields()
+
+  defp allowed_descriptive_fields do
+    (editable_descriptive_schema_fields() ++ editable_descriptive_embed_fields())
+    |> Enum.uniq()
+    |> Enum.reject(&(&1 in read_only_descriptive_metadata_fields()))
+  end
+
+  defp read_only_descriptive_metadata_fields do
+    [
+      :ark,
+      :box_name,
+      :box_number,
+      :folder_name,
+      :folder_number,
+      :identifier,
+      :legacy_identifier,
+      :terms_of_use,
+      :physical_description_material,
+      :physical_description_size,
+      :provenance,
+      :publisher,
+      :related_material,
+      :rights_holder,
+      :scope_and_contents,
+      :series,
+      :source,
+      :table_of_contents,
+      :inserted_at,
+      :updated_at
+    ]
+  end
+
+  defp editable_descriptive_schema_fields, do: WorkDescriptiveMetadata.permitted()
+  defp editable_descriptive_embed_fields, do: WorkDescriptiveMetadata.__schema__(:embeds)
+
+  defp controlled_fields, do: editable_descriptive_embed_fields() -- nested_coded_fields()
+
+  defp coded_fields do
+    editable_descriptive_schema_fields()
+    |> Enum.filter(&(WorkDescriptiveMetadata.__schema__(:type, &1) == Types.CodedTerm))
+  end
+
+  defp replace_only_fields do
+    coded_fields() ++ single_value_string_fields()
+  end
+
+  defp single_value_string_fields do
+    editable_descriptive_schema_fields()
+    |> Enum.filter(&(WorkDescriptiveMetadata.__schema__(:type, &1) == :string))
+  end
+
+  defp date_fields do
+    editable_descriptive_schema_fields()
+    |> Enum.filter(&(WorkDescriptiveMetadata.__schema__(:type, &1) == {:array, Types.EDTFDate}))
+  end
+
+  defp role_required_fields do
+    ~w(subject contributor)a
+  end
+
+  defp nested_coded_fields do
+    ~w(notes related_url)a
+  end
+
+  defp role_optional_fields, do: []
+
+  defp controlled_field?(field), do: field in controlled_fields()
+  defp coded_field?(field), do: field in coded_fields()
+  defp replace_only_field?(field), do: field in replace_only_fields()
+  defp single_value_string_field?(field), do: field in single_value_string_fields()
+  defp nested_coded_field?(field), do: field in nested_coded_fields()
+  defp date_field?(field), do: field in date_fields()
+  defp role_required_field?(field), do: field in role_required_fields()
+  defp role_optional_field?(field), do: field in role_optional_fields()
 end

--- a/app/lib/meadow_web/mcp/tools/update_plan_change.ex
+++ b/app/lib/meadow_web/mcp/tools/update_plan_change.ex
@@ -341,19 +341,17 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChange do
 
   defp dedupe_ai_notes(notes) do
     notes
-    |> Enum.reduce({[], false}, fn note, {acc, seen_ai_note?} ->
-      if same_ai_note?(note, nil) do
-        if seen_ai_note? do
-          {acc, true}
-        else
-          {[note | acc], true}
-        end
-      else
-        {[note | acc], seen_ai_note?}
-      end
-    end)
+    |> Enum.reduce({[], false}, &dedupe_ai_note_entry/2)
     |> elem(0)
     |> Enum.reverse()
+  end
+
+  defp dedupe_ai_note_entry(note, {acc, seen_ai_note?}) do
+    case {same_ai_note?(note, nil), seen_ai_note?} do
+      {true, true} -> {acc, true}
+      {true, false} -> {[note | acc], true}
+      {false, _} -> {[note | acc], seen_ai_note?}
+    end
   end
 
   # Validation functions for coded terms
@@ -608,27 +606,37 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChange do
 
   defp validate_controlled_entry_role(field, entry, path) do
     role = map_value(entry, :role)
+    role_path = "#{path}.role"
 
+    case {role_requirement(field), role} do
+      {:required, nil} ->
+        {:error, "'#{role_path}' is required for #{field}"}
+
+      {:forbidden, nil} ->
+        :ok
+
+      {:forbidden, _role} ->
+        {:error, "'#{role_path}' must be omitted for #{field}"}
+
+      {_requirement, nil} ->
+        :ok
+
+      {_requirement, role_value} ->
+        validate_role_object_and_scheme(field, role_value, role_path)
+    end
+  end
+
+  defp role_requirement(field) do
     cond do
-      role_required_field?(field) and is_nil(role) ->
-        {:error, "'#{path}.role' is required for #{field}"}
+      role_required_field?(field) -> :required
+      role_optional_field?(field) -> :optional
+      true -> :forbidden
+    end
+  end
 
-      role_optional_field?(field) and is_nil(role) ->
-        :ok
-
-      not role_required_field?(field) and
-        not role_optional_field?(field) and
-          not is_nil(role) ->
-        {:error, "'#{path}.role' must be omitted for #{field}"}
-
-      is_nil(role) ->
-        :ok
-
-      true ->
-        with :ok <- validate_coded_object(role, "#{path}.role"),
-             :ok <- validate_role_scheme(field, role, "#{path}.role") do
-          :ok
-        end
+  defp validate_role_object_and_scheme(field, role, role_path) do
+    with :ok <- validate_coded_object(role, role_path) do
+      validate_role_scheme(field, role, role_path)
     end
   end
 

--- a/app/test/meadow_web/mcp/tools/update_plan_change_test.exs
+++ b/app/test/meadow_web/mcp/tools/update_plan_change_test.exs
@@ -24,7 +24,7 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChangeTest do
     test "updates a plan change with simple metadata", %{plan_change: plan_change} do
       params = %{
         "id" => plan_change.id,
-        "add" => %{
+        "replace" => %{
           "descriptive_metadata" => %{
             "title" => "Updated Title"
           }
@@ -32,12 +32,103 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChangeTest do
         "status" => "proposed"
       }
 
-      assert {:ok, [{:text, response}]} = call_tool("update_plan_change", params) |> parse_response()
+      assert {:ok, [{:text, response}]} =
+               call_tool("update_plan_change", params) |> parse_response()
 
       result = Jason.decode!(response)
       assert result["id"] == plan_change.id
       assert result["status"] == "proposed"
-      assert get_in(result, ["add", "descriptive_metadata", "title"]) == "Updated Title"
+      assert get_in(result, ["replace", "descriptive_metadata", "title"]) == "Updated Title"
+    end
+
+    test "rejects title objects", %{plan_change: plan_change} do
+      params = %{
+        "id" => plan_change.id,
+        "replace" => %{
+          "descriptive_metadata" => %{
+            "title" => %{"description" => "Bad shape", "primary" => true}
+          }
+        },
+        "status" => "proposed"
+      }
+
+      assert {:error, _error, _frame} = call_tool("update_plan_change", params)
+    end
+
+    test "rejects JSON-serialized title strings", %{plan_change: plan_change} do
+      params = %{
+        "id" => plan_change.id,
+        "replace" => %{
+          "descriptive_metadata" => %{
+            "title" => ~s({"description":"Bad shape","primary":true})
+          }
+        },
+        "status" => "proposed"
+      }
+
+      assert {:error, _error, _frame} = call_tool("update_plan_change", params)
+    end
+
+    test "rejects replace operation for controlled fields", %{plan_change: plan_change} do
+      params = %{
+        "id" => plan_change.id,
+        "replace" => %{
+          "descriptive_metadata" => %{
+            "creator" => [
+              %{
+                "term" => %{"id" => "mock1:result2"},
+                "role" => %{"id" => "aut", "scheme" => "marc_relator"}
+              }
+            ]
+          }
+        },
+        "status" => "proposed"
+      }
+
+      assert {:error, _error, _frame} = call_tool("update_plan_change", params)
+    end
+
+    test "rejects roles in creator entries", %{plan_change: plan_change} do
+      params = %{
+        "id" => plan_change.id,
+        "add" => %{
+          "descriptive_metadata" => %{
+            "creator" => [
+              %{
+                "term" => %{"id" => "mock1:result2"},
+                "role" => %{"id" => "aut", "scheme" => "marc_relator"}
+              }
+            ]
+          }
+        },
+        "status" => "proposed"
+      }
+
+      assert {:error, _error, _frame} = call_tool("update_plan_change", params)
+    end
+
+    test "returns creator-role validation error even with mixed metadata keys", %{
+      plan_change: plan_change
+    } do
+      params = %{
+        "id" => plan_change.id,
+        "add" => %{
+          "descriptive_metadata" => %{
+            "creator" => [
+              %{
+                "term" => %{"id" => "mock1:result2"},
+                "role" => %{"id" => "aut", "scheme" => "marc_relator"}
+              }
+            ],
+            "description" => ["A description value"]
+          }
+        },
+        "status" => "proposed"
+      }
+
+      {:error, error, _frame} = call_tool("update_plan_change", params)
+      assert error.message =~ "'add.descriptive_metadata.creator[0].role' must be omitted for creator"
+      refute error.message =~ "mixed keys"
     end
 
     test "enriches controlled terms with labels from authority", %{plan_change: plan_change} do
@@ -56,7 +147,8 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChangeTest do
         "status" => "proposed"
       }
 
-      assert {:ok, [{:text, response}]} = call_tool("update_plan_change", params) |> parse_response()
+      assert {:ok, [{:text, response}]} =
+               call_tool("update_plan_change", params) |> parse_response()
 
       result = Jason.decode!(response)
       subject = get_in(result, ["add", "descriptive_metadata", "subject"]) |> List.first()
@@ -98,7 +190,8 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChangeTest do
         "status" => "proposed"
       }
 
-      assert {:ok, [{:text, response}]} = call_tool("update_plan_change", params) |> parse_response()
+      assert {:ok, [{:text, response}]} =
+               call_tool("update_plan_change", params) |> parse_response()
 
       result = Jason.decode!(response)
       metadata = get_in(result, ["add", "descriptive_metadata"])
@@ -126,7 +219,11 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChangeTest do
             "subject" => [
               %{
                 "term" => %{"id" => "mock1:result1", "label" => "Custom Label"},
-                "role" => %{"id" => "TOPICAL", "scheme" => "subject_role", "label" => "Custom Role"}
+                "role" => %{
+                  "id" => "TOPICAL",
+                  "scheme" => "subject_role",
+                  "label" => "Custom Role"
+                }
               }
             ]
           }
@@ -134,7 +231,8 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChangeTest do
         "status" => "proposed"
       }
 
-      assert {:ok, [{:text, response}]} = call_tool("update_plan_change", params) |> parse_response()
+      assert {:ok, [{:text, response}]} =
+               call_tool("update_plan_change", params) |> parse_response()
 
       result = Jason.decode!(response)
       subject = get_in(result, ["add", "descriptive_metadata", "subject"]) |> List.first()
@@ -145,6 +243,9 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChangeTest do
     end
 
     test "handles enrichment for delete and replace operations", %{plan_change: plan_change} do
+      valid_license = Meadow.Data.CodedTerms.list_coded_terms("license") |> List.first()
+      assert valid_license, "No license terms found in database"
+
       params = %{
         "id" => plan_change.id,
         "delete" => %{
@@ -159,30 +260,33 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChangeTest do
         },
         "replace" => %{
           "descriptive_metadata" => %{
-            "creator" => [
-              %{
-                "term" => %{"id" => "mock1:result2"},
-                "role" => %{"id" => "aut", "scheme" => "marc_relator"}
-              }
-            ]
+            "license" => %{
+              "id" => valid_license.id,
+              "scheme" => "license"
+            }
           }
         },
         "status" => "proposed"
       }
 
-      assert {:ok, [{:text, response}]} = call_tool("update_plan_change", params) |> parse_response()
+      assert {:ok, [{:text, response}]} =
+               call_tool("update_plan_change", params) |> parse_response()
 
       result = Jason.decode!(response)
 
       # Verify delete operation enrichment
-      delete_subject = get_in(result, ["delete", "descriptive_metadata", "subject"]) |> List.first()
+      delete_subject =
+        get_in(result, ["delete", "descriptive_metadata", "subject"]) |> List.first()
+
       assert delete_subject["term"]["label"] == "First Result"
       assert delete_subject["role"]["label"] == "Topical"
 
       # Verify replace operation enrichment
-      replace_creator = get_in(result, ["replace", "descriptive_metadata", "creator"]) |> List.first()
-      assert replace_creator["term"]["label"] == "Second Result"
-      assert replace_creator["role"]["label"] == "Author"
+      assert get_in(result, ["replace", "descriptive_metadata", "license", "id"]) ==
+               valid_license.id
+
+      assert get_in(result, ["replace", "descriptive_metadata", "license", "label"]) ==
+               valid_license.label
     end
 
     test "handles gracefully when term lookup fails", %{plan_change: plan_change} do
@@ -202,7 +306,8 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChangeTest do
       }
 
       # Should not error, just log warning and continue without label
-      assert {:ok, [{:text, response}]} = call_tool("update_plan_change", params) |> parse_response()
+      assert {:ok, [{:text, response}]} =
+               call_tool("update_plan_change", params) |> parse_response()
 
       result = Jason.decode!(response)
       subject = get_in(result, ["add", "descriptive_metadata", "subject"]) |> List.first()
@@ -230,12 +335,14 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChangeTest do
     test "updates notes field", %{plan_change: plan_change} do
       params = %{
         "id" => plan_change.id,
-        "add" => %{},  # Need at least one of add/delete/replace
+        # Need at least one of add/delete/replace
+        "add" => %{},
         "notes" => "These are my notes",
         "status" => "proposed"
       }
 
-      assert {:ok, [{:text, response}]} = call_tool("update_plan_change", params) |> parse_response()
+      assert {:ok, [{:text, response}]} =
+               call_tool("update_plan_change", params) |> parse_response()
 
       result = Jason.decode!(response)
       assert result["notes"] == "These are my notes"
@@ -259,10 +366,10 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChangeTest do
       {:ok, plan: plan, plan_change: plan_change, work: work}
     end
 
-    test "rejects invalid license term in add operation", %{plan_change: plan_change} do
+    test "rejects invalid license term in replace operation", %{plan_change: plan_change} do
       params = %{
         "id" => plan_change.id,
-        "add" => %{
+        "replace" => %{
           "descriptive_metadata" => %{
             "license" => %{
               "id" => "http://invalid-license.com/",
@@ -321,7 +428,7 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChangeTest do
 
       params = %{
         "id" => plan_change.id,
-        "add" => %{
+        "replace" => %{
           "descriptive_metadata" => %{
             "license" => %{
               "id" => valid_license.id,
@@ -332,11 +439,16 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChangeTest do
         "status" => "proposed"
       }
 
-      assert {:ok, [{:text, response}]} = call_tool("update_plan_change", params) |> parse_response()
+      assert {:ok, [{:text, response}]} =
+               call_tool("update_plan_change", params) |> parse_response()
 
       result = Jason.decode!(response)
-      assert get_in(result, ["add", "descriptive_metadata", "license", "id"]) == valid_license.id
-      assert get_in(result, ["add", "descriptive_metadata", "license", "label"]) == valid_license.label
+
+      assert get_in(result, ["replace", "descriptive_metadata", "license", "id"]) ==
+               valid_license.id
+
+      assert get_in(result, ["replace", "descriptive_metadata", "license", "label"]) ==
+               valid_license.label
     end
 
     test "accepts valid role coded terms", %{plan_change: plan_change} do
@@ -355,7 +467,8 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChangeTest do
         "status" => "proposed"
       }
 
-      assert {:ok, [{:text, response}]} = call_tool("update_plan_change", params) |> parse_response()
+      assert {:ok, [{:text, response}]} =
+               call_tool("update_plan_change", params) |> parse_response()
 
       result = Jason.decode!(response)
       subject = get_in(result, ["add", "descriptive_metadata", "subject"]) |> List.first()
@@ -363,8 +476,7 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChangeTest do
       assert subject["role"]["label"] == "Topical"
     end
 
-    test "does not validate coded terms in delete operations", %{plan_change: plan_change} do
-      # Delete operations should not be validated since we're removing data
+    test "rejects delete for non-controlled fields", %{plan_change: plan_change} do
       params = %{
         "id" => plan_change.id,
         "delete" => %{
@@ -378,8 +490,7 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChangeTest do
         "status" => "proposed"
       }
 
-      # Should succeed even though license is invalid - we're just deleting it
-      assert {:ok, [{:text, _response}]} = call_tool("update_plan_change", params) |> parse_response()
+      assert {:error, _error, _frame} = call_tool("update_plan_change", params)
     end
   end
 end

--- a/lambdas/metadata-agent/execute.js
+++ b/lambdas/metadata-agent/execute.js
@@ -147,7 +147,34 @@ async function executeAgent(
 ) {
   emitAgentLog("mode: agent");
   emitAgentLog("connecting to MCP tools");
+  const schemaUri = "file://schema/work.json";
+  let schemaRead = false;
+
+  const canUseTool = async (toolName, input) => {
+    const payload = input && typeof input === "object" ? input : {};
+
+    if (
+      toolName === "ReadMcpResource" &&
+      payload.server === "meadow" &&
+      payload.uri === schemaUri
+    ) {
+      schemaRead = true;
+      emitAgentLog(`schema resource read: ${schemaUri}`);
+      return { behavior: "allow" };
+    }
+
+    if (toolName === "mcp__meadow__update_plan_change" && !schemaRead) {
+      const message = `Before update_plan_change, call ReadMcpResource with {"server":"meadow","uri":"${schemaUri}"}.`;
+      emitAgentLog(`blocked tool_call: ${toolName} (schema not read)`, "warning");
+      return { behavior: "deny", message };
+    }
+
+    return { behavior: "allow" };
+  };
+
   const allowedTools = [
+    "ReadMcpResource",
+    "ListMcpResources",
     "mcp__meadow__authority_search",
     "mcp__meadow__get_code_list",
     "mcp__meadow__get_image",
@@ -157,7 +184,7 @@ async function executeAgent(
     "mcp__meadow__send_status_update",
     "mcp__meadow__update_plan_change",
   ];
-  const disallowedTools = ["Bash", "Glob", "Grep", "Read", "WebFetch", "Write"];
+  const disallowedTools = ["Bash", "Glob", "Grep", "WebFetch", "Write"];
   const clientOptions = {
     model,
     mcpServers: {
@@ -165,6 +192,7 @@ async function executeAgent(
     },
     allowedTools,
     disallowedTools,
+    canUseTool,
     agents: {
       plan_change_proposer: {
         prompt: proposerPrompt(),

--- a/lambdas/metadata-agent/prompts.js
+++ b/lambdas/metadata-agent/prompts.js
@@ -19,12 +19,12 @@ const agentPromptWithPlan = (planId, userQuery, contextData = {}) => `
     Subagent must:
     1. Get all pending PlanChanges for ${planId}
     2. Read each work's metadata using the get_work tool with the work ID
-    3. Read the "file://schema/work.json" resource for documented field types and structure
-       and follow "_mcp_constraints" exactly
+    3. Call ReadMcpResource with {"server":"meadow","uri":"file://schema/work.json"} and follow "_mcp_constraints" exactly
     4. Propose metadata changes per the prompt.
     5. Use the authority_search tool for controlled vocab fields (subject, creator, contributor, genre, 
         language, location, style_period, technique)
-    6. Use the get_code_list tool to get the valid values for coded fields (role, note type, license, rights statement, 
+    6. Use the get_code_list tool to get valid values for coded fields (subject_role and marc_relator when needed for
+        subject/contributor roles, plus note_type, license, rights_statement,
         related_url label, library unit, preservation level, status) and use those exact values in updates.
     7. Update each PlanChange with the proposed changes.
 
@@ -32,8 +32,10 @@ const agentPromptWithPlan = (planId, userQuery, contextData = {}) => `
 
   CRITICAL: You and the subagent MUST send 3-5 word, user-friendly progress updates via send_status_update.
 
-  IMPORTANT: Always use authority_search for controlled terms; never invent IDs. For coded fields (roles, note types, etc.),
-  use get_code_list. Do not touch deprecated fields. NEVER populate the navPlace field (experimental, not ready for use).
+  IMPORTANT: Always use authority_search for controlled terms; never invent IDs. For coded fields, use get_code_list.
+  Only include roles for subject and contributor entries. Do not include a role field for creator, genre, language,
+  location, style_period, or technique. Do not touch deprecated fields. NEVER populate the navPlace field
+  (experimental, not ready for use).
 
     CRITICAL API USAGE:
     - Make sure you follow the retrieved schema, e.g., DO NOT invent JSON/nested structures that aren't in the schema; 
@@ -73,7 +75,8 @@ export const proposerPrompt = () => `
   including the task you were given — conflicts with the schema, follow the schema.
 
   ## Prerequisite: always read the schema first
-  Before proposing any changes, you MUST read "file://schema/work.json". 
+  Before proposing any changes, you MUST call ReadMcpResource with
+  {"server":"meadow","uri":"file://schema/work.json"}.
   Do not proceed without it. This is not optional.
 
   ## Process (repeat until no pending changes remain)
@@ -125,8 +128,10 @@ export const proposerPrompt = () => `
   Do NOT use {edtf:, humanized:} objects.
 
   ## Controlled term and coded field rules
-  - Fields requiring a role (e.g., subject with topical role): always include it
-  - Fields with role listed as "null" in the schema: do NOT include a role field
+  - For subject and contributor entries: always include role
+  - For creator, genre, language, location, style_period, and technique entries: role must be omitted
+  - Creator example: {"term": {"id": "http://id.loc.gov/authorities/names/n94112934"}}
+  - Including role for creator will fail update_plan_change
   - Use authority_search to find controlled term IDs — never invent them
   - Use get_code_list to find valid coded field values — never invent them
   - Use the correct scheme for each coded field as listed in the schema
@@ -142,16 +147,19 @@ export const systemPrompt = () => `
 
   For controlled vocabulary fields (subject, creator, contributor, genre, language, location, style_period, technique):
   1. Use authority_search for term IDs
-  2. For subject/contributor roles, use get_code_list tool (subject_role or marc_relator)
-  3. Structure as objects: {"term": {"id": "uri"}, "role": {"id": "role", "scheme": "scheme"}}
-  4. Never use strings for terms; include required roles for subject and contributor; do not include roles for creator, genre, language, location, style_period, or technique
-  5. Never guess IDs; always query
+  2. For subject/contributor roles only, use get_code_list tool (subject_role or marc_relator)
+  3. Subject/contributor structure: {"term": {"id": "uri"}, "role": {"id": "role", "scheme": "scheme"}}
+  4. Creator/genre/language/location/style_period/technique structure: {"term": {"id": "uri"}} (no role key)
+  5. Never include "role" on creator; the API rejects it
+  6. Never call marc_relator for creator
+  7. Never use strings for terms
+  8. Never guess IDs; always query
 
   For coded term fields (license, rights_statement, notes, related_url):
   1. Query get_code_list tool with the appropriate scheme (license, rights_statement, note_type, related_url)
-  3. CRITICAL: Use lowercase scheme names in update_plan_change (e.g., "note_type", not "NOTE_TYPE")
-  4. For notes: each entry has a "note" text field and a "type" coded term object
-  5. For related_url: each entry has a "url" text field and a "label" coded term object (scheme is "related_url")
+  2. CRITICAL: Use lowercase scheme names in update_plan_change (e.g., "note_type", not "NOTE_TYPE")
+  3. For notes: each entry has a "note" text field and a "type" coded term object
+  4. For related_url: each entry has a "url" text field and a "label" coded term object (scheme is "related_url")
 
   For title:
   1. Use replace only

--- a/lambdas/metadata-agent/prompts.js
+++ b/lambdas/metadata-agent/prompts.js
@@ -16,16 +16,17 @@ const agentPromptWithPlan = (planId, userQuery, contextData = {}) => `
   Use the plan_change_proposer subagent to process plan ${planId} for:
   ${userQuery}
 
-  Subagent must:
-  1. Get all pending PlanChanges for ${planId}
-  2. Read each work's metadata using the get_work tool with the work ID
-  3. Read the "file://schema/work.json" resource for documented field types and structure
-  4. Propose metadata changes per the prompt.
-  5. Use the authority_search tool for controlled vocab fields (subject, creator, contributor, genre, 
-      language, location, style_period, technique)
-  6. Use the get_code_list tool to get the valid values for coded fields (role, note type, license, rights statement, 
-      related_url label, library unit, preservation level, status) and use those exact values in updates.
-  7. Update each PlanChange with the proposed changes.
+    Subagent must:
+    1. Get all pending PlanChanges for ${planId}
+    2. Read each work's metadata using the get_work tool with the work ID
+    3. Read the "file://schema/work.json" resource for documented field types and structure
+       and follow "_mcp_constraints" exactly
+    4. Propose metadata changes per the prompt.
+    5. Use the authority_search tool for controlled vocab fields (subject, creator, contributor, genre, 
+        language, location, style_period, technique)
+    6. Use the get_code_list tool to get the valid values for coded fields (role, note type, license, rights statement, 
+        related_url label, library unit, preservation level, status) and use those exact values in updates.
+    7. Update each PlanChange with the proposed changes.
 
   Context: ${JSON.stringify(contextData, null, 2)}
 
@@ -34,11 +35,13 @@ const agentPromptWithPlan = (planId, userQuery, contextData = {}) => `
   IMPORTANT: Always use authority_search for controlled terms; never invent IDs. For coded fields (roles, note types, etc.),
   use get_code_list. Do not touch deprecated fields. NEVER populate the navPlace field (experimental, not ready for use).
 
-  CRITICAL API USAGE:
-  - Make sure you follow the retrived schema, e.g., DO NOT invent JSON/nested structures that aren't in the schema; 
-    use the exact structure from the schema resource
-  - Use the get_image tool with the ID of any file set to retrieve its base64 image for analysis.
-  - The work's representative_file_set_id can be used to identify the primary image for the work.
+    CRITICAL API USAGE:
+    - Make sure you follow the retrieved schema, e.g., DO NOT invent JSON/nested structures that aren't in the schema; 
+      use the exact structure from the schema resource
+    - Title changes must be plain strings only. Never send title as objects/arrays and never send JSON-serialized
+      blobs like "{\\"description\\":\\"...\\",\\"primary\\":true}".
+    - Use the get_image tool with the ID of any file set to retrieve its base64 image for analysis.
+    - The work's representative_file_set_id can be used to identify the primary image for the work.
 
   Finish with a concise summary of proposed changes. Keep the summary focused on the changed fields instead of the plan 
   process itself. Do not mention the subagent or anything related to plan status. Do not include headers or introductory 
@@ -138,10 +141,10 @@ export const systemPrompt = () => `
   Use get_plan_changes to list changes for a plan UUID and work UUID.
 
   For controlled vocabulary fields (subject, creator, contributor, genre, language, location, style_period, technique):
-  1. Use authoritiesSearch for term IDs
+  1. Use authority_search for term IDs
   2. For subject/contributor roles, use get_code_list tool (subject_role or marc_relator)
   3. Structure as objects: {"term": {"id": "uri"}, "role": {"id": "role", "scheme": "scheme"}}
-  4. Never use strings for terms; include required roles for subject and contributor
+  4. Never use strings for terms; include required roles for subject and contributor; do not include roles for creator, genre, language, location, style_period, or technique
   5. Never guess IDs; always query
 
   For coded term fields (license, rights_statement, notes, related_url):
@@ -149,6 +152,11 @@ export const systemPrompt = () => `
   3. CRITICAL: Use lowercase scheme names in update_plan_change (e.g., "note_type", not "NOTE_TYPE")
   4. For notes: each entry has a "note" text field and a "type" coded term object
   5. For related_url: each entry has a "url" text field and a "label" coded term object (scheme is "related_url")
+
+  For title:
+  1. Use replace only
+  2. Value must be a plain string
+  3. Never pass JSON objects/arrays or stringified JSON as title values
 
   Do not look for information in the file system or local codebase.
 `;


### PR DESCRIPTION
# Summary 

Refactors the `update_plan_change` MCP tool to return field-level errors so that the agent can correct formatting mistakes, etc. I was only able to get MCP Resources working and logging properly after removing `Read` from the list of disallowed tools in the MCP config.

All fields prompt reads the MCP `Resource` and succeeds first attempt:
<img width="332" height="771" alt="all_fields" src="https://github.com/user-attachments/assets/3c4c765c-09d0-483c-ae4d-78863d7d932d" />

Logs showing `ReadMcpResourceTool` calls:
<img width="1140" height="348" alt="SCR-20260304-tzpt" src="https://github.com/user-attachments/assets/6f63e94c-d9ba-49d2-b35f-bd7ae96c8a6a" />


Validation error with recovery (warning hard to reproduce at this point 😄 ):
<img width="2551" height="906" alt="error_recovery" src="https://github.com/user-attachments/assets/c52a1c5e-f76d-4234-b0cf-3aad3a2f25f5" />

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
- Agent logs in the UI should show lines like: `[agent-log] tool_call: ReadMcpResourceTool {"server":"meadow","uri":"file://schema/work.json"}`
- Errors in the `update_plan_change` tool calls should now be recoverable

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

