### PR TITLE
Fix release notes timestamp bug causing duplicate notes

### DIFF
--- a/.github/scripts/generate_release_notes.sh
+++ b/.github/scripts/generate_release_notes.sh
@@ -87,8 +87,12 @@ else
   # ---------------------------------------------------------------------------
   echo "==> Fetching merged PRs between ${PREVIOUS_TAG} and ${CURRENT_TAG}..."
 
-  # Get the date of the previous tag so we can filter PRs by merge date
-  PREVIOUS_TAG_DATE=$(git log -1 --format="%cI" "${PREVIOUS_TAG}")
+  # Get the date of the previous tag so we can filter PRs by merge date.
+  # Normalize to UTC so the jq string comparison works correctly against
+  # GitHub's Z-suffixed timestamps (a non-UTC offset like -07:00 would
+  # make "T15:...Z" > "T10:...-07:00" true even when the UTC time is later).
+  PREVIOUS_TAG_UNIX=$(git log -1 --format="%ct" "${PREVIOUS_TAG}")
+  PREVIOUS_TAG_DATE=$(date -u -d "@${PREVIOUS_TAG_UNIX}" "+%Y-%m-%dT%H:%M:%SZ")
   echo "    Previous tag date: ${PREVIOUS_TAG_DATE}"
 
   PR_RESPONSE=$(curl -s \


### PR DESCRIPTION
# Summary 

Release notes are sometimes summarozomg PR's from the previous release/tag (see `v10.4.1` and `v10.5.0` release notes)

The root cause: `git log --format="%cI"` returns the date in the committer's local timezone (e.g., -07:00), but GitHub API timestamps are always UTC with a Z suffix. jq's > operator does a lexicographic string comparison, so "T15:43Z" sorts higher than "T10:49-07:00" even though the latter is actually later in real time.

# Specific Changes in this PR
- Use `%ct` (Unix timestamp, which is always UTC-based) and converts it to a Z-suffixed UTC string, so both sides of the jq comparison are in the same format.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

