### PR TITLE
Move transcription annotations from S3 to postgres

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,8 @@
       "Bash(grep:*)",
       "Bash(node -e:*)",
       "Bash(cd:*)",
-      "Bash(npx jest:*)"
+      "Bash(npx jest:*)",
+      "Bash(make app-test *)"
     ],
     "deny": [],
     "ask": []

--- a/app/lib/meadow/data/file_sets.ex
+++ b/app/lib/meadow/data/file_sets.ex
@@ -479,92 +479,49 @@ defmodule Meadow.Data.FileSets do
   def supplemental?(_), do: false
 
   @doc """
-  Get the S3 location for an annotation file.
-
-  ## Examples
-
-      iex> annotation_location(%FileSetAnnotation{id: "123", file_set_id: "456", type: "transcription"})
-      "s3://bucket-name/annotations/45/6-/transcription-123.txt"
-
-  """
-  def annotation_location(%FileSetAnnotation{id: id, file_set_id: file_set_id, type: type}) do
-    dest_bucket = Config.derivatives_bucket()
-    dest_key = annotation_key(file_set_id, id, type)
-    %URI{scheme: "s3", host: dest_bucket, path: "/#{dest_key}"} |> URI.to_string()
-  end
-
-  @doc """
-  Get the S3 key (path) for an annotation file.
-  """
-  def annotation_key(file_set_id, annotation_id, type) do
-    # Using pairtree for file_set_id to avoid too many files in one directory
-    pairtree = Pairtree.generate!(file_set_id)
-    "annotations/#{pairtree}/#{type}-#{annotation_id}.txt"
-  end
-
-  @doc """
-  Write annotation content to S3.
+  Write annotation content to the database.
 
   ## Examples
 
       iex> write_annotation_content(%FileSetAnnotation{}, "This is the transcription text")
-      {:ok, "s3://bucket/path/to/file.txt"}
+      {:ok, %FileSetAnnotation{}}
 
   """
   def write_annotation_content(%FileSetAnnotation{} = annotation, content)
       when is_binary(content) do
-    location = annotation_location(annotation)
-    %URI{host: bucket, path: "/" <> key} = URI.parse(location)
-
-    case ExAws.S3.put_object(bucket, key, content, content_type: "text/plain; charset=utf-8")
-         |> ExAws.request() do
-      {:ok, _} -> {:ok, location}
-      {:error, reason} -> {:error, reason}
-    end
+    update_annotation(annotation, %{content: content})
   end
 
   @doc """
-  Copy annotation content from a source S3 location to the annotation's destination.
+  Copy annotation content from a source S3 location into the database.
 
   ## Examples
 
       iex> copy_annotation_content(%FileSetAnnotation{}, "source-bucket", "path/to/source.txt")
-      {:ok, "s3://dest-bucket/path/to/annotation.txt"}
+      {:ok, %FileSetAnnotation{}}
 
   """
   def copy_annotation_content(%FileSetAnnotation{} = annotation, source_bucket, source_key) do
-    location = annotation_location(annotation)
-    %URI{host: dest_bucket, path: "/" <> dest_key} = URI.parse(location)
-
-    case ExAws.S3.put_object_copy(dest_bucket, dest_key, source_bucket, source_key,
-           content_type: "text/plain; charset=utf-8"
-         )
-         |> ExAws.request() do
-      {:ok, _} -> {:ok, location}
+    case ExAws.S3.get_object(source_bucket, source_key) |> ExAws.request() do
+      {:ok, %{body: body}} -> write_annotation_content(annotation, body)
       {:error, reason} -> {:error, reason}
     end
   end
 
   @doc """
-  Read annotation content from S3.
+  Read annotation content from the database.
 
   ## Examples
 
-      iex> read_annotation_content(%FileSetAnnotation{s3_location: "s3://..."})
+      iex> read_annotation_content(%FileSetAnnotation{content: "This is the transcription text"})
       {:ok, "This is the transcription text"}
 
   """
-  def read_annotation_content(%FileSetAnnotation{s3_location: location})
-      when is_binary(location) do
-    %URI{host: bucket, path: "/" <> key} = URI.parse(location)
+  def read_annotation_content(%FileSetAnnotation{content: content})
+      when is_binary(content),
+      do: {:ok, content}
 
