### PR TITLE
AI Metadata Evals dashboard

### DIFF
--- a/app/assets/js/components/Dashboards/Evals/ScoreButtons.jsx
+++ b/app/assets/js/components/Dashboards/Evals/ScoreButtons.jsx
@@ -1,0 +1,74 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { useMutation } from "@apollo/client";
+import {
+  SCORE_EVAL_TRIAL,
+  CLEAR_EVAL_TRIAL_SCORE,
+  GET_EVAL_RUN,
+} from "./evals.gql";
+
+export default function ScoreButtons({ trial, runId }) {
+  const [scoreTrialMutation, { loading: scoring }] = useMutation(
+    SCORE_EVAL_TRIAL,
+    {
+      refetchQueries: [{ query: GET_EVAL_RUN, variables: { id: runId } }],
+    },
+  );
+
+  const [clearScoreMutation, { loading: clearing }] = useMutation(
+    CLEAR_EVAL_TRIAL_SCORE,
+    {
+      refetchQueries: [{ query: GET_EVAL_RUN, variables: { id: runId } }],
+    },
+  );
+
+  const isLoading = scoring || clearing;
+  const manualScore = trial.manualScore?.toUpperCase();
+
+  const score = (value) => {
+    scoreTrialMutation({ variables: { id: trial.id, score: value } });
+  };
+
+  const clear = () => {
+    clearScoreMutation({ variables: { id: trial.id } });
+  };
+
+  return (
+    <div className="buttons are-small">
+      <button
+        className={`button is-success${manualScore === "GOOD" ? "" : " is-outlined"}`}
+        disabled={isLoading}
+        onClick={() => score("GOOD")}
+        title="Mark as good"
+      >
+        Good
+      </button>
+      <button
+        className={`button is-danger${manualScore === "BAD" ? "" : " is-outlined"}`}
+        disabled={isLoading}
+        onClick={() => score("BAD")}
+        title="Mark as bad"
+      >
+        Bad
+      </button>
+      {manualScore && manualScore !== "UNSCORED" && (
+        <button
+          className="button is-light"
+          disabled={isLoading}
+          onClick={clear}
+          title="Clear score"
+        >
+          Clear
+        </button>
+      )}
+    </div>
+  );
+}
+
+ScoreButtons.propTypes = {
+  trial: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    manualScore: PropTypes.string,
+  }).isRequired,
+  runId: PropTypes.string.isRequired,
+};

