### PR TITLE
Use Tailscale Funnels for Remote Access

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -14,6 +14,8 @@ help:
 	@echo "make frontend-lint     | run JS lint checks"
 	@echo "make frontend-list     | list front-end dependencies"
 	@echo "make frontend-watch    | watch front-end assets for changes"
+	@echo "make funnel-start      | start a Tailscale Funnel to the local server port"
+	@echo "make funnel-stop       | stop the Tailscale Funnel"
 	@echo "make lint              | run Elixir lint checks"
 	@echo "make livebook          | build Livebook+Meadow release container"
 	@echo "make server            | run Phoenix server"
@@ -64,6 +66,12 @@ frontend-lint: frontend-deps
 frontend-test: frontend-deps
 	npm run-script --prefix assets ci:silent -- -w 1
 
+funnel-start:
+	tailscale funnel --bg https+insecure://localhost:3001
+
+funnel-stop:
+	tailscale funnel off
+
 deps: deps/.install-stamp
 
 all-deps: deps frontend-deps
@@ -95,11 +103,11 @@ cluster: priv/cert/combined.pem
 	done
 	haproxy -f ../extras/haproxy/cluster.cfg
 
-iex-server: deps frontend-deps priv/cert/cert.pem priv/cert/key.pem
-	iex -S mix phx.server
+iex-server: deps frontend-deps priv/cert/cert.pem priv/cert/key.pem funnel-start
+	iex -S mix phx.server && $(MAKE) funnel-stop
 
-server: deps frontend-deps priv/cert/cert.pem priv/cert/key.pem
-	mix phx.server
+server: deps frontend-deps priv/cert/cert.pem priv/cert/key.pem funnel-start
+	mix phx.server && $(MAKE) funnel-stop
 
 test: deps
 	AWS_LOCALSTACK=true \

--- a/app/assets/package-lock.json
+++ b/app/assets/package-lock.json
@@ -7,7 +7,7 @@
       "license": "MIT",
       "dependencies": {
         "@allmaps/leaflet": "^1.0.0-beta.53",
-        "@apollo/client": "*",
+        "@apollo/client": "latest",
         "@apollo/react-hooks": "^4.0.0",
         "@apollo/react-testing": "^4.0.0",
         "@appbaseio/reactivesearch": "3.23.1",
@@ -13378,6 +13378,21 @@
         "object-assign": "^4.1.1"
       }
     },
+    "node_modules/chonky/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "dev": true,
@@ -21921,6 +21936,14 @@
           "optional": true
         }
       }
