### PR TITLE
Move ark to top level of work

### DIFF
--- a/app/assets/codegen.ts
+++ b/app/assets/codegen.ts
@@ -1,4 +1,5 @@
 import { CodegenConfig } from "@graphql-codegen/cli";
+import path from "path";
 
 const config: CodegenConfig = {
   // TODO: Make the schema URL dynamic.  Where is this URL defined?

--- a/app/assets/js/components/Work/Tabs/About.jsx
+++ b/app/assets/js/components/Work/Tabs/About.jsx
@@ -281,7 +281,7 @@ const WorkTabsAbout = ({ work }) => {
             <Skeleton rows={10} />
           ) : (
             <WorkTabsAboutIdentifiersMetadata
-              descriptiveMetadata={descriptiveMetadata}
+              work={work}
               isEditing={isEditing}
             />
           )}

--- a/app/assets/js/components/Work/Tabs/About/IdentifiersMetadata.jsx
+++ b/app/assets/js/components/Work/Tabs/About/IdentifiersMetadata.jsx
@@ -7,11 +7,9 @@ import { IDENTIFIER_METADATA } from "@js/services/metadata";
 import UIFormRelatedURL from "@js/components/UI/Form/RelatedURL";
 import { useCodeLists } from "@js/context/code-list-context";
 