-    case ExAws.S3.get_object(bucket, key) |> ExAws.request() do
-      {:ok, %{body: body}} -> {:ok, body}
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  def read_annotation_content(_), do: {:error, :no_s3_location}
+  def read_annotation_content(_), do: {:error, :no_content}
 
   @doc """
   Transcribes a file set using AI and stores the result as an annotation.
@@ -654,24 +611,15 @@ defmodule Meadow.Data.FileSets do
 
   defp handle_transcription_result(annotation, {:ok, %{text: text} = transcription})
        when is_binary(text) do
-    case write_annotation_content(annotation, transcription.text) do
-      {:ok, s3_location} ->
-        result =
-          update_annotation(annotation, %{
-            status: "completed",
-            s3_location: s3_location,
-            language: transcription.languages
-          })
+    result =
+      update_annotation(annotation, %{
+        status: "completed",
+        content: transcription.text,
+        language: transcription.languages
+      })
 
-        add_transcription_note(annotation)
-
-        result
-
-      {:error, reason} ->
-        result = update_annotation(annotation, %{status: "error"})
-        publish_annotation_error(annotation, reason)
-        result
-    end
+    add_transcription_note(annotation)
+    result
   end
 
   defp handle_transcription_result(annotation, {:error, reason}) do
@@ -775,15 +723,10 @@ defmodule Meadow.Data.FileSets do
   """
   def update_annotation_content(annotation_id, content, opts \\ %{}) when is_binary(content) do
     with %FileSetAnnotation{} = annotation <-
-           get_annotation(annotation_id) || {:error, :not_found},
-         {:ok, s3_location} <- write_annotation_content(annotation, content) do
+           get_annotation(annotation_id) || {:error, :not_found} do
       opts = Enum.into(opts, %{})
-      attrs = Map.merge(%{s3_location: s3_location}, Map.take(opts, [:language]))
-
-      annotation
-      |> FileSetAnnotation.changeset(attrs)
-      |> Ecto.Changeset.force_change(:s3_location, s3_location)
-      |> Repo.update(stale_error_field: :id)
+      attrs = Map.merge(%{content: content}, Map.take(opts, [:language]))
+      update_annotation(annotation, attrs)
     end
   end
 

--- a/app/lib/meadow/data/indexer.ex
+++ b/app/lib/meadow/data/indexer.ex
@@ -5,7 +5,7 @@ defmodule Meadow.Data.Indexer do
   use Meadow.Utils.Logging
 
   alias Meadow.Data.{Collections, Works}
-  alias Meadow.Data.Schemas.{Collection, FileSet, Work}
+  alias Meadow.Data.Schemas.{Collection, FileSet, FileSetAnnotation, Work}
   alias Meadow.Repo
   alias Meadow.Search.Bulk
   alias Meadow.Search.Client, as: SearchClient
@@ -60,6 +60,7 @@ defmodule Meadow.Data.Indexer do
     SearchClient.hot_swap(schema, version, fn index ->
       synchronize_schema(schema, version, index, :all)
       |> check_synchronize_result(schema, index)
+      |> tap(&check_annotation_coverage(&1, schema, index))
       |> clean(schema, version)
     end)
   end
@@ -85,6 +86,32 @@ defmodule Meadow.Data.Indexer do
   end
 
   def check_synchronize_result(other, _, _), do: other
+
+  defp check_annotation_coverage(:ok, FileSet, index) do
+    db_count =
+      from(a in FileSetAnnotation,
+        where: a.status == "completed",
+        select: count(a.file_set_id, :distinct)
+      )
+      |> Repo.one()
+
+    case SearchClient.indexed_doc_count(index, %{query: %{exists: %{field: "annotations"}}}) do
+      {:ok, indexed_count} when indexed_count < db_count ->
+        Logger.warning(
+          "Annotation coverage: #{indexed_count}/#{db_count} file sets indexed with annotations"
+        )
+
+      {:ok, indexed_count} ->
+        Logger.info(
+          "Annotation coverage: #{indexed_count}/#{db_count} file sets indexed with annotations"
+        )
+
+      {:error, reason} ->
+        Logger.warning("Annotation coverage check failed: #{inspect(reason)}")
+    end
+  end
+
+  defp check_annotation_coverage(_, _, _), do: :ok
 
   defp clean(:ok, schema, version) do
     retain =

