### PR TITLE
Update pyramid generator to include pages and tilesize in metadata

### DIFF
--- a/lambdas/pyramid-tiff/package.json
+++ b/lambdas/pyramid-tiff/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.987.0",
     "concat-stream": "^2.0.0",
-    "sharp": "^0.34.4",
-    "uri-js": "^4.4.1"
+    "sharp": "^0.34.4"
   }
 }

--- a/lambdas/pyramid-tiff/pyramid.js
+++ b/lambdas/pyramid-tiff/pyramid.js
@@ -1,14 +1,15 @@
 const { S3Client, GetObjectCommand, PutObjectCommand } = require("@aws-sdk/client-s3");
 const concat = require("concat-stream");
 const sharp = require("sharp");
-const URI = require("uri-js");
+
+const MAX_DIMENSION = 15000;
+const TILE_SIZE = 256;
 
 const createPyramidTiff = (source, dest) => {
   return new Promise((resolve, reject) => {
     console.log(`Creating pyramid from ${source}`);
     streamFromS3(source)
     .then((inputStream) => {
-      let metadata;
       const transformStream = sharp({
         limitInputPixels: false,
         sequentialRead: true,
@@ -16,8 +17,8 @@ const createPyramidTiff = (source, dest) => {
       })
       .removeAlpha()
       .resize({
-        width: 15000,
-        height: 15000,
+        width: MAX_DIMENSION,
+        height: MAX_DIMENSION,
         fit: "inside",
         withoutEnlargement: true
       })
@@ -26,54 +27,62 @@ const createPyramidTiff = (source, dest) => {
         compression: "jpeg",
         quality: 75,
         tile: true,
-        tileHeight: 256,
-        tileWidth: 256,
+        tileHeight: TILE_SIZE,
+        tileWidth: TILE_SIZE,
         pyramid: true
       })
-      .withMetadata()
-      .on("info", (info) => (metadata = info));
+      .withMetadata();
 
       const uploadStream = concat((data) => {
+        sharp(data)
+          .metadata()
+          .then((metadata) => {
+            uploadToS3(data, dest, metadata)
+              .then((result) => resolve(result));
+          });
         console.log(`Saving to ${dest}`);
-        uploadToS3(data, dest, metadata)
-          .then((result) => resolve(result))
-          .catch((err) => reject(err));
       });
 
       inputStream.pipe(transformStream).pipe(uploadStream);
-    })
-    .catch((err) => reject(err));
+    });
   });
 };
 
 const streamFromS3 = async (location) => {
-  const uri = URI.parse(location);
+  const s3Location = getS3Location(location);
   const s3Client = new S3Client(s3ClientOpts());
-  const cmd = new GetObjectCommand({ Bucket: uri.host, Key: getS3Key(uri) });
+  const cmd = new GetObjectCommand(s3Location);
   const { Body } = await s3Client.send(cmd);
   return Body;
 };
 
-const uploadToS3 = (data, location, { width, height }) => {
-  let uri = URI.parse(location);
+const uploadToS3 = (data, location, { width, height, pages }) => {
+  const s3Location = getS3Location(location);
   return new Promise((resolve, reject) => {
     const s3Client = new S3Client(s3ClientOpts());
     const cmd = new PutObjectCommand({
-      Bucket: uri.host,
-      Key: getS3Key(uri),
+      ...s3Location,
       Body: data,
-      Metadata: { width: width.toString(), height: height.toString() }
+      ContentType: "image/tiff",
+      Metadata: {
+        width: width.toString(),
+        height: height.toString(),
+        pages: pages.toString(),
+        tilesize: TILE_SIZE.toString()
+      }
     });
 
     s3Client
       .send(cmd)
-      .then((_data) => resolve(location))
-      .catch((err) => reject(err));
+      .then((_data) => resolve(location));
   });
 };
 
-const getS3Key = (uri) => {
-  return uri.path.replace(/^\/+/, "");
+const getS3Location = (location) => {
+  const uri = new URL(location);
+  const Bucket = uri.host;
+  const Key = uri.pathname.slice(1);
+  return { Bucket, Key };
 };
 
 const s3ClientOpts = () => {


### PR DESCRIPTION
# Summary 
Update pyramid generator to include pages and tilesize in metadata in preparation for serverless-iiif v8.x

# Specific Changes in this PR
- Write pyramids with width, height, pages, and tilesize
- Remove `uri-js` dependency in favor of built-in `URL` 

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

With `USE_SAM_LAMBDAS`, Ingest an access TIFF and then look at its pyramid derivative's metadata.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

