### PR TITLE
Automatically create release on prod deploy

### DIFF
--- a/.github/scripts/generate_release_notes.sh
+++ b/.github/scripts/generate_release_notes.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# .github/scripts/generate_release_notes.sh
+#
+# Generates human-readable release notes for a Meadow production release.
+# Finds PRs merged since the last production tag, filters noise, calls
+# Claude via Bedrock to summarize, then creates a GitHub Release.
+#
+# Required env vars:
+#   GITHUB_TOKEN      - GitHub token with contents:write and pull-requests:read
+#   MEADOW_VERSION    - Version being released (e.g. "1.2.3")
+#   AWS_REGION        - AWS region for Bedrock (e.g. "us-east-1")
+#
+# Optional env vars:
+#   GITHUB_REPOSITORY - Set automatically by GitHub Actions (owner/repo)
+#   DRY_RUN           - Set to "true" to skip release creation and print output only
+#
+# Local testing (dry run):
+#   export GITHUB_TOKEN=<your-pat>
+#   export MEADOW_VERSION=<existing-tag-without-v, e.g. "1.2.3">
+#   export AWS_REGION=us-east-1
+#   export GITHUB_REPOSITORY=nulib/meadow
+#   export DRY_RUN=true
+#   bash .github/scripts/generate_release_notes.sh
+
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY}"
+CURRENT_TAG="v${MEADOW_VERSION}"
+MODEL_ID="us.anthropic.claude-sonnet-4-6"
+DRY_RUN="${DRY_RUN:-false}"
+
+# Initialize so these are always set even if all PRs are filtered out
+FILTERED_COUNT=0
+PR_DETAIL_LIST=""
+SUMMARY=""
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "==> DRY RUN MODE — no GitHub Release will be created"
+fi
+
+# TEST_PR_LIST can be set to bypass GitHub API fetch entirely for testing
+TEST_PR_LIST="${TEST_PR_LIST:-}"
+
+echo "==> Generating release notes for ${CURRENT_TAG}"
+
+if [[ -n "$TEST_PR_LIST" ]]; then
+  # ---------------------------------------------------------------------------
+  # TEST MODE: skip GitHub API and tag lookup, use provided PR list directly
+  # ---------------------------------------------------------------------------
+  echo "==> TEST MODE — using provided TEST_PR_LIST, skipping GitHub API"
+  FILTERED_COUNT=$(echo "$TEST_PR_LIST" | grep -c "^-" || true)
+  PR_DETAIL_LIST="$TEST_PR_LIST"
+
+else
+  # ---------------------------------------------------------------------------
+  # 1. Find the previous production tag
+  # ---------------------------------------------------------------------------
+  echo "==> Finding previous tag..."
+
+  PREVIOUS_TAG=$(git tag \
+    --sort=-creatordate \
+    --list "v*" \
+    | grep -v "^${CURRENT_TAG}$" \
+    | head -1)
+
+  if [[ -z "$PREVIOUS_TAG" ]]; then
+    echo "No previous tag found. Skipping release notes generation."
+    exit 0
+  fi
+
+  echo "    Previous tag: ${PREVIOUS_TAG}"
+  echo "    Current tag:  ${CURRENT_TAG}"
+
+  # ---------------------------------------------------------------------------
+  # 2. Fetch merged PRs between the two tags via GitHub API
+  # ---------------------------------------------------------------------------
+  echo "==> Fetching merged PRs between ${PREVIOUS_TAG} and ${CURRENT_TAG}..."
+
+  # Get the date of the previous tag so we can filter PRs by merge date
+  PREVIOUS_TAG_DATE=$(git log -1 --format="%cI" "${PREVIOUS_TAG}")
+  echo "    Previous tag date: ${PREVIOUS_TAG_DATE}"
+
+  PR_RESPONSE=$(curl -s \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github.v3+json" \
+    "https://api.github.com/repos/${REPO}/pulls?state=closed&base=deploy/staging&sort=updated&direction=desc&per_page=100&since=${PREVIOUS_TAG_DATE}")
+
+  # Filter to PRs merged after the previous tag, extract title + labels + number
+  PR_LIST=$(echo "$PR_RESPONSE" | jq -r --arg since "$PREVIOUS_TAG_DATE" '
+    [
+      .[] |
+      select(
+        .merged_at != null and
+        .merged_at > $since
+      ) |
+      {
+        number: .number,
+        title: .title,
+        labels: [.labels[].name],
+        merged_at: .merged_at
+      }
+    ] | sort_by(.merged_at)
+  ')
+
+  PR_COUNT=$(echo "$PR_LIST" | jq 'length')
+  echo "    Found ${PR_COUNT} merged PRs"
+
+  if [[ "$PR_COUNT" -eq 0 ]]; then
+    echo "No PRs found for this release. Creating release with minimal notes."
+    SUMMARY="No pull requests were found for this release."
+    PR_DETAIL_LIST=""
+  else
+    # -------------------------------------------------------------------------
+    # 3. Filter out noise PRs
+    # -------------------------------------------------------------------------
+    echo "==> Filtering noise PRs..."
+
+    FILTERED_PRS=$(echo "$PR_LIST" | jq -r '
+      [
+        .[] |
+        select(
+          (.title | ascii_downcase | test("^(dependabot|chore:|ci:|build:|bump version|increment version|deploy v|dependency rollup)") | not) and
+          ((.labels | map(ascii_downcase) | any(. == "dependencies" or . == "chore" or . == "ci")) | not)
+        )
+      ]
+    ')
+
+    FILTERED_COUNT=$(echo "$FILTERED_PRS" | jq 'length')
+    EXCLUDED_COUNT=$(( PR_COUNT - FILTERED_COUNT ))
+    echo "    Kept ${FILTERED_COUNT} PRs, excluded ${EXCLUDED_COUNT} noise PRs"
+
+    if [[ "$FILTERED_COUNT" -eq 0 ]]; then
+      echo "All PRs were infrastructure/dependency updates. Creating release with minimal notes."
+      SUMMARY="This release contains dependency updates and infrastructure improvements only."
+      PR_DETAIL_LIST=""
+    else
+      PR_DETAIL_LIST=$(echo "$FILTERED_PRS" | jq -r '
+        .[] | "- #\(.number): \(.title)"
+      ')
+    fi
+  fi
+
+fi # end TEST_PR_LIST bypass
+
+# ---------------------------------------------------------------------------
+# 4. Call Claude via Bedrock to generate plain-language release notes
+# ---------------------------------------------------------------------------
+
+if [[ -n "$PR_DETAIL_LIST" ]]; then
+  echo "==> Calling Claude via Bedrock..."
+  echo "    PRs to summarize:"
+  echo "$PR_DETAIL_LIST" | sed 's/^/      /'
+
+  PROMPT="You are writing release notes for Meadow, a digital collections management application used by library staff at Northwestern University Libraries.
+
+Given the following list of pull request titles merged into this release, write concise, plain-language release notes suitable for non-technical library staff. Focus on what changed from the user's perspective — what they can now do, what was fixed, or what improved. Group related changes if it makes sense. Do not mention PR numbers, branch names, version numbers, or technical implementation details. Do not invent a title or header. Use plain prose or a short bullet list. Keep it under 200 words.
+
+Pull requests in this release:
+${PR_DETAIL_LIST}
+
+Write only the release notes text, nothing else."
+
+  REQUEST_PAYLOAD=$(jq -n \
+    --arg prompt "$PROMPT" \
+    '{
+      anthropic_version: "bedrock-2023-05-31",
+      max_tokens: 1024,
+      messages: [
+        {
+          role: "user",
+          content: $prompt
+        }
+      ]
+    }')
+
+  PAYLOAD_FILE=$(mktemp)
+  echo "$REQUEST_PAYLOAD" > "$PAYLOAD_FILE"
+  RESPONSE_FILE=$(mktemp)
+
+  aws bedrock-runtime invoke-model \
+    --region "${AWS_REGION}" \
+    --model-id "${MODEL_ID}" \
+    --content-type "application/json" \
+    --accept "application/json" \
+    --body "fileb://${PAYLOAD_FILE}" \
+    "$RESPONSE_FILE"
+
+  SUMMARY=$(jq -r '.content[0].text' "$RESPONSE_FILE")
+  rm -f "$PAYLOAD_FILE" "$RESPONSE_FILE"
+
+  echo "    Summary generated (${#SUMMARY} chars)"
+fi
+
+RELEASE_BODY="${SUMMARY}"
+
+# ---------------------------------------------------------------------------
+# 6. Create the GitHub Release (or print in dry run mode)
+# ---------------------------------------------------------------------------
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo ""
+  echo "==> DRY RUN: Would create GitHub Release with the following:"
+  echo ""
+  echo "    Tag:  ${CURRENT_TAG}"
+  echo "    Name: Meadow ${CURRENT_TAG}"
+  echo ""
+  echo "--- RELEASE BODY ---"
+  echo "${RELEASE_BODY}"
+  echo "--- END RELEASE BODY ---"
+  echo ""
+  echo "==> DRY RUN complete. No release was created."
+  exit 0
+fi
+
+echo "==> Creating GitHub Release for ${CURRENT_TAG}..."
+
+RELEASE_PAYLOAD=$(jq -n \
+  --arg tag "$CURRENT_TAG" \
+  --arg name "Meadow ${CURRENT_TAG}" \
+  --arg body "$RELEASE_BODY" \
+  '{
+    tag_name: $tag,
+    name: $name,
+    body: $body,
+    draft: false,
+    prerelease: false
+  }')
+
+RELEASE_RESPONSE=$(curl -s \
+  -X POST \
+  -H "Authorization: token ${GITHUB_TOKEN}" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/${REPO}/releases" \
+  -d "$RELEASE_PAYLOAD")
+
+RELEASE_URL=$(echo "$RELEASE_RESPONSE" | jq -r '.html_url')
+
+if [[ "$RELEASE_URL" == "null" || -z "$RELEASE_URL" ]]; then
+  echo "ERROR: Failed to create release. Response:"
+  echo "$RELEASE_RESPONSE" | jq .
+  exit 1
+fi
+
+echo "==> Release created successfully: ${RELEASE_URL}"

--- a/.github/scripts/generate_release_notes.sh
+++ b/.github/scripts/generate_release_notes.sh
@@ -7,16 +7,21 @@
 #
 # Required env vars:
 #   GITHUB_TOKEN      - GitHub token with contents:write and pull-requests:read
-#   MEADOW_VERSION    - Version being released (e.g. "1.2.3")
 #   AWS_REGION        - AWS region for Bedrock (e.g. "us-east-1")
 #
 # Optional env vars:
+#   CURRENT_TAG       - Tag being released (e.g. "v1.2.3"); derived from MEADOW_VERSION if not set
+#   MEADOW_VERSION    - Version being released (e.g. "1.2.3"); used only if CURRENT_TAG is unset
+#   PREVIOUS_TAG      - Previous release tag; auto-detected from git if not set
+#   DRAFT_RELEASE     - Set to "true" to create a draft GitHub Release
 #   GITHUB_REPOSITORY - Set automatically by GitHub Actions (owner/repo)
 #   DRY_RUN           - Set to "true" to skip release creation and print output only
 #
 # Local testing (dry run):
+# (For local testing you must set CURRENT_TAG and PREVIOUS_TAG explicitly)
 #   export GITHUB_TOKEN=<your-pat>
-#   export MEADOW_VERSION=<existing-tag-without-v, e.g. "1.2.3">
+#   export CURRENT_TAG=v1.2.3
+#   export PREVIOUS_TAG=v1.1.4
 #   export AWS_REGION=us-east-1
 #   export GITHUB_REPOSITORY=nulib/meadow
 #   export DRY_RUN=true
@@ -25,8 +30,10 @@
 set -euo pipefail
 
 REPO="${GITHUB_REPOSITORY}"
-CURRENT_TAG="v${MEADOW_VERSION}"
+CURRENT_TAG="${CURRENT_TAG:-v${MEADOW_VERSION}}"
+PREVIOUS_TAG="${PREVIOUS_TAG:-}"
 MODEL_ID="us.anthropic.claude-sonnet-4-6"
+DRAFT_RELEASE="${DRAFT_RELEASE:-false}"
 DRY_RUN="${DRY_RUN:-false}"
 
 # Initialize so these are always set even if all PRs are filtered out
@@ -55,17 +62,21 @@ else
   # ---------------------------------------------------------------------------
   # 1. Find the previous production tag
   # ---------------------------------------------------------------------------
-  echo "==> Finding previous tag..."
-
-  PREVIOUS_TAG=$(git tag \
-    --sort=-creatordate \
-    --list "v*" \
-    | grep -v "^${CURRENT_TAG}$" \
-    | head -1)
-
   if [[ -z "$PREVIOUS_TAG" ]]; then
-    echo "No previous tag found. Skipping release notes generation."
-    exit 0
+    echo "==> Finding previous tag..."
+
+    PREVIOUS_TAG=$(git tag \
+      --sort=-creatordate \
+      --list "v*" \
+      | grep -v "^${CURRENT_TAG}$" \
+      | head -1 || true)
+
+    if [[ -z "$PREVIOUS_TAG" ]]; then
+      echo "No previous tag found. Skipping release notes generation."
+      exit 0
+    fi
+  else
+    echo "==> Using provided previous tag: ${PREVIOUS_TAG}"
   fi
 
   echo "    Previous tag: ${PREVIOUS_TAG}"
@@ -218,11 +229,12 @@ RELEASE_PAYLOAD=$(jq -n \
   --arg tag "$CURRENT_TAG" \
   --arg name "Meadow ${CURRENT_TAG}" \
   --arg body "$RELEASE_BODY" \
+  --argjson draft "$([[ "$DRAFT_RELEASE" == "true" ]] && echo "true" || echo "false")" \
   '{
     tag_name: $tag,
     name: $name,
     body: $body,
-    draft: false,
+    draft: $draft,
     prerelease: false
   }')
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,11 +141,20 @@ jobs:
           git push origin v${MEADOW_VERSION}
       - name: Generate Release Notes
         if: ${{ github.ref == 'refs/heads/main' }}
-        run: .github/scripts/generate_release_notes.sh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MEADOW_VERSION: ${{ env.MEADOW_VERSION }}
-          AWS_REGION: us-east-1
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'release_notes.yml',
+              ref: 'main',
+              inputs: {
+                current_tag: `v${process.env.MEADOW_VERSION}`,
+                previous_tag: '',
+                draft: 'false',
+              },
+            })
       - name: Dispatch New Production PR
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions/github-script@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ concurrency:
   cancel-in-progress: true
 permissions:
   actions: write
+  contents: write
 jobs:
   get-environment:
     if: ${{ !github.event.pull_request && !contains(github.event.head_commit.message, '[no-deploy]') }}
@@ -64,7 +65,10 @@ jobs:
       IMAGE_TAG: ${{ needs.get-environment.outputs.image_tag }}
       MEADOW_TENANT: ${{ needs.get-environment.outputs.meadow_tenant }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Configure AWS
         run: .github/scripts/configure_aws.sh
         env:
@@ -135,6 +139,13 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           git push origin v${MEADOW_VERSION}
+      - name: Generate Release Notes
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: .github/scripts/generate_release_notes.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MEADOW_VERSION: ${{ env.MEADOW_VERSION }}
+          AWS_REGION: us-east-1
       - name: Dispatch New Production PR
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: actions/github-script@v6

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -1,0 +1,40 @@
+---
+name: Generate Release Notes
+on:
+  workflow_dispatch:
+    inputs:
+      current_tag:
+        description: "Tag being released (e.g. v1.2.3)"
+        required: true
+      previous_tag:
+        description: "Previous release tag (leave empty to auto-detect)"
+        required: false
+        default: ""
+      draft:
+        description: "Create as draft release"
+        type: boolean
+        default: false
+permissions:
+  contents: write
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Configure AWS
+        run: .github/scripts/configure_aws.sh
+        env:
+          DEPLOY_ENV: production
+          GITHUB_ENV: ${{ env.GITHUB_ENV }}
+          SECRETS: ${{ toJSON(secrets) }}
+      - name: Generate Release Notes
+        run: .github/scripts/generate_release_notes.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT_TAG: ${{ inputs.current_tag }}
+          PREVIOUS_TAG: ${{ inputs.previous_tag }}
+          DRAFT_RELEASE: ${{ inputs.draft }}
+          AWS_REGION: us-east-1


### PR DESCRIPTION
# Summary 

fixes: https://github.com/nulib/repodev_planning_and_docs/issues/5798

Adds automated generation of human readable GitHub Releases using Claude via Bedrock on every production deploy, replacing the manual process.

# What this does

When a production deploy completes, a new `.github/scripts/generate_release_notes.sh` script:

1. Finds the previous production tag to establish the commit range
2. Fetches PRs merged into `deploy/staging` since that tag
3. Filters out noise (Dependabot, dependency rollups, version bumps, deploy PRs, CI/chore commits) (can omit with `chore:` in the title or label)
5. Calls Claude via AWS Bedrock to generate a summary 
6. Creates a GitHub Release with the generated notes

# Steps to Test

To test locally (I just created a GH PAT classic token just with read rights & I used what would be the next Meadow version):

```bash
export GITHUB_TOKEN=<your GH PAT>
export CURRENT_TAG=v10.3.0
export PREVIOUS_TAG=v10.2.2
export AWS_REGION=us-east-1
export GITHUB_REPOSITORY=nulib/meadow
export DRY_RUN=true

# then run
# This won't currently find any commits, but will show the GH fetch
bash .github/scripts/generate_release_notes.sh

# You can also mock some PR's to see the Claude call
export TEST_PR_LIST="- #100: Add batch export feature
- #101: Fix metadata validation error on save
- #102: Allow users to set default collection view"

# then run
bash .github/scripts/generate_release_notes.sh
```


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major



# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