--- a/app/lib/meadow/data/schemas/file_set_annotation.ex
+++ b/app/lib/meadow/data/schemas/file_set_annotation.ex
@@ -17,6 +17,7 @@ defmodule Meadow.Data.Schemas.FileSetAnnotation do
     field(:language, {:array, :string})
     field(:model, :string)
     field(:s3_location, :string)
+    field(:content, :string)
     field(:status, :string)
     field(:error, :string, virtual: true)
 
@@ -27,7 +28,7 @@ defmodule Meadow.Data.Schemas.FileSetAnnotation do
 
   def changeset(annotation \\ %__MODULE__{}, attrs) do
     annotation
-    |> cast(attrs, [:file_set_id, :type, :language, :model, :s3_location, :status])
+    |> cast(attrs, [:file_set_id, :type, :language, :model, :s3_location, :content, :status])
     |> validate_required([:file_set_id, :type, :status])
     |> validate_inclusion(:status, @status)
     |> assoc_constraint(:file_set)

--- a/app/lib/meadow/indexing/v2/file_set.ex
+++ b/app/lib/meadow/indexing/v2/file_set.ex
@@ -40,23 +40,15 @@ defmodule Meadow.Indexing.V2.FileSet do
   end
 
   defp encode_annotations(file_set) do
-    annotations = FileSets.list_annotations(file_set.id)
-
-    annotations
+    FileSets.list_annotations(file_set.id)
     |> Enum.filter(&(&1.status == "completed"))
     |> Enum.map(fn annotation ->
-      content =
-        case FileSets.read_annotation_content(annotation) do
-          {:ok, content} -> content
-          _ -> nil
-        end
-
       %{
         id: annotation.id,
         type: annotation.type,
         language: annotation.language,
         model: annotation.model,
-        content: content
+        content: annotation.content
       }
     end)
     |> case do

--- a/app/lib/meadow/pipeline/actions/attach_transcription.ex
+++ b/app/lib/meadow/pipeline/actions/attach_transcription.ex
@@ -43,13 +43,14 @@ defmodule Meadow.Pipeline.Actions.AttachTranscription do
              language: ["en"]
            }) do
       case FileSets.copy_annotation_content(annotation, bucket, key) do
-        {:ok, s3_location} ->
-          FileSets.update_annotation(annotation, %{s3_location: s3_location})
+        {:ok, annotation} ->
+          {:ok, annotation}
+
         {:error, reason} ->
           Logger.error("Failed to copy transcription content: #{inspect(reason)}")
           FileSets.delete_annotation(annotation)
           {:error, reason}
-        end
+      end
     else
       {:error, %Ecto.Changeset{} = changeset} ->
         Logger.error("Failed to create annotation: #{inspect(changeset.errors)}")

--- a/app/lib/meadow/search/client.ex
+++ b/app/lib/meadow/search/client.ex
@@ -124,11 +124,19 @@ defmodule Meadow.Search.Client do
     )
   end
 
-  def indexed_doc_count(schema, version),
+  def indexed_doc_count(schema, version) when is_atom(schema),
     do: indexed_doc_count(SearchConfig.alias_for(schema, version))
 
   def indexed_doc_count(target) do
     case HTTP.get([target, "_count"]) do
+      {:ok, %{body: %{"count" => count}}} -> {:ok, count}
+      {:ok, %{body: %{"error" => %{"reason" => reason}}}} -> {:error, reason}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  def indexed_doc_count(target, query) do
+    case HTTP.post([target, "_count"], query) do
       {:ok, %{body: %{"count" => count}}} -> {:ok, count}
       {:ok, %{body: %{"error" => %{"reason" => reason}}}} -> {:error, reason}
       {:error, reason} -> {:error, reason}

--- a/app/lib/meadow_web/schema/types/data/file_set_types.ex
+++ b/app/lib/meadow_web/schema/types/data/file_set_types.ex
@@ -242,14 +242,6 @@ defmodule MeadowWeb.Schema.Data.FileSetTypes do
     field(:inserted_at, non_null(:datetime))
     field(:updated_at, non_null(:datetime))
 
-    field :content, :string do
-      resolve(fn annotation, _, _ ->
-        case FileSets.read_annotation_content(annotation) do
-          {:ok, content} -> {:ok, content}
-          {:error, :no_s3_location} -> {:ok, nil}
-          {:error, _reason} -> {:ok, nil}
-        end
-      end)
-    end
+    field :content, :string
   end
 end

