### PR TITLE
Mint new ARK for published/private work as reserved and then transition

### DIFF
--- a/app/lib/meadow/ark/mock_server.ex
+++ b/app/lib/meadow/ark/mock_server.ex
@@ -106,7 +106,7 @@ defmodule Meadow.Ark.MockServer do
       send_message({:post, :credentials, Plug.BasicAuth.parse_basic_auth(conn)})
       send_message({:post, :body, body})
 
-      case verify_metadata(body) do
+      case verify_metadata(ark, body) do
         :ok ->
           Cachex.put!(@cache, ark, body)
           send_resp(conn, 201, "success: #{ark}")
@@ -133,7 +133,7 @@ defmodule Meadow.Ark.MockServer do
         send_message({method, :body, body})
       end
 
-      case verify_metadata(body) do
+      case verify_metadata(ark, body) do
         :ok ->
           Cachex.put!(@cache, ark, body)
           send_resp(conn, 200, "success: #{ark}\n#{body}")
@@ -147,13 +147,26 @@ defmodule Meadow.Ark.MockServer do
     end
   end
 
-  defp verify_metadata(body) do
+  defp verify_metadata(ark, body) do
     data =
       body
       |> String.split(~r/\n/)
       |> Enum.map(fn entry -> entry |> String.split(~r/:\s*/, parts: 2) |> List.to_tuple() end)
       |> Enum.into(%{})
 
+    case Cachex.get!(@cache, ark) do
+      nil ->
+        case data["_status"] do
+          "unavailable" <> _ -> {:error, "_status: invalid identifier status change"}
+          _ -> verify_metadata(data)
+        end
+
+      _ ->
+        verify_metadata(data)
+    end
+  end
+
+  defp verify_metadata(data) do
     @schema
     |> Enum.reduce(:ok, fn {field, requirement, validator}, acc ->
       validate_field(acc, data, field, requirement, validator)

--- a/app/lib/meadow/arks.ex
+++ b/app/lib/meadow/arks.ex
@@ -64,7 +64,9 @@ defmodule Meadow.Arks do
     case work |> initial_ark() |> Ark.mint() do
       {:ok, result} ->
         Logger.info("Minted ARK #{result.ark} for work #{work.id}")
+
         Works.update_work(work, %{descriptive_metadata: %{ark: result.ark}})
+        |> maybe_update_metadata()
 
       {:error, error_message} ->
         Meadow.Error.report(error_message, __MODULE__, [], %{work_id: work.id})
@@ -88,6 +90,17 @@ defmodule Meadow.Arks do
         end
     end
   end
+
+  defp maybe_update_metadata(
+         {:ok, %Work{published: true, visibility: %{id: "RESTRICTED"}} = work}
+       ) do
+    case update_ark_metadata(work) do
+      {:ok, _} -> {:ok, work}
+      {:error, message} -> {:error, message}
+    end
+  end
+
+  defp maybe_update_metadata(other), do: other
 
   defp update_existing_ark(_work, ark, ark) do
     Logger.debug("Metadata for #{ark.ark} didn't change. Not sending update.")
@@ -153,7 +166,7 @@ defmodule Meadow.Arks do
   defp initial_ark_attributes(work) do
     status =
       case work do
-        %{published: true, visibility: %{id: "RESTRICTED"}} -> "unavailable | restricted"
+        %{published: true, visibility: %{id: "RESTRICTED"}} -> "reserved"
         %{published: true} -> "public"
         _ -> "reserved"
       end

--- a/app/test/meadow/arks_test.exs
+++ b/app/test/meadow/arks_test.exs
@@ -7,8 +7,14 @@ defmodule Meadow.ArksTest do
   alias Meadow.Data.Works
 
   describe "mint_ark/1" do
-    setup %{work_type: work_type} do
-      {:ok, work: work_fixture(%{work_type: %{id: work_type, scheme: "work_type"}})}
+    @describetag visibility: "OPEN"
+    setup %{work_type: work_type, visibility: visibility} do
+      {:ok,
+       work:
+         work_fixture(%{
+           work_type: %{id: work_type, scheme: "work_type"},
+           visibility: %{id: visibility, scheme: "visibility"}
+         })}
     end
 
     seed_values("coded_terms/work_type")
@@ -32,20 +38,52 @@ defmodule Meadow.ArksTest do
     end
   end
 
-  describe "update_ark_metadata/1" do
+  describe "ark status" do
+    @describetag published: false
+
     setup do
       MockServer.send_to(self())
     end
 
-    setup %{visibility: visibility} do
-      with work <-
-             work_fixture(%{
-               published: false,
-               visibility: %{id: visibility, scheme: "visibility"}
-             })
-             |> Arks.mint_ark!() do
-        {:ok, work: work}
-      end
+    setup %{published: published, visibility: visibility} do
+      work =
+        work_fixture(%{
+          published: published,
+          visibility: %{id: visibility, scheme: "visibility"}
+        })
+        |> Arks.mint_ark!()
+
+      {:ok, work: work}
+    end
+
+    @tag visibility: "OPEN", published: false
+    test "mints an ark for an unpublished/open work", %{work: work} do
+      assert {:ok, %Ark{status: "reserved"}} = Arks.existing_ark(work)
+    end
+
+    @tag visibility: "AUTHENTICATED", published: false
+    test "mints an ark for an unpublished/authenticated work", %{work: work} do
+      assert {:ok, %Ark{status: "reserved"}} = Arks.existing_ark(work)
+    end
+
+    @tag visibility: "RESTRICTED", published: false
+    test "mints an ark for an unpublished/restricted work", %{work: work} do
+      assert {:ok, %Ark{status: "reserved"}} = Arks.existing_ark(work)
+    end
+
+    @tag visibility: "OPEN", published: true
+    test "mints an ark for a published/open work", %{work: work} do
+      assert {:ok, %Ark{status: "public"}} = Arks.existing_ark(work)
+    end
+
+    @tag visibility: "AUTHENTICATED", published: true
+    test "mints an ark for a published/authenticated work", %{work: work} do
+      assert {:ok, %Ark{status: "public"}} = Arks.existing_ark(work)
+    end
+
+    @tag visibility: "RESTRICTED", published: true
+    test "mints an ark for a published/restricted work", %{work: work} do
+      assert {:ok, %Ark{status: "unavailable | restricted"}} = Arks.existing_ark(work)
     end
 
     @tag visibility: "OPEN"


### PR DESCRIPTION
# Summary 
Mint new ARK for published/private work as reserved and then transition. Fixes #5529 

# Specific Changes in this PR
- Update `Meadow.Arks.mint_ark/1` with proper behavior
- Move `Meadow.Arks` module to correct directory

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Best done in IEx, as the UI doesn't provide the option of creating new works with `published: true`.

- Create a new work with `visibility: %{id: "RESTRICTED"}` and `published: true`
- Make sure new work has an ark
- Make sure `Meadow.Ark.get_from_source(work.descriptive_metadata.ark)` has `status: "unavailable | restricted"`
- Create new works with other values for visibility and published
  - ARK status should be `reserved` for unpublished works and `public` for non-restricted published works
- Change visibility and published status on existing works and make sure their new ARK statuses make sense

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

