### PR TITLE
Fix LocalStack health check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
   elixir-test:
     runs-on: ubuntu-latest
     env:
+      LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
       MIX_ENV: test
     steps:
       - uses: actions/checkout@v2
@@ -41,8 +42,6 @@ jobs:
             lambdas/*/package-lock.json
       - name: Start service containers in background
         run: make localstack-start &
-        env:
-          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
       - uses: erlef/setup-beam@v1
         with:
           version-file: ./.tool-versions

--- a/infrastructure/localstack/all-healthy.sh
+++ b/infrastructure/localstack/all-healthy.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 compose_dir=$(dirname "$0")
+docker compose -f $compose_dir/docker-compose.yml ps
 statuses=$(docker compose -f $compose_dir/docker-compose.yml ps -q | xargs docker inspect --format='{{.State.Health.Status}}' 2>/dev/null)
 if [[ $(echo -n $statuses | wc -w) -lt 3 ]] || (echo $statuses | grep "starting\|unhealthy" > /dev/null); then
   echo "One or more services are not healthy"


### PR DESCRIPTION
# Summary 
Fix LocalStack health check

# Specific Changes in this PR
- Update GitHub Actions workflow and health check script

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

