### PR TITLE
Include first part of PR body in release notes summarization

### DIFF
--- a/.github/scripts/generate_release_notes.sh
+++ b/.github/scripts/generate_release_notes.sh
@@ -107,6 +107,7 @@ else
       {
         number: .number,
         title: .title,
+        body: (.body // ""),
         labels: [.labels[].name],
         merged_at: .merged_at
       }
@@ -145,9 +146,33 @@ else
       SUMMARY="This release contains dependency updates and infrastructure improvements only."
       PR_DETAIL_LIST=""
     else
-      PR_DETAIL_LIST=$(echo "$FILTERED_PRS" | jq -r '
-        .[] | "- #\(.number): \(.title)"
-      ')
+      PR_DETAIL_LIST=""
+      while IFS= read -r pr_json; do
+        number=$(echo "$pr_json" | jq -r '.number')
+        title=$(echo "$pr_json" | jq -r '.title')
+        body=$(echo "$pr_json" | jq -r '.body // ""')
+
+        # Extract text under the ## Summary header, stopping at the next ## section.
+        # Strip HTML comments and image markdown; collapse to a single line.
+        summary=$(echo "$body" | awk '
+          /^#+ Summary/{ found=1; next }
+          found && /^##/ { exit }
+          found { print }
+        ' | sed '/^<!--/,/-->/d; s/!\[[^]]*\]([^)]*)//g; s/<img[^>]*>//g; /^[[:space:]]*$/d' \
+          | head -5 | tr '\n' ' ' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+        # Fall back to the first few lines of the body if no Summary section found
+        if [[ -z "$summary" ]]; then
+          summary=$(echo "$body" | sed '/^<!--/,/-->/d; s/!\[[^]]*\]([^)]*)//g; s/<img[^>]*>//g; /^[[:space:]]*$/d; /^#/d' \
+            | head -3 | tr '\n' ' ' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        fi
+
+        if [[ -n "$summary" ]]; then
+          PR_DETAIL_LIST+="- #${number}: ${title}"$'\n'"  ${summary}"$'\n'
+        else
+          PR_DETAIL_LIST+="- #${number}: ${title}"$'\n'
+        fi
+      done < <(echo "$FILTERED_PRS" | jq -c '.[]')
     fi
   fi
 


### PR DESCRIPTION
# Summary 

Enriches the release notes script's input to Claude by extracting context from each PR's body, not just its title. For each merged PR, the script now looks for a `## Summary` section; if found, it takes up to 5 lines from it. If no Summary section exists, it falls back to the first 3 non-header, non-image, non-comment lines of the body. 


# Specific Changes in this PR

- `.github/scripts/generate_release_notes.sh` updated to send part of PR body to Claude

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

```
export GITHUB_TOKEN=<your-gh-pat>
export CURRENT_TAG=v10.4.1
export PREVIOUS_TAG=v10.4.0
export AWS_REGION=us-east-1
export GITHUB_REPOSITORY=nulib/meadow
export DRY_RUN=true

bash .github/scripts/generate_release_notes.sh
```


# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

