### PR TITLE
Index a meaningful width and height on filesets based on extracted metadata

### DIFF
--- a/app/lib/meadow/indexing/v2/file_set.ex
+++ b/app/lib/meadow/indexing/v2/file_set.ex
@@ -30,6 +30,8 @@ defmodule Meadow.Indexing.V2.FileSet do
       published: file_set.work.published,
       rank: file_set.rank,
       representative_image_url: FileSets.representative_image_url_for(file_set),
+      height: representative_dimension(file_set, :height),
+      width: representative_dimension(file_set, :width),
       role: file_set.role.label,
       streaming_url: FileSets.distribution_streaming_uri_for(file_set),
       visibility: file_set.work.visibility.label,
@@ -38,6 +40,38 @@ defmodule Meadow.Indexing.V2.FileSet do
     }
     |> Meadow.Utils.Map.nillify_empty()
   end
+
+  defp representative_dimension(file_set, dimension) do
+    dimensions_from_extracted_metadata(file_set.extracted_metadata)
+    |> Map.get(dimension)
+    |> case do
+      value when is_number(value) -> value
+      value when is_binary(value) -> String.to_integer(value)
+      _ -> nil
+    end
+  end
+
+  defp dimensions_from_extracted_metadata(%{"exif" => exif}) when is_map(exif) do
+    exif
+    |> Map.get("value", %{})
+    |> case do
+      %{"ImageWidth" => width, "ImageHeight" => height} -> %{width: width, height: height}
+      _ -> %{}
+    end
+  end
+
+  defp dimensions_from_extracted_metadata(%{"mediainfo" => mediainfo}) when is_map(mediainfo) do
+    mediainfo
+    |> get_in(["value", "media", "track"])
+    |> then(&(&1 || []))
+    |> Enum.find(&(Map.has_key?(&1, "Width") and Map.has_key?(&1, "Height")))
+    |> case do
+      %{"Width" => width, "Height" => height} -> %{width: width, height: height}
+      _ -> %{}
+    end
+  end
+
+  defp dimensions_from_extracted_metadata(_), do: %{}
 
   defp encode_annotations(file_set) do
     FileSets.list_annotations(file_set.id)

--- a/app/lib/meadow/search/client.ex
+++ b/app/lib/meadow/search/client.ex
@@ -127,16 +127,16 @@ defmodule Meadow.Search.Client do
   def indexed_doc_count(schema, version) when is_atom(schema),
     do: indexed_doc_count(SearchConfig.alias_for(schema, version))
 
-  def indexed_doc_count(target) do
-    case HTTP.get([target, "_count"]) do
+  def indexed_doc_count(target, query) do
+    case HTTP.post([target, "_count"], query) do
       {:ok, %{body: %{"count" => count}}} -> {:ok, count}
       {:ok, %{body: %{"error" => %{"reason" => reason}}}} -> {:error, reason}
       {:error, reason} -> {:error, reason}
     end
   end
 
-  def indexed_doc_count(target, query) do
-    case HTTP.post([target, "_count"], query) do
+  def indexed_doc_count(target) do
+    case HTTP.get([target, "_count"]) do
       {:ok, %{body: %{"count" => count}}} -> {:ok, count}
       {:ok, %{body: %{"error" => %{"reason" => reason}}}} -> {:error, reason}
       {:error, reason} -> {:error, reason}

--- a/app/test/meadow/indexing/v2/encoding_test.exs
+++ b/app/test/meadow/indexing/v2/encoding_test.exs
@@ -152,6 +152,8 @@ defmodule Meadow.Indexing.V2.EncodingTest do
       assert doc |> get_in([:label]) == subject.core_metadata.label
       assert doc |> get_in([:poster_offset]) == 100
       assert doc |> get_in([:rank]) == subject.rank
+      assert doc |> get_in([:width]) |> is_nil()
+      assert doc |> get_in([:height]) |> is_nil()
 
       assert doc |> get_in([:streaming_url]) == Path.join(Config.streaming_url(), "bar.m3u8")
 


### PR DESCRIPTION
# Summary 
Index a meaningful width and height on filesets based on extracted metadata

# Specific Changes in this PR
- Pull ImageWidth and ImageHeight from exif for images
- Pull Width and Height from the first track that features them for video
- return `nil` for everything else

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [x] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

