### PR TITLE
Reindex file sets when collection title changes

### DIFF
--- a/app/lib/meadow/events/indexing.ex
+++ b/app/lib/meadow/events/indexing.ex
@@ -15,6 +15,7 @@ defmodule Meadow.Events.Indexing do
   @cascade_fields %{
     file_sets_works:
       ~w[core_metadata derivatives extracted_metadata group_with poster_offset rank role structural_metadata]a,
+    collections_file_sets: ~w[title]a,
     collections_works: ~w[title description]a,
     ingest_sheets_works: ~w[title]a,
     works_collections: ~w[representative_file_set_id]a,
@@ -58,6 +59,11 @@ defmodule Meadow.Events.Indexing do
     if Map.keys(changes) |> Enum.any?(&(&1 in @cascade_fields[:collections_works])) do
       from(w in Work, where: w.collection_id == ^id)
       |> send_to_batcher(:works)
+    end
+
+    if Map.keys(changes) |> Enum.any?(&(&1 in @cascade_fields[:collections_file_sets])) do
+      from(fs in FileSet, join: w in Work, on: fs.work_id == w.id, where: w.collection_id == ^id)
+      |> send_to_batcher(:file_sets)
     end
   end
 


### PR DESCRIPTION
# Summary 

Reindex child file sets when collection title changes

# Specific Changes in this PR
- Added `collections_file_sets: ~w[title]a` to `@cascade_fields` 
- Extended `do_update_indexing/3` for `:collections` to also reindex all file sets belonging to works in that collection when the title changes, using a join query through Work (since there's no direct       
  collection → file set association).       

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Change a collection title
- Verify that file set index is updated with new title 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

