### PR TITLE
Use latest LocalStack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: ./.tool-versions
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: |
             app/assets/package-lock.json
             app/priv/nodejs/*/package-lock.json
@@ -34,13 +34,15 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: ./.tool-versions
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: |
             app/assets/package-lock.json
             app/priv/nodejs/*/package-lock.json
             lambdas/*/package-lock.json
       - name: Start service containers in background
         run: make localstack-start &
+        env:
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
       - uses: erlef/setup-beam@v1
         with:
           version-file: ./.tool-versions

--- a/infrastructure/localstack/Makefile
+++ b/infrastructure/localstack/Makefile
@@ -8,6 +8,11 @@ terraform.tfstate: .localstack/.start-stamp test.tfvars
 	@touch $@
 
 .localstack/.start-stamp: docker-compose.yml
+	@if [[ -z "$$LOCALSTACK_AUTH_TOKEN" ]]; then \
+		echo "⚠️ IMPORTANT"; \
+		echo "LocalStack authentication token not found. Please go to https://app.localstack.cloud/settings/auth-tokens to retrieve your Personal Auth Token and add \`export LOCALSTACK_AUTH_TOKEN=<your_token>\` to your shell initialization script." >&2; \
+		exit 1; \
+	fi
 	(cd ../pipeline && $(MAKE) deps layers)
 	docker compose up -d
 

--- a/infrastructure/localstack/docker-compose.yml
+++ b/infrastructure/localstack/docker-compose.yml
@@ -26,11 +26,12 @@ services:
     ports:
       - 9200:9200
   localstack:
-    image: localstack/localstack:community-archive
+    image: localstack/localstack:latest
     environment:
       DOCKER_HOST: unix:///var/run/docker.sock
       GATEWAY_LISTEN: 0.0.0.0:4566
       LOCALSTACK_ACKNOWLEDGE_ACCOUNT_REQUIREMENT: 1
+      LOCALSTACK_AUTH_TOKEN: ${LOCALSTACK_AUTH_TOKEN}
     ports:
       - 4566:4566
     volumes:


### PR DESCRIPTION
# Summary 
Brief high level description of this feature or fix

# Specific Changes in this PR
- Use latest LocalStack for testing
- Check for `LOCALSTACK_AUTH_TOKEN` variable and bail if not present

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

