### PR TITLE
Add environment variable to localstack to activate grace period

### DIFF
--- a/infrastructure/localstack/docker-compose.yml
+++ b/infrastructure/localstack/docker-compose.yml
@@ -15,7 +15,11 @@ services:
       DISABLE_SECURITY_PLUGIN: true
       discovery.type: single-node
     healthcheck:
-      test: ["CMD-SHELL", "curl -s -f http://localhost:9200/_cluster/health | grep -q 'green\\|yellow'"]
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s -f http://localhost:9200/_cluster/health | grep -q 'green\\|yellow'",
+        ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -26,6 +30,7 @@ services:
     environment:
       DOCKER_HOST: unix:///var/run/docker.sock
       GATEWAY_LISTEN: 0.0.0.0:4566
+      LOCALSTACK_ACKNOWLEDGE_ACCOUNT_REQUIREMENT: 1
     ports:
       - 4566:4566
     volumes:


### PR DESCRIPTION
# Summary 

Per https://blog.localstack.cloud/localstack-for-aws-release-2026-03-0/

# Specific Changes in this PR
- Add `LOCALSTACK_ACKNOWLEDGE_ACCOUNT_REQUIREMENT` to the localstack docker-compose config

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Provision testing infrastructure and Run tests as documented in README.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