-const WorkTabsAboutIdentifiersMetadata = ({
-  descriptiveMetadata,
-  isEditing,
-}) => {
+const WorkTabsAboutIdentifiersMetadata = ({ work, isEditing }) => {
   const codeLists = useCodeLists();
+  const { ark, descriptiveMetadata } = work;
 
   return (
     <div className="columns is-multiline" data-testid="identifiers-metadata">
@@ -21,7 +19,7 @@ const WorkTabsAboutIdentifiersMetadata = ({
             <strong>ARK</strong>
           </p>
           <ul data-testid="field-array-item-list">
-            <li key="ark-value">{descriptiveMetadata.ark}</li>
+            <li key="ark-value">{ark}</li>
           </ul>
         </div>
       </div>
@@ -70,7 +68,7 @@ const WorkTabsAboutIdentifiersMetadata = ({
 };
 
 WorkTabsAboutIdentifiersMetadata.propTypes = {
-  descriptiveMetadata: PropTypes.object,
+  work: PropTypes.object,
   isEditing: PropTypes.bool,
 };
 

--- a/app/assets/js/components/Work/Tabs/About/IdentifiersMetadata.test.js
+++ b/app/assets/js/components/Work/Tabs/About/IdentifiersMetadata.test.js
@@ -14,7 +14,7 @@ describe("Work About Tab Identifiers metadata component", () => {
   beforeEach(() => {
     const Wrapped = withReactHookForm(WorkTabsAboutIdentifiersMetadata, {
       isEditing: true,
-      descriptiveMetadata: mockWork.descriptiveMetadata,
+      work: mockWork,
     });
     return renderWithRouterApollo(
       <CodeListProvider>

--- a/app/assets/js/components/Work/work.gql.mock.js
+++ b/app/assets/js/components/Work/work.gql.mock.js
@@ -263,6 +263,7 @@ export const mockWork2 = {
     projectTaskNumber: [],
     status: null,
   },
+  ark: "ark123",
   behavior: {
     id: "individuals",
     label: "Individuals",
@@ -272,7 +273,6 @@ export const mockWork2 = {
   descriptiveMetadata: {
     abstract: ["New Abstract Test", "New Abstract Again"],
     alternateTitle: [],
-    ark: "ark123",
     boxName: [],
     boxNumber: [],
     caption: [],

--- a/app/assets/js/components/Work/work.gql.ts
+++ b/app/assets/js/components/Work/work.gql.ts
@@ -88,6 +88,7 @@ export const GET_WORK = gql`
     work(id: $id) {
       id
       accessionNumber
+      ark
       behavior {
         id
         label
@@ -119,7 +120,6 @@ export const GET_WORK = gql`
       descriptiveMetadata {
         abstract
         alternateTitle
-        ark
         boxName
         boxNumber
         caption

--- a/app/assets/js/screens/Work/Work.jsx
+++ b/app/assets/js/screens/Work/Work.jsx
@@ -208,7 +208,7 @@ const ScreensWork = () => {
                     <dt data-testid="work-header-id">Id</dt>
                     <dd>{data.work.id}</dd>
                     <dt data-testid="work-header-ark">Ark</dt>
-                    <dd>{data.work.descriptiveMetadata.ark || ""}</dd>
+                    <dd>{data.work.ark || ""}</dd>
                     <dt data-testid="work-header-accession-number">
                       Accession number
                     </dt>

--- a/app/lib/meadow/arks.ex
+++ b/app/lib/meadow/arks.ex
@@ -50,7 +50,7 @@ defmodule Meadow.Arks do
   {:noop,
    %Work{...}}
   """
-  def mint_ark(%Work{descriptive_metadata: %{ark: ark}} = work)
+  def mint_ark(%Work{ark: ark} = work)
       when not is_nil(ark) do
     Logger.warning("Not minting ARK for work #{work.id} because it already has one: #{ark}")
     {:noop, work}
@@ -65,7 +65,7 @@ defmodule Meadow.Arks do
       {:ok, result} ->
         Logger.info("Minted ARK #{result.ark} for work #{work.id}")
 
-        Works.update_work(work, %{descriptive_metadata: %{ark: result.ark}})
+        Works.update_work(work, %{ark: result.ark})
         |> maybe_update_metadata()
 
       {:error, error_message} ->
@@ -137,9 +137,9 @@ defmodule Meadow.Arks do
   end
 
   def existing_ark(work) do
-    case work.descriptive_metadata.cached_ark do
+    case work.cached_ark do
       %ArkCache{} = cached -> {:ok, Ark.from_cache(cached)}
-      _ -> Ark.get(work.descriptive_metadata.ark)
+      _ -> Ark.get(work.ark)
     end
   end
 
@@ -150,7 +150,7 @@ defmodule Meadow.Arks do
   def ark_attributes(work, attrs) do
     Keyword.merge(
       [
-        ark: work.descriptive_metadata.ark,
+        ark: work.ark,
         creator: scalar_value(work.descriptive_metadata.creator),
         title: work.descriptive_metadata.title,
         publisher: scalar_value(work.descriptive_metadata.publisher),

--- a/app/lib/meadow/data/csv/export.ex
+++ b/app/lib/meadow/data/csv/export.ex
@@ -15,6 +15,7 @@ defmodule Meadow.Data.CSV.Export do
   @top_level_fields [
     ["id"],
     ["accession_number"],
+    ["ark"],
     ["collection", "id"],
     ["published"],
     ["visibility"]

--- a/app/lib/meadow/data/schemas/work.ex
+++ b/app/lib/meadow/data/schemas/work.ex
@@ -5,6 +5,7 @@ defmodule Meadow.Data.Schemas.Work do
 
   use Ecto.Schema
   alias Meadow.Data.Schemas.ActionState
+  alias Meadow.Data.Schemas.ArkCache
   alias Meadow.Data.Schemas.Batch
   alias Meadow.Data.Schemas.Collection
   alias Meadow.Data.Schemas.CSV.MetadataUpdateJob
@@ -34,6 +35,8 @@ defmodule Meadow.Data.Schemas.Work do
     field(:work_type, Types.CodedTerm)
 
     field(:behavior, Types.CodedTerm)
+
+    field(:ark, :string)
 
     timestamps()
 
@@ -70,11 +73,14 @@ defmodule Meadow.Data.Schemas.Work do
       join_through: "works_metadata_update_jobs",
       on_replace: :delete
     )
+
+    belongs_to(:cached_ark, ArkCache, foreign_key: :ark, references: :ark, define_field: false)
   end
 
   defp changeset_params do
     {[:accession_number],
      [
+       :ark,
        :collection_id,
        :ingest_sheet_id,
        :published,
@@ -108,12 +114,13 @@ defmodule Meadow.Data.Schemas.Work do
 
   def update_changeset(work, attrs \\ %{}) do
     allowed_params = [
+      :ark,
       :collection_id,
       :ingest_sheet_id,
       :published,
       :representative_file_set_id,
       :visibility,
-      :behavior,
+      :behavior
     ]
 
     work

--- a/app/lib/meadow/data/schemas/work_descriptive_metadata.ex
+++ b/app/lib/meadow/data/schemas/work_descriptive_metadata.ex
@@ -5,14 +5,13 @@ defmodule Meadow.Data.Schemas.WorkDescriptiveMetadata do
 
   import Ecto.Changeset
   use Ecto.Schema
-  alias Meadow.Data.Schemas.{ArkCache, ControlledMetadataEntry, NoteEntry, RelatedURLEntry}
+  alias Meadow.Data.Schemas.{ControlledMetadataEntry, NoteEntry, RelatedURLEntry}
   alias Meadow.Data.Types
 
   # {field_name, repeating}
   @fields [
     {:abstract, true},
     {:alternate_title, true},
-    {:ark, false},
     {:box_name, true},
     {:box_number, true},
     {:caption, true},
@@ -93,8 +92,6 @@ defmodule Meadow.Data.Schemas.WorkDescriptiveMetadata do
 
     embeds_many(:notes, NoteEntry, on_replace: :delete)
     embeds_many(:related_url, RelatedURLEntry, on_replace: :delete)
-
-    belongs_to(:cached_ark, ArkCache, foreign_key: :ark, references: :ark, define_field: false)
 
     timestamps()
   end

--- a/app/lib/meadow/data/works.ex
+++ b/app/lib/meadow/data/works.ex
@@ -140,8 +140,8 @@ defmodule Meadow.Data.Works do
 
   def get_work_by_ark!(ark) do
     from(w in Work,
-      where: fragment("?.descriptive_metadata->>'ark' = ?", w, ^ark),
-      preload: [:ingest_sheet, :project, descriptive_metadata: :cached_ark]
+      where: w.ark == ^ark,
+      preload: [:ingest_sheet, :project, :cached_ark]
     )
     |> Repo.one!()
     |> add_representative_image()

--- a/app/lib/meadow/events/works/arks.ex
+++ b/app/lib/meadow/events/works/arks.ex
@@ -127,9 +127,7 @@ defmodule Meadow.Events.Works.Arks do
     end
 
     defp update_ark_metadata(work) do
-      Logger.info(
-        "Updating ARK metadata for work: #{work.id}, with ark: #{work.descriptive_metadata.ark}"
-      )
+      Logger.info("Updating ARK metadata for work: #{work.id}, with ark: #{work.ark}")
 
       case Arks.update_ark_metadata(work) do
         :noop ->
@@ -140,7 +138,7 @@ defmodule Meadow.Events.Works.Arks do
 
         {:error, error_message} ->
           Logger.error(
-            "Error updating ARK metadata for work: #{work.id}, with ark: #{work.descriptive_metadata.ark}. #{error_message}"
+            "Error updating ARK metadata for work: #{work.id}, with ark: #{work.ark}. #{error_message}"
           )
       end
     end
@@ -171,12 +169,7 @@ defmodule Meadow.Events.Works.Arks do
   defp ark_changed(%{published: _}), do: false
   defp ark_changed(%{visibility: _}), do: false
 
-  defp ark_changed(%{
-         descriptive_metadata: %{
-           old_value: %{"ark" => old_ark},
-           new_value: %{"ark" => new_ark}
-         }
-       }) do
+  defp ark_changed(%{ark: %{old_value: old_ark, new_value: new_ark}}) do
     old_ark != new_ark
   end
 

--- a/app/lib/meadow/indexing/v2/work.ex
+++ b/app/lib/meadow/indexing/v2/work.ex
@@ -14,7 +14,7 @@ defmodule Meadow.Indexing.V2.Work do
       alternate_title: work.descriptive_metadata.alternate_title,
       api_link: Path.join([api_url(), "works", work.id]),
       api_model: "Work",
-      ark: work.descriptive_metadata.ark,
+      ark: work.ark,
       batch_ids: work.batches |> Enum.map(& &1.id),
       behavior: encode_label(work.behavior),
       box_name: work.descriptive_metadata.box_name,

--- a/app/lib/meadow_web/mcp/resources/schemas.ex
+++ b/app/lib/meadow_web/mcp/resources/schemas.ex
@@ -18,12 +18,16 @@ defmodule MeadowWeb.MCP.Resources.Schemas do
       @impl true
       def read(%{"uri" => unquote(uri)}, frame) do
         content = Meadow.Utils.Ecto.Schema.unroll(unquote(schema), read_only: unquote(read_only))
+
         response =
           Response.resource()
           |> Response.json(content, annotations: [audience: ["assistant"]])
+
         {:reply, response, frame}
       end
-      def read(params, frame), do: {:error, MCPError.resource(:not_found, %{uri: params["uri"]}), frame}
+
+      def read(params, frame),
+        do: {:error, MCPError.resource(:not_found, %{uri: params["uri"]}), frame}
     end
   end
 end
@@ -31,13 +35,43 @@ end
 defmodule MeadowWeb.MCP.Resources.Schemas.Work do
   @moduledoc "JSON schema for a Work resource, including field types and structure"
 
-  @ro_descriptive_metadata_fields  [:ark, :box_name, :box_number, :folder_name, :folder_number, :identifier,
-    :legacy_identifier, :terms_of_use, :physical_description_material, :physical_description_size,
-    :provenance, :publisher, :related_material, :rights_holder, :scope_and_contents, :series, :source,
-    :table_of_contents, :inserted_at, :updated_at]
-  @ro_fields [:id, :accession_number, :collection_id, :behavior, :visibility, :published, :inserted_at,
-    :updated_at, :ingest_sheet_id, :representative_file_set_id, :work_type, :administrative_metadata,
-    descriptive_metadata: @ro_descriptive_metadata_fields]
+  @ro_descriptive_metadata_fields [
+    :box_name,
+    :box_number,
+    :folder_name,
+    :folder_number,
+    :identifier,
+    :legacy_identifier,
+    :terms_of_use,
+    :physical_description_material,
+    :physical_description_size,
+    :provenance,
+    :publisher,
+    :related_material,
+    :rights_holder,
+    :scope_and_contents,
+    :series,
+    :source,
+    :table_of_contents,
+    :inserted_at,
+    :updated_at
+  ]
+  @ro_fields [
+    :id,
+    :accession_number,
+    :ark,
+    :collection_id,
+    :behavior,
+    :visibility,
+    :published,
+    :inserted_at,
+    :updated_at,
+    :ingest_sheet_id,
+    :representative_file_set_id,
+    :work_type,
+    :administrative_metadata,
+    descriptive_metadata: @ro_descriptive_metadata_fields
+  ]
 
   use MeadowWeb.MCP.Resources.Schemas,
     uri: "file://schema/work.json",
@@ -48,8 +82,15 @@ end
 defmodule MeadowWeb.MCP.Resources.Schemas.FileSet do
   @moduledoc "JSON schema for a FileSet resource, including field types and structure"
 
-  @ro_fields [:id, :inserted_at, :updated_at, :work_id, :extracted_metadata, :derivatives,
-    core_metadata: [:id, :original_filename]]
+  @ro_fields [
+    :id,
+    :inserted_at,
+    :updated_at,
+    :work_id,
+    :extracted_metadata,
+    :derivatives,
+    core_metadata: [:id, :original_filename]
+  ]
 
   use MeadowWeb.MCP.Resources.Schemas,
     uri: "file://schema/file_set.json",
@@ -60,7 +101,15 @@ end
 defmodule MeadowWeb.MCP.Resources.Schemas.Collection do
   @moduledoc "JSON schema for a Collection resource, including field types and structure"
 
-  @ro_fields [:id, :representative_work_id, :featured, :published, :visibility, :inserted_at, :updated_at]
+  @ro_fields [
+    :id,
+    :representative_work_id,
+    :featured,
+    :published,
+    :visibility,
+    :inserted_at,
+    :updated_at
+  ]
 
   use MeadowWeb.MCP.Resources.Schemas,
     uri: "file://schema/collection.json",

--- a/app/lib/meadow_web/mcp/tools/update_plan_change.ex
+++ b/app/lib/meadow_web/mcp/tools/update_plan_change.ex
@@ -996,7 +996,6 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChange do
 
   defp read_only_descriptive_metadata_fields do
     [
-      :ark,
       :box_name,
       :box_number,
       :folder_name,

--- a/app/lib/meadow_web/schema/types/data/work_types.ex
+++ b/app/lib/meadow_web/schema/types/data/work_types.ex
@@ -113,11 +113,29 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
 
     @desc "Transfer a subset of file sets to an existing work or create a new work with comprehensive metadata"
     field :transfer_file_sets_subset, :transfer_file_sets_result do
-      arg(:fileset_ids, non_null(list_of(non_null(:id))), description: "List of file set IDs to transfer")
-      arg(:create_work, non_null(:boolean), description: "true = create new work, false = transfer to existing work")
-      arg(:accession_number, :string, description: "Required when create_work is false. Accession number of the target work")
-      arg(:work_attributes, :work_attributes_input, description: "Required when create_work is true. Complete work definition including metadata")
-      arg(:delete_empty_works, :boolean, default_value: true, description: "Whether to delete source works that become empty after transfer (default: true)")
+      arg(:fileset_ids, non_null(list_of(non_null(:id))),
+        description: "List of file set IDs to transfer"
+      )
+
+      arg(:create_work, non_null(:boolean),
+        description: "true = create new work, false = transfer to existing work"
+      )
+
+      arg(:accession_number, :string,
+        description: "Required when create_work is false. Accession number of the target work"
+      )
+
+      arg(:work_attributes, :work_attributes_input,
+        description:
+          "Required when create_work is true. Complete work definition including metadata"
+      )
+
+      arg(:delete_empty_works, :boolean,
+        default_value: true,
+        description:
+          "Whether to delete source works that become empty after transfer (default: true)"
+      )
+
       middleware(Middleware.Authenticate)
       middleware(Middleware.Authorize, "Editor")
       resolve(&Resolvers.Data.transfer_file_sets_subset/3)
@@ -145,6 +163,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
   object :work do
     field(:id, non_null(:id))
     field(:accession_number, non_null(:string))
+    field(:ark, :string)
     field(:administrative_metadata, :work_administrative_metadata)
     field(:descriptive_metadata, :work_descriptive_metadata)
     field(:work_type, :coded_term)
@@ -173,14 +192,14 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     field(:contributor, list_of(:controlled_metadata_entry))
 
     field(:creator, list_of(:controlled_metadata_entry)) do
-      deprecate "Creator field is deprecated"
+      deprecate("Creator field is deprecated")
     end
 
     field(:genre, list_of(:controlled_metadata_entry))
     field(:language, list_of(:controlled_metadata_entry))
 
     field(:location, list_of(:controlled_metadata_entry)) do
-      deprecate "Location field is deprecated"
+      deprecate("Location field is deprecated")
     end
 
     field(:notes, list_of(:note_entry))
@@ -211,7 +230,7 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
     field(:provenance, list_of(:string))
 
     field(:publisher, list_of(:string)) do
-      deprecate "Publisher field is deprecated"
+      deprecate("Publisher field is deprecated")
     end
 
     field(:related_material, list_of(:string))
@@ -225,7 +244,6 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
 
   @desc "`work_descriptive_metadata` represents all descriptive metadata associated with a work object."
   object :work_descriptive_metadata do
-    field(:ark, :string)
     field(:citation, list_of(:string))
     field(:date_created, list_of(:edtf_date_entry))
     field(:license, :coded_term)
@@ -321,14 +339,28 @@ defmodule MeadowWeb.Schema.Data.WorkTypes do
   @desc "Complete work definition for creating a new work during file set transfer"
   input_object :work_attributes_input do
     field(:accession_number, non_null(:string), description: "Unique identifier for the work")
-    field(:work_type, non_null(:string), description: "Work type (e.g., 'IMAGE', 'AUDIO', 'VIDEO')")
+
+    field(:work_type, non_null(:string),
+      description: "Work type (e.g., 'IMAGE', 'AUDIO', 'VIDEO')"
+    )
+
     field(:collection_id, :id, description: "Optional collection to add the work to")
-    field(:published, :boolean, description: "Whether the work should be published (default: false)")
+
+    field(:published, :boolean,
+      description: "Whether the work should be published (default: false)"
+    )
+
     field(:visibility, :coded_term_input, description: "Visibility setting (default: RESTRICTED)")
     field(:behavior, :coded_term_input, description: "Behavior setting for the work")
     field(:ingest_sheet_id, :id, description: "Optional ingest sheet reference")
-    field(:descriptive_metadata, :work_descriptive_metadata_input, description: "Rich descriptive metadata (title, description, etc.)")
-    field(:administrative_metadata, :work_administrative_metadata_input, description: "Administrative metadata (project info, library unit, etc.)")
+
+    field(:descriptive_metadata, :work_descriptive_metadata_input,
+      description: "Rich descriptive metadata (title, description, etc.)"
+    )
+
+    field(:administrative_metadata, :work_administrative_metadata_input,
+      description: "Administrative metadata (project info, library unit, etc.)"
+    )
   end
 
   @desc "Filters for the list of works"

--- a/app/priv/graphql/schema.json
+++ b/app/priv/graphql/schema.json
@@ -12583,6 +12583,18 @@
               "deprecationReason": null,
               "description": null,
               "isDeprecated": false,
+              "name": "ark",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
               "name": "behavior",
               "type": {
                 "kind": "OBJECT",
@@ -13172,18 +13184,6 @@
                   "name": "String",
                   "ofType": null
                 }
-              }
-            },
-            {
-              "args": [],
-              "deprecationReason": null,
-              "description": null,
-              "isDeprecated": false,
-              "name": "ark",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
               }
             },
             {

--- a/app/priv/repo/migrations/20260612214042_move_ark_to_top_level.exs
+++ b/app/priv/repo/migrations/20260612214042_move_ark_to_top_level.exs
@@ -1,0 +1,36 @@
+defmodule Meadow.Repo.Migrations.MoveArkToTopLevel do
+  use Ecto.Migration
+
+  def up do
+    alter table(:works) do
+      add :ark, :string
+    end
+
+    create index(:works, :ark)
+
+    execute("ALTER PUBLICATION events DROP TABLE works")
+    execute("UPDATE works SET ark = descriptive_metadata->>'ark'")
+
+    execute(
+      "UPDATE works SET descriptive_metadata = jsonb_delete_path(descriptive_metadata, '{ark}')"
+    )
+
+    execute("ALTER PUBLICATION events ADD TABLE works")
+  end
+
+  def down do
+    execute("ALTER PUBLICATION events DROP TABLE works")
+
+    execute(
+      "UPDATE works SET descriptive_metadata = jsonb_set(descriptive_metadata, '{ark}', to_jsonb(ark::text))"
+    )
+
+    execute("ALTER PUBLICATION events ADD TABLE works")
+
+    drop index(:works, [:ark])
+
+    alter table(:works) do
+      remove :ark
+    end
+  end
+end

--- a/app/test/fixtures/csv/import_fixture_31.exs
+++ b/app/test/fixtures/csv/import_fixture_31.exs
@@ -10,6 +10,7 @@
     project_task_number: ["1899.827"],
     status: %{id: "NOT STARTED", scheme: "status"}
   },
+  ark: "ark:/99999/fk417148465",
   collection_id: nil,
   descriptive_metadata: %{
     publisher: ["Boam/Cuse Productions", "Warner Bros. Television"],
@@ -52,7 +53,6 @@
     keywords: ["orb", "bly", "western"],
     related_material: ["Related Material"],
     title: "Eaque optio est praesentium tenetur impedit autem minima.",
-    ark: "ark:/99999/fk417148465",
     style_period: [
       %{term: %{id: "http://vocab.getty.edu/aat/300378903"}},
       %{term: %{id: "http://vocab.getty.edu/aat/300312140"}},

--- a/app/test/fixtures/csv/work_fixtures.exs
+++ b/app/test/fixtures/csv/work_fixtures.exs
@@ -1,7 +1,110 @@
 [
   %{
+    id: "ea331225-6c62-4f03-b58b-f70e35c599b6",
+    ark: "ark:/99999/fk415261536",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300438611"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300265034"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500445403"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300056462"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300386217"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300139140"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/div"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79091588"},
+          role: %{id: "pbl", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Voluptatibus nobis nihil minima earum aliquam!",
+      location: [%{term: %{id: "https://sws.geonames.org/2347283/"}, role: nil}],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300375743"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2770003",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -9,115 +112,115 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        },
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        },
-        %{
-          role: %{id: "pbl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}}
-      ],
-      title: "Voluptatibus nobis nihil minima earum aliquam!",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415261536",
-      location: [%{role: nil, term: %{id: "https://sws.geonames.org/2347283/"}}],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "ea331225-6c62-4f03-b58b-f70e35c599b6"
+      project_task_number: []
+    }
   },
   %{
+    id: "c93206e3-e9a7-4cb5-b70f-c05aeadf5494",
+    ark: "ark:/99999/fk415261536",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300265034"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500029268"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79091588"},
+          role: %{id: "pbl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "pbl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79091588"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n83175996"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Consectetur tenetur accusamus fugit laborum qui et atque.",
+      location: [
+        %{term: %{id: "http://vocab.getty.edu/tgn/1114106"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3598132/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2769774",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -125,115 +228,96 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "pbl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
-        },
-        %{
-          role: %{id: "pbl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        },
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
-        },
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        },
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}}
-      ],
-      title: "Consectetur tenetur accusamus fugit laborum qui et atque.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415261536",
-      location: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3598132/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "c93206e3-e9a7-4cb5-b70f-c05aeadf5494"
+      project_task_number: []
+    }
   },
   %{
+    id: "361b9a65-dfd2-4c60-ab2a-ff01c35f54a2",
+    ark: "ark:/99999/fk415261537",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500445403"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300139140"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300056462"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/div"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79091588"},
+          role: %{id: "stl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Quas rerum nisi voluptatem non molestiae iste qui dolores et.",
+      location: [
+        %{term: %{id: "https://sws.geonames.org/4921868/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3703443/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:3677974",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -241,96 +325,94 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        },
-        %{
-          role: %{id: "stl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
-        },
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}}
-      ],
-      title: "Quas rerum nisi voluptatem non molestiae iste qui dolores et.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415261537",
-      location: [
-        %{role: nil, term: %{id: "https://sws.geonames.org/4921868/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3703443/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "361b9a65-dfd2-4c60-ab2a-ff01c35f54a2"
+      project_task_number: []
+    }
   },
   %{
+    id: "443e4f2c-031c-4d1d-b24e-ec1e96942771",
+    ark: "ark:/99999/fk415261536",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500445403"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500029268"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300139140"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Inventore harum ex sequi saepe aut.",
+      location: [
+        %{term: %{id: "https://sws.geonames.org/3703443/"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/tgn/7549617"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3530597/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375743"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:3677625",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -338,94 +420,91 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
-      ],
-      title: "Inventore harum ex sequi saepe aut.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415261536",
-      location: [
-        %{role: nil, term: %{id: "https://sws.geonames.org/3703443/"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/7549617"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3530597/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "443e4f2c-031c-4d1d-b24e-ec1e96942771"
+      project_task_number: []
+    }
   },
   %{
+    id: "6f5c9140-bdf9-4d93-8171-9041746725b5",
+    ark: "ark:/99999/fk415261537",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500029268"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300056462"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79091588"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Est qui ut quibusdam iure laudantium praesentium harum cumque repellendus!",
+      location: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79022925"},
+          role: nil
+        }
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300312140"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375743"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:3680002",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -433,91 +512,122 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
-      ],
-      title: "Est qui ut quibusdam iure laudantium praesentium harum cumque repellendus!",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415261537",
-      location: [
-        %{
-          role: nil,
-          term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
-        }
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "6f5c9140-bdf9-4d93-8171-9041746725b5"
+      project_task_number: []
+    }
   },
   %{
+    id: "36a7295a-f342-4413-805f-c795ace2c709",
+    ark: "ark:/99999/fk415261537",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300265034"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500029268"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300386217"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300139140"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79091588"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79091588"},
+          role: %{id: "stl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79091588"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Consectetur deleniti qui ex molestias veritatis ut minima.",
+      location: [
+        %{term: %{id: "http://vocab.getty.edu/tgn/1114106"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/292932/"}, role: nil},
+        %{term: %{id: "http://id.worldcat.org/fast/1204604"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3598132/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300312140"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:3681611",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -525,122 +635,118 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
-        },
-        %{
-          role: %{id: "stl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
-        },
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
-        },
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
-      ],
-      title: "Consectetur deleniti qui ex molestias veritatis ut minima.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415261537",
-      location: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/292932/"}},
-        %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3598132/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "36a7295a-f342-4413-805f-c795ace2c709"
+      project_task_number: []
+    }
   },
   %{
+    id: "4d8fcc8e-43f1-499d-b188-c091e9c66dec",
+    ark: "ark:/99999/fk415261537",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300438611"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500029268"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300056462"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300139140"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n83175996"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "pbl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "stl", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Veniam sed voluptas beatae minima necessitatibus et officia.",
+      location: [
+        %{term: %{id: "http://vocab.getty.edu/tgn/7549617"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3582677/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/292932/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3530597/"}, role: nil},
+        %{term: %{id: "http://id.worldcat.org/fast/1204604"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300312140"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:3682832",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -648,118 +754,107 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
-        },
-        %{
-          role: %{id: "pbl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        },
-        %{
-          role: %{id: "stl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}}
-      ],
-      title: "Veniam sed voluptas beatae minima necessitatibus et officia.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415261537",
-      location: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/7549617"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3582677/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/292932/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3530597/"}},
-        %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "4d8fcc8e-43f1-499d-b188-c091e9c66dec"
+      project_task_number: []
+    }
   },
   %{
+    id: "e74f050f-d39e-4efe-b145-2a349531dd12",
+    ark: "ark:/99999/fk415261536",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300265034"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300386217"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79091588"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Sunt eos omnis voluptatem voluptatem?",
+      location: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79022925"},
+          role: nil
+        },
+        %{term: %{id: "https://sws.geonames.org/2347283/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375743"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Accession:inu-afrmap-4004497",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -767,107 +862,116 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
-        },
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        },
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}}
-      ],
-      title: "Sunt eos omnis voluptatem voluptatem?",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415261536",
-      location: [
-        %{
-          role: nil,
-          term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
-        },
-        %{role: nil, term: %{id: "https://sws.geonames.org/2347283/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "e74f050f-d39e-4efe-b145-2a349531dd12"
+      project_task_number: []
+    }
   },
   %{
+    id: "0caa2cd5-3cfe-45db-9359-db6bc442a494",
+    ark: "ark:/99999/fk415261536",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500445403"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300386217"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300139140"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300056462"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/div"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "pbl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "pbl", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Omnis totam ipsam minus.",
+      location: [
+        %{term: %{id: "http://id.worldcat.org/fast/1204604"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3703443/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/292932/"}, role: nil},
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79022925"},
+          role: nil
+        },
+        %{term: %{id: "https://sws.geonames.org/3530597/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300312140"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375743"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:3677912",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -875,116 +979,114 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        },
-        %{
-          role: %{id: "pbl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        },
-        %{
-          role: %{id: "pbl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}}
-      ],
-      title: "Omnis totam ipsam minus.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415261536",
-      location: [
-        %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3703443/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/292932/"}},
-        %{
-          role: nil,
-          term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
-        },
-        %{role: nil, term: %{id: "https://sws.geonames.org/3530597/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "0caa2cd5-3cfe-45db-9359-db6bc442a494"
+      project_task_number: []
+    }
   },
   %{
+    id: "4503609b-f441-47b1-85b4-746871c93cd5",
+    ark: "ark:/99999/fk415261537",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300265034"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500445403"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300056462"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300386217"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/div"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "pbl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n83175996"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "At neque iste natus iusto nemo consequatur aperiam consequatur.",
+      location: [
+        %{term: %{id: "http://id.worldcat.org/fast/1204604"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3582677/"}, role: nil},
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79022925"},
+          role: nil
+        }
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300375743"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:3682407",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -992,114 +1094,113 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "pbl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}}
-      ],
-      title: "At neque iste natus iusto nemo consequatur aperiam consequatur.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415261537",
-      location: [
-        %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3582677/"}},
-        %{
-          role: nil,
-          term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
-        }
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "4503609b-f441-47b1-85b4-746871c93cd5"
+      project_task_number: []
+    }
   },
   %{
+    id: "0acfa920-693f-45d4-83f4-ce32154f9d81",
+    ark: "ark:/99999/fk415264062",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300265034"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500445403"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [%{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil}],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "stl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Illo ducimus magni sed.",
+      location: [
+        %{term: %{id: "https://sws.geonames.org/3598132/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3582677/"}, role: nil},
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79022925"},
+          role: nil
+        },
+        %{term: %{id: "https://sws.geonames.org/2347283/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3703443/"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/tgn/1114106"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300312140"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2370677",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -1107,115 +1208,94 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        },
-        %{
-          role: %{id: "stl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}}
-      ],
-      title: "Illo ducimus magni sed.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264062",
-      location: [
-        %{role: nil, term: %{id: "https://sws.geonames.org/3598132/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3582677/"}},
-        %{
-          role: nil,
-          term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
-        },
-        %{role: nil, term: %{id: "https://sws.geonames.org/2347283/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3703443/"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "0acfa920-693f-45d4-83f4-ce32154f9d81"
+      project_task_number: []
+    }
   },
   %{
+    id: "9eb3eb1b-2a2d-425e-ba30-4d352fcf5588",
+    ark: "ark:/99999/fk415264062",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300139140"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300056462"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/div"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n83175996"},
+          role: %{id: "stl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79091588"},
+          role: %{id: "pbl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Non voluptas quas molestias est?",
+      location: [
+        %{term: %{id: "https://sws.geonames.org/4921868/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3530597/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2370807",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -1223,94 +1303,115 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "stl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
-        },
-        %{
-          role: %{id: "pbl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
-        },
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}}
-      ],
-      title: "Non voluptas quas molestias est?",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264062",
-      location: [
-        %{role: nil, term: %{id: "https://sws.geonames.org/4921868/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3530597/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "9eb3eb1b-2a2d-425e-ba30-4d352fcf5588"
+      project_task_number: []
+    }
   },
   %{
+    id: "9121914a-dbe5-4854-85e9-82cddf3df224",
+    ark: "ark:/99999/fk415264062",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300438611"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [%{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil}],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/div"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "pbl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "stl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79091588"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Et quis soluta amet itaque odio et adipisci illo aperiam!",
+      location: [
+        %{term: %{id: "http://vocab.getty.edu/tgn/7549617"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/tgn/1114106"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3530597/"}, role: nil},
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79022925"},
+          role: nil
+        }
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2373630",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -1318,117 +1419,107 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        },
-        %{
-          role: %{id: "pbl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        },
-        %{
-          role: %{id: "stl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        },
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
-      ],
-      title: "Et quis soluta amet itaque odio et adipisci illo aperiam!",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264062",
-      location: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/7549617"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3530597/"}},
-        %{
-          role: nil,
-          term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
-        }
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "9121914a-dbe5-4854-85e9-82cddf3df224"
+      project_task_number: []
+    }
   },
   %{
+    id: "eb406254-ae2d-4ab2-b781-e5877828c712",
+    ark: "ark:/99999/fk415264063",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300438611"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300265034"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500445403"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [%{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil}],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79091588"},
+          role: %{id: "pbl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "pbl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n83175996"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Laborum labore recusandae quia velit vero.",
+      location: [
+        %{term: %{id: "https://sws.geonames.org/3530597/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3703443/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2373664",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -1436,109 +1527,114 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "pbl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
-        },
-        %{
-          role: %{id: "pbl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        },
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        },
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}}
-      ],
-      title: "Laborum labore recusandae quia velit vero.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264063",
-      location: [
-        %{role: nil, term: %{id: "https://sws.geonames.org/3530597/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3703443/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "eb406254-ae2d-4ab2-b781-e5877828c712"
+      project_task_number: []
+    }
   },
   %{
+    id: "a1d79736-6a34-41cf-b1e2-9d89bff422e0",
+    ark: "ark:/99999/fk415264063",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300265034"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500445403"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500029268"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300139140"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300056462"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/div"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n83175996"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "pbl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Esse quia reiciendis nihil error ab iste?",
+      location: [%{term: %{id: "https://sws.geonames.org/3530597/"}, role: nil}],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2553149",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -1546,114 +1642,102 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
-        },
-        %{
-          role: %{id: "pbl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        },
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}}
-      ],
-      title: "Esse quia reiciendis nihil error ab iste?",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264063",
-      location: [%{role: nil, term: %{id: "https://sws.geonames.org/3530597/"}}],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "a1d79736-6a34-41cf-b1e2-9d89bff422e0"
+      project_task_number: []
+    }
   },
   %{
+    id: "c829282a-13c1-4721-a1d2-1ce87129ccd3",
+    ark: "ark:/99999/fk415264063",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300438611"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [%{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil}],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n83175996"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Dolor quos a illo asperiores nihil natus voluptas.",
+      location: [
+        %{term: %{id: "https://sws.geonames.org/4921868/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3530597/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3598132/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375743"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2559667",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -1661,104 +1745,110 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
-        },
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        },
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        },
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}}
-      ],
-      title: "Dolor quos a illo asperiores nihil natus voluptas.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264063",
-      location: [
-        %{role: nil, term: %{id: "https://sws.geonames.org/4921868/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3530597/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3598132/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "c829282a-13c1-4721-a1d2-1ce87129ccd3"
+      project_task_number: []
+    }
   },
   %{
+    id: "8552bac8-ce6f-4bce-ac93-17292d589fc8",
+    ark: "ark:/99999/fk415264063",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300265034"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500445403"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300139140"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300056462"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300386217"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/div"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n83175996"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "stl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Occaecati autem quis aut perspiciatis magni aliquid quas?",
+      location: [
+        %{term: %{id: "http://vocab.getty.edu/tgn/7549617"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/292932/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/4921868/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3598132/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300312140"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375743"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2564709",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -1766,110 +1856,109 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
-        },
-        %{
-          role: %{id: "stl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        },
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        },
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}}
-      ],
-      title: "Occaecati autem quis aut perspiciatis magni aliquid quas?",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264063",
-      location: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/7549617"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/292932/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/4921868/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3598132/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "8552bac8-ce6f-4bce-ac93-17292d589fc8"
+      project_task_number: []
+    }
   },
   %{
+    id: "97b21901-f252-4d80-a421-c9c26f2e11cf",
+    ark: "ark:/99999/fk415264063",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300438611"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500029268"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [%{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil}],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "stl", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Perferendis velit earum molestiae harum.",
+      location: [
+        %{term: %{id: "https://sws.geonames.org/3703443/"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/tgn/1114106"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300312140"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375743"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2559745",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -1877,111 +1966,103 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        },
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        },
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        },
-        %{
-          role: %{id: "stl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}}
-      ],
-      title: "Perferendis velit earum molestiae harum.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264063",
-      location: [
-        %{role: nil, term: %{id: "https://sws.geonames.org/3703443/"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "97b21901-f252-4d80-a421-c9c26f2e11cf"
+      project_task_number: []
+    }
   },
   %{
+    id: "39a3b7d3-a72f-4796-81f3-f02b63b70d87",
+    ark: "ark:/99999/fk415264063",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300139140"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79091588"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79091588"},
+          role: %{id: "stl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79091588"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Est labore quia ea et vel cumque fugit suscipit?",
+      location: [
+        %{term: %{id: "https://sws.geonames.org/3598132/"}, role: nil},
+        %{term: %{id: "http://id.worldcat.org/fast/1204604"}, role: nil},
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79022925"},
+          role: nil
+        }
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300312140"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2564748",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -1989,103 +2070,106 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        },
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
-        },
-        %{
-          role: %{id: "stl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}}
-      ],
-      title: "Est labore quia ea et vel cumque fugit suscipit?",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264063",
-      location: [
-        %{role: nil, term: %{id: "https://sws.geonames.org/3598132/"}},
-        %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}},
-        %{
-          role: nil,
-          term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
-        }
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "39a3b7d3-a72f-4796-81f3-f02b63b70d87"
+      project_task_number: []
+    }
   },
   %{
+    id: "ebc3ff1a-64fd-4e06-a70d-34f7b58e8bcf",
+    ark: "ark:/99999/fk415264063",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300139140"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "pbl", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Mollitia nobis aut saepe!",
+      location: [%{term: %{id: "https://sws.geonames.org/3598132/"}, role: nil}],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300312140"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2564967",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -2093,106 +2177,99 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        },
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        },
-        %{
-          role: %{id: "pbl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
-      ],
-      title: "Mollitia nobis aut saepe!",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264063",
-      location: [%{role: nil, term: %{id: "https://sws.geonames.org/3598132/"}}],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "ebc3ff1a-64fd-4e06-a70d-34f7b58e8bcf"
+      project_task_number: []
+    }
   },
   %{
+    id: "300f5a25-e0cc-43e4-adb4-0f7c7d8aa455",
+    ark: "ark:/99999/fk415264063",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300386217"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300139140"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300056462"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/div"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Et sit delectus atque eum exercitationem?",
+      location: [
+        %{term: %{id: "http://id.worldcat.org/fast/1204604"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3703443/"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/tgn/1114106"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3530597/"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/tgn/7549617"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375743"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2567367",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -2200,99 +2277,85 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}}
-      ],
-      title: "Et sit delectus atque eum exercitationem?",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264063",
-      location: [
-        %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3703443/"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3530597/"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/7549617"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "300f5a25-e0cc-43e4-adb4-0f7c7d8aa455"
+      project_task_number: []
+    }
   },
   %{
+    id: "0094fd27-687a-4e13-a74a-b582fac97ef4",
+    ark: "ark:/99999/fk415264063",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300438611"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [%{term: %{id: "http://vocab.getty.edu/aat/300386217"}, role: nil}],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/div"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Iste aliquam est provident explicabo voluptatem sed perferendis.",
+      location: [%{term: %{id: "https://sws.geonames.org/3582677/"}, role: nil}],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300375743"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2564969",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -2300,87 +2363,110 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
-      ],
-      title: "Iste aliquam est provident explicabo voluptatem sed perferendis.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264063",
-      location: [%{role: nil, term: %{id: "https://sws.geonames.org/3582677/"}}],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "0094fd27-687a-4e13-a74a-b582fac97ef4"
+      project_task_number: []
+    }
   },
   %{
+    id: "afe7f4a9-529e-4571-8da3-dfaa450bcaa8",
+    ark: "ark:/99999/fk415264064",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300265034"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500029268"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300386217"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "stl", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Et corrupti laborum omnis!",
+      location: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79022925"},
+          role: nil
+        },
+        %{term: %{id: "https://sws.geonames.org/292932/"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/tgn/1114106"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3530597/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/2347283/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375743"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2573030",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -2388,110 +2474,93 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        },
-        %{
-          role: %{id: "stl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}}
-      ],
-      title: "Et corrupti laborum omnis!",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264064",
-      location: [
-        %{
-          role: nil,
-          term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
-        },
-        %{role: nil, term: %{id: "https://sws.geonames.org/292932/"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3530597/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/2347283/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "afe7f4a9-529e-4571-8da3-dfaa450bcaa8"
+      project_task_number: []
+    }
   },
   %{
+    id: "07b81bc8-39a9-4c49-959c-8d44a0ea86d9",
+    ark: "ark:/99999/fk415264063",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300265034"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500029268"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300056462"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/div"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n83175996"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Voluptatem officia fugit eos architecto quisquam qui!",
+      location: [
+        %{term: %{id: "http://vocab.getty.edu/tgn/1114106"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3703443/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300375743"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300312140"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2570495",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -2499,93 +2568,100 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}}
-      ],
-      title: "Voluptatem officia fugit eos architecto quisquam qui!",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264063",
-      location: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3703443/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "07b81bc8-39a9-4c49-959c-8d44a0ea86d9"
+      project_task_number: []
+    }
   },
   %{
+    id: "828ce089-5b4c-4c53-b279-6ca6f7c20ce2",
+    ark: "ark:/99999/fk415264064",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300265034"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500029268"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [%{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil}],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "stl", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Voluptatem repellat odit qui sed alias eveniet recusandae.",
+      location: [%{term: %{id: "https://sws.geonames.org/4921868/"}, role: nil}],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2586368",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -2593,102 +2669,108 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        },
-        %{
-          role: %{id: "stl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}}
-      ],
-      title: "Voluptatem repellat odit qui sed alias eveniet recusandae.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264064",
-      location: [%{role: nil, term: %{id: "https://sws.geonames.org/4921868/"}}],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "828ce089-5b4c-4c53-b279-6ca6f7c20ce2"
+      project_task_number: []
+    }
   },
   %{
+    id: "58d0d305-4b33-4939-8276-f6308e39a1f0",
+    ark: "ark:/99999/fk415264064",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300265034"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500445403"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300056462"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300139140"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/div"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79091588"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "stl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Voluptate assumenda eveniet ullam.",
+      location: [
+        %{term: %{id: "http://vocab.getty.edu/tgn/1114106"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300312140"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2576748",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -2696,108 +2778,93 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
-        },
-        %{
-          role: %{id: "stl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        },
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}}
-      ],
-      title: "Voluptate assumenda eveniet ullam.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264064",
-      location: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "58d0d305-4b33-4939-8276-f6308e39a1f0"
+      project_task_number: []
+    }
   },
   %{
+    id: "6f6f79e0-bda1-4de6-a40f-c49c34465e85",
+    ark: "ark:/99999/fk415264065",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300438611"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500029268"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [%{term: %{id: "http://vocab.getty.edu/aat/300139140"}, role: nil}],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/div"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Laborum voluptas maiores quod ut eligendi enim aut dolorum voluptatibus.",
+      location: [
+        %{term: %{id: "http://id.worldcat.org/fast/1204604"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3582677/"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/tgn/1114106"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3703443/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2588297",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -2805,95 +2872,93 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}}
-      ],
-      title: "Laborum voluptas maiores quod ut eligendi enim aut dolorum voluptatibus.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264065",
-      location: [
-        %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3582677/"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3703443/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "6f6f79e0-bda1-4de6-a40f-c49c34465e85"
+      project_task_number: []
+    }
   },
   %{
+    id: "7e26e562-6818-4452-90c8-d8adcd985f46",
+    ark: "ark:/99999/fk415264064",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300438611"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300056462"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n83175996"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Aspernatur animi natus magnam voluptate ab explicabo!",
+      location: [
+        %{term: %{id: "http://id.worldcat.org/fast/1204604"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3530597/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2586736",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -2901,93 +2966,110 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
-        },
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}}
-      ],
-      title: "Aspernatur animi natus magnam voluptate ab explicabo!",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264064",
-      location: [
-        %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3530597/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "7e26e562-6818-4452-90c8-d8adcd985f46"
+      project_task_number: []
+    }
   },
   %{
+    id: "142c1355-203e-4d32-b51a-e8290164e293",
+    ark: "ark:/99999/fk415264065",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300438611"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300056462"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300386217"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300139140"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n83175996"},
+          role: %{id: "pbl", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Eius cum optio et illum?",
+      location: [
+        %{term: %{id: "https://sws.geonames.org/3598132/"}, role: nil},
+        %{term: %{id: "http://id.worldcat.org/fast/1204604"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300312140"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2588396",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -2995,110 +3077,102 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        },
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        },
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        },
-        %{
-          role: %{id: "pbl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}}
-      ],
-      title: "Eius cum optio et illum?",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264065",
-      location: [
-        %{role: nil, term: %{id: "https://sws.geonames.org/3598132/"}},
-        %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "142c1355-203e-4d32-b51a-e8290164e293"
+      project_task_number: []
+    }
   },
   %{
+    id: "38f8a6f1-172c-4af9-8a8b-1364891e742b",
+    ark: "ark:/99999/fk415264065",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300265034"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300438611"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500029268"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300139140"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/div"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "pbl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n83175996"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Laudantium aut omnis eius quia eum animi impedit eum aut?",
+      location: [
+        %{term: %{id: "http://vocab.getty.edu/tgn/1114106"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/2347283/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3703443/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3582677/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300312140"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2588408",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -3106,102 +3180,119 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        },
-        %{
-          role: %{id: "pbl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        },
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        },
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}}
-      ],
-      title: "Laudantium aut omnis eius quia eum animi impedit eum aut?",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264065",
-      location: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/2347283/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3703443/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3582677/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "38f8a6f1-172c-4af9-8a8b-1364891e742b"
+      project_task_number: []
+    }
   },
   %{
+    id: "2b517d8b-e9b5-4076-9bad-c9369567da74",
+    ark: "ark:/99999/fk415264065",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300265034"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500445403"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/div"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "pbl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79091588"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "stl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Aliquid ratione culpa est ad necessitatibus vitae soluta reiciendis!",
+      location: [
+        %{term: %{id: "https://sws.geonames.org/3582677/"}, role: nil},
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79022925"},
+          role: nil
+        }
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300312140"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2591350",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -3209,119 +3300,96 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "pbl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        },
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
-        },
-        %{
-          role: %{id: "stl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}}
-      ],
-      title: "Aliquid ratione culpa est ad necessitatibus vitae soluta reiciendis!",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264065",
-      location: [
-        %{role: nil, term: %{id: "https://sws.geonames.org/3582677/"}},
-        %{
-          role: nil,
-          term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
-        }
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "2b517d8b-e9b5-4076-9bad-c9369567da74"
+      project_task_number: []
+    }
   },
   %{
+    id: "d3b1a1d6-5334-4e2c-9de3-74c8dfe2cb70",
+    ark: "ark:/99999/fk415264065",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500029268"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500445403"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [%{term: %{id: "http://vocab.getty.edu/aat/300139140"}, role: nil}],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n83175996"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Sapiente iure maxime omnis quae et maiores!",
+      location: [
+        %{term: %{id: "https://sws.geonames.org/3582677/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3703443/"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/tgn/1114106"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/4921868/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3598132/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300375743"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2592728",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -3329,98 +3397,92 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        },
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        },
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}}
-      ],
-      title: "Sapiente iure maxime omnis quae et maiores!",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264065",
-      location: [
-        %{role: nil, term: %{id: "https://sws.geonames.org/3582677/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3703443/"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/4921868/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3598132/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "d3b1a1d6-5334-4e2c-9de3-74c8dfe2cb70"
+      project_task_number: []
+    }
   },
   %{
+    id: "fef4c5f8-250a-40a1-8529-dbcbd5ab2676",
+    ark: "ark:/99999/fk415264063",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500029268"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300056462"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/div"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Incidunt eligendi consequatur doloribus ut?",
+      location: [
+        %{term: %{id: "http://id.worldcat.org/fast/1204604"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3598132/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/292932/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2564705",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -3428,92 +3490,114 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
-      ],
-      title: "Incidunt eligendi consequatur doloribus ut?",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264063",
-      location: [
-        %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3598132/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/292932/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "fef4c5f8-250a-40a1-8529-dbcbd5ab2676"
+      project_task_number: []
+    }
   },
   %{
+    id: "fa4881cf-8a84-47be-a552-08e090c189c8",
+    ark: "ark:/99999/fk415264063",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300438611"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500029268"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300056462"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "stl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Molestiae labore distinctio in qui.",
+      location: [
+        %{term: %{id: "https://sws.geonames.org/3703443/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/292932/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300312140"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2564944",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -3521,114 +3605,112 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        },
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        },
-        %{
-          role: %{id: "stl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        },
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}}
-      ],
-      title: "Molestiae labore distinctio in qui.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264063",
-      location: [
-        %{role: nil, term: %{id: "https://sws.geonames.org/3703443/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/292932/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "fa4881cf-8a84-47be-a552-08e090c189c8"
+      project_task_number: []
+    }
   },
   %{
+    id: "7905c2af-18f4-4d2a-b031-7668fc1c284a",
+    ark: "ark:/99999/fk415264063",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300056462"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n83175996"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79091588"},
+          role: %{id: "stl", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Incidunt consequuntur dolores eos!",
+      location: [
+        %{term: %{id: "http://id.worldcat.org/fast/1204604"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/tgn/7549617"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3598132/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/4921868/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3582677/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300312140"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2566127",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -3636,112 +3718,97 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        },
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        },
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
-        },
-        %{
-          role: %{id: "stl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
-      ],
-      title: "Incidunt consequuntur dolores eos!",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264063",
-      location: [
-        %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/7549617"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3598132/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/4921868/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3582677/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "7905c2af-18f4-4d2a-b031-7668fc1c284a"
+      project_task_number: []
+    }
   },
   %{
+    id: "95215ceb-63af-4f5e-88c8-7375798f814d",
+    ark: "ark:/99999/fk415264064",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300265034"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [%{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil}],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Velit quae iste et voluptatibus eligendi voluptas quis est id.",
+      location: [
+        %{term: %{id: "https://sws.geonames.org/292932/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3530597/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375743"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300312140"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2573027",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -3749,99 +3816,99 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/kor"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}}
-      ],
-      title: "Velit quae iste et voluptatibus eligendi voluptas quis est id.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264064",
-      location: [
-        %{role: nil, term: %{id: "https://sws.geonames.org/292932/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3530597/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "95215ceb-63af-4f5e-88c8-7375798f814d"
+      project_task_number: []
+    }
   },
   %{
+    id: "b279db8d-93ac-479c-808b-02cedf0b3b7a",
+    ark: "ark:/99999/fk415264064",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300438611"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500445403"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300139140"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/div"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Dolorum tempore officia occaecati qui omnis sit.",
+      location: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79022925"},
+          role: nil
+        },
+        %{term: %{id: "https://sws.geonames.org/3530597/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3598132/"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/tgn/1114106"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "Voyager:2577952",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -3849,166 +3916,51 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300139140"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        },
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
-      ],
-      title: "Dolorum tempore officia occaecati qui omnis sit.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264064",
-      location: [
-        %{
-          role: nil,
-          term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
-        },
-        %{role: nil, term: %{id: "https://sws.geonames.org/3530597/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3598132/"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "b279db8d-93ac-479c-808b-02cedf0b3b7a"
+      project_task_number: []
+    }
   },
   %{
-    accession_number: "Voyager:2588027",
-    administrative_metadata: %{
-      library_unit: %{
-        "id" => "UNIVERSITY_MAIN_LIBRARY",
-        "label" => "University (MAIN) Library",
-        "scheme" => "library_unit"
-      },
-      preservation_level: %{id: "2", label: "Level 2", scheme: "preservation_level"},
-      project_cycle: "Redevelopment",
-      project_desc: ["Description of Project"],
-      project_manager: ["Brisco County, Jr."],
-      project_name: ["The Coming Thing"],
-      project_proposer: ["Socrates Poole"],
-      project_task_number: ["1899.827"],
-      status: %{id: "NOT STARTED", label: "Started", scheme: "status"}
-    },
+    id: "d4bfad17-1c81-4a4a-aa9d-29aca65fa93e",
+    ark: "ark:/99999/fk415264064",
     descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
-      ],
       legacy_identifier: ["827", "BCDE.2"],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}}
-      ],
-      date_created: [%{"edtf" => "~1899", "humanized" => "circa 1899?"}],
-      contributor: [
-        %{
-          role: %{id: "pbl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
-        },
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        },
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        },
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        },
-        %{
-          role: %{id: "stl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        }
-      ],
-      series: ["The Adventures of Brisco County, Jr."],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}}
-      ],
+      folder_number: ["2"],
+      cultural_context: ["Context 1", "Context 2"],
       table_of_contents: ["Season One", "There Is No Season Two"],
       provenance: ["Television"],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300312140"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}}
+      abstract: ["Abstract"],
+      box_number: ["1"],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300438611"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil}
       ],
-      physical_description_material: ["DVD"],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500445403"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500029268"}, role: nil}
+      ],
+      date_created: [%{"edtf" => "~1899", "humanized" => "circa 1899?"}],
+      publisher: ["Boam/Cuse Productions", "Warner Bros. Television"],
+      genre: [%{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil}],
+      identifier: ["BRISCO"],
+      catalog_key: ["Catalog Key"],
+      citation: ["Citation"],
+      scope_and_contents: ["Scope", "Contents"],
+      series: ["The Adventures of Brisco County, Jr."],
+      folder_name: ["Folder 2"],
+      source: ["Source"],
+      rights_statement: %{
+        id: "http://rightsstatements.org/vocab/InC/1.0/",
+        label: "In Copyright",
+        scheme: "rights_statement"
+      },
+      notes: [
+        %{type: %{id: "GENERAL_NOTE", scheme: "note_type"}, note: "Notes"}
+      ],
+      related_material: ["Related Material"],
+      rights_holder: ["Rights Holder"],
       related_url: [
         %{
           "label" => %{
@@ -4019,97 +3971,211 @@
           "url" => "https://www.imdb.com/title/tt0105932/"
         }
       ],
-      keywords: ["orb", "bly", "western"],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}}
-      ],
-      title: "Eaque optio est praesentium tenetur impedit autem minima.",
-      terms_of_use: "Terms of Use",
-      ark: "ark:/99999/fk415264064",
-      location: [
-        %{role: nil, term: %{id: "https://sws.geonames.org/2347283/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3530597/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3582677/"}}
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}, role: nil}
       ],
       nav_place: [
         %{
+          "coordinates" => [-87.65005, 41.85003],
           "id" => "https://sws.geonames.org/4887398/",
           "label" => "Chicago",
-          "summary" => "Illinois, United States",
-          "coordinates" => [-87.65005, 41.85003]
+          "summary" => "Illinois, United States"
         },
         %{
+          "coordinates" => [166.93453, -0.5033],
           "id" => "https://sws.geonames.org/2110435/",
           "label" => "Ewa District",
-          "summary" => "Ewa District, Nauru",
-          "coordinates" => [166.93453, -0.5033]
+          "summary" => "Ewa District, Nauru"
         }
       ],
-      description: ["Three", "Descriptions", "With a | pipe in the third"],
-      citation: ["Citation"],
-      cultural_context: ["Context 1", "Context 2"],
-      rights_holder: ["Rights Holder"],
-      notes: [%{note: "Notes", type: %{id: "GENERAL_NOTE", scheme: "note_type"}}],
-      physical_description_size: ["12cm"],
-      alternate_title: ["That Bruce Campbell Show"],
-      catalog_key: ["Catalog Key"],
-      source: ["Source"],
-      rights_statement: %{
-        id: "http://rightsstatements.org/vocab/InC/1.0/",
-        label: "In Copyright",
-        scheme: "rights_statement"
-      },
-      abstract: ["Abstract"],
-      folder_name: ["Folder 2"],
-      box_name: ["Box 1"],
-      box_number: ["1"],
       license: %{
         id: "http://www.europeana.eu/portal/rights/rr-r.html",
         label: "All rights reserved",
         scheme: "license"
       },
-      publisher: ["Boam/Cuse Productions", "Warner Bros. Television"],
-      folder_number: ["2"],
-      subject: [
+      contributor: [
         %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
+          term: %{id: "http://id.loc.gov/authorities/names/n83175996"},
+          role: %{id: "pbl", scheme: "marc_relator"}
         },
         %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "vac", scheme: "marc_relator"}
         },
         %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "lil", scheme: "marc_relator"}
         },
         %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "aut", scheme: "marc_relator"}
         },
         %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "stl", scheme: "marc_relator"}
         }
       ],
-      related_material: ["Related Material"],
-      identifier: ["BRISCO"],
-      scope_and_contents: ["Scope", "Contents"],
-      caption: ["Caption"]
+      box_name: ["Box 1"],
+      keywords: ["orb", "bly", "western"],
+      title: "Eaque optio est praesentium tenetur impedit autem minima.",
+      location: [
+        %{term: %{id: "https://sws.geonames.org/2347283/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3530597/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3582677/"}, role: nil}
+      ],
+      physical_description_material: ["DVD"],
+      alternate_title: ["That Bruce Campbell Show"],
+      caption: ["Caption"],
+      description: ["Three", "Descriptions", "With a | pipe in the third"],
+      physical_description_size: ["12cm"],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300312140"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375743"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: "Terms of Use"
     },
-    id: "d4bfad17-1c81-4a4a-aa9d-29aca65fa93e",
     published: false,
     visibility: %{
       id: "AUTHENTICATED",
       label: "Institution",
       scheme: "visibility"
+    },
+    accession_number: "Voyager:2588027",
+    administrative_metadata: %{
+      status: %{id: "NOT STARTED", label: "Started", scheme: "status"},
+      library_unit: %{
+        "id" => "UNIVERSITY_MAIN_LIBRARY",
+        "label" => "University (MAIN) Library",
+        "scheme" => "library_unit"
+      },
+      preservation_level: %{
+        id: "2",
+        label: "Level 2",
+        scheme: "preservation_level"
+      },
+      project_cycle: "Redevelopment",
+      project_desc: ["Description of Project"],
+      project_manager: ["Brisco County, Jr."],
+      project_name: ["The Coming Thing"],
+      project_proposer: ["Socrates Poole"],
+      project_task_number: ["1899.827"]
     }
   },
   %{
+    id: "dc20eb57-2333-4e57-9067-72c91a3fa7fe",
+    ark: "ark:/99999/fk415264065",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300438611"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300265034"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500102192"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300386217"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300056462"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n83175996"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Molestiae quia voluptas porro officiis qui commodi nobis animi.",
+      location: [
+        %{term: %{id: "https://sws.geonames.org/2347283/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3703443/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/292932/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3582677/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
+    published: true,
+    visibility: %{id: "OPEN", label: "Public", scheme: "visibility"},
     accession_number: "Voyager:2592725",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -4117,98 +4183,111 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500102192"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}}
-      ],
-      title: "Molestiae quia voluptas porro officiis qui commodi nobis animi.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264065",
-      location: [
-        %{role: nil, term: %{id: "https://sws.geonames.org/2347283/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3703443/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/292932/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3582677/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "dc20eb57-2333-4e57-9067-72c91a3fa7fe",
-    published: true,
-    visibility: %{
-      id: "OPEN",
-      label: "Public",
-      scheme: "visibility"
+      project_task_number: []
     }
   },
   %{
+    id: "0bb6bd72-b349-4855-8ea6-0500dc752ff7",
+    ark: "ark:/99999/fk415264065",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300265034"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300438611"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500445403"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500029268"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n83175996"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "mrb", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Esse maxime ipsa qui iure.",
+      location: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79022925"},
+          role: nil
+        }
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375743"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
+    published: false,
+    visibility: %{id: "OPEN", label: "Public", scheme: "visibility"},
     accession_number: "Voyager:3744344",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -4216,115 +4295,113 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
-        },
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        },
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        },
-        %{
-          role: %{id: "mrb", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/lin"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375743"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}}
-      ],
-      title: "Esse maxime ipsa qui iure.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264065",
-      location: [
-        %{
-          role: nil,
-          term: %{id: "http://id.loc.gov/authorities/names/n79022925"}
-        }
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076710"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "0bb6bd72-b349-4855-8ea6-0500dc752ff7",
-    published: false,
-    visibility: %{
-      id: "OPEN",
-      label: "Public",
-      scheme: "visibility"
+      project_task_number: []
     }
   },
   %{
+    id: "370b9abc-cd6a-4544-a7de-de773cdd82f8",
+    ark: "ark:/99999/fk415264460",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300438611"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300435429"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300265034"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500445403"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500029268"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300056462"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300026031"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/div"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n83175996"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n78030997"},
+          role: %{id: "pbl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "vac", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n50053919"},
+          role: %{id: "lil", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Aut architecto excepturi omnis!",
+      location: [
+        %{term: %{id: "http://id.worldcat.org/fast/1204604"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378903"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300375728"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "UA065",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -4332,113 +4409,96 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300056462"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300026031"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        },
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n83175996"}
-        },
-        %{
-          role: %{id: "pbl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n78030997"}
-        },
-        %{
-          role: %{id: "vac", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        },
-        %{
-          role: %{id: "lil", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n50053919"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/cha"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378903"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375728"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300435429"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300265034"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}}
-      ],
-      title: "Aut architecto excepturi omnis!",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264460",
-      location: [
-        %{role: nil, term: %{id: "http://id.worldcat.org/fast/1204604"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "370b9abc-cd6a-4544-a7de-de773cdd82f8"
+      project_task_number: []
+    }
   },
   %{
+    id: "d468e803-2228-424e-8a59-876c31ac6316",
+    ark: "ark:/99999/fk415264460",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300438611"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300400619"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500029268"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500115207"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500445403"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500030701"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300386217"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300266117"}, role: nil}
+      ],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/div"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n79091588"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "aut", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Qui quae aliquam quam molestiae omnis nisi omnis et delectus?",
+      location: [
+        %{term: %{id: "https://sws.geonames.org/3530597/"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/tgn/1114106"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/tgn/7549617"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/3582677/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300378910"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "S003",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -4446,96 +4506,93 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300386217"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300266117"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500029268"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500115207"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500030701"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n79091588"}
-        },
-        %{
-          role: %{id: "aut", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/div"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300378910"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300400619"}}
-      ],
-      title: "Qui quae aliquam quam molestiae omnis nisi omnis et delectus?",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264460",
-      location: [
-        %{role: nil, term: %{id: "https://sws.geonames.org/3530597/"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/1114106"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/tgn/7549617"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/3582677/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh2002006395"}
-        },
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "d468e803-2228-424e-8a59-876c31ac6316"
+      project_task_number: []
+    }
   },
   %{
+    id: "3ddaf8fa-99d3-4962-88ab-da36bde05bbe",
+    ark: "ark:/99999/fk415264460",
+    descriptive_metadata: %{
+      legacy_identifier: [],
+      folder_number: [],
+      cultural_context: [],
+      table_of_contents: [],
+      provenance: [],
+      abstract: [],
+      box_number: [],
+      technique: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300053376"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300410254"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/aat/300438611"}, role: nil}
+      ],
+      creator: [
+        %{term: %{id: "http://vocab.getty.edu/ulan/500445403"}, role: nil},
+        %{term: %{id: "http://vocab.getty.edu/ulan/500018219"}, role: nil}
+      ],
+      date_created: [],
+      publisher: [],
+      genre: [%{term: %{id: "http://vocab.getty.edu/aat/300185712"}, role: nil}],
+      identifier: [],
+      catalog_key: [],
+      citation: [],
+      scope_and_contents: [],
+      series: [],
+      folder_name: [],
+      source: [],
+      rights_statement: nil,
+      notes: [],
+      related_material: [],
+      rights_holder: [],
+      related_url: [],
+      language: [
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}, role: nil},
+        %{term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}, role: nil}
+      ],
+      license: nil,
+      contributor: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"},
+          role: %{id: "pbl", scheme: "marc_relator"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/names/n85153068"},
+          role: %{id: "stl", scheme: "marc_relator"}
+        }
+      ],
+      box_name: [],
+      keywords: [],
+      title: "Voluptatem commodi quia molestiae.",
+      location: [
+        %{term: %{id: "https://sws.geonames.org/3530597/"}, role: nil},
+        %{term: %{id: "https://sws.geonames.org/4921868/"}, role: nil}
+      ],
+      physical_description_material: [],
+      alternate_title: [],
+      caption: [],
+      description: [],
+      physical_description_size: [],
+      style_period: [
+        %{term: %{id: "http://vocab.getty.edu/aat/300375737"}, role: nil}
+      ],
+      subject: [
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "TOPICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        },
+        %{
+          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"},
+          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"}
+        }
+      ],
+      terms_of_use: nil
+    },
     accession_number: "PAWA004",
     administrative_metadata: %{
+      status: nil,
       library_unit: nil,
       preservation_level: nil,
       project_cycle: nil,
@@ -4543,90 +4600,7 @@
       project_manager: [],
       project_name: [],
       project_proposer: [],
-      project_task_number: [],
-      status: nil
-    },
-    descriptive_metadata: %{
-      genre: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300185712"}}
-      ],
-      legacy_identifier: [],
-      creator: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500445403"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/ulan/500018219"}}
-      ],
-      date_created: [],
-      contributor: [
-        %{
-          role: %{id: "pbl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/no2011087251"}
-        },
-        %{
-          role: %{id: "stl", scheme: "marc_relator"},
-          term: %{id: "http://id.loc.gov/authorities/names/n85153068"}
-        }
-      ],
-      series: [],
-      language: [
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/nia"}},
-        %{role: nil, term: %{id: "http://id.loc.gov/vocabulary/languages/bug"}}
-      ],
-      table_of_contents: [],
-      provenance: [],
-      style_period: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300375737"}}
-      ],
-      physical_description_material: [],
-      related_url: [],
-      keywords: [],
-      technique: [
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300053376"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300410254"}},
-        %{role: nil, term: %{id: "http://vocab.getty.edu/aat/300438611"}}
-      ],
-      title: "Voluptatem commodi quia molestiae.",
-      terms_of_use: nil,
-      ark: "ark:/99999/fk415264460",
-      location: [
-        %{role: nil, term: %{id: "https://sws.geonames.org/3530597/"}},
-        %{role: nil, term: %{id: "https://sws.geonames.org/4921868/"}}
-      ],
-      description: [],
-      citation: [],
-      cultural_context: [],
-      rights_holder: [],
-      notes: [],
-      physical_description_size: [],
-      alternate_title: [],
-      catalog_key: [],
-      source: [],
-      rights_statement: nil,
-      abstract: [],
-      folder_name: [],
-      box_name: [],
-      box_number: [],
-      license: nil,
-      publisher: [],
-      folder_number: [],
-      subject: [
-        %{
-          role: %{id: "TOPICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85070610"}
-        },
-        %{
-          role: %{id: "GEOGRAPHICAL", scheme: "subject_role"},
-          term: %{id: "http://id.loc.gov/authorities/subjects/sh85076671"}
-        }
-      ],
-      related_material: [],
-      identifier: [],
-      scope_and_contents: [],
-      caption: []
-    },
-    id: "3ddaf8fa-99d3-4962-88ab-da36bde05bbe"
+      project_task_number: []
+    }
   }
 ]

--- a/app/test/gql/WorkDescriptiveMetadataFields.frag.gql
+++ b/app/test/gql/WorkDescriptiveMetadataFields.frag.gql
@@ -1,6 +1,5 @@
 fragment WorkDescriptiveMetadataFields on Work {
   descriptiveMetadata {
-    ark
     title
     dateCreated {
       edtf

--- a/app/test/gql/WorkFields.frag.gql
+++ b/app/test/gql/WorkFields.frag.gql
@@ -1,6 +1,7 @@
 fragment WorkFields on Work {
   id
   accessionNumber
+  ark
   collection {
     id
     title

--- a/app/test/meadow/arks_test.exs
+++ b/app/test/meadow/arks_test.exs
@@ -21,7 +21,7 @@ defmodule Meadow.ArksTest do
     |> Enum.each(fn %{id: work_type} ->
       @tag work_type: work_type
       test "mint_ark/1 mints an ark for #{work_type} work type", %{work: work} do
-        assert {:ok, %{descriptive_metadata: %{ark: ark}}} = Arks.mint_ark(work)
+        assert {:ok, %{ark: ark}} = Arks.mint_ark(work)
         assert is_binary(ark)
       end
 
@@ -33,8 +33,8 @@ defmodule Meadow.ArksTest do
 
     @tag work_type: "IMAGE"
     test "mint_ark/1 does not mint a new ark for a work that already has an ark", %{work: work} do
-      assert {:ok, %Work{descriptive_metadata: %{ark: ark}} = work} = Arks.mint_ark(work)
-      assert {:noop, %Work{descriptive_metadata: %{ark: ^ark}}} = Arks.mint_ark(work)
+      assert {:ok, %Work{ark: ark} = work} = Arks.mint_ark(work)
+      assert {:noop, %Work{ark: ^ark}} = Arks.mint_ark(work)
     end
   end
 

--- a/app/test/meadow/data/works_test.exs
+++ b/app/test/meadow/data/works_test.exs
@@ -162,9 +162,9 @@ defmodule Meadow.Data.WorksTest do
 
     test "get_work_by_ark!/1", %{work: work, image_url: image_url} do
       with {:ok, work} <-
-             work |> Works.update_work(%{descriptive_metadata: %{ark: "ark:/12345/nu209876543"}}) do
+             work |> Works.update_work(%{ark: "ark:/12345/nu209876543"}) do
         assert(
-          Works.get_work_by_ark!(work.descriptive_metadata.ark)
+          Works.get_work_by_ark!(work.ark)
           |> Map.get(:representative_image) == image_url
         )
       end

--- a/app/test/meadow/events/works/arks_test.exs
+++ b/app/test/meadow/events/works/arks_test.exs
@@ -9,6 +9,7 @@ defmodule Meadow.Events.Works.ArksTest do
   import Assertions
   import Ecto.Query
   import Meadow.TestHelpers
+  require IEx
 
   def assert_ark_status(work, expected_status) do
     assert_async(timeout: 2000) do
@@ -23,7 +24,6 @@ defmodule Meadow.Events.Works.ArksTest do
 
   def get_ark_for_work(work) do
     Works.get_work(work.id)
-    |> Map.get(:descriptive_metadata)
     |> Map.get(:ark)
     |> Ark.get()
   end
@@ -85,7 +85,7 @@ defmodule Meadow.Events.Works.ArksTest do
 
     test "delete never-published work", %{work: work} do
       assert_ark_status(work, :any)
-      ark = Works.get_work(work.id).descriptive_metadata.ark
+      ark = Works.get_work(work.id).ark
 
       Works.delete_work(work)
 
@@ -96,7 +96,7 @@ defmodule Meadow.Events.Works.ArksTest do
 
     test "delete published work", %{work: work} do
       assert_ark_status(work, :any)
-      ark = Works.get_work(work.id).descriptive_metadata.ark
+      ark = Works.get_work(work.id).ark
 
       work
       |> Works.update_work!(%{
@@ -125,7 +125,7 @@ defmodule Meadow.Events.Works.ArksTest do
 
     test "ark events are rate limited" do
       test_query =
-        from(Work, where: fragment("descriptive_metadata ->> 'ark' IS NOT NULL"))
+        from(w in Work, where: not is_nil(w.ark))
 
       # Make sure only 5 requests are processed within the first 2 seconds
       1..10

--- a/app/test/meadow/search/client_test.exs
+++ b/app/test/meadow/search/client_test.exs
@@ -48,7 +48,7 @@ defmodule Meadow.Search.ClientTest do
         end)
 
       assert log =~ ~r"Reindexing in progress: 0/\d+ \(\d+.\d+%\) complete"
-      assert log =~ ~r"Reindexed #{count} documents in \d+\.\d{2} seconds"
+      assert log =~ ~r"Reindexed #{count} documents in \d+\.\d{1,2} seconds"
     end
 
     test "search/2" do


### PR DESCRIPTION
# Summary 
Any time there is ARK remediation to be done, it has involved exporting all of our ARKs from CDLIB, importing that data into a temporary table, and doing a bunch of joins on the works table to figure out what's right and what's wrong. Those joins would be a lot faster and easier if `ark` were an indexed top-level field instead of being buried inside `descriptive_metadata`.

# Specific Changes in this PR
- Move `ark` from `work.descriptive_metadata.ark` to `work.ark`
- Update all downstream code and test fixtures to read/write ARKs in the right spot
- Write up/down migrations to preserve existing data

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [x] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [x] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [x] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

