### PR TITLE
Reindex transcription annotation after edit

### DIFF
--- a/app/lib/meadow/data/file_sets.ex
+++ b/app/lib/meadow/data/file_sets.ex
@@ -779,7 +779,11 @@ defmodule Meadow.Data.FileSets do
          {:ok, s3_location} <- write_annotation_content(annotation, content) do
       opts = Enum.into(opts, %{})
       attrs = Map.merge(%{s3_location: s3_location}, Map.take(opts, [:language]))
-      update_annotation(annotation, attrs)
+
+      annotation
+      |> FileSetAnnotation.changeset(attrs)
+      |> Ecto.Changeset.force_change(:s3_location, s3_location)
+      |> Repo.update(stale_error_field: :id)
     end
   end
 


### PR DESCRIPTION
# Summary 

Fix bug where transcriptions were not reindexing after editing.

partially fixes https://github.com/nulib/repodev_planning_and_docs/issues/5821

# Specific Changes in this PR

- Bypass`update_annotation/2` directly here since we need the extra `force_change` step

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Generate a transcription in Meadow
- Edit the transcription and save
- Verify the index is updated (you can just check for the updated annotation in Clover)

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

