### PR TITLE
Override the default effort level, now set to 'low'

### DIFF
--- a/lambdas/metadata-agent/execute.js
+++ b/lambdas/metadata-agent/execute.js
@@ -200,6 +200,7 @@ async function executeAgent(
       },
     },
     systemPrompt: systemPrompt(),
+    effort: "low"
   };
   logVerbose("Client options:", clientOptions);
 


### PR DESCRIPTION
# Summary 
We can save time and tokens by setting the `Sonnet 4.6` effort value to "low" (default is "high"). Documentation available here: https://platform.claude.com/docs/en/build-with-claude/effort

# Specific Changes in this PR
- `clientOptions` now includes `effort` in `lambdas/metadata-agent/execute.js`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
The auto-edit should work the same, just faster in general and with less tool calls.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