--- a/app/assets/js/components/Dashboards/Evals/StartRunModal.jsx
+++ b/app/assets/js/components/Dashboards/Evals/StartRunModal.jsx
@@ -1,0 +1,243 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import { useMutation, useQuery } from "@apollo/client";
+import {
+  GET_EVAL_SETS,
+  GET_EVAL_PROMPT_VERSIONS,
+  GET_DEFAULT_EVAL_QUERY,
+  CREATE_EVAL_SET,
+  CREATE_EVAL_SET_FROM_WORK_IDS,
+  CREATE_EVAL_RUN,
+  GET_EVAL_RUNS,
+} from "./evals.gql";
+
+const MAX_WORK_IDS = 20;
+
+function parseWorkIds(text) {
+  return Array.from(
+    new Set(
+      text
+        .split(/\r?\n/)
+        .map((s) => s.trim())
+        .filter(Boolean)
+    )
+  );
+}
+
+export default function StartRunModal({ onClose, onStarted }) {
+  const [evalSetId, setEvalSetId] = useState("");
+  const [promptVersionId, setPromptVersionId] = useState("");
+  const [createSetName, setCreateSetName] = useState("");
+  const [selectedQueryId, setSelectedQueryId] = useState("");
+  const [workIdsText, setWorkIdsText] = useState("");
+  const [mode, setMode] = useState("existing");
+
+  const { data: setsData } = useQuery(GET_EVAL_SETS);
+  const { data: promptsData } = useQuery(GET_EVAL_PROMPT_VERSIONS);
+  const { data: defaultQueryData } = useQuery(GET_DEFAULT_EVAL_QUERY, {
+    onCompleted: (d) => {
+      if (d?.defaultEvalQuery) setSelectedQueryId(d.defaultEvalQuery.id);
+    },
+  });
+
+  const [createSet, { loading: creatingSet }] = useMutation(CREATE_EVAL_SET, {
+    refetchQueries: [{ query: GET_EVAL_SETS }],
+  });
+
+  const [createSetFromIds, { loading: creatingSetFromIds }] = useMutation(
+    CREATE_EVAL_SET_FROM_WORK_IDS,
+    { refetchQueries: [{ query: GET_EVAL_SETS }] }
+  );
+
+  const [createRun, { loading: creatingRun }] = useMutation(CREATE_EVAL_RUN, {
+    refetchQueries: [{ query: GET_EVAL_RUNS }],
+  });
+
+  const sets = setsData?.evalSets || [];
+  const prompts = promptsData?.evalPromptVersions || [];
+  const latestPrompt = prompts[0];
+
+  React.useEffect(() => {
+    if (latestPrompt && !promptVersionId) setPromptVersionId(latestPrompt.id);
+  }, [latestPrompt]);
+
+  React.useEffect(() => {
+    if (sets.length > 0 && !evalSetId) setEvalSetId(sets[0].id);
+  }, [sets]);
+
+  const parsedIds = parseWorkIds(workIdsText);
+  const tooManyIds = parsedIds.length > MAX_WORK_IDS;
+
+  const handleCreateSetAndRun = async () => {
+    let setId = evalSetId;
+
+    if (mode === "new") {
+      const result = await createSet({
+        variables: { queryId: selectedQueryId, name: createSetName || `Set ${new Date().toISOString()}` },
+      });
+      setId = result.data?.createEvalSet?.id;
+    } else if (mode === "ids") {
+      const result = await createSetFromIds({
+        variables: {
+          workIds: parsedIds,
+          name: createSetName || `Set ${new Date().toISOString()}`,
+        },
+      });
+      setId = result.data?.createEvalSetFromWorkIds?.id;
+    }
+
+    if (!setId) return;
+
+    const result = await createRun({
+      variables: {
+        evalSetId: setId,
+        promptVersionId,
+        trialsPerWork: 1,
+        concurrency: 3,
+      },
+    });
+
+    if (result.data?.createEvalRun) {
+      onStarted(result.data.createEvalRun.id);
+    }
+  };
+
+  const isLoading = creatingSet || creatingSetFromIds || creatingRun;
+
+  const canSubmit =
+    !!promptVersionId &&
+    !tooManyIds &&
+    (mode === "existing"
+      ? !!evalSetId
+      : mode === "new"
+        ? !!selectedQueryId
+        : parsedIds.length >= 1);
+
+  return (
+    <div className="modal is-active">
+      <div className="modal-background" onClick={onClose} />
+      <div className="modal-card">
+        <header className="modal-card-head">
+          <p className="modal-card-title">Start New Eval Run</p>
+          <button className="delete" onClick={onClose} />
+        </header>
+
+        <section className="modal-card-body">
+          <div className="field">
+            <label className="label">Eval Set</label>
+            <div className="control">
+              <div className="select" style={{ marginBottom: "0.5rem" }}>
+                <select value={mode} onChange={(e) => setMode(e.target.value)}>
+                  <option value="existing">Use existing set</option>
+                  <option value="new">Create new set from query</option>
+                  <option value="ids">Paste work IDs</option>
+                </select>
+              </div>
+            </div>
+
+            {mode === "existing" && (
+              <div className="control">
+                <div className="select is-fullwidth">
+                  <select value={evalSetId} onChange={(e) => setEvalSetId(e.target.value)}>
+                    {sets.map((s) => (
+                      <option key={s.id} value={s.id}>
+                        {s.name} ({s.workCount} works)
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+            )}
+
+            {mode === "new" && (
+              <>
+                <div className="control" style={{ marginBottom: "0.5rem" }}>
+                  <input
+                    className="input"
+                    placeholder="New set name"
+                    value={createSetName}
+                    onChange={(e) => setCreateSetName(e.target.value)}
+                  />
+                </div>
+                <div className="control">
+                  <div className="select is-fullwidth">
+                    <select value={selectedQueryId} onChange={(e) => setSelectedQueryId(e.target.value)}>
+                      <option value="">Select a query…</option>
+                      {defaultQueryData?.defaultEvalQuery && (
+                        <option value={defaultQueryData.defaultEvalQuery.id}>
+                          {defaultQueryData.defaultEvalQuery.name} (default)
+                        </option>
+                      )}
+                    </select>
+                  </div>
+                </div>
+              </>
+            )}
+
+            {mode === "ids" && (
+              <>
+                <div className="control" style={{ marginBottom: "0.5rem" }}>
+                  <input
+                    className="input"
+                    placeholder="New set name (optional)"
+                    value={createSetName}
+                    onChange={(e) => setCreateSetName(e.target.value)}
+                  />
+                </div>
+                <div className="control">
+                  <textarea
+                    className={`textarea is-family-monospace is-size-7${tooManyIds ? " is-danger" : ""}`}
+                    rows={6}
+                    placeholder={"One work ID per line — up to 20"}
+                    value={workIdsText}
+                    onChange={(e) => setWorkIdsText(e.target.value)}
+                  />
+                </div>
+                <p className={`help${tooManyIds ? " is-danger" : ""}`}>
+                  {parsedIds.length === 0
+                    ? `Max ${MAX_WORK_IDS} IDs`
+                    : tooManyIds
+                      ? `${parsedIds.length} IDs — trim to ${MAX_WORK_IDS} or fewer`
+                      : `${parsedIds.length} ID${parsedIds.length !== 1 ? "s" : ""} (max ${MAX_WORK_IDS})`}
+                </p>
+              </>
+            )}
+          </div>
+
+          <div className="field">
+            <label className="label">Prompt Version</label>
+            <div className="control">
+              <div className="select is-fullwidth">
+                <select value={promptVersionId} onChange={(e) => setPromptVersionId(e.target.value)}>
+                  {prompts.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <footer className="modal-card-foot">
+          <button
+            className={`button is-primary${isLoading ? " is-loading" : ""}`}
+            disabled={!canSubmit || isLoading}
+            onClick={handleCreateSetAndRun}
+          >
+            Start Run
+          </button>
+          <button className="button" onClick={onClose}>
+            Cancel
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+StartRunModal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  onStarted: PropTypes.func.isRequired,
+};

--- a/app/assets/js/components/Dashboards/Evals/TrialComparison.jsx
+++ b/app/assets/js/components/Dashboards/Evals/TrialComparison.jsx
@@ -1,0 +1,126 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faScaleBalanced } from "@fortawesome/free-solid-svg-icons";
+
+function SubjectList({ subjects }) {
+  if (!subjects || subjects.length === 0) {
+    return <span className="has-text-grey">(none)</span>;
+  }
+  return (
+    <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+      {subjects.map((s, i) => {
+        const label = s.label || s.id || "";
+        const id = s.id || "";
+        const isUrl = id.startsWith("http://") || id.startsWith("https://");
+        return (
+          <li key={i} style={{ marginBottom: "0.5rem" }}>
+            <span>{label}</span>
+            {id && (
+              <div>
+                {isUrl ? (
+                  <a
+                    href={id}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="is-size-7 has-text-grey-dark"
+                    style={{ fontFamily: "monospace", wordBreak: "break-all" }}
+                  >
+                    {id}
+                  </a>
+                ) : (
+                  <span
+                    className="is-size-7 has-text-grey"
+                    style={{ fontFamily: "monospace" }}
+                  >
+                    {id}
+                  </span>
+                )}
+              </div>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function DescriptionBlock({ description }) {
+  const paragraphs = Array.isArray(description)
+    ? description.filter(Boolean)
+    : description
+      ? [description]
+      : [];
+
+  if (paragraphs.length === 0) {
+    return <span className="has-text-grey">(none)</span>;
+  }
+
+  return (
+    <div style={{ maxHeight: "24rem", overflowY: "auto" }}>
+      {paragraphs.map((p, i) => (
+        <p key={i} style={{ whiteSpace: "pre-wrap", marginBottom: "0.5rem" }}>
+          {p}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+export default function TrialComparison({ groundTruth, agentOutput, judgeRationale }) {
+  const gt = groundTruth || {};
+  const ai = agentOutput || {};
+
+  return (
+    <div style={{ padding: "1rem 0" }}>
+      <div className="columns">
+        <div className="column">
+          <div className="box" style={{ height: "100%" }}>
+            <p className="heading has-text-grey">Ground Truth</p>
+            <p className="label is-small">Description</p>
+            <DescriptionBlock description={gt.description} />
+            <p className="label is-small mt-4">Subjects</p>
+            <SubjectList subjects={gt.subjects} />
+          </div>
+        </div>
+        <div className="column">
+          <div className="box" style={{ height: "100%" }}>
+            <p className="heading has-text-grey">AI output</p>
+            <p className="label is-small">Description</p>
+            <DescriptionBlock description={ai.description} />
+            <p className="label is-small mt-4">Subjects</p>
+            <SubjectList subjects={ai.subjects} />
+          </div>
+        </div>
+      </div>
+      {judgeRationale && (
+        <div className="notification is-light is-size-7">
+          <strong>
+            <FontAwesomeIcon icon={faScaleBalanced} style={{ marginRight: "0.35rem" }} />
+            Judge:
+          </strong>{" "}
+          {judgeRationale}
+        </div>
+      )}
+    </div>
+  );
+}
+
+TrialComparison.propTypes = {
+  groundTruth: PropTypes.shape({
+    description: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string),
+    ]),
+    subjects: PropTypes.arrayOf(
+      PropTypes.shape({ id: PropTypes.string, label: PropTypes.string })
+    ),
+  }),
+  agentOutput: PropTypes.shape({
+    description: PropTypes.string,
+    subjects: PropTypes.arrayOf(
+      PropTypes.shape({ id: PropTypes.string, label: PropTypes.string })
+    ),
+  }),
+  judgeRationale: PropTypes.string,
+};

--- a/app/assets/js/components/Dashboards/Evals/evals.gql.js
+++ b/app/assets/js/components/Dashboards/Evals/evals.gql.js
@@ -1,0 +1,293 @@
+import { gql } from "@apollo/client";
+
+export const GET_EVAL_QUERY_LIST = gql`
+  query GetEvalQueryList {
+    evalQueryList {
+      id
+      name
+      description
+      queryJson
+      author
+      insertedAt
+    }
+  }
+`;
+
+export const GET_DEFAULT_EVAL_QUERY = gql`
+  query GetDefaultEvalQuery {
+    defaultEvalQuery {
+      id
+      name
+      description
+      queryJson
+    }
+  }
+`;
+
+export const GET_EVAL_PROMPT_VERSIONS = gql`
+  query GetEvalPromptVersions {
+    evalPromptVersions {
+      id
+      name
+      subjectPrompt
+      descriptionPrompt
+      systemPrompt
+      userPromptTemplate
+      parentVersionId
+      author
+      changeNotes
+      archived
+      insertedAt
+    }
+  }
+`;
+
+export const GET_EVAL_SETS = gql`
+  query GetEvalSets {
+    evalSets {
+      id
+      name
+      description
+      workCount
+      author
+      insertedAt
+    }
+  }
+`;
+
+export const GET_EVAL_RUNS = gql`
+  query GetEvalRuns($limit: Int, $offset: Int) {
+    evalRuns(limit: $limit, offset: $offset) {
+      id
+      name
+      status
+      trialsPerWork
+      author
+      startedAt
+      completedAt
+      insertedAt
+      evalSet {
+        id
+        name
+        workCount
+      }
+      promptVersion {
+        id
+        name
+      }
+      summary {
+        total
+        complete
+        errored
+        pending
+        manualGood
+        manualBad
+        meanDescriptionJudgeScore
+        meanSubjectsJudgeScore
+      }
+    }
+  }
+`;
+
+export const GET_EVAL_RUN = gql`
+  query GetEvalRun($id: ID!) {
+    evalRun(id: $id) {
+      id
+      name
+      status
+      trialsPerWork
+      author
+      startedAt
+      completedAt
+      insertedAt
+      error
+      evalSet {
+        id
+        name
+        workCount
+        evalSetMembers {
+          id
+          workId
+          accessionNumber
+          groundTruth
+        }
+      }
+      promptVersion {
+        id
+        name
+        subjectPrompt
+        descriptionPrompt
+        systemPrompt
+        userPromptTemplate
+      }
+      summary {
+        total
+        complete
+        errored
+        pending
+        running
+        manualGood
+        manualBad
+        meanDescriptionJudgeScore
+        meanSubjectsJudgeScore
+      }
+      evalTrials {
+        id
+        workId
+        trialIndex
+        status
+        descriptionJudgeScore
+        subjectsJudgeScore
+        judgeRationale
+        manualScore
+        manualNotes
+        manualScoredBy
+        manualScoredAt
+        durationMs
+        error
+        agentOutput
+        updatedAt
+      }
+    }
+  }
+`;
+
+export const CREATE_EVAL_QUERY = gql`
+  mutation CreateEvalQuery($name: String!, $description: String, $queryJson: Json!) {
+    createEvalQuery(name: $name, description: $description, queryJson: $queryJson) {
+      id
+      name
+      description
+      queryJson
+      author
+      insertedAt
+    }
+  }
+`;
+
+export const UPDATE_EVAL_QUERY = gql`
+  mutation UpdateEvalQuery($id: ID!, $name: String, $description: String, $queryJson: Json) {
+    updateEvalQuery(id: $id, name: $name, description: $description, queryJson: $queryJson) {
+      id
+      name
+      description
+      queryJson
+    }
+  }
+`;
+
+export const DELETE_EVAL_QUERY = gql`
+  mutation DeleteEvalQuery($id: ID!) {
+    deleteEvalQuery(id: $id) {
+      id
+      name
+    }
+  }
+`;
+
+export const CREATE_EVAL_PROMPT_VERSION = gql`
+  mutation CreateEvalPromptVersion(
+    $name: String!
+    $subjectPrompt: String!
+    $descriptionPrompt: String!
+    $parentVersionId: ID
+    $changeNotes: String
+  ) {
+    createEvalPromptVersion(
+      name: $name
+      subjectPrompt: $subjectPrompt
+      descriptionPrompt: $descriptionPrompt
+      parentVersionId: $parentVersionId
+      changeNotes: $changeNotes
+    ) {
+      id
+      name
+      archived
+      insertedAt
+    }
+  }
+`;
+
+export const ARCHIVE_EVAL_PROMPT_VERSION = gql`
+  mutation ArchiveEvalPromptVersion($id: ID!) {
+    archiveEvalPromptVersion(id: $id) {
+      id
+      archived
+    }
+  }
+`;
+
+export const CREATE_EVAL_SET_FROM_WORK_IDS = gql`
+  mutation CreateEvalSetFromWorkIds($workIds: [ID!]!, $name: String!, $description: String) {
+    createEvalSetFromWorkIds(workIds: $workIds, name: $name, description: $description) {
+      id
+      name
+      workCount
+      insertedAt
+    }
+  }
+`;
+
+export const CREATE_EVAL_SET = gql`
+  mutation CreateEvalSet($queryId: ID!, $name: String!, $description: String) {
+    createEvalSet(queryId: $queryId, name: $name, description: $description) {
+      id
+      name
+      workCount
+      insertedAt
+    }
+  }
+`;
+
+export const CREATE_EVAL_RUN = gql`
+  mutation CreateEvalRun(
+    $evalSetId: ID!
+    $promptVersionId: ID!
+    $name: String
+    $trialsPerWork: Int
+    $concurrency: Int
+  ) {
+    createEvalRun(
+      evalSetId: $evalSetId
+      promptVersionId: $promptVersionId
+      name: $name
+      trialsPerWork: $trialsPerWork
+      concurrency: $concurrency
+    ) {
+      id
+      name
+      status
+    }
+  }
+`;
+
+export const CANCEL_EVAL_RUN = gql`
+  mutation CancelEvalRun($id: ID!) {
+    cancelEvalRun(id: $id) {
+      id
+      status
+    }
+  }
+`;
+
+export const SCORE_EVAL_TRIAL = gql`
+  mutation ScoreEvalTrial($id: ID!, $score: EvalManualScore!, $notes: String) {
+    scoreEvalTrial(id: $id, score: $score, notes: $notes) {
+      id
+      manualScore
+      manualNotes
+      manualScoredBy
+      manualScoredAt
+    }
+  }
+`;
+
+export const CLEAR_EVAL_TRIAL_SCORE = gql`
+  mutation ClearEvalTrialScore($id: ID!) {
+    clearEvalTrialScore(id: $id) {
+      id
+      manualScore
+      manualNotes
+    }
+  }
+`;

--- a/app/assets/js/components/UI/Layout/NavBar.jsx
+++ b/app/assets/js/components/UI/Layout/NavBar.jsx
@@ -208,6 +208,13 @@ const UILayoutNavBar = () => {
                           </IconText>
                         </Link>
                       </UILayoutNavDropdownItem>
+                      <UILayoutNavDropdownItem>
+                        <Link to="/dashboards/evals">
+                          <IconText icon={<IconCheck />}>
+                            AI Metadata Evals
+                          </IconText>
+                        </Link>
+                      </UILayoutNavDropdownItem>
                       <AuthDisplayAuthorized level="SUPERUSER">
                         <UILayoutNavDropdownItem>
                           <Link to="/dashboards/users">

--- a/app/assets/js/screens/Dashboards/Evals/Details.jsx
+++ b/app/assets/js/screens/Dashboards/Evals/Details.jsx
@@ -1,0 +1,292 @@
+import React, { useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import { useQuery, useMutation } from "@apollo/client";
+import Layout from "@js/screens/Layout";
+import { Breadcrumbs } from "@js/components/UI/UI";
+import ScoreButtons from "@js/components/Dashboards/Evals/ScoreButtons";
+import TrialComparison from "@js/components/Dashboards/Evals/TrialComparison";
+import {
+  GET_EVAL_RUN,
+  CANCEL_EVAL_RUN,
+} from "@js/components/Dashboards/Evals/evals.gql";
+
+const STATUS_COLORS = {
+  PENDING: "is-warning",
+  RUNNING: "is-info",
+  COMPLETE: "is-success",
+  ERRORED: "is-danger",
+  CANCELLED: "is-light",
+  SKIPPED: "is-light",
+};
+
+function percent(n) {
+  if (n == null) return "—";
+  return `${(n * 100).toFixed(1)}%`;
+}
+
+function scoreColor(_n) {
+  return "";
+}
+
+function enumKey(value) {
+  return value?.toString().toUpperCase();
+}
+
+function enumLabel(value) {
+  return value?.toString().toLowerCase() || "";
+}
+
+export default function EvalsDetailsScreen() {
+  const { id } = useParams();
+  const [expandedTrialId, setExpandedTrialId] = useState(null);
+  const [showPrompt, setShowPrompt] = useState(false);
+
+  const { data, loading } = useQuery(GET_EVAL_RUN, {
+    variables: { id },
+    pollInterval: 5000,
+  });
+
+  const [cancelRun, { loading: cancelling }] = useMutation(CANCEL_EVAL_RUN, {
+    refetchQueries: [{ query: GET_EVAL_RUN, variables: { id } }],
+  });
+
+  const run = data?.evalRun;
+  const s = run?.summary || {};
+  const trials = run?.evalTrials || [];
+  const memberMap = Object.fromEntries(
+    (run?.evalSet?.evalSetMembers || []).map((m) => [m.workId, m]),
+  );
+
+  const handleDownloadCsv = () => {
+    const form = document.createElement("form");
+    form.method = "POST";
+    form.action = `/api/evals/${encodeURIComponent(`eval_run_${id}.csv`)}`;
+    const input = document.createElement("input");
+    input.type = "hidden";
+    input.name = "run_id";
+    input.value = id;
+    form.appendChild(input);
+    document.body.appendChild(form);
+    form.submit();
+    document.body.removeChild(form);
+  };
+
+  if (loading) return <progress className="progress is-small is-primary" />;
+  if (!run) return <div className="notification is-danger">Run not found.</div>;
+
+  const runStatus = enumKey(run.status);
+  const isActive = runStatus === "RUNNING" || runStatus === "PENDING";
+
+  return (
+    <Layout>
+      <section className="section" data-testid="evals-detail-screen">
+        <div className="container">
+          <Breadcrumbs
+            items={[
+              { label: "Dashboards", isActive: false },
+              {
+                label: "AI Metadata Evals",
+                route: "/dashboards/evals",
+                isActive: false,
+              },
+              {
+                label: run.name || run.evalSet?.name || id.slice(0, 8),
+                route: `/dashboards/evals/runs/${id}`,
+                isActive: true,
+              },
+            ]}
+          />
+
+          {/* Run header */}
+          <div className="level">
+            <div className="level-left">
+              <div>
+                <h1 className="title is-4">
+                  {run.name || run.evalSet?.name}
+                  <span
+                    className={`tag ml-3 ${STATUS_COLORS[runStatus] || "is-light"}`}
+                  >
+                    {enumLabel(run.status)}
+                  </span>
+                </h1>
+                <p className="subtitle is-6 has-text-grey">
+                  Prompt:{" "}
+                  <button
+                    className="button is-ghost is-small p-0"
+                    style={{ verticalAlign: "baseline", height: "auto", fontWeight: "normal", color: "inherit" }}
+                    onClick={() => setShowPrompt((s) => !s)}
+                  >
+                    {run.promptVersion?.name}
+                    <span className="ml-1" style={{ fontSize: "0.7rem" }}>{showPrompt ? "▴" : "▾"}</span>
+                  </button>
+                </p>
+              </div>
+            </div>
+            <div className="level-right">
+              <div className="level-item buttons">
+                {isActive && (
+                  <button
+                    className={`button is-danger is-outlined${cancelling ? " is-loading" : ""}`}
+                    onClick={() => cancelRun({ variables: { id } })}
+                  >
+                    Cancel Run
+                  </button>
+                )}
+                <button className="button is-light" onClick={handleDownloadCsv}>
+                  Download CSV
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Prompt content (collapsible) */}
+          {showPrompt && run.promptVersion && (
+            <div className="box mb-4 is-size-7" style={{ background: "#fafafa" }}>
+              <p className="label is-small">Subject headings task</p>
+              <pre style={{ whiteSpace: "pre-wrap", background: "#f0f0f0", padding: "0.75rem", borderRadius: "4px", marginBottom: "1rem", fontSize: "0.75rem" }}>
+                {run.promptVersion.subjectPrompt || "(none)"}
+              </pre>
+              <p className="label is-small">Description task</p>
+              <pre style={{ whiteSpace: "pre-wrap", background: "#f0f0f0", padding: "0.75rem", borderRadius: "4px", fontSize: "0.75rem" }}>
+                {run.promptVersion.descriptionPrompt || "(none)"}
+              </pre>
+            </div>
+          )}
+
+          {/* Summary stats */}
+          <div className="columns mb-4">
+            <div className="column is-narrow">
+              <div className="box has-text-centered" style={{ borderTop: "3px solid #48c78e" }}>
+                <p className="heading">Manual scoring</p>
+                <p className="title is-3">
+                  <span className="has-text-success">{s.manualGood ?? 0}</span>
+                  {" / "}
+                  <span className="has-text-danger">{s.manualBad ?? 0}</span>
+                </p>
+                <p className="is-size-7 has-text-grey">good / bad</p>
+              </div>
+            </div>
+            <div className="column is-narrow">
+              <div className="box has-text-centered">
+                <p className="heading">Avg description score</p>
+                <p className={`title is-3 ${scoreColor(s.meanDescriptionJudgeScore)}`}>
+                  {percent(s.meanDescriptionJudgeScore)}
+                </p>
+                <p className="is-size-7 has-text-grey">LLM judge</p>
+              </div>
+            </div>
+            <div className="column is-narrow">
+              <div className="box has-text-centered">
+                <p className="heading">Avg subjects score</p>
+                <p className={`title is-3 ${scoreColor(s.meanSubjectsJudgeScore)}`}>
+                  {percent(s.meanSubjectsJudgeScore)}
+                </p>
+                <p className="is-size-7 has-text-grey">LLM judge</p>
+              </div>
+            </div>
+            <div className="column is-narrow">
+              <div className="box has-text-centered">
+                <p className="heading">Trials</p>
+                <p className="title is-3">
+                  {s.complete}/{s.total}
+                </p>
+                <p className="is-size-7 has-text-grey">{s.errored} errored</p>
+              </div>
+            </div>
+          </div>
+
+          {run.error && (
+            <div className="notification is-danger is-light mb-4">
+              <strong>Error:</strong> {run.error}
+            </div>
+          )}
+
+          {/* Trials table */}
+          <div className="table-container">
+            <table className="table is-striped is-hoverable is-fullwidth is-size-7">
+              <thead>
+                <tr>
+                  <th style={{ width: "1.5rem" }}></th>
+                  <th>Work / Accession</th>
+                  <th>#</th>
+                  <th>Status</th>
+                  <th>Desc score</th>
+                  <th>Subj score</th>
+                  <th>Manual Score</th>
+                  <th>Scored By</th>
+                </tr>
+              </thead>
+              <tbody>
+                {trials.map((trial) => {
+                  const member = memberMap[trial.workId] || {};
+                  const trialStatus = enumKey(trial.status);
+                  const isExpanded = expandedTrialId === trial.id;
+                  const toggleExpand = () =>
+                    setExpandedTrialId(isExpanded ? null : trial.id);
+                  return (
+                    <React.Fragment key={trial.id}>
+                      <tr style={{ cursor: "pointer" }} onClick={toggleExpand}>
+                        <td style={{ verticalAlign: "middle" }}>
+                          <span style={{ fontSize: "0.75rem" }}>
+                            {isExpanded ? "▾" : "▸"}
+                          </span>
+                        </td>
+                        <td>
+                          <div>
+                            {member.accessionNumber || trial.workId?.slice(0, 8)}
+                          </div>
+                        </td>
+                        <td>{trial.trialIndex + 1}</td>
+                        <td>
+                          <span
+                            className={`tag ${STATUS_COLORS[trialStatus] || "is-light"}`}
+                          >
+                            {enumLabel(trial.status)}
+                          </span>
+                        </td>
+                        <td className={scoreColor(trial.descriptionJudgeScore)}>
+                          {percent(trial.descriptionJudgeScore)}
+                        </td>
+                        <td className={scoreColor(trial.subjectsJudgeScore)}>
+                          {percent(trial.subjectsJudgeScore)}
+                        </td>
+                        <td onClick={(e) => e.stopPropagation()}>
+                          {trialStatus === "COMPLETE" && (
+                            <ScoreButtons trial={trial} runId={id} />
+                          )}
+                        </td>
+                        <td className="is-size-7 has-text-grey">
+                          {trial.manualScoredBy || "—"}
+                        </td>
+                      </tr>
+                      {isExpanded && (
+                        <tr>
+                          <td
+                            colSpan={8}
+                            style={{ background: "#fafafa", borderTop: "none" }}
+                          >
+                            {trialStatus === "COMPLETE" ? (
+                              <TrialComparison
+                                groundTruth={member.groundTruth}
+                                agentOutput={trial.agentOutput}
+                                judgeRationale={trial.judgeRationale}
+                              />
+                            ) : (
+                              <p className="has-text-grey is-size-7" style={{ padding: "1rem 0" }}>
+                                {enumLabel(trial.status)} — no output yet
+                              </p>
+                            )}
+                          </td>
+                        </tr>
+                      )}
+                    </React.Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/app/assets/js/screens/Dashboards/Evals/List.jsx
+++ b/app/assets/js/screens/Dashboards/Evals/List.jsx
@@ -1,0 +1,189 @@
+import React, { useState } from "react";
+import { Link, useHistory } from "react-router-dom";
+import { useQuery } from "@apollo/client";
+import Layout from "@js/screens/Layout";
+import { Breadcrumbs } from "@js/components/UI/UI";
+import AuthDisplayAuthorized from "@js/components/Auth/DisplayAuthorized";
+import StartRunModal from "@js/components/Dashboards/Evals/StartRunModal";
+import { GET_EVAL_RUNS } from "@js/components/Dashboards/Evals/evals.gql";
+
+const STATUS_COLORS = {
+  PENDING: "is-warning",
+  RUNNING: "is-info",
+  COMPLETE: "is-success",
+  ERRORED: "is-danger",
+  CANCELLED: "is-light",
+};
+
+function enumKey(value) {
+  return value?.toString().toUpperCase();
+}
+
+function enumLabel(value) {
+  return value?.toString().toLowerCase() || "";
+}
+
+export default function EvalsListScreen() {
+  const history = useHistory();
+  const [showModal, setShowModal] = useState(false);
+  const { data, loading } = useQuery(GET_EVAL_RUNS, {
+    variables: { limit: 50, offset: 0 },
+    pollInterval: 5000,
+  });
+
+  const runs = data?.evalRuns || [];
+
+  const handleStarted = (runId) => {
+    setShowModal(false);
+    history.push(`/dashboards/evals/runs/${runId}`);
+  };
+
+  return (
+    <Layout>
+      <section className="section" data-testid="evals-list-screen">
+        <div className="container">
+          <Breadcrumbs
+            items={[
+              { label: "Dashboards", isActive: false },
+              {
+                label: "AI Metadata Evals",
+                route: "/dashboards/evals",
+                isActive: true,
+              },
+            ]}
+          />
+
+          <div className="level">
+            <div className="level-left">
+              <div className="level-item">
+                <h1 className="title">AI Metadata Evals</h1>
+              </div>
+            </div>
+            <div className="level-right">
+              <div className="level-item">
+                <AuthDisplayAuthorized level="EDITOR">
+                  <Link
+                    to="/dashboards/evals/prompts"
+                    className="button is-light mr-2"
+                  >
+                    Prompt Versions
+                  </Link>
+                </AuthDisplayAuthorized>
+                <AuthDisplayAuthorized level="SUPERUSER">
+                  <Link
+                    to="/dashboards/evals/queries"
+                    className="button is-light mr-2"
+                  >
+                    Manage Queries
+                  </Link>
+                </AuthDisplayAuthorized>
+                <AuthDisplayAuthorized level="EDITOR">
+                  <button
+                    className="button is-primary"
+                    onClick={() => setShowModal(true)}
+                  >
+                    Start New Run
+                  </button>
+                </AuthDisplayAuthorized>
+              </div>
+            </div>
+          </div>
+
+          {loading && <progress className="progress is-small is-primary" />}
+
+          {runs.length === 0 && !loading ? (
+            <div className="notification is-light">
+              No eval runs yet. Click &ldquo;Start New Run&rdquo; to begin.
+            </div>
+          ) : (
+            <div className="table-container">
+              <table className="table is-striped is-hoverable is-fullwidth">
+                <thead>
+                  <tr>
+                    <th>Name / Set</th>
+                    <th>Prompt</th>
+                    <th>Status</th>
+                    <th>Trials</th>
+                    <th>Desc score</th>
+                    <th>Subj score</th>
+                    <th>Manual</th>
+                    <th>Started</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {runs.map((run) => {
+                    const s = run.summary || {};
+                    const status = enumKey(run.status);
+                    return (
+                      <tr key={run.id}>
+                        <td>
+                          <Link to={`/dashboards/evals/runs/${run.id}`}>
+                            {run.name ||
+                              run.evalSet?.name ||
+                              run.id.slice(0, 8)}
+                          </Link>
+                          {run.evalSet && (
+                            <div className="is-size-7 has-text-grey">
+                              {run.evalSet.name}
+                            </div>
+                          )}
+                        </td>
+                        <td className="is-size-7">{run.promptVersion?.name}</td>
+                        <td>
+                          <span
+                            className={`tag ${STATUS_COLORS[status] || "is-light"}`}
+                          >
+                            {enumLabel(run.status)}
+                          </span>
+                        </td>
+                        <td>
+                          {s.complete ?? 0}/{s.total ?? 0}
+                        </td>
+                        <td className="is-size-7">
+                          {s.meanDescriptionJudgeScore != null
+                            ? `${(s.meanDescriptionJudgeScore * 100).toFixed(0)}%`
+                            : "—"}
+                        </td>
+                        <td className="is-size-7">
+                          {s.meanSubjectsJudgeScore != null
+                            ? `${(s.meanSubjectsJudgeScore * 100).toFixed(0)}%`
+                            : "—"}
+                        </td>
+                        <td className="is-size-7">
+                          <span className="has-text-success">{s.manualGood ?? 0}</span>
+                          {" / "}
+                          <span className="has-text-danger">{s.manualBad ?? 0}</span>
+                        </td>
+                        <td className="is-size-7">
+                          {run.startedAt
+                            ? new Date(run.startedAt).toLocaleDateString()
+                            : "—"}
+                        </td>
+                        <td>
+                          <Link
+                            to={`/dashboards/evals/runs/${run.id}`}
+                            className="button is-small is-light"
+                          >
+                            View
+                          </Link>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {showModal && (
+        <StartRunModal
+          onClose={() => setShowModal(false)}
+          onStarted={handleStarted}
+        />
+      )}
+    </Layout>
+  );
+}

--- a/app/assets/js/screens/Dashboards/Evals/Prompts.jsx
+++ b/app/assets/js/screens/Dashboards/Evals/Prompts.jsx
@@ -1,0 +1,172 @@
+import React, { useState } from "react";
+import { useQuery, useMutation } from "@apollo/client";
+import Layout from "@js/screens/Layout";
+import { Breadcrumbs } from "@js/components/UI/UI";
+import {
+  GET_EVAL_PROMPT_VERSIONS,
+  CREATE_EVAL_PROMPT_VERSION,
+  ARCHIVE_EVAL_PROMPT_VERSION,
+} from "@js/components/Dashboards/Evals/evals.gql";
+
+function PromptVersionCard({ v, isLatest, onArchive }) {
+  const [showPrompts, setShowPrompts] = useState(false);
+  return (
+    <div className="box">
+      <div className="level is-marginless">
+        <div className="level-left">
+          <div>
+            <strong>{v.name}</strong>
+            {isLatest && <span className="tag is-success is-light ml-2">latest</span>}
+            {v.archived && <span className="tag is-light ml-2">archived</span>}
+            {v.changeNotes && <p className="is-size-7 has-text-grey">{v.changeNotes}</p>}
+            <p className="is-size-7 has-text-grey-light">by {v.author || "unknown"} · {new Date(v.insertedAt).toLocaleDateString()}</p>
+          </div>
+        </div>
+        <div className="level-right" style={{ gap: "0.5rem" }}>
+          <button
+            className="button is-small is-light"
+            onClick={() => setShowPrompts((s) => !s)}
+          >
+            {showPrompts ? "Hide tasks" : "View tasks"}
+          </button>
+          {!v.archived && (
+            <button className="button is-small is-light is-warning" onClick={onArchive}>
+              Archive
+            </button>
+          )}
+        </div>
+      </div>
+      {showPrompts && (
+        <div className="mt-4">
+          <p className="label is-small">Subject headings task</p>
+          <pre className="is-size-7" style={{ whiteSpace: "pre-wrap", background: "#f5f5f5", padding: "0.75rem", borderRadius: "4px", marginBottom: "1rem" }}>
+            {v.subjectPrompt || "(none)"}
+          </pre>
+          <p className="label is-small">Description task</p>
+          <pre className="is-size-7" style={{ whiteSpace: "pre-wrap", background: "#f5f5f5", padding: "0.75rem", borderRadius: "4px" }}>
+            {v.descriptionPrompt || "(none)"}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function EvalsPromptsScreen() {
+  const { data, loading } = useQuery(GET_EVAL_PROMPT_VERSIONS);
+  const [showNew, setShowNew] = useState(false);
+  const [form, setForm] = useState({
+    name: "",
+    subjectPrompt: "",
+    descriptionPrompt: "",
+    changeNotes: "",
+  });
+
+  const [createVersion] = useMutation(CREATE_EVAL_PROMPT_VERSION, {
+    refetchQueries: [{ query: GET_EVAL_PROMPT_VERSIONS }],
+  });
+  const [archiveVersion] = useMutation(ARCHIVE_EVAL_PROMPT_VERSION, {
+    refetchQueries: [{ query: GET_EVAL_PROMPT_VERSIONS }],
+  });
+
+  const versions = data?.evalPromptVersions || [];
+  const latest = versions[0];
+  const latestId = latest?.id;
+
+  const resetForm = () => {
+    setForm({
+      name: "",
+      subjectPrompt: latest?.subjectPrompt || "",
+      descriptionPrompt: latest?.descriptionPrompt || "",
+      changeNotes: "",
+    });
+  };
+
+  const handleSave = async () => {
+    await createVersion({
+      variables: {
+        ...form,
+        parentVersionId: latestId,
+      },
+    });
+    setShowNew(false);
+    resetForm();
+  };
+
+  return (
+    <Layout>
+      <section className="section">
+        <div className="container">
+          <Breadcrumbs items={[
+            { label: "Dashboards", isActive: false },
+            { label: "AI Metadata Evals", route: "/dashboards/evals", isActive: false },
+            { label: "Prompt Versions", route: "/dashboards/evals/prompts", isActive: true },
+          ]} />
+
+          <div className="level">
+            <div className="level-left"><h1 className="title">Prompt Versions</h1></div>
+            <div className="level-right">
+              <button
+                className="button is-primary"
+                onClick={() => {
+                  resetForm();
+                  setShowNew(true);
+                }}
+              >
+                New Version
+              </button>
+            </div>
+          </div>
+
+          {showNew && (
+            <div className="box">
+              <h2 className="subtitle">New Prompt Version</h2>
+              <p className="is-size-7 has-text-grey mb-3">Parent will be set to the latest active version automatically.</p>
+              <div className="field">
+                <label className="label">Name</label>
+                <input className="input" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} />
+              </div>
+              <div className="field">
+                <label className="label">Change notes</label>
+                <input className="input" value={form.changeNotes} onChange={(e) => setForm({ ...form, changeNotes: e.target.value })} />
+              </div>
+              <div className="field">
+                <label className="label">Subject headings task</label>
+                <textarea
+                  className="textarea"
+                  rows={5}
+                  value={form.subjectPrompt}
+                  onChange={(e) => setForm({ ...form, subjectPrompt: e.target.value })}
+                />
+              </div>
+              <div className="field">
+                <label className="label">Description task</label>
+                <textarea
+                  className="textarea"
+                  rows={4}
+                  value={form.descriptionPrompt}
+                  onChange={(e) => setForm({ ...form, descriptionPrompt: e.target.value })}
+                />
+              </div>
+              <div className="buttons">
+                <button className="button is-primary" onClick={handleSave} disabled={!form.name || !form.subjectPrompt || !form.descriptionPrompt}>Save</button>
+                <button className="button" onClick={() => { setShowNew(false); resetForm(); }}>Cancel</button>
+              </div>
+            </div>
+          )}
+
+          {loading && <progress className="progress is-small is-primary" />}
+
+          {versions.map((v, i) => (
+            <PromptVersionCard
+              key={v.id}
+              v={v}
+              isLatest={i === 0}
+              onArchive={() => { if (confirm(`Archive "${v.name}"?`)) archiveVersion({ variables: { id: v.id } }); }}
+            />
+          ))}
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/app/assets/js/screens/Dashboards/Evals/Queries.jsx
+++ b/app/assets/js/screens/Dashboards/Evals/Queries.jsx
@@ -1,0 +1,120 @@
+import React, { useState } from "react";
+import { useQuery, useMutation } from "@apollo/client";
+import Layout from "@js/screens/Layout";
+import { Breadcrumbs } from "@js/components/UI/UI";
+import {
+  GET_EVAL_QUERY_LIST,
+  CREATE_EVAL_QUERY,
+  UPDATE_EVAL_QUERY,
+  DELETE_EVAL_QUERY,
+} from "@js/components/Dashboards/Evals/evals.gql";
+
+export default function EvalsQueriesScreen() {
+  const { data, loading } = useQuery(GET_EVAL_QUERY_LIST);
+  const [editing, setEditing] = useState(null);
+  const [showNew, setShowNew] = useState(false);
+  const [form, setForm] = useState({ name: "", description: "", queryJson: "{}" });
+  const [jsonError, setJsonError] = useState(null);
+
+  const [createQuery] = useMutation(CREATE_EVAL_QUERY, { refetchQueries: [{ query: GET_EVAL_QUERY_LIST }] });
+  const [updateQuery] = useMutation(UPDATE_EVAL_QUERY, { refetchQueries: [{ query: GET_EVAL_QUERY_LIST }] });
+  const [deleteQuery] = useMutation(DELETE_EVAL_QUERY, { refetchQueries: [{ query: GET_EVAL_QUERY_LIST }] });
+
+  const queries = data?.evalQueryList || [];
+
+  const validateJson = (str) => {
+    try { JSON.parse(str); setJsonError(null); return true; }
+    catch (e) { setJsonError(e.message); return false; }
+  };
+
+  const handleSave = async () => {
+    if (!validateJson(form.queryJson)) return;
+    const vars = { name: form.name, description: form.description, queryJson: form.queryJson };
+    if (editing) {
+      await updateQuery({ variables: { id: editing.id, ...vars } });
+      setEditing(null);
+    } else {
+      await createQuery({ variables: vars });
+      setShowNew(false);
+    }
+    setForm({ name: "", description: "", queryJson: "{}" });
+  };
+
+  const startEdit = (q) => {
+    setEditing(q);
+    setForm({ name: q.name, description: q.description || "", queryJson: JSON.stringify(q.queryJson, null, 2) });
+    setShowNew(false);
+  };
+
+  const queries_form = (
+    <div className="box">
+      <h2 className="subtitle">{editing ? "Edit Query" : "New Query"}</h2>
+      <div className="field">
+        <label className="label">Name</label>
+        <input className="input" value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} />
+      </div>
+      <div className="field">
+        <label className="label">Description</label>
+        <input className="input" value={form.description} onChange={(e) => setForm({ ...form, description: e.target.value })} />
+      </div>
+      <div className="field">
+        <label className="label">OpenSearch query JSON</label>
+        <textarea
+          className={`textarea is-family-monospace${jsonError ? " is-danger" : ""}`}
+          rows={8}
+          value={form.queryJson}
+          onChange={(e) => { setForm({ ...form, queryJson: e.target.value }); validateJson(e.target.value); }}
+        />
+        {jsonError && <p className="help is-danger">{jsonError}</p>}
+      </div>
+      <div className="buttons">
+        <button className="button is-primary" onClick={handleSave} disabled={!!jsonError}>Save</button>
+        <button className="button" onClick={() => { setEditing(null); setShowNew(false); }}>Cancel</button>
+      </div>
+    </div>
+  );
+
+  return (
+    <Layout>
+      <section className="section">
+        <div className="container">
+          <Breadcrumbs items={[
+            { label: "Dashboards", isActive: false },
+            { label: "AI Metadata Evals", route: "/dashboards/evals", isActive: false },
+            { label: "Manage Queries", route: "/dashboards/evals/queries", isActive: true },
+          ]} />
+          <div className="level">
+            <div className="level-left"><h1 className="title">Eval Queries</h1></div>
+            <div className="level-right">
+              <button className="button is-primary" onClick={() => { setShowNew(true); setEditing(null); setForm({ name: "", description: "", queryJson: '{"query":{"match_all":{}}}' }); }}>
+                New Query
+              </button>
+            </div>
+          </div>
+
+          {showNew && queries_form}
+
+          {loading && <progress className="progress is-small is-primary" />}
+
+          {queries.map((q) => (
+            <div key={q.id}>
+              {editing?.id === q.id ? queries_form : (
+                <div className="box is-flex is-justify-content-space-between is-align-items-center">
+                  <div>
+                    <strong>{q.name}</strong>
+                    {q.description && <p className="is-size-7 has-text-grey">{q.description}</p>}
+                    <p className="is-size-7 has-text-grey-light">by {q.author || "unknown"}</p>
+                  </div>
+                  <div className="buttons">
+                    <button className="button is-small is-light" onClick={() => startEdit(q)}>Edit</button>
+                    <button className="button is-small is-danger is-outlined" onClick={() => { if (confirm(`Delete "${q.name}"?`)) deleteQuery({ variables: { id: q.id } }); }}>Delete</button>
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/app/assets/js/screens/Root.jsx
+++ b/app/assets/js/screens/Root.jsx
@@ -26,6 +26,10 @@ import ScreensDashboardsLocalAuthoritiesList from "@js/screens/Dashboards/LocalA
 import ScreensDashboardsObsoleteTermsList from "./Dashboards/Authorities/ObsoleteTerms/List";
 import ScreensDashboardsPreservationChecksList from "@js/screens/Dashboards/PreservationChecks/List";
 import ScreensDashboardsUsersList from "@js/screens/Dashboards/Users/List";
+import ScreensDashboardsEvalsDetails from "@js/screens/Dashboards/Evals/Details";
+import ScreensDashboardsEvalsList from "@js/screens/Dashboards/Evals/List";
+import ScreensDashboardsEvalsPrompts from "@js/screens/Dashboards/Evals/Prompts";
+import ScreensDashboardsEvalsQueries from "@js/screens/Dashboards/Evals/Queries";
 import ScreensIngestSheet from "./IngestSheet/IngestSheet";
 import ScreensProject from "./Project/Project";
 import ScreensProjectList from "./Project/List";
@@ -132,6 +136,26 @@ export default class Root extends React.Component {
                   exact
                   path="/dashboards/users"
                   component={ScreensDashboardsUsersList}
+                />
+                <PrivateRoute
+                  exact
+                  path="/dashboards/evals"
+                  component={ScreensDashboardsEvalsList}
+                />
+                <PrivateRoute
+                  exact
+                  path="/dashboards/evals/runs/:id"
+                  component={ScreensDashboardsEvalsDetails}
+                />
+                <PrivateRoute
+                  exact
+                  path="/dashboards/evals/queries"
+                  component={ScreensDashboardsEvalsQueries}
+                />
+                <PrivateRoute
+                  exact
+                  path="/dashboards/evals/prompts"
+                  component={ScreensDashboardsEvalsPrompts}
                 />
                 <PrivateRoute exact path="/" component={Home} />
                 <PrivateRoute component={NotFound} />

--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "@allmaps/leaflet": "^1.0.0-beta.53",
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",
@@ -13378,6 +13378,21 @@
         "object-assign": "^4.1.1"
       }
     },
+    "node_modules/chonky/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "dev": true,
@@ -21921,6 +21936,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/recharts/node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/recharts/node_modules/reselect": {
       "version": "5.1.1",

--- a/app/config/dev.exs
+++ b/app/config/dev.exs
@@ -49,3 +49,5 @@ config :phoenix, :stacktrace_depth, 20
 
 # Initialize plugs at runtime for faster development compilation
 config :phoenix, :plug_init_mode, :runtime
+
+config :meadow, :evals, default_query_name: "match_all"

--- a/app/config/prod.exs
+++ b/app/config/prod.exs
@@ -10,3 +10,5 @@ config :logger,
     [level_lower_than: :info]
   ],
   level: :info
+
+config :meadow, :evals, default_query_name: "Berkeley Folk Music Festival — has description + subjects"

--- a/app/config/test.exs
+++ b/app/config/test.exs
@@ -24,3 +24,5 @@ config :logger, level: :info
 config :logger, :console, format: {Meadow.TestLogHandler, :format}
 
 config :elixir, :ansi_enabled, true
+
+config :meadow, :evals, default_query_name: "match_all"

--- a/app/lib/meadow/application/children.ex
+++ b/app/lib/meadow/application/children.ex
@@ -49,6 +49,12 @@ defmodule Meadow.Application.Children do
          registry:
            {MeadowWeb.MCP.HordeRegistry,
             [name: Anubis.Server.Registry.registry_name(MeadowWeb.MCP.Server)]},
+         supervisor: {MeadowWeb.MCP.HordeSupervisor, []}},
+        {MeadowWeb.MCP.EvalServer,
+         transport: :streamable_http,
+         registry:
+           {MeadowWeb.MCP.HordeRegistry,
+            [name: Anubis.Server.Registry.registry_name(MeadowWeb.MCP.EvalServer)]},
          supervisor: {MeadowWeb.MCP.HordeSupervisor, []}}
       ],
       "web.notifiers" => [
@@ -61,7 +67,8 @@ defmodule Meadow.Application.Children do
     %{
       "metadata" => [
         {MeadowAI.MetadataAgent, []},
-        {Task.Supervisor, name: MeadowAI.MetadataAgent.TaskSupervisor}
+        {Task.Supervisor, name: MeadowAI.MetadataAgent.TaskSupervisor},
+        {Task.Supervisor, name: Meadow.Evals.TaskSupervisor}
       ]
     }
   end

--- a/app/lib/meadow/config.ex
+++ b/app/lib/meadow/config.ex
@@ -11,6 +11,12 @@ defmodule Meadow.Config do
     |> Keyword.get(key, default)
   end
 
+  @doc "Get evals-related configuration"
+  def evals(key, default \\ nil) do
+    Application.get_env(:meadow, :evals, [])
+    |> Keyword.get(key, default)
+  end
+
   @doc "Retrieve the environment specific URL for the Digital Collections website"
   def digital_collections_url do
     Application.get_env(:meadow, :digital_collections_url)

--- a/app/lib/meadow/evals.ex
+++ b/app/lib/meadow/evals.ex
@@ -1,0 +1,496 @@
+defmodule Meadow.Evals do
+  @moduledoc "Context for the evals feature."
+
+  import Ecto.Query
+  alias Meadow.{Config, Repo}
+  alias Meadow.Data.{Schemas.Work, Works}
+
+  alias Meadow.Evals.Schemas.{
+    EvalPromptVersion,
+    EvalQuery,
+    EvalRun,
+    EvalSet,
+    EvalSetMember,
+    EvalTrial
+  }
+
+  alias Meadow.Search.Config, as: SearchConfig
+  alias Meadow.Search.Slice
+  require Logger
+
+  @max_works_per_set 20
+  @default_eval_system_prompt """
+  You are a digital library metadata specialist generating structured metadata for image works.
+  Use the available tools to analyze the image, find appropriate subject headings, then call
+  mcp__meadow__submit_eval_metadata to store the results. Do not return the results as text.
+  """
+
+  @default_subject_prompt """
+  Find 3 appropriate subject headings
+  based on what you see - people, places, events, topics, or objects in the image.
+  Use authority_code: "lcnaf" for names and "fast" for everything else.
+  """
+
+  @default_description_prompt "Write a concise descriptive summary (1-3 sentences)."
+
+  # ---------------------------------------------------------------------------
+  # Eval Queries
+  # ---------------------------------------------------------------------------
+
+  def list_eval_queries do
+    Repo.all(from q in EvalQuery, order_by: [asc: q.name])
+  end
+
+  def get_eval_query!(id), do: Repo.get!(EvalQuery, id)
+
+  def get_eval_query_by_name(name), do: Repo.get_by(EvalQuery, name: name)
+
+  def create_eval_query(attrs) do
+    %EvalQuery{} |> EvalQuery.changeset(attrs) |> Repo.insert()
+  end
+
+  def update_eval_query(%EvalQuery{} = q, attrs) do
+    q |> EvalQuery.changeset(attrs) |> Repo.update()
+  end
+
+  def delete_eval_query(%EvalQuery{} = q), do: Repo.delete(q)
+
+  def default_eval_query do
+    case Config.evals(:default_query_name) do
+      nil -> nil
+      name -> get_eval_query_by_name(name)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Eval Prompt Versions
+  # ---------------------------------------------------------------------------
+
+  def list_prompt_versions do
+    Repo.all(from pv in EvalPromptVersion, order_by: [desc: pv.inserted_at])
+  end
+
+  def list_active_prompt_versions do
+    Repo.all(
+      from pv in EvalPromptVersion, where: pv.archived == false, order_by: [desc: pv.inserted_at]
+    )
+  end
+
+  def get_prompt_version!(id), do: Repo.get!(EvalPromptVersion, id)
+
+  def create_prompt_version(attrs) do
+    %EvalPromptVersion{}
+    |> EvalPromptVersion.changeset(assemble_prompt_version(attrs))
+    |> Repo.insert()
+  end
+
+  def archive_prompt_version(%EvalPromptVersion{} = pv) do
+    pv |> EvalPromptVersion.archive() |> Repo.update()
+  end
+
+  def latest_prompt_version do
+    Repo.one(
+      from pv in EvalPromptVersion,
+        where: pv.archived == false,
+        order_by: [desc: pv.inserted_at],
+        limit: 1
+    )
+  end
+
+  def default_eval_system_prompt, do: String.trim(@default_eval_system_prompt)
+  def default_subject_prompt, do: String.trim(@default_subject_prompt)
+  def default_description_prompt, do: String.trim(@default_description_prompt)
+
+  def eval_user_prompt_template(subject_prompt, description_prompt) do
+    subject_prompt = prompt_task_text(subject_prompt, default_subject_prompt())
+    description_prompt = prompt_task_text(description_prompt, default_description_prompt())
+
+    """
+    Analyze the following IMAGE work from a digital library collection.
+
+    Work ID: {work_id}
+    Trial ID: {trial_id}
+    Accession Number: {accession_number}
+
+    1. Call `mcp__meadow__get_iiif_image` with file_set_id: "{file_set_id}" to view the image.
+    #{numbered_prompt_task(2, subject_prompt)}
+    #{numbered_prompt_task(3, description_prompt)}
+    4. Call `mcp__meadow__submit_eval_metadata` with:
+       - trial_id: "{trial_id}"
+       - description: your 1-3 sentence summary
+       - subjects: array from mcp__meadow__authority_search results, each with id and label
+    """
+    |> String.trim()
+  end
+
+  defp assemble_prompt_version(attrs) do
+    subject_prompt = prompt_attr(attrs, :subject_prompt)
+    description_prompt = prompt_attr(attrs, :description_prompt)
+
+    if present?(subject_prompt) or present?(description_prompt) do
+      subject_prompt = prompt_task_text(subject_prompt, default_subject_prompt())
+      description_prompt = prompt_task_text(description_prompt, default_description_prompt())
+
+      attrs
+      |> Map.put(:subject_prompt, subject_prompt)
+      |> Map.put(:description_prompt, description_prompt)
+      |> Map.put_new(:system_prompt, default_eval_system_prompt())
+      |> Map.put_new(
+        :user_prompt_template,
+        eval_user_prompt_template(subject_prompt, description_prompt)
+      )
+    else
+      attrs
+    end
+  end
+
+  defp prompt_attr(attrs, key) do
+    Map.get(attrs, key) || Map.get(attrs, Atom.to_string(key))
+  end
+
+  defp present?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present?(value), do: not is_nil(value)
+
+  defp prompt_task_text(value, default) when is_binary(value) do
+    case String.trim(value) do
+      "" -> default
+      trimmed -> trimmed
+    end
+  end
+
+  defp prompt_task_text(_value, default), do: default
+
+  defp numbered_prompt_task(number, text) do
+    [first_line | remaining_lines] = String.split(text, "\n")
+
+    ([to_string(number) <> ". " <> first_line] ++ Enum.map(remaining_lines, &("   " <> &1)))
+    |> Enum.join("\n")
+  end
+
+  def eval_system_prompt(nil), do: nil
+
+  def eval_system_prompt(system_prompt) do
+    """
+    #{eval_tool_prompt(system_prompt)}
+
+    Eval runs use the IIIF-ready Meadow MCP tools. Use these exact tool names:
+    - mcp__meadow__get_iiif_image
+    - mcp__meadow__authority_search
+    - mcp__meadow__submit_eval_metadata
+    """
+    |> String.trim()
+  end
+
+  def eval_tool_prompt(prompt) do
+    prompt
+    |> String.replace(
+      ~r/(?<!mcp__meadow__)\bapply_work_metadata\b/,
+      "mcp__meadow__submit_eval_metadata"
+    )
+    |> String.replace(
+      ~r/(?<!mcp__meadow__)\bsubmit_eval_metadata\b/,
+      "mcp__meadow__submit_eval_metadata"
+    )
+    |> String.replace(~r/(?<!mcp__meadow__)\bauthority_search\b/, "mcp__meadow__authority_search")
+    |> String.replace(~r/(?<!mcp__meadow__)\bget_iiif_image\b/, "mcp__meadow__get_iiif_image")
+    |> String.replace(~r/(?<!mcp__meadow__)\bget_image\b/, "mcp__meadow__get_iiif_image")
+    |> String.replace(~r/\bmcp__meadow__mcp__meadow__/, "mcp__meadow__")
+  end
+
+  # ---------------------------------------------------------------------------
+  # Eval Sets
+  # ---------------------------------------------------------------------------
+
+  def list_eval_sets do
+    Repo.all(from es in EvalSet, order_by: [desc: es.inserted_at])
+  end
+
+  def get_eval_set!(id) do
+    Repo.get!(EvalSet, id)
+    |> Repo.preload([:eval_query, :eval_set_members])
+  end
+
+  @doc """
+  Materialize a new EvalSet from a saved EvalQuery.
+
+  Runs the query against OpenSearch, loads each matching Work, snapshots ground
+  truth (description + subjects), and stores one EvalSetMember per work.
+  Works with no description AND fewer than 3 subjects are skipped.
+  Returns {:ok, eval_set, skipped_count} or {:error, reason}.
+  """
+  def create_eval_set_from_work_ids(work_ids, attrs) when is_list(work_ids) do
+    query_json = %{"query" => %{"ids" => %{"values" => work_ids}}}
+    transient = %EvalQuery{id: nil, query_json: query_json}
+    create_eval_set_from_query(transient, attrs)
+  end
+
+  def create_eval_set_from_query(%EvalQuery{} = eval_query, attrs) do
+    Logger.info("Evals: materializing set from query #{eval_query.id}")
+
+    query_body =
+      Map.merge(eval_query.query_json, %{"_source" => false, "fields" => [], "size" => 10_000})
+
+    with {:ok, work_ids} <- fetch_work_ids(query_body),
+         work_ids <- truncate_work_ids(work_ids),
+         {members_attrs, skipped} <- build_members(work_ids),
+         work_count <- length(members_attrs) do
+      set_attrs =
+        attrs
+        |> Map.put(:query_id, eval_query.id)
+        |> Map.put(:query_snapshot, eval_query.query_json)
+        |> Map.put(:work_count, work_count)
+
+      Repo.transaction(fn ->
+        set = %EvalSet{} |> EvalSet.changeset(set_attrs) |> Repo.insert!()
+        Enum.each(members_attrs, &insert_eval_set_member(&1, set.id))
+        {set, skipped}
+      end)
+      |> case do
+        {:ok, {set, skipped}} -> {:ok, set, skipped}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  defp truncate_work_ids(work_ids) do
+    if length(work_ids) > @max_works_per_set do
+      Logger.info(
+        "Evals: query returned #{length(work_ids)} works; truncating to #{@max_works_per_set}"
+      )
+
+      Enum.take(work_ids, @max_works_per_set)
+    else
+      work_ids
+    end
+  end
+
+  defp insert_eval_set_member(member_attrs, eval_set_id) do
+    %EvalSetMember{}
+    |> EvalSetMember.changeset(Map.put(member_attrs, :eval_set_id, eval_set_id))
+    |> Repo.insert!()
+  end
+
+  defp fetch_work_ids(query_body) do
+    case Slice.paginate(query_body, SearchConfig.alias_for(Work, 2)) do
+      {:error, reason} ->
+        {:error, reason}
+
+      slice ->
+        ids =
+          0..(slice.max_slices - 1)
+          |> Enum.chunk_every(10)
+          |> Enum.flat_map(&fetch_slice_ids_chunk(slice, &1))
+
+        Slice.finish(slice)
+        {:ok, ids}
+    end
+  end
+
+  defp fetch_slice_ids_chunk(slice, chunk) do
+    chunk
+    |> Enum.map(&Task.async(fn -> fetch_slice_ids(slice, &1) end))
+    |> Enum.map(&Task.await(&1, 30_000))
+    |> List.flatten()
+  end
+
+  defp fetch_slice_ids(slice, slice_number) do
+    case Slice.slice(slice, slice_number) do
+      {:ok, hits} -> Enum.map(hits, fn %{"_id" => id} -> id end)
+      {:error, _} -> []
+    end
+  end
+
+  defp build_members(work_ids) do
+    work_ids
+    |> Enum.reduce({[], 0}, fn work_id, {acc, skipped} ->
+      case build_member_attrs(work_id) do
+        nil -> {acc, skipped + 1}
+        attrs -> {[attrs | acc], skipped}
+      end
+    end)
+    |> then(fn {members, skipped} -> {Enum.reverse(members), skipped} end)
+  end
+
+  defp build_member_attrs(work_id) do
+    work = Works.get_work!(work_id)
+    dm = work.descriptive_metadata
+    subjects = snapshot_subjects(dm.subject || [])
+    descriptions = dm.description || []
+
+    if descriptions == [] and length(subjects) < 3 do
+      nil
+    else
+      rep_fs_id = work.representative_file_set_id || first_access_file_set_id(work_id)
+
+      %{
+        work_id: work.id,
+        accession_number: work.accession_number,
+        representative_file_set_id: rep_fs_id,
+        ground_truth: %{
+          description: descriptions,
+          subjects: subjects
+        }
+      }
+    end
+  rescue
+    _ -> nil
+  end
+
+  defp first_access_file_set_id(work_id) do
+    case Works.get_access_files(work_id) |> List.first() do
+      nil -> nil
+      %{id: id} -> id
+    end
+  end
+
+  defp snapshot_subjects(subject_entries) do
+    Enum.map(subject_entries, fn entry ->
+      %{
+        id: entry.term.id,
+        label: entry.term.label
+      }
+    end)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Eval Runs
+  # ---------------------------------------------------------------------------
+
+  def list_runs(opts \\ []) do
+    limit = Keyword.get(opts, :limit, 50)
+    offset = Keyword.get(opts, :offset, 0)
+
+    Repo.all(
+      from r in EvalRun,
+        order_by: [desc: r.inserted_at],
+        limit: ^limit,
+        offset: ^offset,
+        preload: [:eval_set, :prompt_version]
+    )
+  end
+
+  def get_run!(id) do
+    Repo.get!(EvalRun, id)
+    |> Repo.preload([:prompt_version, :eval_trials, eval_set: :eval_set_members])
+  end
+
+  @doc """
+  Create a new run and pre-create all trial rows in :pending state.
+  Does NOT start execution — caller is responsible for calling Runner.start/1.
+  """
+  def create_run(attrs) do
+    Repo.transaction(fn ->
+      run =
+        %EvalRun{}
+        |> EvalRun.changeset(attrs)
+        |> Repo.insert!()
+
+      set = get_eval_set!(run.eval_set_id)
+      trials_per_work = run.trials_per_work
+
+      Enum.each(set.eval_set_members, &insert_trials_for_member(&1, run.id, trials_per_work))
+
+      run
+    end)
+  end
+
+  defp insert_trials_for_member(member, run_id, trials_per_work) do
+    Enum.each(0..(trials_per_work - 1), fn idx ->
+      %EvalTrial{}
+      |> EvalTrial.changeset(%{
+        eval_run_id: run_id,
+        work_id: member.work_id,
+        trial_index: idx
+      })
+      |> Repo.insert!()
+    end)
+  end
+
+  def cancel_run(%EvalRun{} = run) do
+    run |> EvalRun.mark_cancelled() |> Repo.update()
+  end
+
+  def cancel_run(id) when is_binary(id) do
+    get_run!(id) |> cancel_run()
+  end
+
+  # ---------------------------------------------------------------------------
+  # Eval Trials
+  # ---------------------------------------------------------------------------
+
+  def get_trial!(id), do: Repo.get!(EvalTrial, id)
+
+  def list_trials_for_run(run_id) do
+    Repo.all(
+      from t in EvalTrial,
+        where: t.eval_run_id == ^run_id,
+        order_by: [asc: t.work_id, asc: t.trial_index]
+    )
+  end
+
+  def record_agent_output(trial_id, output) do
+    trial = get_trial!(trial_id)
+
+    trial
+    |> Ecto.Changeset.cast(%{agent_output: output}, [:agent_output])
+    |> Repo.update()
+  end
+
+  def score_trial(trial_id, score, notes \\ nil, user \\ nil) when is_binary(trial_id) do
+    trial = get_trial!(trial_id)
+    trial |> EvalTrial.apply_manual_score(score, notes, user) |> Repo.update()
+  end
+
+  def clear_trial_score(trial_id) when is_binary(trial_id) do
+    trial = get_trial!(trial_id)
+    trial |> EvalTrial.clear_manual_score() |> Repo.update()
+  end
+
+  # ---------------------------------------------------------------------------
+  # Run summary stats
+  # ---------------------------------------------------------------------------
+
+  @doc """
+  Compute summary statistics for a run.
+  Returns a map with trial counts, pass rates, cost, and per-work consistency.
+  """
+  def run_summary(%EvalRun{id: run_id}) do
+    trials = list_trials_for_run(run_id)
+    total = length(trials)
+    complete = Enum.count(trials, &(&1.status == :complete))
+    errored = Enum.count(trials, &(&1.status == :errored))
+    pending = Enum.count(trials, &(&1.status == :pending))
+    running = Enum.count(trials, &(&1.status == :running))
+
+    manual_good = Enum.count(trials, &(&1.manual_score == :good))
+    manual_bad = Enum.count(trials, &(&1.manual_score == :bad))
+
+    scored_trials = Enum.filter(trials, &(&1.status == :complete))
+
+    %{
+      total: total,
+      complete: complete,
+      errored: errored,
+      pending: pending,
+      running: running,
+      manual_good: manual_good,
+      manual_bad: manual_bad,
+      mean_description_judge_score: mean_float(scored_trials, & &1.description_judge_score),
+      mean_subjects_judge_score: mean_float(scored_trials, & &1.subjects_judge_score)
+    }
+  end
+
+  def run_summary(run_id) when is_binary(run_id), do: run_summary(get_run!(run_id))
+
+  defp mean_float([], _), do: nil
+
+  defp mean_float(trials, getter) do
+    values = trials |> Enum.map(getter) |> Enum.reject(&is_nil/1)
+
+    if values == [] do
+      nil
+    else
+      (Enum.sum(values) / length(values)) |> Float.round(3)
+    end
+  end
+end

--- a/app/lib/meadow/evals/judge.ex
+++ b/app/lib/meadow/evals/judge.ex
@@ -1,0 +1,203 @@
+defmodule Meadow.Evals.Judge do
+  @moduledoc "LLM-as-judge semantic scoring for eval trials via AWS Bedrock Converse."
+
+  alias Meadow.Config
+  require Logger
+
+  @default_model "us.anthropic.claude-sonnet-4-6"
+  @max_tokens 512
+
+  @judge_system_prompt """
+  You are a metadata quality evaluator for a digital library. Compare AI-generated metadata
+  against a cataloger's ground-truth metadata for the same cultural heritage object. The
+  cataloger's data is known to be incomplete — the AI may provide additional accurate details
+  beyond what the cataloger noted. Judge based on factual consistency and topic coverage, not
+  vocabulary match or length.
+  """
+
+  @doc """
+  Score an eval trial's agent output against ground truth using an LLM judge.
+
+  Returns {:ok, %{description_judge_score, subjects_judge_score, judge_rationale}}
+  or {:error, reason}. On error the caller should store nil for judge fields.
+  """
+  @spec score(map(), map()) ::
+          {:ok, %{description_judge_score: float() | nil, subjects_judge_score: float() | nil, judge_rationale: String.t() | nil}}
+          | {:error, term()}
+  def score(agent_output, ground_truth) do
+    gt_desc = extract_description(ground_truth)
+    gt_subjects = extract_subjects(ground_truth)
+    agent_desc = extract_description(agent_output)
+    agent_subjects = extract_subjects(agent_output)
+
+    prompt = build_prompt(gt_desc, gt_subjects, agent_desc, agent_subjects)
+
+    with {:ok, model_id} <- judge_model(),
+         {:ok, text} <- invoke_bedrock(model_id, prompt) do
+      parse_response(text)
+    end
+  rescue
+    error ->
+      Logger.error("Evals.Judge.score failed: #{Exception.message(error)}")
+      {:error, {:judge_exception, Exception.message(error)}}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private
+  # ---------------------------------------------------------------------------
+
+  defp judge_model do
+    case Config.ai(:transcriber_model, @default_model) do
+      model when is_binary(model) and byte_size(model) > 0 -> {:ok, model}
+      _ -> {:ok, @default_model}
+    end
+  end
+
+  defp invoke_bedrock(model_id, prompt) do
+    body = %{
+      "system" => [%{"text" => @judge_system_prompt |> String.trim()}],
+      "messages" => [%{"role" => "user", "content" => [%{"text" => prompt}]}],
+      "inferenceConfig" => %{"maxTokens" => @max_tokens, "temperature" => 0}
+    }
+
+    operation = %ExAws.Operation.JSON{
+      data: body,
+      headers: [{"Content-Type", "application/json"}],
+      http_method: :post,
+      path: "/model/#{model_id}/converse",
+      service: :"bedrock-runtime"
+    }
+
+    case ExAws.request(operation, service_override: :bedrock) do
+      {:ok, %{"output" => %{"message" => %{"content" => [%{"text" => text} | _]}}}} ->
+        {:ok, text}
+
+      {:ok, unexpected} ->
+        Logger.warning("Evals.Judge: unexpected Bedrock response: #{inspect(unexpected)}")
+        {:error, {:unexpected_response, unexpected}}
+
+      {:error, reason} ->
+        Logger.error("Evals.Judge: Bedrock call failed: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  defp parse_response(text) do
+    # Strip markdown code fences and whitespace, then extract JSON object
+    cleaned =
+      text
+      |> String.replace(~r/```(?:json)?\s*/i, "")
+      |> String.replace("```", "")
+      |> String.trim()
+
+    decoded =
+      case Jason.decode(cleaned) do
+        {:ok, map} ->
+          {:ok, map}
+
+        _ ->
+          case Regex.run(~r/\{.+\}/s, cleaned) do
+            [json] -> Jason.decode(json)
+            nil -> {:error, :no_json_found}
+          end
+      end
+
+    case decoded do
+      {:ok, map} ->
+        desc_score = parse_score(Map.get(map, "description_score"))
+        subj_score = parse_score(Map.get(map, "subjects_score"))
+        rationale = Map.get(map, "rationale", "") |> to_string() |> String.slice(0, 500)
+
+        {:ok,
+         %{
+           description_judge_score: desc_score,
+           subjects_judge_score: subj_score,
+           judge_rationale: if(rationale == "", do: nil, else: rationale)
+         }}
+
+      {:error, reason} ->
+        Logger.warning("Evals.Judge: could not parse judge JSON: #{inspect(reason)}\nRaw: #{text}")
+        {:error, {:json_parse_failed, reason}}
+    end
+  end
+
+  defp parse_score(nil), do: nil
+
+  defp parse_score(value) when is_number(value) do
+    Float.round(max(0.0, min(1.0, value / 1)), 3)
+  end
+
+  defp parse_score(value) when is_binary(value) do
+    case Float.parse(value) do
+      {f, _} -> parse_score(f)
+      :error -> nil
+    end
+  end
+
+  defp parse_score(_), do: nil
+
+  defp extract_description(map) when is_map(map) do
+    (Map.get(map, "description") || Map.get(map, :description) || "")
+    |> List.wrap()
+    |> Enum.join(" ")
+    |> String.trim()
+  end
+
+  defp extract_description(_), do: ""
+
+  defp extract_subjects(map) when is_map(map) do
+    (Map.get(map, "subjects") || Map.get(map, :subjects) || [])
+    |> Enum.map(fn s ->
+      label = Map.get(s, "label") || Map.get(s, :label) || ""
+      id = Map.get(s, "id") || Map.get(s, :id) || ""
+      if label != "", do: label, else: id
+    end)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("; ")
+  end
+
+  defp extract_subjects(_), do: ""
+
+  defp build_prompt(gt_desc, gt_subjects, agent_desc, agent_subjects) do
+    """
+    Score the AI-generated metadata against the cataloger's metadata.
+
+    SCORING DIMENSIONS (each 0.0–1.0):
+
+    description_score — Fidelity of the AI description to the cataloger's stated facts:
+    • 1.0: AI covers all cataloger facts; any extras are plausible and consistent
+    • 0.7–0.9: Covers most key facts; minor omissions or stylistic differences
+    • 0.4–0.6: Partial overlap; substantive gaps or mild contradictions
+    • 0.0–0.3: Mostly misses cataloger facts or directly contradicts them
+    DO NOT penalize the AI for providing more detail than the cataloger.
+
+    subjects_score — Alignment of AI subjects with cataloger subjects:
+    • Treat LCSH and FAST subjects with the same meaning as equivalent
+    • Reward coverage of the cataloger's main topics regardless of vocabulary
+    • DO NOT penalize extra plausible subjects
+    • Penalize only: (a) missing major cataloger topics, (b) clearly off-topic additions
+    • 1.0: All major cataloger topics represented; extras are plausible
+    • 0.7–0.9: Most cataloger topics covered; minor gaps
+    • 0.4–0.6: Several cataloger topics missing or some questionable additions
+    • 0.0–0.3: Most cataloger topics absent or AI subjects are largely off-topic
+
+    Return ONLY valid JSON with no other text:
+    {"description_score": <float>, "subjects_score": <float>, "rationale": "<1-2 sentences>"}
+
+    ---
+
+    CATALOGER DESCRIPTION:
+    #{if gt_desc == "", do: "(none provided)", else: gt_desc}
+
+    CATALOGER SUBJECTS:
+    #{if gt_subjects == "", do: "(none provided)", else: gt_subjects}
+
+    AI DESCRIPTION:
+    #{if agent_desc == "", do: "(none provided)", else: agent_desc}
+
+    AI SUBJECTS:
+    #{if agent_subjects == "", do: "(none provided)", else: agent_subjects}
+    """
+    |> String.trim()
+  end
+end

--- a/app/lib/meadow/evals/runner.ex
+++ b/app/lib/meadow/evals/runner.ex
@@ -1,0 +1,200 @@
+defmodule Meadow.Evals.Runner do
+  @moduledoc "Executes an EvalRun by dispatching agent calls for each trial."
+
+  require Logger
+
+  import Ecto.Query
+  alias Meadow.{Evals, Repo}
+  alias Meadow.Evals.{Judge, Schemas.EvalRun, Schemas.EvalTrial}
+  alias MeadowWeb.Router.Helpers, as: Routes
+
+  @doc """
+  Start execution of a run in a supervised background task.
+  Idempotent: if the run is already running or complete, this is a no-op.
+  """
+  def start(run_id) when is_binary(run_id) do
+    Task.Supervisor.start_child(
+      Meadow.Evals.TaskSupervisor,
+      fn -> execute(run_id) end,
+      restart: :temporary
+    )
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private execution logic
+  # ---------------------------------------------------------------------------
+
+  defp execute(run_id) do
+    run = Evals.get_run!(run_id)
+
+    if run.status in [:pending, :running] do
+      run
+      |> EvalRun.mark_running()
+      |> Repo.update!()
+
+      Logger.info("Evals.Runner: starting run #{run_id} (#{length(run.eval_trials)} trials)")
+
+      try do
+        execute_trials(run)
+        run = Repo.get!(EvalRun, run_id)
+        run |> EvalRun.mark_complete() |> Repo.update!()
+        Logger.info("Evals.Runner: run #{run_id} complete")
+      rescue
+        error ->
+          Logger.error("Evals.Runner: run #{run_id} failed: #{Exception.message(error)}")
+
+          Repo.get!(EvalRun, run_id)
+          |> EvalRun.mark_errored(Exception.message(error))
+          |> Repo.update!()
+      end
+    else
+      Logger.info("Evals.Runner: run #{run_id} already #{run.status}, skipping")
+      :ok
+    end
+  end
+
+  defp execute_trials(run) do
+    set = Evals.get_eval_set!(run.eval_set_id)
+    prompt_version = Evals.get_prompt_version!(run.prompt_version_id)
+    concurrency = run.concurrency || 3
+
+    # Build (member, trial_index) pairs for all pending trials
+    work_map = Map.new(set.eval_set_members, &{&1.work_id, &1})
+
+    pending_trials =
+      from(t in EvalTrial,
+        where: t.eval_run_id == ^run.id and t.status == :pending,
+        order_by: [asc: t.work_id, asc: t.trial_index]
+      )
+      |> Repo.all()
+
+    pending_trials
+    |> Task.async_stream(
+      fn trial ->
+        member = Map.get(work_map, trial.work_id)
+
+        if halted?(run.id) do
+          :halted
+        else
+          execute_trial(run, trial, member, prompt_version)
+        end
+      end,
+      max_concurrency: concurrency,
+      timeout: :infinity,
+      on_timeout: :kill_task
+    )
+    |> Stream.run()
+  end
+
+  defp halted?(run_id) do
+    case Repo.get(EvalRun, run_id) do
+      %EvalRun{status: status} when status in [:cancelled, :errored] -> true
+      _ -> false
+    end
+  end
+
+  defp execute_trial(run, trial, member, prompt_version) do
+    do_execute_trial(run, trial, member, prompt_version)
+  end
+
+  defp do_execute_trial(run, trial, member, prompt_version) do
+    trial |> EvalTrial.mark_running() |> Repo.update!()
+
+    mcp_url = Routes.page_url(MeadowWeb.Endpoint, :index, ["api", "mcp", "eval"])
+
+    prompt =
+      prompt_version.user_prompt_template
+      |> render_prompt(%{
+        work_id: trial.work_id,
+        trial_id: trial.id,
+        file_set_id: member && member.representative_file_set_id,
+        accession_number: member && member.accession_number
+      })
+      |> Evals.eval_tool_prompt()
+
+    context = %{
+      system_prompt: Evals.eval_system_prompt(prompt_version.system_prompt),
+      eval: true,
+      run_id: run.id,
+      trial_id: trial.id,
+      work_id: trial.work_id
+    }
+
+    started_at = System.monotonic_time(:millisecond)
+
+    result = MeadowAI.query(prompt, mcp_url: mcp_url, context: context)
+
+    duration_ms = System.monotonic_time(:millisecond) - started_at
+
+    case result do
+      {:ok, response} ->
+        handle_agent_response(trial, member, prompt, duration_ms, response)
+
+      {:error, reason} ->
+        Logger.error("Evals.Runner: trial #{trial.id} failed: #{inspect(reason)}")
+
+        trial |> EvalTrial.mark_errored(inspect(reason)) |> Repo.update!()
+    end
+  end
+
+  defp handle_agent_response(trial, member, prompt, duration_ms, response) do
+    # Reload trial to get agent_output written by SubmitEvalMetadata
+    fresh_trial = Evals.get_trial!(trial.id)
+
+    if missing_agent_output?(fresh_trial.agent_output) do
+      fresh_trial
+      |> EvalTrial.mark_errored("Agent completed without calling submit_eval_metadata")
+      |> Repo.update!()
+    else
+      complete_trial(fresh_trial, member, prompt, duration_ms, response)
+    end
+  end
+
+  defp complete_trial(trial, member, prompt, duration_ms, response) do
+    judge = judge_scores(trial, member)
+
+    trial
+    |> EvalTrial.mark_complete(%{
+      transcript: %{
+        result: Map.get(response, "result"),
+        model: Map.get(response, "model"),
+        prompt: prompt
+      },
+      duration_ms: duration_ms,
+      description_judge_score: judge.description_judge_score,
+      subjects_judge_score: judge.subjects_judge_score,
+      judge_rationale: judge.judge_rationale
+    })
+    |> Repo.update!()
+  end
+
+  defp judge_scores(trial, member) do
+    ground_truth = (member && member.ground_truth) || %{}
+
+    case Judge.score(trial.agent_output, ground_truth) do
+      {:ok, scores} ->
+        scores
+
+      {:error, reason} ->
+        Logger.warning(
+          "Evals.Runner: judge scoring failed for trial #{trial.id}: #{inspect(reason)}"
+        )
+
+        %{
+          description_judge_score: nil,
+          subjects_judge_score: nil,
+          judge_rationale: nil
+        }
+    end
+  end
+
+  defp render_prompt(template, assigns) do
+    Enum.reduce(assigns, template, fn {key, value}, acc ->
+      String.replace(acc, "{#{key}}", to_string(value || ""))
+    end)
+  end
+
+  defp missing_agent_output?(nil), do: true
+  defp missing_agent_output?(output) when output == %{}, do: true
+  defp missing_agent_output?(_), do: false
+end

--- a/app/lib/meadow/evals/schemas/eval_prompt_version.ex
+++ b/app/lib/meadow/evals/schemas/eval_prompt_version.ex
@@ -1,0 +1,42 @@
+defmodule Meadow.Evals.Schemas.EvalPromptVersion do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, Ecto.UUID, autogenerate: false, read_after_writes: true}
+  @foreign_key_type Ecto.UUID
+  @timestamps_opts [type: :utc_datetime_usec]
+  schema "eval_prompt_versions" do
+    field(:name, :string)
+    field(:system_prompt, :string)
+    field(:user_prompt_template, :string)
+    field(:subject_prompt, :string)
+    field(:description_prompt, :string)
+    field(:parent_version_id, Ecto.UUID)
+    field(:author, :string)
+    field(:change_notes, :string)
+    field(:archived, :boolean, default: false)
+    timestamps()
+  end
+
+  def changeset(prompt_version, attrs) do
+    prompt_version
+    |> cast(attrs, [
+      :name,
+      :system_prompt,
+      :user_prompt_template,
+      :subject_prompt,
+      :description_prompt,
+      :parent_version_id,
+      :author,
+      :change_notes,
+      :archived
+    ])
+    |> validate_required([:name, :system_prompt, :user_prompt_template])
+    |> foreign_key_constraint(:parent_version_id)
+  end
+
+  def archive(prompt_version) do
+    prompt_version
+    |> cast(%{archived: true}, [:archived])
+  end
+end

--- a/app/lib/meadow/evals/schemas/eval_query.ex
+++ b/app/lib/meadow/evals/schemas/eval_query.ex
@@ -1,0 +1,22 @@
+defmodule Meadow.Evals.Schemas.EvalQuery do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, Ecto.UUID, autogenerate: false, read_after_writes: true}
+  @foreign_key_type Ecto.UUID
+  @timestamps_opts [type: :utc_datetime_usec]
+  schema "eval_queries" do
+    field(:name, :string)
+    field(:description, :string)
+    field(:query_json, :map)
+    field(:author, :string)
+    timestamps()
+  end
+
+  def changeset(eval_query, attrs) do
+    eval_query
+    |> cast(attrs, [:name, :description, :query_json, :author])
+    |> validate_required([:name, :query_json])
+    |> unique_constraint(:name)
+  end
+end

--- a/app/lib/meadow/evals/schemas/eval_run.ex
+++ b/app/lib/meadow/evals/schemas/eval_run.ex
@@ -1,0 +1,71 @@
+defmodule Meadow.Evals.Schemas.EvalRun do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Meadow.Evals.Schemas.{EvalPromptVersion, EvalSet, EvalTrial}
+
+  @statuses [:pending, :running, :complete, :errored, :cancelled]
+
+  @primary_key {:id, Ecto.UUID, autogenerate: false, read_after_writes: true}
+  @foreign_key_type Ecto.UUID
+  @timestamps_opts [type: :utc_datetime_usec]
+  schema "eval_runs" do
+    field(:name, :string)
+    field(:trials_per_work, :integer, default: 1)
+    field(:concurrency, :integer, default: 3)
+    field(:status, Ecto.Enum, values: @statuses, default: :pending)
+    field(:started_at, :utc_datetime_usec)
+    field(:completed_at, :utc_datetime_usec)
+    field(:author, :string)
+    field(:error, :string)
+
+    belongs_to(:eval_set, EvalSet, foreign_key: :eval_set_id)
+
+    belongs_to(:prompt_version, EvalPromptVersion,
+      foreign_key: :prompt_version_id,
+      references: :id
+    )
+
+    has_many(:eval_trials, EvalTrial, foreign_key: :eval_run_id)
+
+    timestamps()
+  end
+
+  def changeset(run, attrs) do
+    run
+    |> cast(attrs, [
+      :name,
+      :eval_set_id,
+      :prompt_version_id,
+      :trials_per_work,
+      :concurrency,
+      :author
+    ])
+    |> validate_required([:eval_set_id, :prompt_version_id])
+    |> validate_number(:trials_per_work, greater_than: 0)
+    |> validate_number(:concurrency, greater_than: 0)
+    |> foreign_key_constraint(:eval_set_id)
+    |> foreign_key_constraint(:prompt_version_id)
+  end
+
+  def mark_running(run) do
+    run
+    |> cast(%{status: :running, started_at: DateTime.utc_now()}, [:status, :started_at])
+  end
+
+  def mark_complete(run) do
+    run
+    |> cast(%{status: :complete, completed_at: DateTime.utc_now()}, [:status, :completed_at])
+  end
+
+  def mark_errored(run, error) do
+    run
+    |> cast(%{status: :errored, error: error, completed_at: DateTime.utc_now()},
+      [:status, :error, :completed_at])
+  end
+
+  def mark_cancelled(run) do
+    run
+    |> cast(%{status: :cancelled, completed_at: DateTime.utc_now()}, [:status, :completed_at])
+  end
+end

--- a/app/lib/meadow/evals/schemas/eval_set.ex
+++ b/app/lib/meadow/evals/schemas/eval_set.ex
@@ -1,0 +1,29 @@
+defmodule Meadow.Evals.Schemas.EvalSet do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Meadow.Evals.Schemas.{EvalQuery, EvalSetMember}
+
+  @primary_key {:id, Ecto.UUID, autogenerate: false, read_after_writes: true}
+  @foreign_key_type Ecto.UUID
+  @timestamps_opts [type: :utc_datetime_usec]
+  schema "eval_sets" do
+    field(:name, :string)
+    field(:description, :string)
+    field(:query_snapshot, :map)
+    field(:work_count, :integer)
+    field(:author, :string)
+
+    belongs_to(:eval_query, EvalQuery, foreign_key: :query_id)
+    has_many(:eval_set_members, EvalSetMember, foreign_key: :eval_set_id)
+
+    timestamps()
+  end
+
+  def changeset(eval_set, attrs) do
+    eval_set
+    |> cast(attrs, [:name, :description, :query_id, :query_snapshot, :work_count, :author])
+    |> validate_required([:name])
+    |> foreign_key_constraint(:query_id)
+  end
+end

--- a/app/lib/meadow/evals/schemas/eval_set_member.ex
+++ b/app/lib/meadow/evals/schemas/eval_set_member.ex
@@ -1,0 +1,34 @@
+defmodule Meadow.Evals.Schemas.EvalSetMember do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Meadow.Evals.Schemas.EvalSet
+
+  @primary_key {:id, Ecto.UUID, autogenerate: false, read_after_writes: true}
+  @foreign_key_type Ecto.UUID
+  @timestamps_opts [type: :utc_datetime_usec]
+  schema "eval_set_members" do
+    field(:work_id, Ecto.UUID)
+    field(:accession_number, :string)
+    field(:representative_file_set_id, Ecto.UUID)
+    field(:ground_truth, :map)
+
+    belongs_to(:eval_set, EvalSet, foreign_key: :eval_set_id)
+
+    timestamps()
+  end
+
+  def changeset(member, attrs) do
+    member
+    |> cast(attrs, [
+      :eval_set_id,
+      :work_id,
+      :accession_number,
+      :representative_file_set_id,
+      :ground_truth
+    ])
+    |> validate_required([:eval_set_id, :work_id])
+    |> unique_constraint([:eval_set_id, :work_id])
+    |> foreign_key_constraint(:eval_set_id)
+  end
+end

--- a/app/lib/meadow/evals/schemas/eval_trial.ex
+++ b/app/lib/meadow/evals/schemas/eval_trial.ex
@@ -1,0 +1,91 @@
+defmodule Meadow.Evals.Schemas.EvalTrial do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Meadow.Evals.Schemas.EvalRun
+
+  @trial_statuses [:pending, :running, :complete, :errored, :skipped]
+  @manual_scores [:unscored, :good, :bad]
+
+  @primary_key {:id, Ecto.UUID, autogenerate: false, read_after_writes: true}
+  @foreign_key_type Ecto.UUID
+  @timestamps_opts [type: :utc_datetime_usec]
+  schema "eval_trials" do
+    field(:work_id, Ecto.UUID)
+    field(:trial_index, :integer)
+    field(:status, Ecto.Enum, values: @trial_statuses, default: :pending)
+    field(:agent_output, :map)
+    field(:transcript, :map)
+    field(:description_judge_score, :float)
+    field(:subjects_judge_score, :float)
+    field(:judge_rationale, :string)
+    field(:manual_score, Ecto.Enum, values: @manual_scores, default: :unscored)
+    field(:manual_notes, :string)
+    field(:manual_scored_by, :string)
+    field(:manual_scored_at, :utc_datetime_usec)
+    field(:error, :string)
+    field(:duration_ms, :integer)
+
+    belongs_to(:eval_run, EvalRun, foreign_key: :eval_run_id)
+
+    timestamps()
+  end
+
+  def changeset(trial, attrs) do
+    trial
+    |> cast(attrs, [:eval_run_id, :work_id, :trial_index, :status])
+    |> validate_required([:eval_run_id, :work_id, :trial_index])
+    |> foreign_key_constraint(:eval_run_id)
+  end
+
+  def mark_running(trial) do
+    trial |> cast(%{status: :running}, [:status])
+  end
+
+  def mark_complete(trial, attrs) do
+    trial
+    |> cast(
+      Map.merge(attrs, %{status: :complete}),
+      [
+        :status,
+        :agent_output,
+        :transcript,
+        :description_judge_score,
+        :subjects_judge_score,
+        :judge_rationale,
+        :duration_ms
+      ]
+    )
+  end
+
+  def mark_errored(trial, error) do
+    trial |> cast(%{status: :errored, error: error}, [:status, :error])
+  end
+
+  def apply_manual_score(trial, score, notes, user) do
+    trial
+    |> cast(
+      %{
+        manual_score: score,
+        manual_notes: notes,
+        manual_scored_by: user,
+        manual_scored_at: DateTime.utc_now()
+      },
+      [:manual_score, :manual_notes, :manual_scored_by, :manual_scored_at]
+    )
+    |> validate_inclusion(:manual_score, @manual_scores)
+  end
+
+  def clear_manual_score(trial) do
+    trial
+    |> cast(
+      %{
+        manual_score: :unscored,
+        manual_notes: nil,
+        manual_scored_by: nil,
+        manual_scored_at: nil
+      },
+      [:manual_score, :manual_notes, :manual_scored_by, :manual_scored_at]
+    )
+  end
+end

--- a/app/lib/meadow_ai/metadata_agent.ex
+++ b/app/lib/meadow_ai/metadata_agent.ex
@@ -107,6 +107,7 @@ defmodule MeadowAI.MetadataAgent do
         :firewall_security_header,
         Application.get_env(:meadow, :firewall_security_header)
       )
+      |> Keyword.update!(:mcp_url, &docker_reachable_mcp_url/1)
 
     Task.Supervisor.start_child(MeadowAI.MetadataAgent.TaskSupervisor, fn ->
       result =
@@ -199,6 +200,38 @@ defmodule MeadowAI.MetadataAgent do
     error ->
       Logger.error("Error executing Claude query: #{Exception.message(error)}")
       {:error, {:query_execution_error, error}}
+  end
+
+  defp docker_reachable_mcp_url(nil), do: nil
+
+  defp docker_reachable_mcp_url(url) do
+    if System.get_env("USE_SAM_LAMBDAS") do
+      rewrite_url_base(url, System.get_env("MEADOW_SAM_HOST_URL", "http://172.17.0.1:4000"))
+    else
+      url
+    end
+  end
+
+  defp rewrite_url_base(url, replacement_base) do
+    with %URI{} = uri <- URI.parse(url),
+         %URI{} = replacement <- URI.parse(replacement_base) do
+      %{
+        uri
+        | scheme: replacement.scheme || uri.scheme,
+          host: replacement.host,
+          port: explicit_port(replacement_base) || uri.port
+      }
+      |> URI.to_string()
+    else
+      _ -> url
+    end
+  end
+
+  defp explicit_port(url) do
+    case Regex.run(~r/^[a-z][a-z0-9+.-]*:\/\/(?:\[[^\]]+\]|[^\/:]+):(\d+)/i, url) do
+      [_, port] -> String.to_integer(port)
+      _ -> nil
+    end
   end
 
   defp process_execution_result({:ok, %{"statusCode" => 200, "body" => body}}, opts) do

--- a/app/lib/meadow_web/controllers/evals_controller.ex
+++ b/app/lib/meadow_web/controllers/evals_controller.ex
@@ -1,0 +1,113 @@
+defmodule MeadowWeb.EvalsController do
+  use MeadowWeb, :controller
+  alias Meadow.Evals
+  alias Meadow.Roles
+  alias NimbleCSV.RFC4180, as: CSV
+  import Plug.Conn
+
+  plug(:authorize_user)
+
+  @csv_headers ~w(
+    run_id prompt_version eval_set
+    work_id accession_number status
+    gt_description gt_subjects
+    agent_description agent_subjects
+    description_judge_score subjects_judge_score judge_rationale
+    manual_score manual_scored_by
+    duration_ms error
+  )
+
+  def export(conn, %{"file" => file, "run_id" => run_id}) do
+    run = Evals.get_run!(run_id)
+    set = run.eval_set
+    prompt = run.prompt_version
+
+    set_members = Map.new(set.eval_set_members, &{&1.work_id, &1})
+
+    conn =
+      conn
+      |> put_resp_content_type("text/csv")
+      |> put_resp_header("content-disposition", ~s[attachment; filename="#{file}"])
+      |> send_chunked(:ok)
+
+    header_row = CSV.dump_to_iodata([@csv_headers])
+    chunk(conn, header_row)
+
+    for trial <- run.eval_trials do
+      member = Map.get(set_members, trial.work_id)
+      row = trial_row(run, set, prompt, trial, member)
+      chunk(conn, CSV.dump_to_iodata([row]))
+    end
+
+    conn
+  rescue
+    Ecto.NoResultsError ->
+      conn
+      |> put_resp_content_type("text/plain")
+      |> resp(404, "Eval run not found")
+      |> halt()
+  end
+
+  def export(conn, _params) do
+    conn
+    |> put_resp_content_type("text/plain")
+    |> resp(400, "Missing run_id parameter")
+    |> halt()
+  end
+
+  defp trial_row(run, set, prompt, trial, member) do
+    gt = blank_map(member && member.ground_truth)
+    gt_desc = gt |> Map.get(:description, Map.get(gt, "description", [])) |> List.wrap() |> Enum.join(" | ")
+    gt_subjects = gt |> Map.get(:subjects, Map.get(gt, "subjects", [])) |> join_subject_ids()
+
+    agent_out = blank_map(trial.agent_output)
+    agent_desc = Map.get(agent_out, :description, Map.get(agent_out, "description", ""))
+    agent_subjects = agent_out |> Map.get(:subjects, Map.get(agent_out, "subjects", [])) |> join_subject_ids()
+
+    [
+      run.id,
+      blank(prompt && prompt.name),
+      blank(set && set.name),
+      trial.work_id,
+      blank(member && member.accession_number),
+      trial.status,
+      gt_desc,
+      gt_subjects,
+      agent_desc,
+      agent_subjects,
+      blank(trial.description_judge_score),
+      blank(trial.subjects_judge_score),
+      blank(trial.judge_rationale),
+      trial.manual_score,
+      blank(trial.manual_scored_by),
+      blank(trial.duration_ms),
+      blank(trial.error)
+    ]
+    |> Enum.map(&to_string/1)
+  end
+
+  defp blank(nil), do: ""
+  defp blank(value), do: value
+
+  defp blank_map(map) when is_map(map), do: map
+  defp blank_map(_), do: %{}
+
+  defp join_subject_ids(subjects) do
+    Enum.map_join(subjects, ", ", fn s ->
+      id = Map.get(s, :id) || Map.get(s, "id") || ""
+      label = Map.get(s, :label) || Map.get(s, "label")
+      if label && label != "", do: "#{id} (#{label})", else: id
+    end)
+  end
+
+  def authorize_user(%{assigns: %{current_user: current_user}} = conn, _params) do
+    if Roles.authorized?(current_user, :editor) do
+      conn
+    else
+      conn
+      |> put_resp_content_type("text/plain")
+      |> resp(403, "Unauthorized")
+      |> halt()
+    end
+  end
+end

--- a/app/lib/meadow_web/mcp/eval_server.ex
+++ b/app/lib/meadow_web/mcp/eval_server.ex
@@ -1,0 +1,16 @@
+defmodule MeadowWeb.MCP.EvalServer do
+  @moduledoc "Eval-only MCP server. Exposes only read and submit-eval tools — never apply_work_metadata."
+
+  alias MeadowWeb.MCP.{Resources, Tools}
+
+  use Anubis.Server,
+    name: "meadow-mcp-eval-server",
+    version: "0.1.0",
+    capabilities: [:resources, :tools]
+
+  component(Resources.Schemas.Work)
+  component(Resources.Schemas.FileSet)
+  component(Tools.AuthoritySearch)
+  component(Tools.GetIIIFImage)
+  component(Tools.SubmitEvalMetadata)
+end

--- a/app/lib/meadow_web/mcp/server.ex
+++ b/app/lib/meadow_web/mcp/server.ex
@@ -13,6 +13,7 @@ defmodule MeadowWeb.MCP.Server do
   component(Resources.Schemas.Collection)
   component(Tools.AuthoritySearch)
   component(Tools.GetImage)
+  component(Tools.GetIIIFImage)
   component(Tools.GetIngestImage)
   component(Tools.GetWork)
   component(Tools.GetCodeList)

--- a/app/lib/meadow_web/mcp/tools/apply_work_metadata.ex
+++ b/app/lib/meadow_web/mcp/tools/apply_work_metadata.ex
@@ -40,6 +40,16 @@ defmodule MeadowWeb.MCP.Tools.ApplyWorkMetadata do
 
   @impl true
   def execute(%{work_id: work_id, description: description, subjects: subjects}, frame) do
+    if get_in(frame.assigns, [:context, :eval]) == true or
+         get_in(frame.assigns, ["context", "eval"]) == true do
+      Logger.error("ApplyWorkMetadata: refusing eval-context call for work #{work_id}")
+      {:error, MCPError.execution("apply_work_metadata is disabled during eval runs"), frame}
+    else
+      do_execute(work_id, description, subjects, frame)
+    end
+  end
+
+  defp do_execute(work_id, description, subjects, frame) do
     Logger.info("ApplyWorkMetadata: updating work #{work_id}")
 
     work = Works.get_work!(work_id)

--- a/app/lib/meadow_web/mcp/tools/get_iiif_image.ex
+++ b/app/lib/meadow_web/mcp/tools/get_iiif_image.ex
@@ -1,0 +1,25 @@
+defmodule MeadowWeb.MCP.Tools.GetIIIFImage do
+  @moduledoc """
+  Fetch an IIIF-ready image given a file set ID.
+
+  This is the eval-safe image tool. Batch AI ingest should use get_ingest_image
+  because those files are not IIIF-ready yet.
+  """
+
+  use Anubis.Server.Component,
+    type: :tool,
+    name: "get_iiif_image",
+    mime_type: "image/jpeg"
+
+  alias MeadowWeb.MCP.Tools.GetImage
+
+  schema do
+    field(:file_set_id, :string,
+      description: "The ID of the IIIF-ready file set to fetch the image for",
+      required: true
+    )
+  end
+
+  @impl true
+  def execute(params, frame), do: GetImage.execute(params, frame)
+end

--- a/app/lib/meadow_web/mcp/tools/submit_eval_metadata.ex
+++ b/app/lib/meadow_web/mcp/tools/submit_eval_metadata.ex
@@ -1,0 +1,59 @@
+defmodule MeadowWeb.MCP.Tools.SubmitEvalMetadata do
+  @moduledoc """
+  Store the AI-generated metadata for an eval trial.
+
+  Called by the eval agent after analyzing an image and finding subject headings.
+  Writes output to the eval_trials table instead of the live Work record, so the
+  ground truth is never overwritten.
+  """
+
+  use Anubis.Server.Component,
+    type: :tool,
+    mime_type: "application/json",
+    description: "Store AI-generated description and subjects for an eval trial."
+
+  alias Anubis.MCP.Error, as: MCPError
+  alias Anubis.Server.Response
+  alias Meadow.Evals
+  require Logger
+
+  @subject_schema %{id: :string, label: :string}
+
+  schema do
+    field(:trial_id, :string,
+      required: true,
+      description: "UUID of the eval trial to record output for"
+    )
+
+    field(:description, :string,
+      required: true,
+      description: "1-3 sentence descriptive summary of the image"
+    )
+
+    field(:subjects, {:list, @subject_schema},
+      required: true,
+      description: "Subject headings from authority_search, each with id (URI) and label"
+    )
+  end
+
+  @impl true
+  def execute(%{trial_id: trial_id, description: description, subjects: subjects}, frame) do
+    Logger.info("SubmitEvalMetadata: recording output for trial #{trial_id}")
+
+    output = %{
+      description: description,
+      subjects: Enum.map(subjects, fn s -> %{id: s.id, label: s.label} end)
+    }
+
+    case Evals.record_agent_output(trial_id, output) do
+      {:ok, _} ->
+        {:reply,
+         Response.tool() |> Response.structured(%{recorded: true, trial_id: trial_id}), frame}
+
+      {:error, reason} ->
+        {:error, MCPError.execution(inspect(reason)), frame}
+    end
+  rescue
+    error -> {:error, MCPError.protocol(:internal_error, %{error: inspect(error)}), frame}
+  end
+end

--- a/app/lib/meadow_web/resolvers/evals.ex
+++ b/app/lib/meadow_web/resolvers/evals.ex
@@ -1,0 +1,155 @@
+defmodule MeadowWeb.Resolvers.Evals do
+  @moduledoc "Absinthe resolvers for the evals feature."
+
+  alias Meadow.Evals
+  alias Meadow.Evals.Runner
+
+  # ---------------------------------------------------------------------------
+  # Eval Query resolvers
+  # ---------------------------------------------------------------------------
+
+  def list_eval_queries(_root, _args, _info), do: {:ok, Evals.list_eval_queries()}
+
+  def default_eval_query(_root, _args, _info), do: {:ok, Evals.default_eval_query()}
+
+  def create_eval_query(_root, args, %{context: %{current_user: user}}) do
+    Evals.create_eval_query(Map.put(args, :author, user.email))
+  end
+
+  def update_eval_query(_root, %{id: id} = args, _info) do
+    eval_query = Evals.get_eval_query!(id)
+    Evals.update_eval_query(eval_query, Map.delete(args, :id))
+  end
+
+  def delete_eval_query(_root, %{id: id}, _info) do
+    eval_query = Evals.get_eval_query!(id)
+    Evals.delete_eval_query(eval_query)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Prompt version resolvers
+  # ---------------------------------------------------------------------------
+
+  def list_prompt_versions(_root, _args, _info), do: {:ok, Evals.list_active_prompt_versions()}
+
+  def create_prompt_version(_root, args, %{context: %{current_user: user}}) do
+    Evals.create_prompt_version(Map.put(args, :author, user.email))
+  end
+
+  def archive_prompt_version(_root, %{id: id}, _info) do
+    pv = Evals.get_prompt_version!(id)
+    Evals.archive_prompt_version(pv)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Eval set resolvers
+  # ---------------------------------------------------------------------------
+
+  def list_eval_sets(_root, _args, _info), do: {:ok, Evals.list_eval_sets()}
+
+  def get_eval_set(_root, %{id: id}, _info) do
+    {:ok, Evals.get_eval_set!(id)}
+  rescue
+    Ecto.NoResultsError -> {:error, "Eval set not found"}
+  end
+
+  def create_eval_set_from_work_ids(_root, %{work_ids: ids} = args, %{context: %{current_user: user}}) do
+    set_attrs =
+      args
+      |> Map.delete(:work_ids)
+      |> Map.put(:author, user.email)
+
+    case Evals.create_eval_set_from_work_ids(ids, set_attrs) do
+      {:ok, set, _skipped} -> {:ok, set}
+      {:error, reason} -> {:error, inspect(reason)}
+    end
+  end
+
+  def create_eval_set(_root, %{query_id: query_id} = args, %{context: %{current_user: user}}) do
+    eval_query = Evals.get_eval_query!(query_id)
+
+    set_attrs =
+      args
+      |> Map.delete(:query_id)
+      |> Map.put(:author, user.email)
+
+    case Evals.create_eval_set_from_query(eval_query, set_attrs) do
+      {:ok, set, _skipped} -> {:ok, set}
+      {:error, reason} -> {:error, inspect(reason)}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Run resolvers
+  # ---------------------------------------------------------------------------
+
+  def list_runs(_root, args, _info) do
+    opts = [
+      limit: Map.get(args, :limit, 50),
+      offset: Map.get(args, :offset, 0)
+    ]
+
+    {:ok, Evals.list_runs(opts)}
+  end
+
+  def get_run(_root, %{id: id}, _info) do
+    {:ok, Evals.get_run!(id)}
+  rescue
+    Ecto.NoResultsError -> {:error, "Eval run not found"}
+  end
+
+  def create_run(_root, args, %{context: %{current_user: user}}) do
+    run_attrs = Map.put(args, :author, user.email)
+
+    case Evals.create_run(run_attrs) do
+      {:ok, run} ->
+        Runner.start(run.id)
+        {:ok, run}
+
+      {:error, changeset} ->
+        {:error, format_errors(changeset)}
+    end
+  end
+
+  def cancel_run(_root, %{id: id}, _info) do
+    case Evals.cancel_run(id) do
+      {:ok, run} -> {:ok, run}
+      {:error, reason} -> {:error, inspect(reason)}
+    end
+  end
+
+  def run_summary(run, _args, _info) do
+    {:ok, Evals.run_summary(run)}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Trial resolvers
+  # ---------------------------------------------------------------------------
+
+  def score_trial(_root, %{id: id, score: score} = args, %{context: %{current_user: user}}) do
+    notes = Map.get(args, :notes)
+
+    case Evals.score_trial(id, score, notes, user.email) do
+      {:ok, trial} -> {:ok, trial}
+      {:error, changeset} -> {:error, format_errors(changeset)}
+    end
+  end
+
+  def clear_trial_score(_root, %{id: id}, _info) do
+    case Evals.clear_trial_score(id) do
+      {:ok, trial} -> {:ok, trial}
+      {:error, reason} -> {:error, inspect(reason)}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp format_errors(%Ecto.Changeset{} = changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, _opts} -> msg end)
+    |> Enum.map_join("; ", fn {k, v} -> "#{k}: #{Enum.join(v, ", ")}" end)
+  end
+
+  defp format_errors(other), do: inspect(other)
+end

--- a/app/lib/meadow_web/router.ex
+++ b/app/lib/meadow_web/router.ex
@@ -61,6 +61,7 @@ defmodule MeadowWeb.Router do
     pipe_through(:api)
 
     post("/export/:file", MeadowWeb.ExportController, :export)
+    post("/evals/:file", MeadowWeb.EvalsController, :export)
     post("/authority_records/bulk_create", MeadowWeb.AuthorityRecordsController, :bulk_create)
     post("/authority_records/bulk_update", MeadowWeb.AuthorityRecordsController, :bulk_update)
     post("/authority_records/:file", MeadowWeb.AuthorityRecordsController, :export)
@@ -76,6 +77,15 @@ defmodule MeadowWeb.Router do
       interface: :simple,
       socket: MeadowWeb.UserSocket,
       before_send: {Middleware.AssumeRole, :update_user_role}
+    )
+
+    forward("/mcp/eval", MeadowWeb.Plugs.Authorize,
+      require: :editor,
+      forward_to: {
+        Anubis.Server.Transport.StreamableHTTP.Plug,
+        server: MeadowWeb.MCP.EvalServer,
+        timeout: 120_000
+      }
     )
 
     forward("/mcp", MeadowWeb.Plugs.Authorize,

--- a/app/lib/meadow_web/schema/schema.ex
+++ b/app/lib/meadow_web/schema/schema.ex
@@ -28,6 +28,7 @@ defmodule MeadowWeb.Schema do
   import_types(__MODULE__.NULAuthorityTypes)
   import_types(__MODULE__.ChatTypes)
   import_types(__MODULE__.Data.PlanTypes)
+  import_types(__MODULE__.EvalTypes)
 
   query do
     import_fields(:account_queries)
@@ -41,6 +42,7 @@ defmodule MeadowWeb.Schema do
     import_fields(:csv_metadata_update_queries)
     import_fields(:nul_authority_queries)
     import_fields(:plan_queries)
+    import_fields(:eval_queries)
     import_fields(:preservation_check_queries)
     import_fields(:s3_queries)
     import_fields(:work_queries)
@@ -55,6 +57,7 @@ defmodule MeadowWeb.Schema do
     import_fields(:csv_metadata_update_mutations)
     import_fields(:nul_authority_mutations)
     import_fields(:plan_mutations)
+    import_fields(:eval_mutations)
     import_fields(:shared_link_mutations)
     import_fields(:work_mutations)
     import_fields(:chat_mutations)

--- a/app/lib/meadow_web/schema/types/eval_types.ex
+++ b/app/lib/meadow_web/schema/types/eval_types.ex
@@ -1,0 +1,321 @@
+defmodule MeadowWeb.Schema.EvalTypes do
+  @moduledoc "Absinthe types and resolvers for the evals feature."
+
+  use Absinthe.Schema.Notation
+  alias MeadowWeb.Resolvers.Evals
+  alias MeadowWeb.Schema.Middleware
+
+  # ---------------------------------------------------------------------------
+  # Scalar / enum types
+  # ---------------------------------------------------------------------------
+
+  enum :eval_run_status do
+    value(:pending)
+    value(:running)
+    value(:complete)
+    value(:errored)
+    value(:cancelled)
+  end
+
+  enum :eval_trial_status do
+    value(:pending)
+    value(:running)
+    value(:complete)
+    value(:errored)
+    value(:skipped)
+  end
+
+  enum :eval_manual_score do
+    value(:unscored)
+    value(:good)
+    value(:bad)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Object types
+  # ---------------------------------------------------------------------------
+
+  object :eval_query_type do
+    field(:id, non_null(:id))
+    field(:name, non_null(:string))
+    field(:description, :string)
+    field(:query_json, :json)
+    field(:author, :string)
+    field(:inserted_at, :datetime)
+    field(:updated_at, :datetime)
+  end
+
+  object :eval_prompt_version do
+    field(:id, non_null(:id))
+    field(:name, non_null(:string))
+    field(:system_prompt, non_null(:string))
+    field(:user_prompt_template, non_null(:string))
+
+    field :subject_prompt, :string do
+      resolve(fn prompt_version, _, _ ->
+        {:ok, prompt_version.subject_prompt || Meadow.Evals.default_subject_prompt()}
+      end)
+    end
+
+    field :description_prompt, :string do
+      resolve(fn prompt_version, _, _ ->
+        {:ok, prompt_version.description_prompt || Meadow.Evals.default_description_prompt()}
+      end)
+    end
+
+    field(:parent_version_id, :id)
+    field(:author, :string)
+    field(:change_notes, :string)
+    field(:archived, non_null(:boolean))
+    field(:inserted_at, :datetime)
+  end
+
+  object :eval_set_member do
+    field(:id, non_null(:id))
+    field(:work_id, non_null(:id))
+    field(:accession_number, :string)
+    field(:representative_file_set_id, :id)
+    field(:ground_truth, :json)
+  end
+
+  object :eval_set do
+    field(:id, non_null(:id))
+    field(:name, non_null(:string))
+    field(:description, :string)
+    field(:query_id, :id)
+    field(:query_snapshot, :json)
+    field(:work_count, :integer)
+    field(:author, :string)
+    field(:inserted_at, :datetime)
+    field(:eval_set_members, list_of(:eval_set_member))
+  end
+
+  object :eval_run_summary do
+    field(:total, :integer)
+    field(:complete, :integer)
+    field(:errored, :integer)
+    field(:pending, :integer)
+    field(:running, :integer)
+    field(:manual_good, :integer)
+    field(:manual_bad, :integer)
+    field(:mean_description_judge_score, :float)
+    field(:mean_subjects_judge_score, :float)
+  end
+
+  object :eval_run do
+    field(:id, non_null(:id))
+    field(:name, :string)
+    field(:eval_set_id, non_null(:id))
+    field(:prompt_version_id, non_null(:id))
+    field(:trials_per_work, non_null(:integer))
+    field(:concurrency, :integer)
+    field(:status, :eval_run_status)
+    field(:started_at, :datetime)
+    field(:completed_at, :datetime)
+    field(:author, :string)
+    field(:error, :string)
+    field(:inserted_at, :datetime)
+    field(:eval_set, :eval_set)
+    field(:prompt_version, :eval_prompt_version)
+    field(:eval_trials, list_of(:eval_trial))
+
+    field :summary, :eval_run_summary do
+      resolve(&Evals.run_summary/3)
+    end
+  end
+
+  object :eval_trial do
+    field(:id, non_null(:id))
+    field(:eval_run_id, non_null(:id))
+    field(:work_id, non_null(:id))
+    field(:trial_index, non_null(:integer))
+    field(:status, :eval_trial_status)
+    field(:agent_output, :json)
+    field(:transcript, :json)
+    field(:description_judge_score, :float)
+    field(:subjects_judge_score, :float)
+    field(:judge_rationale, :string)
+    field(:manual_score, :eval_manual_score)
+    field(:manual_notes, :string)
+    field(:manual_scored_by, :string)
+    field(:manual_scored_at, :datetime)
+    field(:error, :string)
+    field(:duration_ms, :integer)
+    field(:inserted_at, :datetime)
+    field(:updated_at, :datetime)
+  end
+
+  # ---------------------------------------------------------------------------
+  # Queries
+  # ---------------------------------------------------------------------------
+
+  object :eval_queries do
+    @desc "List all saved eval queries"
+    field :eval_query_list, list_of(:eval_query_type) do
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Evals.list_eval_queries/3)
+    end
+
+    @desc "Get the environment-default eval query"
+    field :default_eval_query, :eval_query_type do
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Evals.default_eval_query/3)
+    end
+
+    @desc "List all prompt versions"
+    field :eval_prompt_versions, list_of(:eval_prompt_version) do
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Evals.list_prompt_versions/3)
+    end
+
+    @desc "List all eval sets"
+    field :eval_sets, list_of(:eval_set) do
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Evals.list_eval_sets/3)
+    end
+
+    @desc "Get a single eval set with members"
+    field :eval_set, :eval_set do
+      arg(:id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Evals.get_eval_set/3)
+    end
+
+    @desc "List eval runs (most recent first)"
+    field :eval_runs, list_of(:eval_run) do
+      arg(:limit, :integer)
+      arg(:offset, :integer)
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Evals.list_runs/3)
+    end
+
+    @desc "Get a single eval run with trials"
+    field :eval_run, :eval_run do
+      arg(:id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Evals.get_run/3)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Mutations
+  # ---------------------------------------------------------------------------
+
+  object :eval_mutations do
+    @desc "Create a saved eval query (Superuser only)"
+    field :create_eval_query, :eval_query_type do
+      arg(:name, non_null(:string))
+      arg(:description, :string)
+      arg(:query_json, non_null(:json))
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Superuser")
+      resolve(&Evals.create_eval_query/3)
+    end
+
+    @desc "Update a saved eval query (Superuser only)"
+    field :update_eval_query, :eval_query_type do
+      arg(:id, non_null(:id))
+      arg(:name, :string)
+      arg(:description, :string)
+      arg(:query_json, :json)
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Superuser")
+      resolve(&Evals.update_eval_query/3)
+    end
+
+    @desc "Delete a saved eval query (Superuser only)"
+    field :delete_eval_query, :eval_query_type do
+      arg(:id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Superuser")
+      resolve(&Evals.delete_eval_query/3)
+    end
+
+    @desc "Create a new prompt version"
+    field :create_eval_prompt_version, :eval_prompt_version do
+      arg(:name, non_null(:string))
+      arg(:subject_prompt, non_null(:string))
+      arg(:description_prompt, non_null(:string))
+      arg(:system_prompt, :string)
+      arg(:user_prompt_template, :string)
+      arg(:parent_version_id, :id)
+      arg(:change_notes, :string)
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Evals.create_prompt_version/3)
+    end
+
+    @desc "Archive a prompt version"
+    field :archive_eval_prompt_version, :eval_prompt_version do
+      arg(:id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Evals.archive_prompt_version/3)
+    end
+
+    @desc "Create an eval set by materializing works from a saved query"
+    field :create_eval_set, :eval_set do
+      arg(:query_id, non_null(:id))
+      arg(:name, non_null(:string))
+      arg(:description, :string)
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Evals.create_eval_set/3)
+    end
+
+    @desc "Create an eval set from a pasted list of work IDs"
+    field :create_eval_set_from_work_ids, :eval_set do
+      arg(:work_ids, non_null(list_of(non_null(:id))))
+      arg(:name, non_null(:string))
+      arg(:description, :string)
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Evals.create_eval_set_from_work_ids/3)
+    end
+
+    @desc "Create and start an eval run"
+    field :create_eval_run, :eval_run do
+      arg(:eval_set_id, non_null(:id))
+      arg(:prompt_version_id, non_null(:id))
+      arg(:name, :string)
+      arg(:trials_per_work, :integer)
+      arg(:concurrency, :integer)
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Evals.create_run/3)
+    end
+
+    @desc "Cancel a running eval run"
+    field :cancel_eval_run, :eval_run do
+      arg(:id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Evals.cancel_run/3)
+    end
+
+    @desc "Set manual score for an eval trial"
+    field :score_eval_trial, :eval_trial do
+      arg(:id, non_null(:id))
+      arg(:score, non_null(:eval_manual_score))
+      arg(:notes, :string)
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Evals.score_trial/3)
+    end
+
+    @desc "Clear manual score for an eval trial"
+    field :clear_eval_trial_score, :eval_trial do
+      arg(:id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Evals.clear_trial_score/3)
+    end
+  end
+end

--- a/app/priv/repo/migrations/20260522120000_create_evals.exs
+++ b/app/priv/repo/migrations/20260522120000_create_evals.exs
@@ -1,0 +1,113 @@
+defmodule Meadow.Repo.Migrations.CreateEvals do
+  use Ecto.Migration
+
+  def change do
+    create table(:eval_queries, primary_key: false) do
+      add(:id, :uuid, primary_key: true, default: fragment("gen_random_uuid()"))
+      add(:name, :string, null: false)
+      add(:description, :text)
+      add(:query_json, :jsonb, null: false)
+      add(:author, :string)
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create(unique_index(:eval_queries, [:name]))
+
+    create table(:eval_prompt_versions, primary_key: false) do
+      add(:id, :uuid, primary_key: true, default: fragment("gen_random_uuid()"))
+      add(:name, :string, null: false)
+      add(:system_prompt, :text, null: false)
+      add(:user_prompt_template, :text, null: false)
+      add(:subject_prompt, :text)
+      add(:description_prompt, :text)
+
+      add(
+        :parent_version_id,
+        references(:eval_prompt_versions, type: :uuid, on_delete: :nilify_all)
+      )
+
+      add(:author, :string)
+      add(:change_notes, :text)
+      add(:archived, :boolean, default: false, null: false)
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create table(:eval_sets, primary_key: false) do
+      add(:id, :uuid, primary_key: true, default: fragment("gen_random_uuid()"))
+      add(:name, :string, null: false)
+      add(:description, :text)
+
+      add(:query_id, references(:eval_queries, type: :uuid, on_delete: :nilify_all))
+
+      add(:query_snapshot, :jsonb)
+      add(:work_count, :integer)
+      add(:author, :string)
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create table(:eval_set_members, primary_key: false) do
+      add(:id, :uuid, primary_key: true, default: fragment("gen_random_uuid()"))
+
+      add(:eval_set_id, references(:eval_sets, type: :uuid, on_delete: :delete_all), null: false)
+
+      add(:work_id, :uuid, null: false)
+      add(:accession_number, :string)
+      add(:representative_file_set_id, :uuid)
+      add(:ground_truth, :jsonb)
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create(unique_index(:eval_set_members, [:eval_set_id, :work_id]))
+    create(index(:eval_set_members, [:eval_set_id]))
+
+    create table(:eval_runs, primary_key: false) do
+      add(:id, :uuid, primary_key: true, default: fragment("gen_random_uuid()"))
+      add(:name, :string)
+
+      add(:eval_set_id, references(:eval_sets, type: :uuid, on_delete: :restrict), null: false)
+
+      add(
+        :prompt_version_id,
+        references(:eval_prompt_versions, type: :uuid, on_delete: :restrict),
+        null: false
+      )
+
+      add(:trials_per_work, :integer, null: false, default: 1)
+      add(:concurrency, :integer, default: 3)
+      add(:status, :string, null: false, default: "pending")
+      add(:started_at, :utc_datetime_usec)
+      add(:completed_at, :utc_datetime_usec)
+      add(:author, :string)
+      add(:error, :text)
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create(index(:eval_runs, [:status]))
+    create(index(:eval_runs, [:eval_set_id]))
+
+    create table(:eval_trials, primary_key: false) do
+      add(:id, :uuid, primary_key: true, default: fragment("gen_random_uuid()"))
+
+      add(:eval_run_id, references(:eval_runs, type: :uuid, on_delete: :delete_all), null: false)
+
+      add(:work_id, :uuid, null: false)
+      add(:trial_index, :integer, null: false)
+      add(:status, :string, null: false, default: "pending")
+      add(:agent_output, :jsonb)
+      add(:transcript, :jsonb)
+      add(:description_judge_score, :float)
+      add(:subjects_judge_score, :float)
+      add(:judge_rationale, :text)
+      add(:manual_score, :string, default: "unscored")
+      add(:manual_notes, :text)
+      add(:manual_scored_by, :string)
+      add(:manual_scored_at, :utc_datetime_usec)
+      add(:error, :text)
+      add(:duration_ms, :integer)
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create(unique_index(:eval_trials, [:eval_run_id, :work_id, :trial_index]))
+    create(index(:eval_trials, [:eval_run_id, :status]))
+  end
+end

--- a/app/priv/repo/seeds/evals.exs
+++ b/app/priv/repo/seeds/evals.exs
@@ -1,0 +1,35 @@
+alias Meadow.Evals
+# Seed the default "match_all" eval query for dev/test environments
+case Evals.get_eval_query_by_name("match_all") do
+  nil ->
+    {:ok, _} =
+      Evals.create_eval_query(%{
+        name: "match_all",
+        description: "Match all works in the index. Use for dev/test environments.",
+        query_json: %{"query" => %{"match_all" => %{}}},
+        author: "system"
+      })
+
+    IO.puts("Evals: created match_all query")
+
+  _ ->
+    IO.puts("Evals: match_all query already exists, skipping")
+end
+
+# Seed the initial prompt version from the current GenerateAIMetadata prompts
+case Evals.latest_prompt_version() do
+  nil ->
+    {:ok, _} =
+      Evals.create_prompt_version(%{
+        name: "v1 — initial (from GenerateAIMetadata)",
+        subject_prompt: Evals.default_subject_prompt(),
+        description_prompt: Evals.default_description_prompt(),
+        author: "system",
+        change_notes: "Initial version seeded from GenerateAIMetadata action prompts"
+      })
+
+    IO.puts("Evals: created initial prompt version")
+
+  _ ->
+    IO.puts("Evals: prompt version already exists, skipping")
+end

--- a/app/test/meadow/evals/prompt_test.exs
+++ b/app/test/meadow/evals/prompt_test.exs
@@ -1,0 +1,28 @@
+defmodule Meadow.Evals.PromptTest do
+  use ExUnit.Case, async: true
+
+  alias Meadow.Evals
+
+  describe "eval_tool_prompt/1" do
+    test "normalizes eval tool names to Claude MCP namespaced tools" do
+      prompt = """
+      Call get_image, authority_search, and submit_eval_metadata.
+      Do not call apply_work_metadata.
+      """
+
+      normalized = Evals.eval_tool_prompt(prompt)
+
+      assert normalized =~ "mcp__meadow__get_iiif_image"
+      assert normalized =~ "mcp__meadow__authority_search"
+      assert normalized =~ "mcp__meadow__submit_eval_metadata"
+      refute normalized =~ " get_image"
+      refute normalized =~ " apply_work_metadata"
+    end
+
+    test "does not double-prefix already namespaced tools" do
+      prompt = "Call mcp__meadow__get_iiif_image and mcp__meadow__submit_eval_metadata."
+
+      assert Evals.eval_tool_prompt(prompt) == prompt
+    end
+  end
+end

--- a/app/test/meadow/evals/prompt_version_test.exs
+++ b/app/test/meadow/evals/prompt_version_test.exs
@@ -1,0 +1,37 @@
+defmodule Meadow.Evals.PromptVersionTest do
+  use Meadow.DataCase
+
+  alias Meadow.Evals
+
+  describe "create_prompt_version/1" do
+    test "assembles internal prompts from editable task prompts" do
+      {:ok, prompt_version} =
+        Evals.create_prompt_version(%{
+          name: "task-prompt-#{System.unique_integer()}",
+          subject_prompt: "Find LCNAF names and FAST topics.",
+          description_prompt: "Write one sentence for catalog display.",
+          author: "test"
+        })
+
+      assert prompt_version.subject_prompt == "Find LCNAF names and FAST topics."
+      assert prompt_version.description_prompt == "Write one sentence for catalog display."
+      assert prompt_version.system_prompt == Evals.default_eval_system_prompt()
+      assert prompt_version.user_prompt_template =~ "2. Find LCNAF names and FAST topics."
+      assert prompt_version.user_prompt_template =~ "3. Write one sentence for catalog display."
+      assert prompt_version.user_prompt_template =~ "mcp__meadow__submit_eval_metadata"
+    end
+
+    test "still accepts explicitly assembled prompts" do
+      {:ok, prompt_version} =
+        Evals.create_prompt_version(%{
+          name: "legacy-prompt-#{System.unique_integer()}",
+          system_prompt: "You are a test agent.",
+          user_prompt_template: "Analyze work {work_id}.",
+          author: "test"
+        })
+
+      assert prompt_version.system_prompt == "You are a test agent."
+      assert prompt_version.user_prompt_template == "Analyze work {work_id}."
+    end
+  end
+end

--- a/app/test/meadow/evals/runner_test.exs
+++ b/app/test/meadow/evals/runner_test.exs
@@ -1,0 +1,93 @@
+defmodule Meadow.Evals.RunnerTest do
+  use Meadow.DataCase, async: false
+
+  alias Meadow.Evals
+  alias Meadow.Evals.Runner
+  alias Meadow.Evals.Schemas.EvalRun
+  alias Meadow.Repo
+
+  setup do
+    start_supervised!({Task.Supervisor, name: Meadow.Evals.TaskSupervisor})
+    :ok
+  end
+
+  describe "start/1" do
+    test "transitions run to running and complete" do
+      {run, _trials} = setup_run(trials_per_work: 1)
+      assert run.status == :pending
+
+      # Stub MeadowAI.query to return a test response.
+      # We can't easily stub in integration here, so we just check the runner
+      # doesn't crash and transitions correctly when the agent call fails gracefully.
+      # Full integration requires a running Lambda.
+
+      # A cancelled run should be a no-op
+      {:ok, cancelled_run} = Evals.cancel_run(run.id)
+      assert cancelled_run.status == :cancelled
+
+      # Starting a cancelled run is a no-op
+      assert {:ok, _pid} = Runner.start(cancelled_run.id)
+      :timer.sleep(200)
+
+      # Status should remain cancelled
+      fresh = Repo.get!(EvalRun, run.id)
+      assert fresh.status == :cancelled
+    end
+  end
+
+  describe "cancel_run/1" do
+    test "transitions run to cancelled" do
+      {run, _trials} = setup_run(trials_per_work: 2)
+      {:ok, cancelled} = Evals.cancel_run(run.id)
+      assert cancelled.status == :cancelled
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  defp setup_run(opts) do
+    trials_per_work = Keyword.get(opts, :trials_per_work, 1)
+
+    {:ok, eval_query} = Evals.create_eval_query(%{
+      name: "test-query-#{System.unique_integer()}",
+      query_json: %{"query" => %{"match_all" => %{}}},
+      author: "test"
+    })
+
+    {:ok, prompt_version} = Evals.create_prompt_version(%{
+      name: "test-prompt-#{System.unique_integer()}",
+      system_prompt: "You are a test agent.",
+      user_prompt_template: "Analyze work {work_id}, trial {trial_id}.",
+      author: "test"
+    })
+
+    # Create eval set manually (skip OpenSearch in unit tests)
+    work_id = Ecto.UUID.generate()
+
+    eval_set =
+      Repo.insert!(%Meadow.Evals.Schemas.EvalSet{
+        name: "test-set-#{System.unique_integer()}",
+        query_id: eval_query.id,
+        work_count: 1
+      })
+
+    Repo.insert!(%Meadow.Evals.Schemas.EvalSetMember{
+      eval_set_id: eval_set.id,
+      work_id: work_id,
+      accession_number: "TEST.001",
+      ground_truth: %{description: ["test description"], subjects: [%{id: "http://id.worldcat.org/fast/1"}]}
+    })
+
+    {:ok, run} = Evals.create_run(%{
+      eval_set_id: eval_set.id,
+      prompt_version_id: prompt_version.id,
+      trials_per_work: trials_per_work,
+      author: "test"
+    })
+
+    trials = Evals.list_trials_for_run(run.id)
+    {run, trials}
+  end
+end

--- a/app/test/meadow_ai/metadata_agent_test.exs
+++ b/app/test/meadow_ai/metadata_agent_test.exs
@@ -1,5 +1,5 @@
 defmodule MeadowAI.MetadataAgentTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias MeadowAI.MetadataAgent
 
@@ -33,6 +33,48 @@ defmodule MeadowAI.MetadataAgentTest do
 
       assert {:ok, %{request_count: 2, failure_count: 1, last_failure: %DateTime{}}} =
                MetadataAgent.status()
+    end
+
+    test "test queries rewrite localhost MCP URLs for SAM lambdas" do
+      System.put_env("USE_SAM_LAMBDAS", "true")
+      System.put_env("MEADOW_SAM_HOST_URL", "http://host.docker.internal")
+
+      on_exit(fn ->
+        System.delete_env("USE_SAM_LAMBDAS")
+        System.delete_env("MEADOW_SAM_HOST_URL")
+      end)
+
+      prompt = "Test prompt"
+
+      assert {:ok, {%{"result" => "test"}, ^prompt, opts}} =
+               MetadataAgent.query(prompt,
+                 test: true,
+                 timeout: 1_000,
+                 mcp_url: "http://localhost:4000/api/mcp/eval"
+               )
+
+      assert opts[:mcp_url] == "http://host.docker.internal:4000/api/mcp/eval"
+    end
+
+    test "test queries rewrite generated external MCP URLs for SAM lambdas" do
+      System.put_env("USE_SAM_LAMBDAS", "true")
+      System.delete_env("MEADOW_SAM_HOST_URL")
+
+      on_exit(fn ->
+        System.delete_env("USE_SAM_LAMBDAS")
+        System.delete_env("MEADOW_SAM_HOST_URL")
+      end)
+
+      prompt = "Test prompt"
+
+      assert {:ok, {%{"result" => "test"}, ^prompt, opts}} =
+               MetadataAgent.query(prompt,
+                 test: true,
+                 timeout: 1_000,
+                 mcp_url: "https://bmq.dev.rdc.library.northwestern.edu:3001/api/mcp/eval"
+               )
+
+      assert opts[:mcp_url] == "http://172.17.0.1:4000/api/mcp/eval"
     end
   end
 end

--- a/app/test/meadow_web/mcp/server_test.exs
+++ b/app/test/meadow_web/mcp/server_test.exs
@@ -7,5 +7,21 @@ defmodule MeadowWeb.MCP.ServerTest do
       assert Map.has_key?(response, "tools")
       assert is_list(response["tools"])
     end
+
+    test "eval server exposes only eval-safe tools" do
+      tool_names =
+        MeadowWeb.MCP.EvalServer
+        |> list_tools()
+        |> Map.fetch!("tools")
+        |> Enum.map(& &1["name"])
+
+      assert "authority_search" in tool_names
+      assert "get_iiif_image" in tool_names
+      assert "submit_eval_metadata" in tool_names
+
+      refute "get_image" in tool_names
+      refute "get_ingest_image" in tool_names
+      refute "apply_work_metadata" in tool_names
+    end
   end
 end

--- a/app/test/meadow_web/mcp/tools/apply_work_metadata_test.exs
+++ b/app/test/meadow_web/mcp/tools/apply_work_metadata_test.exs
@@ -1,0 +1,43 @@
+defmodule MeadowWeb.MCP.Tools.ApplyWorkMetadataTest do
+  use MeadowWeb.MCPCase
+
+  alias MeadowWeb.MCP.Tools.ApplyWorkMetadata
+
+  describe "eval context guard" do
+    test "refuses to execute when context.eval is true" do
+      work = work_fixture(%{descriptive_metadata: %{title: "Guard Test"}})
+
+      frame = %Anubis.Server.Frame{
+        assigns: %{context: %{eval: true}}
+      }
+
+      args = %{
+        work_id: work.id,
+        description: "Should not be applied.",
+        subjects: []
+      }
+
+      assert {:error, _reason, _frame} = ApplyWorkMetadata.execute(args, frame)
+
+      # Verify work was NOT mutated
+      fresh = Meadow.Data.Works.get_work!(work.id)
+      assert fresh.descriptive_metadata.description == []
+    end
+
+    test "executes normally when eval context is absent" do
+      work = work_fixture(%{descriptive_metadata: %{title: "Normal Test"}})
+      frame = %Anubis.Server.Frame{}
+
+      args = %{
+        work_id: work.id,
+        description: "A test description.",
+        subjects: []
+      }
+
+      assert {:reply, _response, _frame} = ApplyWorkMetadata.execute(args, frame)
+
+      fresh = Meadow.Data.Works.get_work!(work.id)
+      assert fresh.descriptive_metadata.description == ["A test description."]
+    end
+  end
+end

--- a/app/test/meadow_web/mcp/tools/submit_eval_metadata_test.exs
+++ b/app/test/meadow_web/mcp/tools/submit_eval_metadata_test.exs
@@ -1,0 +1,81 @@
+defmodule MeadowWeb.MCP.Tools.SubmitEvalMetadataTest do
+  use Meadow.DataCase, async: true
+
+  alias Meadow.Evals
+  alias Meadow.Evals.Schemas.{EvalSetMember, EvalSet}
+  alias Meadow.Repo
+  alias MeadowWeb.MCP.Tools.SubmitEvalMetadata
+
+  describe "execute/2" do
+    test "writes agent_output to the trial row" do
+      trial = setup_trial()
+      frame = %Anubis.Server.Frame{}
+
+      args = %{
+        trial_id: trial.id,
+        description: "A photograph of folk dancers at the festival.",
+        subjects: [
+          %{id: "http://id.worldcat.org/fast/928794", label: "Folk dancing"},
+          %{id: "http://id.worldcat.org/fast/856724", label: "Festivals"}
+        ]
+      }
+
+      assert {:reply, _response, _frame} = SubmitEvalMetadata.execute(args, frame)
+
+      updated = Evals.get_trial!(trial.id)
+      assert updated.agent_output["description"] == "A photograph of folk dancers at the festival."
+      assert length(updated.agent_output["subjects"]) == 2
+    end
+
+    test "returns error for unknown trial_id" do
+      frame = %Anubis.Server.Frame{}
+
+      args = %{
+        trial_id: Ecto.UUID.generate(),
+        description: "Test",
+        subjects: []
+      }
+
+      assert {:error, _reason, _frame} = SubmitEvalMetadata.execute(args, frame)
+    end
+  end
+
+  defp setup_trial do
+    work_id = Ecto.UUID.generate()
+
+    {:ok, query} = Evals.create_eval_query(%{
+      name: "test-#{System.unique_integer()}",
+      query_json: %{"query" => %{"match_all" => %{}}},
+      author: "test"
+    })
+
+    set = Repo.insert!(%EvalSet{
+      name: "test-set-#{System.unique_integer()}",
+      query_id: query.id,
+      work_count: 1
+    })
+
+    Repo.insert!(%EvalSetMember{
+      eval_set_id: set.id,
+      work_id: work_id,
+      accession_number: "TEST.001",
+      ground_truth: %{description: [], subjects: []}
+    })
+
+    {:ok, prompt} = Evals.create_prompt_version(%{
+      name: "test-prompt-#{System.unique_integer()}",
+      system_prompt: "test",
+      user_prompt_template: "test {trial_id}",
+      author: "test"
+    })
+
+    {:ok, run} = Evals.create_run(%{
+      eval_set_id: set.id,
+      prompt_version_id: prompt.id,
+      trials_per_work: 1,
+      author: "test"
+    })
+
+    Evals.list_trials_for_run(run.id) |> List.first()
+  end
+end

--- a/app/test/support/mcp_case.ex
+++ b/app/test/support/mcp_case.ex
@@ -18,9 +18,9 @@ defmodule MeadowWeb.MCPCase do
   @doc """
   Fetch the list of available MCP tools.
   """
-  def list_tools do
+  def list_tools(server \\ MeadowWeb.MCP.Server) do
     Frame.new()
-    |> call_mcp("tools/list")
+    |> call_mcp(server, "tools/list")
     |> Map.update("tools", [], fn tools ->
       Enum.map(tools, fn tool ->
         %{
@@ -36,9 +36,9 @@ defmodule MeadowWeb.MCPCase do
   @doc """
   Call an MCP tool with the given name and parameters.
   """
-  def call_tool(tool, params, context \\ []) do
+  def call_tool(tool, params, context \\ [], server \\ MeadowWeb.MCP.Server) do
     Frame.new(context)
-    |> call_mcp("tools/call", %{
+    |> call_mcp(server, "tools/call", %{
       "name" => tool,
       "arguments" => params
     })
@@ -49,7 +49,7 @@ defmodule MeadowWeb.MCPCase do
   """
   def read_resource(uri, context \\ []) do
     Frame.new(context)
-    |> call_mcp("resources/read", %{"uri" => uri})
+    |> call_mcp(MeadowWeb.MCP.Server, "resources/read", %{"uri" => uri})
   end
 
   @doc """
@@ -79,10 +79,10 @@ defmodule MeadowWeb.MCPCase do
 
   def parse_response(other), do: other
 
-  defp call_mcp(frame, method, params \\ %{}) do
+  defp call_mcp(frame, server, method, params \\ %{}) do
     request = %{"method" => method, "params" => params}
 
-    case Handlers.handle(request, MeadowWeb.MCP.Server, frame) do
+    case Handlers.handle(request, server, frame) do
       {:reply, response, _frame} -> response
       {:error, _error, _frame} = error_tuple -> error_tuple
     end

--- a/lambdas/metadata-agent/execute.js
+++ b/lambdas/metadata-agent/execute.js
@@ -147,11 +147,13 @@ async function executeAgent(
 ) {
   emitAgentLog("mode: agent");
   emitAgentLog("connecting to MCP tools");
+  emitAgentLog(`mcp_url: ${mcp_url}`);
   const schemaUri = "file://schema/work.json";
   let schemaRead = false;
 
   const canUseTool = async (toolName, input) => {
     const payload = input && typeof input === "object" ? input : {};
+    const allow = () => ({ behavior: "allow", updatedInput: payload });
 
     if (
       toolName === "ReadMcpResource" &&
@@ -160,24 +162,28 @@ async function executeAgent(
     ) {
       schemaRead = true;
       emitAgentLog(`schema resource read: ${schemaUri}`);
-      return { behavior: "allow" };
+      return allow();
     }
 
     if (toolName === "mcp__meadow__update_plan_change" && !schemaRead) {
       const message = `Before update_plan_change, call ReadMcpResource with {"server":"meadow","uri":"${schemaUri}"}.`;
-      emitAgentLog(`blocked tool_call: ${toolName} (schema not read)`, "warning");
+      emitAgentLog(
+        `blocked tool_call: ${toolName} (schema not read)`,
+        "warning",
+      );
       return { behavior: "deny", message };
     }
 
-    return { behavior: "allow" };
+    return allow();
   };
 
-  const allowedTools = [
+  const defaultAllowedTools = [
     "ReadMcpResource",
     "ListMcpResources",
     "mcp__meadow__authority_search",
     "mcp__meadow__get_code_list",
     "mcp__meadow__get_image",
+    "mcp__meadow__get_iiif_image",
     "mcp__meadow__get_ingest_image",
     "mcp__meadow__get_plan_changes",
     "mcp__meadow__get_work",
@@ -185,9 +191,38 @@ async function executeAgent(
     "mcp__meadow__send_status_update",
     "mcp__meadow__update_plan_change",
     "mcp__meadow__submit_ai_previews",
+    "mcp__meadow__submit_eval_metadata",
     "mcp__meadow__apply_work_metadata",
   ];
-  const disallowedTools = ["Bash", "Glob", "Grep", "WebFetch", "Write"];
+  const evalAllowedTools = [
+    "mcp__meadow__authority_search",
+    "mcp__meadow__get_iiif_image",
+    "mcp__meadow__submit_eval_metadata",
+  ];
+  const allowedTools = contextData?.eval
+    ? evalAllowedTools
+    : defaultAllowedTools;
+  const tools = { type: "preset", preset: "claude_code" };
+  const disallowedTools = contextData?.eval
+    ? [
+        "Task",
+        "TaskOutput",
+        "TaskStop",
+        "Skill",
+        "Read",
+        "TodoWrite",
+        "Bash",
+        "Edit",
+        "Glob",
+        "Grep",
+        "NotebookEdit",
+        "WebFetch",
+        "Write",
+        "AskUserQuestion",
+        "EnterPlanMode",
+        "ExitPlanMode",
+      ]
+    : ["Bash", "Glob", "Grep", "WebFetch", "Write"];
   const clientOptions = {
     model,
     mcpServers: {
@@ -195,15 +230,19 @@ async function executeAgent(
     },
     allowedTools,
     disallowedTools,
+    tools,
+    strictMcpConfig: true,
     canUseTool,
-    agents: {
-      plan_change_proposer: {
-        prompt: proposerPrompt(),
-        tools: allowedTools,
-      },
-    },
+    agents: contextData?.eval
+      ? {}
+      : {
+          plan_change_proposer: {
+            prompt: proposerPrompt(),
+            tools: allowedTools,
+          },
+        },
     systemPrompt: contextData?.system_prompt || systemPrompt(),
-    effort: "low"
+    effort: "low",
   };
   logVerbose("Client options:", clientOptions);
 
@@ -215,7 +254,43 @@ async function executeAgent(
     prompt: enhancedPrompt,
     options: clientOptions,
   });
+  await logMcpServerStatus(result, contextData);
   return await processAgentMessages(result);
+}
+
+async function logMcpServerStatus(result, contextData) {
+  if (!contextData?.eval || typeof result?.mcpServerStatus !== "function") {
+    return;
+  }
+
+  try {
+    const servers = await result.mcpServerStatus();
+    const meadow = servers.find((server) => server.name === "meadow");
+
+    if (!meadow) {
+      emitAgentLog("mcp_status: meadow server not present", "warning");
+      throw new Error("Meadow MCP server not present");
+    }
+
+    const toolNames = (meadow.tools || []).map((tool) => tool.name).join(", ");
+    const toolSummary = toolNames || "none";
+    const error = meadow.error ? ` error=${meadow.error}` : "";
+
+    emitAgentLog(
+      `mcp_status: meadow ${meadow.status} tools=${toolSummary}${error}`,
+      meadow.status === "connected" ? "info" : "warning",
+    );
+
+    if (meadow.status !== "connected") {
+      throw new Error(`Meadow MCP server ${meadow.status}${error}`);
+    }
+  } catch (error) {
+    emitAgentLog(
+      `mcp_status_error: ${error?.message || String(error)}`,
+      "warning",
+    );
+    throw error;
+  }
 }
 
 function createLogReporter(context, mcpUrl, additionalHeaders) {

--- a/lambdas/metadata-agent/prompts.js
+++ b/lambdas/metadata-agent/prompts.js
@@ -44,6 +44,7 @@ const agentPromptWithPlan = (planId, userQuery, contextData = {}) => `
     - Title changes must be plain strings only. Never send title as objects/arrays and never send JSON-serialized
       blobs like "{\\"description\\":\\"...\\",\\"primary\\":true}".
     - Use the get_image tool with the ID of any file set to retrieve its base64 image for analysis.
+    - For eval runs, use get_iiif_image instead; eval works are already IIIF-ready.
     - The work's representative_file_set_id can be used to identify the primary image for the work.
 
   Finish with a concise summary of proposed changes. Keep the summary focused on the changed fields instead of the plan 


### PR DESCRIPTION
# Summary 
AI Metadata Evals dashboard

<img width="1418" height="1265" alt="meadow_evals_evanston_scored" src="https://github.com/user-attachments/assets/57f6b272-58e2-43c7-b4ed-b87facf18d6e" />

# Specific Changes in this PR

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test
- From the app dir:

```
mix ecto.migrate
mix run priv/repo/seeds/evals.exs
USE_SAM_LAMBDAS=true iex -S mix phx.server

(make pipeline-start in another terminal)

# Note: you probably need to delete your `priv/static` dir contents to clear out stale builds
```

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [x] Database Schema changes
  - [x] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

