### PR TITLE
Ensure refreshed media metadata gets written when fileset is replaced

### DIFF
--- a/app/assets/js/components/Work/Tabs/Preservation/S3ObjectPicker.test.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/S3ObjectPicker.test.jsx
@@ -12,7 +12,7 @@ const mocks = [
     },
     result: {
       data: {
-        ListIngestBucketObjects: {
+        listIngestBucketObjects: {
           objects: [
             {
               uri: "s3://bucket/file1.jpg",

--- a/app/assets/js/components/Work/Tabs/Preservation/S3ObjectProvider.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/S3ObjectProvider.jsx
@@ -38,7 +38,7 @@ const S3ObjectProvider = forwardRef(
 
     useImperativeHandle(ref, () => ({
       findFileSetByUri: (value) => {
-        const objects = data?.ListIngestBucketObjects?.objects;
+        const objects = data?.listIngestBucketObjects?.objects;
         const found = objects?.find(({ uri }) => uri == value);
         if (!found) return null;
 
@@ -48,7 +48,7 @@ const S3ObjectProvider = forwardRef(
 
     useEffect(() => {
       if (!data) return;
-      const { ListIngestBucketObjects: contents } = data;
+      const { listIngestBucketObjects: contents } = data;
       const newFiles = contents.objects
         .filter((entry) => {
           const { isValid } = isFileValid(

--- a/app/assets/js/components/Work/Tabs/Preservation/S3ObjectProvider.test.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/S3ObjectProvider.test.jsx
@@ -12,7 +12,7 @@ const mocks = [
     },
     result: {
       data: {
-        ListIngestBucketObjects: {
+        listIngestBucketObjects: {
           objects: [
             {
               uri: "s3://bucket/file1.jpg",
@@ -73,7 +73,7 @@ const mocks = [
     },
     result: {
       data: {
-        ListIngestBucketObjects: {
+        listIngestBucketObjects: {
           objects: [
             {
               uri: "s3://bucket/file_sets/file3.jpg",

--- a/app/lib/meadow/pipeline/actions/extract_media_metadata.ex
+++ b/app/lib/meadow/pipeline/actions/extract_media_metadata.ex
@@ -52,7 +52,7 @@ defmodule Meadow.Pipeline.Actions.ExtractMediaMetadata do
     extracted_metadata =
       case file_set.extracted_metadata do
         nil -> %{mediainfo: metadata}
-        map -> Map.put(map, :mediainfo, metadata)
+        map -> Map.delete(map, "mediainfo") |> Map.put(:mediainfo, metadata)
       end
 
     FileSets.update_file_set(file_set, %{extracted_metadata: extracted_metadata})

--- a/app/test/meadow_web/schema/query/s3_objects_test.exs
+++ b/app/test/meadow_web/schema/query/s3_objects_test.exs
@@ -53,7 +53,7 @@
 
 #     assert %{
 #              "data" => %{
-#                "ListIngestBucketObjects" => %{
+#                "listIngestBucketObjects" => %{
 #                  "objects" => [s3_object | []],
 #                  "folders" => []
 #                }
@@ -78,7 +78,7 @@
 
 #     assert %{
 #              "data" => %{
-#                "ListIngestBucketObjects" => %{
+#                "listIngestBucketObjects" => %{
 #                  "objects" => [s3_object | []],
 #                  "folders" => ["coffee"]
 #                }


### PR DESCRIPTION
# Summary 
Ensure refreshed media metadata gets written when fileset is replaced

# Specific Changes in this PR
- Delete existing media metadata by string key before writing by atom key
- Fix mismatched object key in `S3ObjectProvider`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Create an audio work
- Attach a `WAV/FLAC` audio fileset with role `A` or `P` (`P` is faster because it doesn't transcode)
- When the pipeline is done, refresh the page and make sure the tech metadata shows `FLAC`
- Replace that fileset with a `WAV/PCM` file.
- When the pipeline is done, refresh the page and make sure the tech metadata shows `PCM`

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