+    },
+    "node_modules/recharts/node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/recharts/node_modules/reselect": {
       "version": "5.1.1",

--- a/app/lib/meadow/config/runtime/test.ex
+++ b/app/lib/meadow/config/runtime/test.ex
@@ -12,7 +12,8 @@ defmodule Meadow.Config.Runtime.Test do
     # you can enable the server option below.
     config :meadow, MeadowWeb.Endpoint,
       http: [port: 4002],
-      server: false
+      server: false,
+      url: [host: "localhost", port: 4002]
 
     config :meadow,
       index_interval: 1234,

--- a/app/lib/meadow_ai/metadata_agent.ex
+++ b/app/lib/meadow_ai/metadata_agent.ex
@@ -6,7 +6,6 @@ defmodule MeadowAI.MetadataAgent do
   alias Meadow.Utils.Lambda
   alias Meadow.Utils.DCAPI
   alias MeadowAI.Config, as: AIConfig
-  alias MeadowWeb.Router.Helpers, as: Routes
 
   @moduledoc """
   A GenServer that provides AI-powered metadata generation tools.
@@ -100,7 +99,7 @@ defmodule MeadowAI.MetadataAgent do
       opts
       |> Keyword.put_new(
         :mcp_url,
-        Routes.page_url(MeadowWeb.Endpoint, :index, ["api", "mcp"])
+        MeadowWeb.RemoteAccess.url("api/mcp")
       )
       |> Keyword.put_new(:auth_token, token)
       |> Keyword.put_new(

--- a/app/lib/meadow_web/remote_access.ex
+++ b/app/lib/meadow_web/remote_access.ex
@@ -1,0 +1,111 @@
+defmodule MeadowWeb.RemoteAccess do
+  @moduledoc """
+  Routes requests to the public funnel URL if a funnel is active, otherwise to the local server URL.
+  """
+
+  require Logger
+
+  @doc """
+  Returns the funnel URL if a funnel is active, otherwise the local server URL.
+  """
+  def url(path \\ nil) do
+    case detect_funnel() do
+      {:ok, funnel_url} ->
+        case path do
+          nil -> URI.to_string(funnel_url)
+          _ -> URI.merge(funnel_url, path) |> URI.to_string()
+        end
+        |> String.trim_trailing("/")
+
+      {:error, _} ->
+        Path.join(default_url(), path || "")
+    end
+  end
+
+  defp detect_funnel do
+    case cli(~w(funnel status --json)) do
+      {:ok, json} ->
+        case JSON.decode(json) do
+          {:ok, json} -> find_proxy(json, [http_port(), https_port()])
+          {:error, _} = err -> err
+        end
+
+      {:error, _} = err ->
+        err
+    end
+  end
+
+  defp default_url do
+    cfg = Application.get_env(:meadow, MeadowWeb.Endpoint) |> get_in([:url])
+    scheme = Keyword.get(cfg, :scheme, "http")
+    host = Keyword.get(cfg, :host, "localhost")
+    port = Keyword.get(cfg, :port, http_port())
+
+    case {scheme, port} do
+      {"https", 443} -> "https://#{host}"
+      {"http", 80} -> "http://#{host}"
+      _ -> "#{scheme}://#{host}:#{port}"
+    end
+  end
+
+  defp find_proxy(map, target_ports) do
+    top_level_web = Map.get(map, "Web", %{})
+
+    foreground_web =
+      map
+      |> Map.get("Foreground", %{})
+      |> Map.values()
+      |> Enum.flat_map(fn fg -> Map.get(fg, "Web", %{}) |> Map.to_list() end)
+      |> Map.new()
+
+    Map.merge(top_level_web, foreground_web)
+    |> Enum.find_value(fn {host, %{"Handlers" => handlers}} ->
+      find_handler(host, handlers, target_ports)
+    end)
+    |> case do
+      {host, "/"} -> {:ok, URI.parse("https://#{host}/")}
+      {host, path} -> {:ok, URI.parse("https://#{host}#{path}/")}
+      nil -> {:error, :no_funnel}
+    end
+  end
+
+  defp find_handler(host, handlers, target_ports) do
+    Enum.find_value(handlers, fn {path, handler} ->
+      port =
+        Map.get(handler, "Proxy")
+        |> URI.parse()
+        |> Map.get(:port)
+
+      if Enum.member?(target_ports, port), do: {host, path}, else: nil
+    end)
+  end
+
+  defp http_port do
+    Application.get_env(:meadow, MeadowWeb.Endpoint) |> get_in([:http, :port])
+  end
+
+  defp https_port do
+    Application.get_env(:meadow, MeadowWeb.Endpoint) |> get_in([:https, :port])
+  end
+
+  defp cli(args) do
+    {mod, fun} = Application.get_env(:meadow, :system_cmd, {System, :cmd})
+
+    case apply(mod, fun, ["tailscale", args, [stderr_to_stdout: true]]) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {output, code} -> {:error, {code, String.trim(output)}}
+    end
+  rescue
+    e in ErlangError ->
+      case e do
+        %ErlangError{original: original, reason: reason} ->
+          {:error, {original, reason}}
+
+        other ->
+          reraise(other, __STACKTRACE__)
+      end
+
+    e ->
+      reraise(e, __STACKTRACE__)
+  end
+end

--- a/app/test/meadow_web/remote_access_test.exs
+++ b/app/test/meadow_web/remote_access_test.exs
@@ -1,0 +1,126 @@
+defmodule MeadowWeb.RemoteAccessTest do
+  use ExUnit.Case, async: true
+
+  alias MeadowWeb.RemoteAccess
+
+  describe "url/1" do
+    setup tags do
+      Application.put_env(:meadow, :system_cmd, {__MODULE__, tags[:cmd_function]})
+      on_exit(fn -> Application.delete_env(:meadow, :system_cmd) end)
+    end
+
+    @tag cmd_function: :mock_system_cmd_complex
+    test "returns the funnel URL if a funnel is active" do
+      assert RemoteAccess.url() == "https://my.tailnet:3333"
+      assert RemoteAccess.url("api/mcp") == "https://my.tailnet:3333/api/mcp"
+    end
+
+    @tag cmd_function: :mock_system_cmd_with_path
+    test "returns the funnel URL if the funnel is mounted on a path" do
+      assert RemoteAccess.url() == "https://my.tailnet/meadow"
+      assert RemoteAccess.url("api/mcp") == "https://my.tailnet/meadow/api/mcp"
+    end
+
+    @tag cmd_function: :mock_system_cmd_no_funnel
+    test "returns the local server URL if no funnel is active" do
+      assert RemoteAccess.url() == "http://localhost:4002"
+      assert RemoteAccess.url("api/mcp") == "http://localhost:4002/api/mcp"
+    end
+
+    @tag cmd_function: :mock_system_cmd_failure
+    test "returns the local server URL if the CLI command fails" do
+      assert RemoteAccess.url() == "http://localhost:4002"
+      assert RemoteAccess.url("api/mcp") == "http://localhost:4002/api/mcp"
+    end
+  end
+
+  def mock_system_cmd_complex("tailscale", ["funnel", "status", "--json"], _opts) do
+    json = ~s({
+      "TCP": {
+        "3333": {
+          "HTTPS": true
+        },
+        "3334": {
+          "HTTPS": true
+        }
+      },
+      "Web": {
+        "my.tailnet:3333": {
+          "Handlers": {
+            "/": {
+              "Proxy": "http://127.0.0.1:4002"
+            }
+          }
+        },
+        "my.tailnet:3334": {
+          "Handlers": {
+            "/": {
+              "Proxy": "http://127.0.0.1:4001"
+            }
+          }
+        }
+      },
+      "AllowFunnel": {
+        "my.tailnet:3333": true,
+        "my.tailnet:3334": true
+      },
+      "Foreground": {
+        "7edeb8adee154976": {
+          "TCP": {
+            "3335": {
+              "HTTPS": true
+            }
+          },
+          "Web": {
+            "my.tailnet:3335": {
+              "Handlers": {
+                "/": {
+                  "Proxy": "http://127.0.0.1:4000"
+                }
+              }
+            }
+          },
+          "AllowFunnel": {
+            "my.tailnet:3335": true
+          }
+        }
+      }
+    })
+    {json, 0}
+  end
+
+  def mock_system_cmd_with_path("tailscale", ["funnel", "status", "--json"], _opts) do
+    json = ~s({
+      "Foreground": {
+        "1b49bd0113eb0615": {
+          "TCP": {
+            "443": {
+              "HTTPS": true
+            }
+          },
+          "Web": {
+            "my.tailnet:443": {
+              "Handlers": {
+                "/meadow": {
+                  "Proxy": "http://127.0.0.1:4002"
+                }
+              }
+            }
+          },
+          "AllowFunnel": {
+            "my.tailnet:443": true
+          }
+        }
+      }
+    })
+    {json, 0}
+  end
+
+  def mock_system_cmd_no_funnel("tailscale", ["funnel", "status", "--json"], _opts) do
+    {"{}", 0}
+  end
+
+  def mock_system_cmd_failure("tailscale", ["funnel", "status", "--json"], _opts) do
+    raise ErlangError, original: :enoent, reason: nil
+  end
+end


### PR DESCRIPTION
# Summary 
Allow Meadow to generate incoming URLs using a Tailscale funnel if one is active

# Specific Changes in this PR
- Add `Meadow.RemoteAccess` module to generate remote URLs
- Add `app-funnel-start` and `app-funnel-stop` to make targets
- Update metadata agent to use `Meadow.RemoteAccess` for the MCP URL.

**Important**: Funnel URLs can be used with API token bearer auth to provide secure access to Meadow (in dev) from outside the Tailnet, but it can't be used for UI access because NUSSO/cookie-based authentication depends on Meadow running in the `northwestern.edu` domain.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

Meadow will detect a funnel directing traffic at it no matter how the funnel was started, whether it's running in the foreground or background, whether it's proxying to HTTP or HTTPS, and what port the funnel is listening on.

1. Make sure `sgport` is _not_ open to port 3001.
2. Start Meadow.
3. Try an AI ingest (either with SAM lambdas or deployed pipeline). It shouldn't work because the agent can't reach Meadow.
4. In a different terminal, run `tailscale funnel 4000` (foreground funnel) or `make app-funnel-start` (background funnel).
5. Try the AI ingest again. It should work now.
6. If you used `make app-funnel-start`, stop the funnel with `make app-funnel-stop`.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

