### PR TITLE
Add collection to file set index

### DIFF
--- a/app/lib/meadow/data/schemas/file_set.ex
+++ b/app/lib/meadow/data/schemas/file_set.ex
@@ -99,7 +99,7 @@ defmodule Meadow.Data.Schemas.FileSet do
     end
   end
 
-  def required_index_preloads, do: [:work]
+  def required_index_preloads, do: [work: :collection]
 
   defp rename_core_metadata(%{metadata: _, core_metadata: _} = params) do
     Logger.warning("Parameter map has both :metadata and :core_metadata. Ignoring :metadata.")

--- a/app/lib/meadow/indexing/v2/file_set.ex
+++ b/app/lib/meadow/indexing/v2/file_set.ex
@@ -13,6 +13,7 @@ defmodule Meadow.Indexing.V2.FileSet do
       annotations: encode_annotations(file_set),
       api_link: Path.join([api_url(), "file-sets", file_set.id]),
       api_model: "FileSet",
+      collection: collection(file_set.work.collection),
       create_date: file_set.inserted_at,
       digests: file_set.core_metadata.digests,
       description: file_set.core_metadata.description,
@@ -63,6 +64,9 @@ defmodule Meadow.Indexing.V2.FileSet do
       annotations -> annotations
     end
   end
+
+  def collection(%{id: id, title: title}), do: %{id: id, title: title}
+  def collection(_), do: %{}
 
   def api_url, do: Application.get_env(:meadow, :dc_api) |> get_in([:v2, "base_url"])
 

--- a/app/priv/search/v2/settings/file_set.json
+++ b/app/priv/search/v2/settings/file_set.json
@@ -56,6 +56,24 @@
         }
       },
       {
+        "collection_title": {
+          "path_match": "^collection.title$|^work_title$",
+          "match_pattern": "regex",
+          "mapping": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            },
+            "analyzer": "full_analyzer",
+            "search_analyzer": "stopword_analyzer",
+            "search_quote_analyzer": "full_analyzer"
+          }
+        }
+      },
+      {
         "annotation_content": {
           "path_match": "annotations.content",
           "mapping": {


### PR DESCRIPTION
# Summary 

Adds collection title and id to the file set index so that we can provide more context for transcription search results.

# Specific Changes in this PR

`app/lib/meadow/data/schemas/file_set.ex `                                                               
  - `required_index_preloads` updated from `[:work]` to `[work: :collection]` so the collection is preloaded   
  through the work association.                                                                          
                                                                                                         
 ` app/lib/meadow/indexing/v2/file_set.ex`                                                          
  - Added `collection: collection(file_set.work.collection)` to the encode map (accessed via `file_set.work.collection` since there's no direct association).                                         
  - Added `collection/1` helper function to limit collection fields to only id and  title (no description).                                                                                
                                                                                                         
`  app/priv/search/v2/settings/file_set.json`
  - Added a `collection_title` dynamic template mapping `collection.title` as text+keyword. The `collection.id` field is handled automatically by the existing catch-all strings template, which maps any string as keyword.
- Did the same for `work_title` as that mapping had previously been overlooked

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Start up meadow and reindex all
- Verify that collection id and title are present in a file set document

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [x] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

