### PR TITLE
Add generate-ai-metadata pipeline action to terraform config

### DIFF
--- a/infrastructure/deploy/pipeline.tf
+++ b/infrastructure/deploy/pipeline.tf
@@ -2,7 +2,7 @@ locals {
   actions = ["ingest-file-set", "extract-mime-type", "generate-file-set-digests",
     "extract-exif-metadata", "extract-media-metadata", "copy-file-to-preservation", 
     "attach-transcription", "create-derivative-copy", "create-pyramid-tiff", "create-transcode-job", 
-    "generate-poster-image", "initialize-dispatch", "transcode-complete", "file-set-complete"]
+    "generate-poster-image", "initialize-dispatch", "transcode-complete", "file-set-complete", "generate-ai-metadata"]
 }
 
 resource "aws_sqs_queue" "sequins_queue" {


### PR DESCRIPTION

# Summary 
- Add generate-ai-metadata pipeline action to terraform config
- Already applied to staging

:chore chore:

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
- AI batches ingest on staging, should no longer error because the SQS queue now exists.

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [x] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

