### PR TITLE
Refactor transcription error handling

### DIFF
--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Workflow.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Workflow.jsx
@@ -1,12 +1,52 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { Button } from "@nulib/design-system";
 import WorkTabsStructureTranscriptionPane from "@js/components/Work/Tabs/Structure/Transcription/Pane";
-import { TRANSCRIBE_FILE_SET } from "@js/components/Work/Tabs/Structure/Transcription/transcription.gql";
+import {
+  DELETE_FILE_SET_ANNOTATION,
+  TRANSCRIBE_FILE_SET,
+} from "@js/components/Work/Tabs/Structure/Transcription/transcription.gql";
 import { useMutation, useQuery } from "@apollo/client/react";
 import { useFileSetAnnotation } from "@js/hooks/useFileSetAnnotation";
 import { toastWrapper } from "@js/services/helpers";
 
 import { GET_WORK } from "@js/components/Work/work.gql";
+
+const humanizeFieldName = (field) =>
+  field.replace(/_/g, " ").replace(/^./, (c) => c.toUpperCase());
+
+const humanizeMessage = (message) => message.replace(/file_set/g, "file set");
+
+const formatDetails = (details) => {
+  if (!details) return "";
+  if (typeof details === "string") return details;
+
+  return Object.entries(details)
+    .map(([field, message]) => {
+      const text = Array.isArray(message) ? message.join(", ") : message;
+      return `${humanizeFieldName(field)}: ${text}`;
+    })
+    .join("; ");
+};
+
+const flashTranscriptionError = (error) => {
+  const graphQLErrors = error?.graphQLErrors || error?.errors || [];
+
+  if (graphQLErrors.length === 0) {
+    toastWrapper(
+      "is-danger",
+      error?.message || "There was an error generating transcription.",
+    );
+    return;
+  }
+
+  graphQLErrors.forEach(({ message, details, extensions }) => {
+    const detailText = formatDetails(details || extensions?.details);
+    const flashMessage = detailText
+      ? `${humanizeMessage(message)} — ${detailText}`
+      : humanizeMessage(message);
+    toastWrapper("is-danger", flashMessage);
+  });
+};
 
 function WorkTabsStructureTranscriptionWorkflow({
   fileSetId,
@@ -14,6 +54,7 @@ function WorkTabsStructureTranscriptionWorkflow({
   workId,
   hasTranscriptionCallback,
 }) {
+  const flashedAnnotationErrorIdRef = useRef(null);
   const { data: { fileSetAnnotation } = {} } = useFileSetAnnotation(fileSetId);
   const {
     data: { work } = {},
@@ -24,14 +65,23 @@ function WorkTabsStructureTranscriptionWorkflow({
   });
 
   const [transcribeFileSet] = useMutation(TRANSCRIBE_FILE_SET);
+  const [deleteFileSetAnnotation] = useMutation(DELETE_FILE_SET_ANNOTATION);
 
   const workFileSet = work?.fileSets?.find((fs) => fs.id === fileSetId);
+  const existingTranscriptionAnnotation = workFileSet?.annotations?.find(
+    (annotation) => annotation.type === "transcription",
+  );
   const annotation =
     fileSetAnnotation?.status === "completed"
       ? fileSetAnnotation
-      : workFileSet?.annotations?.find(
-          (annotation) => annotation.type === "transcription",
-        );
+      : existingTranscriptionAnnotation;
+
+  const failedAnnotationId =
+    (fileSetAnnotation?.status === "error" && fileSetAnnotation?.id) ||
+    (existingTranscriptionAnnotation?.status === "error" &&
+      existingTranscriptionAnnotation?.id) ||
+    null;
+  const annotationFailed = Boolean(failedAnnotationId);
 
   useEffect(() => {
     if (isActive) {
@@ -39,15 +89,29 @@ function WorkTabsStructureTranscriptionWorkflow({
     }
   }, [isActive]);
 
-  const handleStartTranscription = () => {
-    if (!fileSetId) return;
+  useEffect(() => {
+    if (
+      fileSetAnnotation?.status === "error" &&
+      flashedAnnotationErrorIdRef.current !== fileSetAnnotation.id
+    ) {
+      const detail = fileSetAnnotation.error;
+      toastWrapper(
+        "is-danger",
+        detail
+          ? `Transcription failed: ${detail}`
+          : "Transcription failed. Please try again.",
+      );
+      flashedAnnotationErrorIdRef.current = fileSetAnnotation.id;
+    }
+  }, [fileSetAnnotation?.id, fileSetAnnotation?.status, fileSetAnnotation?.error]);
 
+  const runTranscribeMutation = () => {
     transcribeFileSet({
       variables: {
         fileSetId,
       },
-      onCompleted: () => {
-        toastWrapper("is-success", "Generating transcription");
+      onError: (error) => {
+        flashTranscriptionError(error);
       },
       refetchQueries: [
         {
@@ -57,6 +121,29 @@ function WorkTabsStructureTranscriptionWorkflow({
       ],
       awaitRefetchQueries: true,
     });
+  };
+
+  const handleStartTranscription = async () => {
+    if (!fileSetId) return;
+
+    toastWrapper("is-success", "Generating transcription");
+
+    if (failedAnnotationId) {
+      try {
+        await deleteFileSetAnnotation({
+          variables: { annotationId: failedAnnotationId },
+          refetchQueries: [
+            { query: GET_WORK, variables: { id: workId } },
+          ],
+          awaitRefetchQueries: true,
+        });
+      } catch (error) {
+        flashTranscriptionError(error);
+        return;
+      }
+    }
+
+    runTranscribeMutation();
   };
 
   if (workLoading) return null;
@@ -73,15 +160,17 @@ function WorkTabsStructureTranscriptionWorkflow({
         alignItems: "center",
       }}
     >
-      {!annotation ? (
-        <Button
-          isPrimary
-          isLowercase
-          onClick={handleStartTranscription}
-          style={{ gap: "0.5rem" }}
-        >
-          Generate Transcription
-        </Button>
+      {!annotation || annotationFailed ? (
+        <div>
+          <Button
+            isPrimary
+            isLowercase
+            onClick={handleStartTranscription}
+            style={{ gap: "0.5rem" }}
+          >
+            Generate Transcription
+          </Button>
+        </div>
       ) : (
         <WorkTabsStructureTranscriptionPane
           annotation={annotation}

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Workflow.test.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Workflow.test.jsx
@@ -26,6 +26,7 @@ jest.mock("@nulib/design-system", () => {
   const React = require("react");
   return {
     Button: ({ children, ...props }) => <button {...props}>{children}</button>,
+    Notification: ({ children, ...props }) => <div {...props}>{children}</div>,
   };
 });
 
@@ -164,6 +165,73 @@ describe("WorkTabsStructureTranscriptionWorkflow", () => {
 
     // Still no Pane yet (annotation will appear on a subsequent fetch)
     expect(screen.queryByTestId("transcription-pane")).not.toBeInTheDocument();
+  });
+
+  it("renders GraphQL errors from TRANSCRIBE_FILE_SET when transcription fails", async () => {
+    const details = { model: "is invalid" };
+    const workMocks = [
+      {
+        request: {
+          query: GET_WORK,
+          variables: { id: workId },
+        },
+        result: {
+          data: {
+            work: baseWork,
+          },
+        },
+      },
+      {
+        request: {
+          query: GET_WORK,
+          variables: { id: workId },
+        },
+        result: {
+          data: {
+            work: baseWork,
+          },
+        },
+      },
+      {
+        request: {
+          query: TRANSCRIBE_FILE_SET,
+          variables: { fileSetId },
+        },
+        result: {
+          data: {
+            transcribeFileSet: null,
+          },
+          errors: [
+            {
+              message: "Could not transcribe file_set",
+              details,
+              path: ["transcribeFileSet"],
+            },
+          ],
+        },
+      },
+    ];
+
+    renderWorkflow({ mocks: workMocks });
+
+    const button = await screen.findByRole("button", {
+      name: /generate transcription/i,
+    });
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(toastWrapper).toHaveBeenCalledWith(
+        "is-danger",
+        expect.stringMatching(/Could not transcribe file set.*Model:.*is invalid/i),
+      );
+    });
+    const toastMessage = toastWrapper.mock.calls.find(
+      ([type]) => type === "is-danger",
+    )?.[1];
+    expect(toastMessage).toBe(
+      "Could not transcribe file set — Model: is invalid",
+    );
   });
 
   it("renders Pane when an annotation already exists", async () => {

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/transcription.gql.js
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/transcription.gql.js
@@ -11,6 +11,7 @@ export const FILE_SET_ANNOTATION = gql`
       model
       s3Location
       status
+      error
       type
       updatedAt
     }

--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "license": "MIT",
       "dependencies": {
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",
@@ -13732,6 +13732,21 @@
         "object-assign": "^4.1.1"
       }
     },
+    "node_modules/chonky/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "dev": true,
@@ -22115,6 +22130,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/recharts/node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/recharts/node_modules/reselect": {
       "version": "5.1.1",

--- a/app/lib/meadow/data/file_sets.ex
+++ b/app/lib/meadow/data/file_sets.ex
@@ -15,6 +15,8 @@ defmodule Meadow.Data.FileSets do
   alias Meadow.Repo
   alias Meadow.Utils.Pairtree
 
+  require Logger
+
   @doc """
   Returns the list of FileSets.
 
@@ -292,11 +294,15 @@ defmodule Meadow.Data.FileSets do
   @doc """
   Get the pyramid path for a file set
   """
-  def pyramid_uri_for(%FileSet{role: %{id: "A"}, core_metadata: %{mime_type: "image/" <> _thing}} = file_set),
-    do: pyramid_uri_from_id(file_set.id)
+  def pyramid_uri_for(
+        %FileSet{role: %{id: "A"}, core_metadata: %{mime_type: "image/" <> _thing}} = file_set
+      ),
+      do: pyramid_uri_from_id(file_set.id)
 
-  def pyramid_uri_for(%FileSet{role: %{id: "X"}, core_metadata: %{mime_type: "image/" <> _thing}} = file_set),
-    do: pyramid_uri_from_id(file_set.id)
+  def pyramid_uri_for(
+        %FileSet{role: %{id: "X"}, core_metadata: %{mime_type: "image/" <> _thing}} = file_set
+      ),
+      do: pyramid_uri_from_id(file_set.id)
 
   def pyramid_uri_for(_), do: nil
 
@@ -505,7 +511,8 @@ defmodule Meadow.Data.FileSets do
       {:ok, "s3://bucket/path/to/file.txt"}
 
   """
-  def write_annotation_content(%FileSetAnnotation{} = annotation, content) when is_binary(content) do
+  def write_annotation_content(%FileSetAnnotation{} = annotation, content)
+      when is_binary(content) do
     location = annotation_location(annotation)
     %URI{host: bucket, path: "/" <> key} = URI.parse(location)
 
@@ -547,7 +554,8 @@ defmodule Meadow.Data.FileSets do
       {:ok, "This is the transcription text"}
 
   """
-  def read_annotation_content(%FileSetAnnotation{s3_location: location}) when is_binary(location) do
+  def read_annotation_content(%FileSetAnnotation{s3_location: location})
+      when is_binary(location) do
     %URI{host: bucket, path: "/" <> key} = URI.parse(location)
 
     case ExAws.S3.get_object(bucket, key) |> ExAws.request() do
@@ -584,7 +592,6 @@ defmodule Meadow.Data.FileSets do
   def transcribe_file_set(file_set_id, opts \\ []) when is_binary(file_set_id) do
     with {:ok, file_set} <- fetch_file_set_for_transcription(file_set_id),
          {:ok, annotation} <- create_pending_annotation(file_set, opts) do
-      # Kick off transcription in background
       Task.start(fn -> process_transcription(annotation, opts) end)
       {:ok, annotation}
     end
@@ -593,27 +600,94 @@ defmodule Meadow.Data.FileSets do
   defp process_transcription(annotation, opts) do
     {:ok, annotation} = update_annotation(annotation, %{status: "in_progress"})
 
-    case Transcriber.transcribe(annotation.file_set_id, opts) do
-      {:ok, transcription} ->
-        case write_annotation_content(annotation, transcription.text) do
-          {:ok, s3_location} ->
-            result = update_annotation(annotation, %{
-              status: "completed",
-              s3_location: s3_location,
-              language: transcription.languages
-            })
+    handle_transcription_result(
+      annotation,
+      transcriber().transcribe(annotation.file_set_id, opts)
+    )
+  end
 
-            add_transcription_note(annotation)
+  defp publish_annotation_error(annotation, reason) do
+    payload = %{annotation | status: "error", error: format_transcription_error(reason)}
 
-            result
+    Absinthe.Subscription.publish(MeadowWeb.Endpoint, payload,
+      file_set_annotation: annotation.file_set_id
+    )
+  end
 
-          {:error, _reason} ->
-            update_annotation(annotation, %{status: "error"})
-        end
+  defp format_transcription_error({:bedrock_stream_failed, %{message: msg}})
+       when is_binary(msg),
+       do: "Transcription service error: #{msg}"
 
-      {:error, _reason} ->
-        update_annotation(annotation, %{status: "error"})
+  defp format_transcription_error({:bedrock_stream_failed, error}),
+    do: "Transcription service error: #{inspect(error)}"
+
+  defp format_transcription_error({:image_fetch_failed, status, _body}),
+    do: "Could not fetch source image (HTTP #{status})"
+
+  defp format_transcription_error({:image_fetch_error, reason}),
+    do: "Could not fetch source image: #{inspect(reason)}"
+
+  defp format_transcription_error({:no_representative_image, _id}),
+    do: "No representative image available for transcription"
+
+  defp format_transcription_error({:invalid_transcriber_model, model}),
+    do: "Invalid transcriber model: #{inspect(model)}"
+
+  defp format_transcription_error({:file_set_not_found, _id}),
+    do: "File set not found"
+
+  defp format_transcription_error(:blank_transcription),
+    do: "The transcription service returned no text"
+
+  defp format_transcription_error(reason), do: inspect(reason)
+
+  # Resolved at runtime (not via compile_env) so Mox can swap the implementation per test.
+  defp transcriber do
+    Application.get_env(:meadow, :transcriber, Transcriber)
+  end
+
+  defp handle_transcription_result(annotation, {:ok, %{text: ""}}),
+    do: mark_blank_transcription_error(annotation)
+
+  defp handle_transcription_result(annotation, {:ok, %{text: nil}}),
+    do: mark_blank_transcription_error(annotation)
+
+  defp handle_transcription_result(annotation, {:ok, %{text: text} = transcription})
+       when is_binary(text) do
+    case write_annotation_content(annotation, transcription.text) do
+      {:ok, s3_location} ->
+        result =
+          update_annotation(annotation, %{
+            status: "completed",
+            s3_location: s3_location,
+            language: transcription.languages
+          })
+
+        add_transcription_note(annotation)
+
+        result
+
+      {:error, reason} ->
+        result = update_annotation(annotation, %{status: "error"})
+        publish_annotation_error(annotation, reason)
+        result
     end
+  end
+
+  defp handle_transcription_result(annotation, {:error, reason}) do
+    result = update_annotation(annotation, %{status: "error"})
+    publish_annotation_error(annotation, reason)
+    result
+  end
+
+  defp mark_blank_transcription_error(annotation) do
+    Logger.warning(
+      "Transcription for file set #{annotation.file_set_id} returned blank text; marking annotation as error"
+    )
+
+    result = update_annotation(annotation, %{status: "error"})
+    publish_annotation_error(annotation, :blank_transcription)
+    result
   end
 
   defp add_transcription_note(%{file_set_id: file_set_id, model: model}) do
@@ -621,10 +695,11 @@ defmodule Meadow.Data.FileSets do
       %FileSet{work: work, core_metadata: %{label: label}} when not is_nil(work) ->
         today = Date.utc_today() |> Date.to_iso8601()
 
-        note_text = case model do
-          nil -> "Transcription generated for #{label} by AI on #{today}"
-          model_id -> "Transcription generated for #{label} by AI (#{model_id}) on #{today}"
-        end
+        note_text =
+          case model do
+            nil -> "Transcription generated for #{label} by AI on #{today}"
+            model_id -> "Transcription generated for #{label} by AI (#{model_id}) on #{today}"
+          end
 
         new_note = %{
           note: note_text,
@@ -654,7 +729,7 @@ defmodule Meadow.Data.FileSets do
   defp fetch_file_set_for_transcription(file_set_id) do
     case Repo.get(FileSet, file_set_id) |> Repo.preload(work: []) do
       nil ->
-        {:error, :file_set_not_found}
+        {:error, {:file_set_not_found, file_set_id}}
 
       %FileSet{role: %{id: role_id}} when role_id != "A" ->
         {:error, :invalid_role}
@@ -699,17 +774,12 @@ defmodule Meadow.Data.FileSets do
 
   """
   def update_annotation_content(annotation_id, content, opts \\ %{}) when is_binary(content) do
-    case get_annotation(annotation_id) do
-      nil ->
-        {:error, :not_found}
-
-      annotation ->
-        update_attrs = %{s3_location: nil}
-        update_attrs = if opts[:language], do: Map.put(update_attrs, :language, opts[:language]), else: update_attrs
-
-        with {:ok, s3_location} <- write_annotation_content(annotation, content) do
-          update_annotation(annotation, Map.put(update_attrs, :s3_location, s3_location))
-        end
+    with %FileSetAnnotation{} = annotation <-
+           get_annotation(annotation_id) || {:error, :not_found},
+         {:ok, s3_location} <- write_annotation_content(annotation, content) do
+      opts = Enum.into(opts, %{})
+      attrs = Map.merge(%{s3_location: s3_location}, Map.take(opts, [:language]))
+      update_annotation(annotation, attrs)
     end
   end
 

--- a/app/lib/meadow/data/schemas/file_set_annotation.ex
+++ b/app/lib/meadow/data/schemas/file_set_annotation.ex
@@ -18,6 +18,7 @@ defmodule Meadow.Data.Schemas.FileSetAnnotation do
     field(:model, :string)
     field(:s3_location, :string)
     field(:status, :string)
+    field(:error, :string, virtual: true)
 
     belongs_to(:file_set, FileSet)
 

--- a/app/lib/meadow/data/transcriber.ex
+++ b/app/lib/meadow/data/transcriber.ex
@@ -3,6 +3,8 @@ defmodule Meadow.Data.Transcriber do
   Facilitates image transcription by invoking the configured AWS Bedrock model.
   """
 
+  @behaviour Meadow.Data.TranscriberBehaviour
+
   alias Meadow.Config
   alias Meadow.Data.FileSets
   alias Meadow.Data.Schemas.FileSet
@@ -32,8 +34,7 @@ defmodule Meadow.Data.Transcriber do
 
   Note: This function uses Bedrock's streaming API for better performance and real-time feedback.
   """
-  @spec transcribe(binary(), keyword()) ::
-          {:ok, %{text: binary(), raw: map(), streamed_chunks: list()}} | {:error, term()}
+  @impl Meadow.Data.TranscriberBehaviour
   def transcribe(file_set_id, opts \\ []) when is_binary(file_set_id) do
     previous_metadata = Logger.metadata()
     Logger.metadata(id: file_set_id)
@@ -293,11 +294,7 @@ defmodule Meadow.Data.Transcriber do
     end
   end
 
-  # ConverseStream final events (text extracted from chunks, not final payload)
-  defp extract_transcription_data(%{"messageStop" => _}), do: %{text: "", languages: []}
-  defp extract_transcription_data(%{"metadata" => _}), do: %{text: "", languages: []}
-  defp extract_transcription_data(%{"usage" => _}), do: %{text: "", languages: []}
-  defp extract_transcription_data(%{"metrics" => _}), do: %{text: "", languages: []}
+  # ConverseStream final events carry metadata only; text comes from chunk accumulation.
   defp extract_transcription_data(_), do: %{text: "", languages: []}
 
   defp extract_data_from_chunks(chunks) do

--- a/app/lib/meadow/data/transcriber_behaviour.ex
+++ b/app/lib/meadow/data/transcriber_behaviour.ex
@@ -1,0 +1,25 @@
+defmodule Meadow.Data.TranscriberBehaviour do
+  @moduledoc """
+  Contract for an AI transcription backend used by `Meadow.Data.FileSets`.
+
+  Implementations invoke a model (e.g. AWS Bedrock) and return the transcribed
+  text plus detected languages. Swapped at runtime via `:meadow, :transcriber`
+  so tests can supply a Mox mock.
+  """
+
+  @type t :: %{
+          text: String.t(),
+          languages: [String.t()],
+          raw: map(),
+          streamed_chunks: list()
+        }
+
+  @doc """
+  Transcribe the representative image for the given file set id.
+
+  Returns `{:ok, t:t/0}` on success, or `{:error, reason}` when the request
+  cannot be completed.
+  """
+  @callback transcribe(file_set_id :: String.t(), opts :: keyword()) ::
+              {:ok, t()} | {:error, term()}
+end

--- a/app/lib/meadow/utils/changeset_errors.ex
+++ b/app/lib/meadow/utils/changeset_errors.ex
@@ -22,6 +22,7 @@ defmodule Meadow.Utils.ChangesetErrors do
   defp format_value(%{edtf: value}), do: format_value(value)
   defp format_value(nil), do: nil
   defp format_value(""), do: ""
+  defp format_value([]), do: []
   defp format_value(value), do: inspect(value)
 
   defp format_error({404, _opts}), do: "is an unknown identifier"

--- a/app/lib/meadow_web/resolvers/data.ex
+++ b/app/lib/meadow_web/resolvers/data.ex
@@ -159,9 +159,21 @@ defmodule MeadowWeb.Resolvers.Data do
         {:error, message: "Transcription is only available for Image works"}
 
       {:error, reason} ->
-        {:error, message: "Could not transcribe file_set", details: inspect(reason)}
+        {
+          :error,
+          message: "Could not transcribe file_set",
+          details: transcribe_file_set_error_details(reason)
+        }
     end
   end
+
+  defp transcribe_file_set_error_details(%Ecto.Changeset{} = changeset),
+    do: ChangesetErrors.humanize_errors(changeset)
+
+  defp transcribe_file_set_error_details({:file_set_not_found, _file_set_id}),
+    do: %{"file_set" => "was not found"}
+
+  defp transcribe_file_set_error_details(reason), do: inspect(reason)
 
   def update_file_set_annotation(_, args, _) do
     opts = if args[:language], do: %{language: args[:language]}, else: %{}
@@ -174,7 +186,9 @@ defmodule MeadowWeb.Resolvers.Data do
         {:error, message: "Annotation not found"}
 
       {:error, %Ecto.Changeset{} = changeset} ->
-        {:error, message: "Could not update annotation", details: ChangesetErrors.humanize_errors(changeset)}
+        {:error,
+         message: "Could not update annotation",
+         details: ChangesetErrors.humanize_errors(changeset)}
 
       {:error, reason} ->
         {:error, message: "Could not update annotation", details: inspect(reason)}
@@ -192,7 +206,9 @@ defmodule MeadowWeb.Resolvers.Data do
             {:ok, annotation}
 
           {:error, %Ecto.Changeset{} = changeset} ->
-            {:error, message: "Could not delete annotation", details: ChangesetErrors.humanize_errors(changeset)}
+            {:error,
+             message: "Could not delete annotation",
+             details: ChangesetErrors.humanize_errors(changeset)}
 
           {:error, reason} ->
             {:error, message: "Could not delete annotation", details: inspect(reason)}

--- a/app/lib/meadow_web/schema/types/data/file_set_types.ex
+++ b/app/lib/meadow_web/schema/types/data/file_set_types.ex
@@ -238,6 +238,7 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
     field(:model, :string)
     field(:s3_location, :string)
     field(:status, non_null(:string))
+    field(:error, :string)
     field(:inserted_at, non_null(:datetime))
     field(:updated_at, non_null(:datetime))
 

--- a/app/test/gql/TranscribeFileSet.gql
+++ b/app/test/gql/TranscribeFileSet.gql
@@ -1,0 +1,6 @@
+mutation TranscribeFileSet($fileSetId: ID!) {
+  transcribeFileSet(fileSetId: $fileSetId) {
+    id
+    status
+  }
+}

--- a/app/test/meadow/data/file_set_annotations_test.exs
+++ b/app/test/meadow/data/file_set_annotations_test.exs
@@ -5,7 +5,11 @@ defmodule Meadow.Data.FileSetAnnotationsTest do
   alias Meadow.Data.FileSets
   alias Meadow.Data.Schemas.FileSetAnnotation
 
+  import Assertions
   import Meadow.TestHelpers
+  import Mox
+
+  @moduletag :capture_log
 
   describe "annotations" do
     setup do
@@ -20,45 +24,61 @@ defmodule Meadow.Data.FileSetAnnotationsTest do
         language: ["en"]
       }
 
-      assert {:ok, %FileSetAnnotation{} = annotation} = FileSets.create_annotation(file_set, attrs)
+      assert {:ok, %FileSetAnnotation{} = annotation} =
+               FileSets.create_annotation(file_set, attrs)
+
       assert annotation.file_set_id == file_set.id
       assert annotation.type == "transcription"
       assert annotation.status == "pending"
       assert annotation.language == ["en"]
     end
 
-    test "create_annotation/2 enforces unique constraint on file_set_id + type", %{file_set: file_set} do
+    test "create_annotation/2 enforces unique constraint on file_set_id + type", %{
+      file_set: file_set
+    } do
       attrs = %{type: "transcription", status: "pending"}
 
       assert {:ok, _annotation} = FileSets.create_annotation(file_set, attrs)
       assert {:error, changeset} = FileSets.create_annotation(file_set, attrs)
-      assert %{file_set_id: ["annotation of this type already exists for this file set"]} = errors_on(changeset)
+
+      assert %{file_set_id: ["annotation of this type already exists for this file set"]} =
+               errors_on(changeset)
     end
 
     test "list_annotations/1 returns all annotations for a file set", %{file_set: file_set} do
-      {:ok, _annotation1} = FileSets.create_annotation(file_set, %{type: "transcription", status: "pending"})
+      {:ok, _annotation1} =
+        FileSets.create_annotation(file_set, %{type: "transcription", status: "pending"})
 
       annotations = FileSets.list_annotations(file_set)
       assert length(annotations) == 1
     end
 
     test "update_annotation/2 updates an annotation", %{file_set: file_set} do
-      {:ok, annotation} = FileSets.create_annotation(file_set, %{type: "transcription", status: "pending"})
+      {:ok, annotation} =
+        FileSets.create_annotation(file_set, %{type: "transcription", status: "pending"})
 
-      assert {:ok, updated} = FileSets.update_annotation(annotation, %{status: "completed", language: ["lg", "en"]})
+      assert {:ok, updated} =
+               FileSets.update_annotation(annotation, %{
+                 status: "completed",
+                 language: ["lg", "en"]
+               })
+
       assert updated.status == "completed"
       assert updated.language == ["lg", "en"]
     end
 
     test "delete_annotation/1 deletes an annotation", %{file_set: file_set} do
-      {:ok, annotation} = FileSets.create_annotation(file_set, %{type: "transcription", status: "pending"})
+      {:ok, annotation} =
+        FileSets.create_annotation(file_set, %{type: "transcription", status: "pending"})
 
       assert {:ok, _deleted} = FileSets.delete_annotation(annotation)
       assert [] = FileSets.list_annotations(file_set)
     end
 
     test "write_annotation_content/2 writes content to S3", %{file_set: file_set} do
-      {:ok, annotation} = FileSets.create_annotation(file_set, %{type: "transcription", status: "pending"})
+      {:ok, annotation} =
+        FileSets.create_annotation(file_set, %{type: "transcription", status: "pending"})
+
       content = "This is the transcription text"
 
       assert {:ok, s3_location} = FileSets.write_annotation_content(annotation, content)
@@ -66,7 +86,9 @@ defmodule Meadow.Data.FileSetAnnotationsTest do
     end
 
     test "read_annotation_content/1 reads content from S3", %{file_set: file_set} do
-      {:ok, annotation} = FileSets.create_annotation(file_set, %{type: "transcription", status: "pending"})
+      {:ok, annotation} =
+        FileSets.create_annotation(file_set, %{type: "transcription", status: "pending"})
+
       content = "This is the transcription text"
 
       {:ok, s3_location} = FileSets.write_annotation_content(annotation, content)
@@ -76,16 +98,118 @@ defmodule Meadow.Data.FileSetAnnotationsTest do
       assert read_content == content
     end
 
-    test "update_annotation_content/3 updates both content and language", %{file_set: file_set} do
-      {:ok, annotation} = FileSets.create_annotation(file_set, %{type: "transcription", status: "completed", language: ["en"]})
+    test "update_annotation_content/3 accepts keyword opts", %{file_set: file_set} do
+      {:ok, annotation} =
+        FileSets.create_annotation(file_set, %{
+          type: "transcription",
+          status: "completed",
+          language: ["en"]
+        })
+
       {:ok, s3_location} = FileSets.write_annotation_content(annotation, "Original content")
       {:ok, annotation} = FileSets.update_annotation(annotation, %{s3_location: s3_location})
 
-      assert {:ok, updated} = FileSets.update_annotation_content(annotation.id, "Updated content", %{language: ["lg"]})
+      assert {:ok, updated} =
+               FileSets.update_annotation_content(annotation.id, "Updated content",
+                 language: ["lg"]
+               )
+
       assert updated.language == ["lg"]
 
       assert {:ok, content} = FileSets.read_annotation_content(updated)
       assert content == "Updated content"
     end
+
+    test "update_annotation_content/3 updates both content and language", %{file_set: file_set} do
+      {:ok, annotation} =
+        FileSets.create_annotation(file_set, %{
+          type: "transcription",
+          status: "completed",
+          language: ["en"]
+        })
+
+      {:ok, s3_location} = FileSets.write_annotation_content(annotation, "Original content")
+      {:ok, annotation} = FileSets.update_annotation(annotation, %{s3_location: s3_location})
+
+      assert {:ok, updated} =
+               FileSets.update_annotation_content(annotation.id, "Updated content", %{
+                 language: ["lg"]
+               })
+
+      assert updated.language == ["lg"]
+
+      assert {:ok, content} = FileSets.read_annotation_content(updated)
+      assert content == "Updated content"
+    end
+  end
+
+  describe "transcription" do
+    setup [:set_mox_from_context, :verify_on_exit!, :use_transcriber_mock]
+
+    setup do
+      file_set = file_set_fixture(role: %{id: "A", scheme: "FILE_SET_ROLE"})
+      {:ok, file_set: file_set}
+    end
+
+    test "transcribe_file_set/2 marks annotation as error when text is blank", %{
+      file_set: file_set
+    } do
+      expect(Meadow.Data.TranscriberMock, :transcribe, fn _id, _opts ->
+        {:ok, %{text: "", languages: ["en"], raw: %{}, streamed_chunks: []}}
+      end)
+
+      assert {:ok, %FileSetAnnotation{id: annotation_id, status: "pending"}} =
+               FileSets.transcribe_file_set(file_set.id, [])
+
+      assert_async(timeout: 2000, sleep_time: 100) do
+        assert %FileSetAnnotation{status: "error", s3_location: nil} =
+                 FileSets.get_annotation!(annotation_id)
+      end
+    end
+
+    test "transcribe_file_set/2 marks annotation as error when text is nil", %{
+      file_set: file_set
+    } do
+      expect(Meadow.Data.TranscriberMock, :transcribe, fn _id, _opts ->
+        {:ok, %{text: nil, languages: ["en"], raw: %{}, streamed_chunks: []}}
+      end)
+
+      assert {:ok, %FileSetAnnotation{id: annotation_id, status: "pending"}} =
+               FileSets.transcribe_file_set(file_set.id, [])
+
+      assert_async(timeout: 2000, sleep_time: 100) do
+        assert %FileSetAnnotation{status: "error", s3_location: nil} =
+                 FileSets.get_annotation!(annotation_id)
+      end
+    end
+
+    test "transcribe_file_set/2 marks annotation as error on transcriber error", %{
+      file_set: file_set
+    } do
+      expect(Meadow.Data.TranscriberMock, :transcribe, fn _id, _opts ->
+        {:error, :bedrock_stream_failed}
+      end)
+
+      assert {:ok, %FileSetAnnotation{id: annotation_id, status: "pending"}} =
+               FileSets.transcribe_file_set(file_set.id, [])
+
+      assert_async(timeout: 2000, sleep_time: 100) do
+        assert %FileSetAnnotation{status: "error"} = FileSets.get_annotation!(annotation_id)
+      end
+    end
+  end
+
+  defp use_transcriber_mock(_context) do
+    previous = Application.get_env(:meadow, :transcriber)
+    Application.put_env(:meadow, :transcriber, Meadow.Data.TranscriberMock)
+
+    on_exit(fn ->
+      case previous do
+        nil -> Application.delete_env(:meadow, :transcriber)
+        value -> Application.put_env(:meadow, :transcriber, value)
+      end
+    end)
+
+    :ok
   end
 end

--- a/app/test/meadow_web/schema/mutation/transcribe_file_set_test.exs
+++ b/app/test/meadow_web/schema/mutation/transcribe_file_set_test.exs
@@ -1,0 +1,35 @@
+defmodule MeadowWeb.Schema.Mutation.TranscribeFileSetTest do
+  use Meadow.DataCase
+  use MeadowWeb.ConnCase, async: false
+  use Wormwood.GQLCase
+
+  load_gql(MeadowWeb.Schema, "test/gql/TranscribeFileSet.gql")
+
+  test "returns human-readable changeset details when transcription cannot be created" do
+    original_ai_config = Application.get_env(:meadow, :ai, [])
+
+    on_exit(fn ->
+      Application.put_env(:meadow, :ai, original_ai_config)
+    end)
+
+    Application.put_env(:meadow, :ai, Keyword.put(original_ai_config, :transcriber_model, []))
+
+    work =
+      work_with_file_sets_fixture(1, %{work_type: %{id: "IMAGE", scheme: "work_type"}}, %{
+        role: %{id: "A", scheme: "FILE_SET_ROLE"}
+      })
+
+    file_set = List.first(work.file_sets)
+
+    result =
+      query_gql(
+        variables: %{"fileSetId" => file_set.id},
+        context: gql_context()
+      )
+
+    assert {:ok, %{data: %{"transcribeFileSet" => nil}, errors: [error]}} = result
+    assert error.message == "Could not transcribe file_set"
+    assert error.details == %{"model" => "is invalid"}
+    refute inspect(error.details) =~ "Ecto.Changeset"
+  end
+end

--- a/app/test/test_helper.exs
+++ b/app/test/test_helper.exs
@@ -31,24 +31,34 @@ if Meadow.Config.use_localstack?() do
   Mix.Task.run("meadow.buckets.create")
 end
 
-formatters = case System.get_env("MEADOW_TEST_TRACE") do
-  nil -> [ExUnit.CLIFormatter]
-  _ -> [TraceFormatter, ExUnit.CLIFormatter]
-end
+formatters =
+  case System.get_env("MEADOW_TEST_TRACE") do
+    nil -> [ExUnit.CLIFormatter]
+    _ -> [TraceFormatter, ExUnit.CLIFormatter]
+  end
 
-ExUnit.start(capture_log: true, exclude: [:skip, :validator, manual: true], formatters: formatters)
+ExUnit.start(
+  capture_log: true,
+  exclude: [:skip, :validator, manual: true],
+  formatters: formatters
+)
 
 Faker.start()
 Meadow.Directory.MockServer.prewarm()
 Ecto.Adapters.SQL.Sandbox.mode(Meadow.Repo, :manual)
 Authoritex.Mock.init()
+
+Mox.defmock(Meadow.Data.TranscriberMock, for: Meadow.Data.TranscriberBehaviour)
 System.delete_env("MEADOW_PROCESSES")
 
 ExUnit.after_suite(fn _ ->
   Meadow.S3Case.show_cleanup_warnings()
   Mix.Task.run("meadow.search.teardown")
+
   case System.get_env("MEADOW_TEST_SAVE_SEED") do
-    nil -> :ok
+    nil ->
+      :ok
+
     path ->
       File.write!(path, Integer.to_string(ExUnit.configuration()[:seed]))
   end


### PR DESCRIPTION
# Summary 

Refactors transcription error handling. Fixes https://github.com/nulib/repodev_planning_and_docs/issues/5781

<img width="1862" height="958" alt="SCR-20260427-migx" src="https://github.com/user-attachments/assets/ebdd595d-f22c-4dfb-915c-135985356a07" />

<img width="2346" height="1149" alt="SCR-20260427-lejm" src="https://github.com/user-attachments/assets/9cf6d7d4-d6ba-405a-a739-53e5cbba67b5" />

Hard refresh shows no annotation:
<img width="1156" height="674" alt="SCR-20260427-kvyr" src="https://github.com/user-attachments/assets/ba2dd57b-0173-4a60-8e0c-72c5d5872aa6" />


# Specific Changes in this PR
- list changes
- list changes

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
To force a Bedrock error, change `app/lib/meadow/data/transcriber.ex` (and `recompile()`):
```elixir
  defp invoke_with_stream(operation) do
    # ExAws.stream!(operation, service_override: :bedrock)
    # |> consume_stream()

    {:error, {:bedrock_stream_failed,
    %RuntimeError{message: "Service unavailable"}}}
  rescue
    error ->
      Logger.error("Streaming invocation failed: #{Exception.message(error)}")
      {:error, {:bedrock_stream_failed, error}}
  end
  ```

To force a config error, run `iex -S mix phx.server` and change the running config:
```elixir
old_ai = Application.get_env(:meadow, :ai, [])

Application.put_env(
  :meadow,
  :ai,
  Keyword.put(old_ai, :transcriber_model, :broken)
)

# Test out the generate transcription button in Meadow, should error now

# restore old config
# Application.put_env(:meadow, :ai, old_ai)
```



Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [x] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

