### PR TITLE
Validate filenames in ingest sheet

### DIFF
--- a/app/lib/meadow/ingest/validator.ex
+++ b/app/lib/meadow/ingest/validator.ex
@@ -415,7 +415,17 @@ defmodule Meadow.Ingest.Validator do
     work_type = Row.field_value(row, "work_type")
     mime_type = MIME.from_path(value)
 
+    unsafe_chars =
+      ~r/[^a-zA-Z0-9!\-_.*'()\/]/
+      |> Regex.scan(value)
+      |> List.flatten()
+      |> Enum.uniq()
+
     cond do
+      unsafe_chars != [] ->
+        {:error, "filename",
+         "#{value} contains characters that are not safe for S3 object keys: #{Enum.join(unsafe_chars, ", ")}"}
+
       Truth.false?(MapSet.member?(existing_files, value)) ->
         {:error, "filename", "File not Found: #{value}"}
 

--- a/app/test/fixtures/ingest_sheet_unsafe_filename.csv
+++ b/app/test/fixtures/ingest_sheet_unsafe_filename.csv
@@ -1,0 +1,7 @@
+work_type,work_accession_number,file_accession_number,filename,description,role,label,work_image,structure
+IMAGE,Donohue_001,Donohue_001_01,coffee.tif,"Letter, page 1, Dear Sir, recto",A,"The label",,
+IMAGE,Donohue_001,Donohue_001_02,coffee copy.tif,"Letter, page 1, Dear Sir, verso, blank",A,"The label",,
+IMAGE,Donohue_001,Donohue_001_03,coffee.tif,"Letter, page 2, If these papers, recto",A,"The label",,
+IMAGE,Donohue_002,Donohue_002_01,coffee.tif,"Photo, man with two children",A,"The label",,
+IMAGE,Donohue_002,Donohue_002_02,coffee.tif,Verso,A,"The label",,
+IMAGE,Donohue_002,Donohue_002_03,coffee.tif,"Photo, two children praying",A,"The label",,

--- a/app/test/meadow/ingest/validator_test.exs
+++ b/app/test/meadow/ingest/validator_test.exs
@@ -228,6 +228,25 @@ defmodule Meadow.Ingest.ValidatorTest do
       assert ingest_sheet.status == "row_fail"
     end
 
+    @tag sheet: "ingest_sheet_unsafe_filename.csv"
+    test "fails when a filename contains characters that are not safe for S3 object keys", context do
+      assert(Validator.result(context.sheet.id) == "fail")
+      ingest_sheet = Validator.validate(context.sheet.id)
+      assert(ingest_sheet.status == "row_fail")
+
+      %{
+        errors: [
+          %Meadow.Ingest.Schemas.Row.Error{
+            field: "filename",
+            message: message
+          }
+        ]
+      } = Rows.get_row(ingest_sheet.id, 2)
+
+      assert String.contains?(message, "contains characters that are not safe for S3 object keys")
+      assert String.contains?(message, " ")
+    end
+
     @tag sheet: "ingest_sheet_wrong_mime_type.csv"
     test "fails when the a file set has an invalid mime type", context do
       assert(Validator.result(context.sheet.id) == "fail")


### PR DESCRIPTION
# Summary 

Validates filenames in ingest sheet confirm to AWS S3 object key naming guidelines list of safe characters
Allowed chars: `alphanumeric [0-9a-zA-Z] plus !, -, _, ., *, ', (, )`

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5815

# Specific Changes in this PR

- updates the validator to fail if filenames include chars not in AWS's S3 Object Key naming guidelines list of safe characters: https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-guidelines

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

