### PR TITLE
Increase Bedrock transcription timeouts

### DIFF
--- a/app/lib/meadow/config/runtime.ex
+++ b/app/lib/meadow/config/runtime.ex
@@ -26,6 +26,7 @@ defmodule Meadow.Config.Runtime do
       )
 
     Logger.info("Configuring authoritex")
+
     config :authoritex,
       connection_pool: Meadow.FinchPool,
       geonames_username: get_secret(:meadow, ["geonames", "username"])
@@ -95,7 +96,14 @@ defmodule Meadow.Config.Runtime do
       database: get_secret(:meadow, ["db", "database"], prefix("meadow")),
       port: get_secret(:meadow, ["db", "port"]),
       publication: "events",
-      subscriptions: ["works", "file_sets", "file_set_annotations", "collections", "ingest_sheets", "projects"],
+      subscriptions: [
+        "works",
+        "file_sets",
+        "file_set_annotations",
+        "collections",
+        "ingest_sheets",
+        "projects"
+      ],
       modules: [
         Meadow.Events.FileSets.Annotations,
         Meadow.Events.FileSets.Cleanup,
@@ -293,6 +301,7 @@ defmodule Meadow.Config.Runtime do
 
     config :meadow, :ai,
       metrics_log: log_configuration(),
+      transcriber_stream_timeout: 900_000,
       transcriber_model:
         get_secret(
           :meadow,
@@ -319,10 +328,10 @@ defmodule Meadow.Config.Runtime do
         digester: {:lambda, get_secret(:pipeline, ["digester"], "digester:$LATEST")},
         exif: {:lambda, get_secret(:pipeline, ["exif"], "exif:$LATEST")},
         frame_extractor:
-          {:lambda,
-           get_secret(:pipeline, ["frame_extractor"], "frame-extractor:$LATEST")},
+          {:lambda, get_secret(:pipeline, ["frame_extractor"], "frame-extractor:$LATEST")},
         mediainfo: {:lambda, get_secret(:pipeline, ["mediainfo"], "mediainfo:$LATEST")},
-        metadataAgent: {:lambda, get_secret(:pipeline, ["metadata_agent"], "metadata-agent:$LATEST")},
+        metadataAgent:
+          {:lambda, get_secret(:pipeline, ["metadata_agent"], "metadata-agent:$LATEST")},
         mime_type: {:lambda, get_secret(:pipeline, ["mime_type"], "mime-type:$LATEST")},
         tiff: {:lambda, get_secret(:pipeline, ["tiff"], "pyramid-tiff:$LATEST")}
     end

--- a/app/lib/meadow/data/file_sets.ex
+++ b/app/lib/meadow/data/file_sets.ex
@@ -850,7 +850,7 @@ defmodule Meadow.Data.FileSets do
   def update_annotation(%FileSetAnnotation{} = annotation, attrs) do
     annotation
     |> FileSetAnnotation.changeset(attrs)
-    |> Repo.update()
+    |> Repo.update(stale_error_field: :id)
   end
 
   @doc """

--- a/app/lib/meadow/utils/aws/bedrock_stream.ex
+++ b/app/lib/meadow/utils/aws/bedrock_stream.ex
@@ -8,11 +8,13 @@ defmodule Meadow.Utils.AWS.BedrockStream do
   """
 
   alias ExAws.Request.Url
+  alias Meadow.Config
 
   require Logger
 
   @content_type "application/vnd.amazon.eventstream"
-  @default_timeout 120_000
+  @default_timeout 900_000
+  @default_connect_timeout 30_000
 
   @uint32_size 4
   @checksum_size 4
@@ -38,12 +40,14 @@ defmodule Meadow.Utils.AWS.BedrockStream do
               message: "Failed to sign Bedrock streaming request: #{inspect(reason)}"
         end
 
+      timeout = stream_timeout()
+
       hackney_opts =
         Application.get_env(:ex_aws, :hackney_opts, [])
         |> Keyword.merge(
           async: :once,
-          recv_timeout: 120_000,
-          connect_timeout: 30_000,
+          recv_timeout: timeout,
+          connect_timeout: @default_connect_timeout,
           ssl_options: [verify: :verify_peer]
         )
 
@@ -59,13 +63,13 @@ defmodule Meadow.Utils.AWS.BedrockStream do
               message: "Failed to initiate Bedrock streaming request: #{inspect(reason)}"
         end
 
-      ref = await_status!(ref)
+      ref = await_status!(ref, timeout)
       :ok = :hackney.stream_next(ref)
-      ref = await_headers!(ref)
+      ref = await_headers!(ref, timeout)
 
       stream =
         Stream.resource(
-          fn -> {:streaming, ref} end,
+          fn -> {:streaming, ref, timeout} end,
           &next_chunk/1,
           &close_stream/1
         )
@@ -73,7 +77,7 @@ defmodule Meadow.Utils.AWS.BedrockStream do
       Stream.flat_map(stream, &decode_chunk/1)
     end
 
-    defp next_chunk({:streaming, ref}) do
+    defp next_chunk({:streaming, ref, timeout}) do
       :ok = :hackney.stream_next(ref)
 
       receive do
@@ -88,10 +92,11 @@ defmodule Meadow.Utils.AWS.BedrockStream do
           raise ExAws.Error, message: "Bedrock streaming error: #{inspect(reason)}"
 
         {:hackney_response, ^ref, data} ->
-          {[data], {:streaming, ref}}
+          {[data], {:streaming, ref, timeout}}
       after
-        @default_timeout ->
-          raise ExAws.Error, message: "Bedrock streaming timed out waiting for data"
+        timeout ->
+          raise ExAws.Error,
+            message: "Bedrock streaming timed out waiting for data after #{timeout}ms"
       end
     end
 
@@ -99,11 +104,11 @@ defmodule Meadow.Utils.AWS.BedrockStream do
       {:halt, {:closed, ref}}
     end
 
-    defp close_stream({:streaming, ref}), do: :hackney.stop_async(ref)
+    defp close_stream({:streaming, ref, _timeout}), do: :hackney.stop_async(ref)
     defp close_stream({:closed, ref}), do: :hackney.stop_async(ref)
     defp close_stream(_), do: :ok
 
-    defp await_status!(ref) do
+    defp await_status!(ref, timeout) do
       Logger.debug("Waiting for Bedrock streaming status")
 
       receive do
@@ -118,12 +123,13 @@ defmodule Meadow.Utils.AWS.BedrockStream do
         {:hackney_response, ^ref, {:error, reason}} ->
           raise ExAws.Error, message: "Bedrock streaming connection error: #{inspect(reason)}"
       after
-        @default_timeout ->
-          raise ExAws.Error, message: "Timed out waiting for Bedrock streaming status"
+        timeout ->
+          raise ExAws.Error,
+            message: "Timed out waiting for Bedrock streaming status after #{timeout}ms"
       end
     end
 
-    defp await_headers!(ref) do
+    defp await_headers!(ref, timeout) do
       Logger.debug("Waiting for Bedrock streaming headers")
 
       receive do
@@ -137,14 +143,13 @@ defmodule Meadow.Utils.AWS.BedrockStream do
 
         {:hackney_response, ^ref, other} ->
           Logger.debug("Unexpected message while waiting for headers: #{inspect(other)}")
-          await_headers!(ref)
+          await_headers!(ref, timeout)
       after
-        @default_timeout ->
-          Logger.error(
-            "Timed out waiting for Bedrock streaming headers after #{@default_timeout}ms"
-          )
+        timeout ->
+          Logger.error("Timed out waiting for Bedrock streaming headers after #{timeout}ms")
 
-          raise ExAws.Error, message: "Timed out waiting for Bedrock streaming headers"
+          raise ExAws.Error,
+            message: "Timed out waiting for Bedrock streaming headers after #{timeout}ms"
       end
     end
 
@@ -194,6 +199,22 @@ defmodule Meadow.Utils.AWS.BedrockStream do
     [hackney_agent, "meadow/#{meadow_version}", "bedrock-stream/0.1.0"]
     |> Enum.join(" ")
   end
+
+  defp stream_timeout do
+    Config.ai(:transcriber_stream_timeout, @default_timeout)
+    |> normalize_timeout()
+  end
+
+  defp normalize_timeout(timeout) when is_integer(timeout) and timeout > 0, do: timeout
+
+  defp normalize_timeout(timeout) when is_binary(timeout) do
+    case Integer.parse(timeout) do
+      {int, _} when int > 0 -> int
+      _ -> @default_timeout
+    end
+  end
+
+  defp normalize_timeout(_), do: @default_timeout
 
   @doc false
   @spec decode_chunk(binary()) ::
@@ -287,7 +308,7 @@ defmodule Meadow.Utils.AWS.BedrockStream do
       %{"bytes" => bytes} when is_binary(bytes) ->
         # Messages API: decode base64 then parse inner JSON
         with {:ok, json} <- Base.decode64(bytes),
-              {:ok, inner_payload} <- Jason.decode(json) do
+             {:ok, inner_payload} <- Jason.decode(json) do
           {:ok, inner_payload}
         else
           _ -> {:ok, payload}

--- a/app/test/meadow/data/file_set_annotations_test.exs
+++ b/app/test/meadow/data/file_set_annotations_test.exs
@@ -75,6 +75,20 @@ defmodule Meadow.Data.FileSetAnnotationsTest do
       assert [] = FileSets.list_annotations(file_set)
     end
 
+    test "update_annotation/2 returns a changeset error for stale annotations", %{
+      file_set: file_set
+    } do
+      {:ok, annotation} =
+        FileSets.create_annotation(file_set, %{type: "transcription", status: "pending"})
+
+      assert {:ok, _deleted} = FileSets.delete_annotation(annotation)
+
+      assert {:error, changeset} =
+               FileSets.update_annotation(annotation, %{status: "error"})
+
+      assert %{id: ["is stale"]} = errors_on(changeset)
+    end
+
     test "write_annotation_content/2 writes content to S3", %{file_set: file_set} do
       {:ok, annotation} =
         FileSets.create_annotation(file_set, %{type: "transcription", status: "pending"})


### PR DESCRIPTION
# Summary 
Fixes Bedrock transcription stream timeout handling so long-running transcription responses do not fail too early.

Downloaded and tested https://dc.library.northwestern.edu/items/fc7f8c32-6743-4218-ac39-dc1c4ac08d30:
<img width="2374" height="1976" alt="news_transcription" src="https://github.com/user-attachments/assets/0cf5f5d1-b8e3-4114-b590-5a39474a4ba1" />

# Specific Changes in this PR
- Adds a Meadow runtime config default for `transcriber_stream_timeout`.
- Updates Bedrock streaming to read the timeout through `Meadow.Config.ai/2`.
- Adds/fixes test coverage for Bedrock transcription timeout behavior.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

