### PR TITLE
Add work title to file set index

### DIFF
--- a/app/lib/meadow/events/indexing.ex
+++ b/app/lib/meadow/events/indexing.ex
@@ -68,7 +68,8 @@ defmodule Meadow.Events.Indexing do
       IndexBatcher.reindex([collection_id], :collections)
     end
 
-    if Map.keys(changes) |> Enum.any?(&(&1 in @cascade_fields[:works_file_sets])) do
+    if Map.keys(changes) |> Enum.any?(&(&1 in @cascade_fields[:works_file_sets])) or
+         work_title_changed?(changes) do
       from(fs in FileSet, where: fs.work_id == ^id)
       |> send_to_batcher(:file_sets)
     end
@@ -131,6 +132,13 @@ defmodule Meadow.Events.Indexing do
   defp do_delete_indexing(_, _) do
     :noop
   end
+
+  defp work_title_changed?(%{descriptive_metadata: %{old_value: old, new_value: new}})
+       when is_map(old) and is_map(new) do
+    Map.get(old, "title") != Map.get(new, "title")
+  end
+
+  defp work_title_changed?(_), do: false
 
   defp send_to_batcher(queryable, schema) do
     query = queryable |> select([q], q.id)

--- a/app/lib/meadow/indexing/v2/file_set.ex
+++ b/app/lib/meadow/indexing/v2/file_set.ex
@@ -32,7 +32,8 @@ defmodule Meadow.Indexing.V2.FileSet do
       role: file_set.role.label,
       streaming_url: FileSets.distribution_streaming_uri_for(file_set),
       visibility: file_set.work.visibility.label,
-      work_id: file_set.work_id
+      work_id: file_set.work_id,
+      work_title: file_set.work.descriptive_metadata.title
     }
     |> Meadow.Utils.Map.nillify_empty()
   end


### PR DESCRIPTION
# Summary 

Indexing work title on the file set will allow us to better identify the work when searching transcription content 


# Specific Changes in this PR

- Adds `work_title` to file set index
- Make sure file set reindex will be triggered on parent work title update

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test


<img width="739" height="650" alt="Screenshot 2026-05-01 at 7 16 14 AM" src="https://github.com/user-attachments/assets/aa717f29-5927-4d02-a695-7c7cc19f9125" />

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [x] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

