### PR TITLE
Fix eval query size handling and make run cancellation actually stop work

### DIFF
--- a/app/lib/meadow/evals.ex
+++ b/app/lib/meadow/evals.ex
@@ -228,8 +228,14 @@ defmodule Meadow.Evals do
   def create_eval_set_from_query(%EvalQuery{} = eval_query, attrs) do
     Logger.info("Evals: materializing set from query #{eval_query.id}")
 
+    requested_size = Map.get(eval_query.query_json, "size", @max_works_per_set)
+    size = min(requested_size, @max_works_per_set)
+
     query_body =
-      Map.merge(eval_query.query_json, %{"_source" => false, "fields" => [], "size" => 10_000})
+      Map.merge(
+        %{"size" => size},
+        Map.merge(eval_query.query_json, %{"_source" => false, "fields" => []})
+      )
 
     with {:ok, work_ids} <- fetch_work_ids(query_body),
          work_ids <- truncate_work_ids(work_ids),
@@ -408,11 +414,23 @@ defmodule Meadow.Evals do
   end
 
   def cancel_run(%EvalRun{} = run) do
-    run |> EvalRun.mark_cancelled() |> Repo.update()
+    result = run |> EvalRun.mark_cancelled() |> Repo.update()
+
+    # Kill the in-flight runner (and its trial workers) before reaping trials so
+    # no worker can flip a row back to running/complete after we've skipped it.
+    Meadow.Evals.Runner.abort(run.id)
+    skip_unfinished_trials(run.id)
+
+    result
   end
 
   def cancel_run(id) when is_binary(id) do
     get_run!(id) |> cancel_run()
+  end
+
+  defp skip_unfinished_trials(run_id) do
+    from(t in EvalTrial, where: t.eval_run_id == ^run_id and t.status in [:pending, :running])
+    |> Repo.update_all(set: [status: :skipped, updated_at: DateTime.utc_now()])
   end
 
   # ---------------------------------------------------------------------------

--- a/app/lib/meadow/evals/runner.ex
+++ b/app/lib/meadow/evals/runner.ex
@@ -8,6 +8,8 @@ defmodule Meadow.Evals.Runner do
   alias Meadow.Evals.{Judge, Schemas.EvalRun, Schemas.EvalTrial}
   alias MeadowWeb.Router.Helpers, as: Routes
 
+  @registry Meadow.HordeRegistry
+
   @doc """
   Start execution of a run in a supervised background task.
   Idempotent: if the run is already running or complete, this is a no-op.
@@ -20,11 +22,38 @@ defmodule Meadow.Evals.Runner do
     )
   end
 
+  @doc """
+  Abort a running run by killing its supervised task. The task is linked to the
+  `Task.async_stream` workers running each trial, so killing it tears down any
+  in-flight agent calls immediately. Cluster-wide: the registry lookup and the
+  exit signal both cross nodes, so it works regardless of where the runner lives.
+  No-op if the run isn't currently executing.
+
+  Caveat: this stops Meadow from *dispatching* further trials and discards the
+  results of in-flight ones, but it cannot stop the agent Lambdas themselves. A
+  synchronous Lambda invocation runs to completion on AWS no matter what the
+  caller does, so up to `concurrency` agents already in flight will keep running
+  (and billing) until they finish. Cancellation bounds cost to the queued work,
+  not to zero.
+  """
+  def abort(run_id) when is_binary(run_id) do
+    case Horde.Registry.lookup(@registry, {:eval_run, run_id}) do
+      [{pid, _}] -> Process.exit(pid, :kill)
+      _ -> :ok
+    end
+
+    :ok
+  end
+
   # ---------------------------------------------------------------------------
   # Private execution logic
   # ---------------------------------------------------------------------------
 
   defp execute(run_id) do
+    # Register under the run id so Runner.abort/1 can find and kill this task
+    # (and its linked trial workers) from any node in the cluster.
+    Horde.Registry.register(@registry, {:eval_run, run_id}, nil)
+
     run = Evals.get_run!(run_id)
 
     if run.status in [:pending, :running] do
@@ -36,9 +65,15 @@ defmodule Meadow.Evals.Runner do
 
       try do
         execute_trials(run)
-        run = Repo.get!(EvalRun, run_id)
-        run |> EvalRun.mark_complete() |> Repo.update!()
-        Logger.info("Evals.Runner: run #{run_id} complete")
+        # Only finalize as complete if the run wasn't cancelled out from under us.
+        final = Repo.get!(EvalRun, run_id)
+
+        if final.status == :running do
+          final |> EvalRun.mark_complete() |> Repo.update!()
+          Logger.info("Evals.Runner: run #{run_id} complete")
+        else
+          Logger.info("Evals.Runner: run #{run_id} finished as #{final.status}")
+        end
       rescue
         error ->
           Logger.error("Evals.Runner: run #{run_id} failed: #{Exception.message(error)}")
@@ -72,12 +107,7 @@ defmodule Meadow.Evals.Runner do
     |> Task.async_stream(
       fn trial ->
         member = Map.get(work_map, trial.work_id)
-
-        if halted?(run.id) do
-          :halted
-        else
-          execute_trial(run, trial, member, prompt_version)
-        end
+        execute_trial(run, trial, member, prompt_version)
       end,
       max_concurrency: concurrency,
       timeout: :infinity,
@@ -86,18 +116,7 @@ defmodule Meadow.Evals.Runner do
     |> Stream.run()
   end
 
-  defp halted?(run_id) do
-    case Repo.get(EvalRun, run_id) do
-      %EvalRun{status: status} when status in [:cancelled, :errored] -> true
-      _ -> false
-    end
-  end
-
   defp execute_trial(run, trial, member, prompt_version) do
-    do_execute_trial(run, trial, member, prompt_version)
-  end
-
-  defp do_execute_trial(run, trial, member, prompt_version) do
     trial |> EvalTrial.mark_running() |> Repo.update!()
 
     mcp_url = Routes.page_url(MeadowWeb.Endpoint, :index, ["api", "mcp", "eval"])


### PR DESCRIPTION
# Summary
- Eval set `size` was ignored. When creating a set from a saved query, the merge order let the default 10,000 overwrite a `"size": 3`, so every match (up to the cap of 20) was pulled in. Now size is honored and clamped to `@max_works_per_set`.
- Cancel didn't actually cancel. Three stacked issues: the run got re-marked complete after the stream drained, in-flight trials couldn't be interrupted, and skipped trials dangled as pending. Now the runner registers in `Meadow.HordeRegistry`; `cancel_run/1` marks the run cancelled, kills the runner task (tearing down its linked trial workers cluster-wide), and sweeps unfinished trials to skipped so the DB stays consistent.
  - _Caveat (commented in the code):_ in-flight Lambdas still run. A synchronous Lambda invocation runs to completion on AWS no matter what the caller does, so up to concurrency agents already in flight keep running (and billing) until they finish.

Cancelled run:
<img width="1448" height="533" alt="SCR-20260618-nduu" src="https://github.com/user-attachments/assets/86713b0b-5d34-4012-adb7-c49192cd619e" />

In the dashboard:
<img width="1397" height="321" alt="SCR-20260618-ndpb" src="https://github.com/user-attachments/assets/3f425c9e-d909-4ee4-b98c-c41cfd50e9c1" />


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