--- a/app/lib/mix/tasks/meadow.ex
+++ b/app/lib/mix/tasks/meadow.ex
@@ -64,6 +64,76 @@ defmodule Mix.Tasks.Meadow.Processes do
   end
 end
 
+defmodule Mix.Tasks.Meadow.BackfillAnnotationContent do
+  @moduledoc """
+  Backfill annotation content from S3 into the database content column.
+
+  Reads all completed file_set_annotations that have an s3_location but no content,
+  fetches the content from S3, and writes it to the content column.
+
+  Run this after deploying the add_content_to_file_set_annotations migration
+  and before deploying the code that removes s3_location.
+  """
+  use Mix.Task
+
+  alias Meadow.Data.FileSets
+  alias Meadow.Data.Schemas.FileSetAnnotation
+  alias Meadow.Repo
+
+  import Ecto.Query
+
+  @shortdoc "Backfill annotation content from S3 to DB"
+
+  def run(_) do
+    System.put_env("MEADOW_PROCESSES", "none")
+    Mix.Task.run("app.start")
+
+    annotations =
+      from(a in FileSetAnnotation,
+        where: a.status == "completed" and not is_nil(a.s3_location) and is_nil(a.content)
+      )
+      |> Repo.all()
+
+    total = length(annotations)
+    Mix.shell().info("Backfilling #{total} annotations...")
+
+    {ok, err} =
+      annotations
+      |> Enum.with_index(1)
+      |> Enum.reduce({0, 0}, fn {annotation, i}, {ok, err} ->
+        case fetch_and_store(annotation) do
+          :ok ->
+            Mix.shell().info("[#{i}/#{total}] #{annotation.id} ok")
+            {ok + 1, err}
+
+          {:error, reason} ->
+            Mix.shell().error("[#{i}/#{total}] #{annotation.id} failed: #{inspect(reason)}")
+            {ok, err + 1}
+        end
+      end)
+
+    Mix.shell().info("Done. #{ok} succeeded, #{err} failed.")
+
+    if err > 0,
+      do: Mix.shell().error("Re-run to retry failed annotations.")
+  end
+
+  defp fetch_and_store(%FileSetAnnotation{s3_location: s3_location} = annotation) do
+    %URI{host: bucket, path: "/" <> key} = URI.parse(s3_location)
+
+    case ExAws.S3.get_object(bucket, key) |> ExAws.request() do
+      {:ok, %{body: body}} ->
+        case FileSets.update_annotation(annotation, %{content: body}) do
+          {:ok, _} -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+end
+
 defmodule Mix.Tasks.Meadow.InitializeDerivatives do
   @moduledoc """
   Initialize derivatives map for existing image file sets

--- a/app/priv/repo/migrations/20260508120000_add_content_to_file_set_annotations.exs
+++ b/app/priv/repo/migrations/20260508120000_add_content_to_file_set_annotations.exs
@@ -1,0 +1,24 @@
+defmodule Meadow.Repo.Migrations.AddContentToFileSetAnnotations do
+  use Ecto.Migration
+
+  def up do
+    execute("CREATE EXTENSION IF NOT EXISTS pg_trgm", "")
+
+    alter table(:file_set_annotations) do
+      add :content, :text
+    end
+
+    execute(
+      "CREATE INDEX file_set_annotations_content_trgm_idx ON file_set_annotations USING gin (content gin_trgm_ops)",
+      "DROP INDEX IF EXISTS file_set_annotations_content_trgm_idx"
+    )
+  end
+
+  def down do
+    execute("DROP INDEX IF EXISTS file_set_annotations_content_trgm_idx", "")
+
+    alter table(:file_set_annotations) do
+      remove :content
+    end
+  end
+end

--- a/app/test/meadow/data/file_set_annotations_test.exs
+++ b/app/test/meadow/data/file_set_annotations_test.exs
@@ -89,26 +89,25 @@ defmodule Meadow.Data.FileSetAnnotationsTest do
       assert %{id: ["is stale"]} = errors_on(changeset)
     end
 
-    test "write_annotation_content/2 writes content to S3", %{file_set: file_set} do
+    test "write_annotation_content/2 writes content to DB", %{file_set: file_set} do
       {:ok, annotation} =
         FileSets.create_annotation(file_set, %{type: "transcription", status: "pending"})
 
       content = "This is the transcription text"
 
-      assert {:ok, s3_location} = FileSets.write_annotation_content(annotation, content)
-      assert String.starts_with?(s3_location, "s3://")
+      assert {:ok, updated} = FileSets.write_annotation_content(annotation, content)
+      assert updated.content == content
     end
 
-    test "read_annotation_content/1 reads content from S3", %{file_set: file_set} do
+    test "read_annotation_content/1 reads content from DB", %{file_set: file_set} do
       {:ok, annotation} =
         FileSets.create_annotation(file_set, %{type: "transcription", status: "pending"})
 
       content = "This is the transcription text"
 
-      {:ok, s3_location} = FileSets.write_annotation_content(annotation, content)
-      {:ok, annotation} = FileSets.update_annotation(annotation, %{s3_location: s3_location})
+      {:ok, updated} = FileSets.write_annotation_content(annotation, content)
 
-      assert {:ok, read_content} = FileSets.read_annotation_content(annotation)
+      assert {:ok, read_content} = FileSets.read_annotation_content(updated)
       assert read_content == content
     end
 
@@ -120,8 +119,7 @@ defmodule Meadow.Data.FileSetAnnotationsTest do
           language: ["en"]
         })
 
-      {:ok, s3_location} = FileSets.write_annotation_content(annotation, "Original content")
-      {:ok, annotation} = FileSets.update_annotation(annotation, %{s3_location: s3_location})
+      {:ok, annotation} = FileSets.write_annotation_content(annotation, "Original content")
 
       assert {:ok, updated} =
                FileSets.update_annotation_content(annotation.id, "Updated content",
@@ -142,8 +140,7 @@ defmodule Meadow.Data.FileSetAnnotationsTest do
           language: ["en"]
         })
 
-      {:ok, s3_location} = FileSets.write_annotation_content(annotation, "Original content")
-      {:ok, annotation} = FileSets.update_annotation(annotation, %{s3_location: s3_location})
+      {:ok, annotation} = FileSets.write_annotation_content(annotation, "Original content")
 
       assert {:ok, updated} =
                FileSets.update_annotation_content(annotation.id, "Updated content", %{

--- a/app/test/meadow/events/file_sets/annotations_test.exs
+++ b/app/test/meadow/events/file_sets/annotations_test.exs
@@ -4,8 +4,6 @@ defmodule Meadow.Events.FileSets.AnnotationsTest do
 
   alias Meadow.Data.FileSets
 
-  import Assertions
-  import ExUnit.CaptureLog
   import Meadow.TestHelpers
 
   @moduletag walex: [Meadow.Events.FileSets.Annotations]
@@ -25,19 +23,10 @@ defmodule Meadow.Events.FileSets.AnnotationsTest do
       {:ok, %{annotation: annotation}}
     end
 
-    test "deleting an annotation removes its S3 object", %{annotation: annotation} do
-      assert object_exists?(annotation.s3_location) == true
-
-      log =
-        capture_log(fn ->
-          {:ok, _} = FileSets.delete_annotation(annotation)
-
-          assert_async(timeout: 2000) do
-            assert object_exists?(annotation.s3_location) == false
-          end
-        end)
-
-      assert log =~ "Deleting annotation S3 object"
+    test "deleting an annotation removes it from the database", %{annotation: annotation} do
+      annotation_id = annotation.id
+      assert {:ok, _} = FileSets.delete_annotation(annotation)
+      assert_raise Ecto.NoResultsError, fn -> FileSets.get_annotation!(annotation_id) end
     end
   end
 end

--- a/app/test/meadow_web/schema/mutation/delete_file_set_annotation_test.exs
+++ b/app/test/meadow_web/schema/mutation/delete_file_set_annotation_test.exs
@@ -11,8 +11,7 @@ defmodule MeadowWeb.Schema.Mutation.DeleteFileSetAnnotationTest do
   setup do
     file_set = file_set_fixture()
     {:ok, annotation} = FileSets.create_annotation(file_set, %{type: "transcription", status: "completed"})
-    {:ok, s3_location} = FileSets.write_annotation_content(annotation, "Original content")
-    {:ok, annotation} = FileSets.update_annotation(annotation, %{s3_location: s3_location})
+    {:ok, annotation} = FileSets.write_annotation_content(annotation, "Original content")
 
     {:ok, annotation: annotation, file_set: file_set}
   end

--- a/app/test/meadow_web/schema/mutation/update_file_set_annotation_test.exs
+++ b/app/test/meadow_web/schema/mutation/update_file_set_annotation_test.exs
@@ -11,8 +11,7 @@ defmodule MeadowWeb.Schema.Mutation.UpdateFileSetAnnotationTest do
   setup do
     file_set = file_set_fixture()
     {:ok, annotation} = FileSets.create_annotation(file_set, %{type: "transcription", status: "completed"})
-    {:ok, s3_location} = FileSets.write_annotation_content(annotation, "Original content")
-    {:ok, annotation} = FileSets.update_annotation(annotation, %{s3_location: s3_location})
+    {:ok, annotation} = FileSets.write_annotation_content(annotation, "Original content")
 
     {:ok, annotation: annotation}
   end

--- a/app/test/meadow_web/schema/subscription/file_set_annotation_status_test.exs
+++ b/app/test/meadow_web/schema/subscription/file_set_annotation_status_test.exs
@@ -16,8 +16,7 @@ defmodule MeadowWeb.Schema.Subscription.FileSetAnnotationTest do
       {:ok, annotation} =
         FileSets.create_annotation(file_set, %{type: "transcription", status: "in_progress"})
 
-      {:ok, s3_location} = FileSets.write_annotation_content(annotation, "Original content")
-      {:ok, annotation} = FileSets.update_annotation(annotation, %{s3_location: s3_location})
+      {:ok, annotation} = FileSets.write_annotation_content(annotation, "Original content")
 
       {:ok,
        %{

--- a/app/test/meadow_web/schema/subscription/work_file_set_annotation_status_test.exs
+++ b/app/test/meadow_web/schema/subscription/work_file_set_annotation_status_test.exs
@@ -19,10 +19,8 @@ defmodule MeadowWeb.Schema.Subscription.WorkFileSetAnnotationTest do
           {:ok, annotation} =
             FileSets.create_annotation(fs, %{type: "transcription", status: "in_progress"})
 
-          {:ok, s3_location} =
+          {:ok, annotation} =
             FileSets.write_annotation_content(annotation, "Original content for " <> fs.id)
-
-          {:ok, annotation} = FileSets.update_annotation(annotation, %{s3_location: s3_location})
           annotation
         end)
 

--- a/app/test/pipeline/actions/attach_transcription_test.exs
+++ b/app/test/pipeline/actions/attach_transcription_test.exs
@@ -58,11 +58,7 @@ defmodule Meadow.Pipeline.Actions.AttachTranscriptionTest do
       annotation = List.first(annotations)
       assert annotation.type == "transcription"
       assert annotation.status == "completed"
-      assert annotation.s3_location
-
-      # Verify content was copied to S3
-      {:ok, content} = FileSets.read_annotation_content(annotation)
-      assert content == "This is the transcription for the image!"
+      assert annotation.content == "This is the transcription for the image!"
     end
   end
 


### PR DESCRIPTION
# Summary 

Performing S3 `getObject` requests sequentially on all file sets during a reindex is error prone and potentially slow. Storing them in the database is a better solution.

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5821

# Specific Changes in this PR

- Migration to add `content` to the `file_set_annotations` table
- `mix` task to migrate content from s3 to the database
- Update code to store transcriptions in database
- Update code for both manual edit and ingest sheet transcription processing  
- Adds a check in the logs for annotation counts after reindex (does not fail the reindex if counts don't match). 

NOTE: Leaving the `s3_location` column for now, we will remove with future migration after content move, as well as S3 artifact removal

# Steps to Test

- Run `mix ecto.migrate` to create the `content` column in the `file_set_annotations` table
- Run `mix meadow.backfill_annotation_content`  to populate existing records with data from S3 transcriptions
- Create transcriptions manually in Meadow and via ingest sheets and verify all existing functionality.
- Verify transcriptions reindex after updating in the UI 
- Run a `reindex_all`, verify that all existing transcriptions are still present. (There will be a check count noted in the log as well: `module=Meadow.Data.Indexer [info] Annotation coverage: 16/16 file sets indexed with annotations`)

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [x] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [x] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

