### PR TITLE
Fix bug in query dropdown for AI Metadata Evals

### DIFF
--- a/app/assets/js/components/Dashboards/Evals/StartRunModal.jsx
+++ b/app/assets/js/components/Dashboards/Evals/StartRunModal.jsx
@@ -5,6 +5,7 @@ import {
   GET_EVAL_SETS,
   GET_EVAL_PROMPT_VERSIONS,
   GET_DEFAULT_EVAL_QUERY,
+  GET_EVAL_QUERY_LIST,
   CREATE_EVAL_SET,
   CREATE_EVAL_SET_FROM_WORK_IDS,
   CREATE_EVAL_RUN,
@@ -34,6 +35,7 @@ export default function StartRunModal({ onClose, onStarted }) {
 
   const { data: setsData } = useQuery(GET_EVAL_SETS);
   const { data: promptsData } = useQuery(GET_EVAL_PROMPT_VERSIONS);
+  const { data: queriesData } = useQuery(GET_EVAL_QUERY_LIST);
   const { data: defaultQueryData } = useQuery(GET_DEFAULT_EVAL_QUERY, {
     onCompleted: (d) => {
       if (d?.defaultEvalQuery) setSelectedQueryId(d.defaultEvalQuery.id);
@@ -163,11 +165,11 @@ export default function StartRunModal({ onClose, onStarted }) {
                   <div className="select is-fullwidth">
                     <select value={selectedQueryId} onChange={(e) => setSelectedQueryId(e.target.value)}>
                       <option value="">Select a query…</option>
-                      {defaultQueryData?.defaultEvalQuery && (
-                        <option value={defaultQueryData.defaultEvalQuery.id}>
-                          {defaultQueryData.defaultEvalQuery.name} (default)
+                      {(queriesData?.evalQueryList || []).map((q) => (
+                        <option key={q.id} value={q.id}>
+                          {q.name}{q.id === defaultQueryData?.defaultEvalQuery?.id ? " (default)" : ""}
                         </option>
-                      )}
+                      ))}
                     </select>
                   </div>
                 </div>


### PR DESCRIPTION
# Summary 

Show all queries in the "Start New Run" modal dropdown

### Problem
In the AI Metadata Eval dashboard, the "Start New Run" modal (Create new set from query) only listed the single *default* query in its dropdown. Newly-added queries visible in "Manage Queries" never appeared. The modal only fetched `GET_DEFAULT_EVAL_QUERY` and hardcoded that one row as the lone option.

### Fix
`assets/js/components/Dashboards/Evals/StartRunModal.jsx` now also runs `GET_EVAL_QUERY_LIST` and renders every query in the dropdown, tagging the default one with `(default)` and keeping it pre-selected. This mirrors how the "Manage Queries" screen already fetches its data.

## Note

We don't currently have a default query on staging/prod: https://github.com/nulib/meadow/blob/deploy/staging/app/config/prod.exs#L14

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

