### PR TITLE
Set Finch's open connection idle time to less than AWS's

### DIFF
--- a/app/lib/meadow/application/children.ex
+++ b/app/lib/meadow/application/children.ex
@@ -142,7 +142,7 @@ defmodule Meadow.Application.Children do
       [
         name: Meadow.FinchPool,
         pools: %{
-          default: [size: pool_size]
+          default: [size: pool_size, conn_max_idle_time: 45_000]
         }
       ]
     }


### PR DESCRIPTION
# Summary 
AWS closes idle connections after 60 seconds. By default, Finch will hold a connection open indefinitely waiting for another request to the same host. By reducing Finch's `conn_max_idle_time` to <60s, Finch will close the connection before AWS does, preventing an errant idle connection from causing a `Req.TransportError` on the next call.

# Specific Changes in this PR
- Set Finch's `conn_max_idle_time` to 45 seconds

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
- Ingest a FileSet
- After the pipeline is complete, wait about a minute
- Try to invoke the MetadataAgent (either via Auto Edit or Metadata Eval)  

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

