### PR TITLE
Change transcription annotation mapping in file set index to text

### DIFF
--- a/app/priv/search/v2/settings/file_set.json
+++ b/app/priv/search/v2/settings/file_set.json
@@ -16,6 +16,16 @@
           "tokenizer": "standard",
           "char_filter": ["html_strip"],
           "filter": ["lowercase", "asciifolding", "english_stop"]
+        },
+        "fulltext_analyzer": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": ["lowercase", "asciifolding"]
+        },
+        "fulltext_stopword_analyzer": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": ["lowercase", "asciifolding", "english_stop"]
         }
       },
       "filter": {
@@ -42,6 +52,17 @@
             "analyzer": "full_analyzer",
             "search_analyzer": "stopword_analyzer",
             "search_quote_analyzer": "full_analyzer"
+          }
+        }
+      },
+      {
+        "annotation_content": {
+          "path_match": "annotations.content",
+          "mapping": {
+            "type": "text",
+            "analyzer": "fulltext_analyzer",
+            "search_analyzer": "fulltext_stopword_analyzer",
+            "search_quote_analyzer": "fulltext_analyzer"
           }
         }
       },


### PR DESCRIPTION
# Summary 

Currently annotations are mapped to be keyword type fields in OpenSearch. This is not what we want for full text searching within the cotnent of transcript annotations.

# Specific Changes in this PR

- Update file-set index mappings for `annotation.content` to text

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

A search like below should return results (on transcribed coffee.tif)

```json
GET /*-dev-dc-v2-file-set/_search
{
  "query": {
    "bool": {
      "must": [
        {
          "term": {
            "annotations.type": "transcription"
          }
        },
        {
          "match": {
            "annotations.content": "PidMinter"
          }
        }
      ]
    }
  },
  "size": 3
}
```

or

```json
GET /*-dev-dc-v2-file-set/_search
{
  "query": {
    "match": {
      "annotations.content": "PidMinter
    }
  }
}
```

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [x] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

