### PR TITLE
Fix bug with adding 3 or more notes or related urls

### DIFF
--- a/app/assets/js/components/UI/Form/Note.jsx
+++ b/app/assets/js/components/UI/Form/Note.jsx
@@ -70,7 +70,7 @@ const UIFormNote = ({
                       type="hidden"
                       name={`${itemName}.typeId`}
                       {...register(`${itemName}.typeId`)}
-                      value={item.type ? item.type.id : ""}
+                      value={item.type ? item.type.id : item.typeId}
                     />
                   </div>
                 )}

--- a/app/assets/js/components/UI/Form/Note.test.jsx
+++ b/app/assets/js/components/UI/Form/Note.test.jsx
@@ -1,0 +1,170 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { FormProvider, useForm } from "react-hook-form";
+import UIFormNote from "./Note";
+import { notesSchemeMock } from "../../Work/controlledVocabulary.gql.mock";
+import { renderWithReactHookForm } from "../../../services/testing-helpers";
+import userEvent from "@testing-library/user-event";
+
+const props = {
+  codeLists: notesSchemeMock,
+  name: "notes",
+  label: "Note",
+};
+
+describe("Note controlled metadata form component", () => {
+  describe("error handling", () => {
+    it("renders appropriate error message when url errors are set manually", async () => {
+      const user = userEvent.setup();
+      const { findByText, getByTestId, reactHookFormMethods } =
+        renderWithReactHookForm(<UIFormNote {...props} />, {
+          toPassBack: ["setError"],
+        });
+
+      await user.click(getByTestId("button-add-field-array-row"));
+
+      await waitFor(() => {
+        reactHookFormMethods.setError("notes[0].note", {
+          type: "required",
+          message: "Note is required",
+        });
+      });
+      expect(await findByText("Note is required"));
+    });
+  });
+
+  describe("standard component behavior", () => {
+    beforeEach(() => {
+      renderWithReactHookForm(<UIFormNote {...props} />, {
+        defaultValues: {
+          notes: [
+            {
+              note: "A sample general note",
+              type: {
+                id: "GENERAL_NOTE",
+                label: "General note",
+                scheme: "NOTE_TYPE",
+              },
+            },
+          ],
+        },
+      });
+    });
+
+    it("renders component and an add button", () => {
+      expect(screen.getByTestId("note-wrapper"));
+      expect(screen.getByTestId("button-add-field-array-row"));
+    });
+
+    it("renders existing note values", () => {
+      expect(screen.getAllByTestId("note-existing-value")).toHaveLength(1);
+      expect(screen.getByText("A sample general note, General note"));
+    });
+
+    it("renders form elements when adding a new note value", () => {
+      const addButton = screen.getByTestId("button-add-field-array-row");
+      fireEvent.click(addButton);
+      fireEvent.click(addButton);
+      expect(screen.getAllByTestId("note-form-item")).toHaveLength(2);
+      expect(screen.getAllByTestId("note-input")).toHaveLength(2);
+      expect(screen.getAllByTestId("note-select")).toHaveLength(2);
+    });
+
+    it("renders delete button, removes note on click", () => {
+      const addButton = screen.getByTestId("button-add-field-array-row");
+      fireEvent.click(addButton);
+      fireEvent.click(addButton);
+      fireEvent.click(addButton);
+      fireEvent.click(addButton);
+
+      expect(screen.getAllByTestId("note-form-item")).toHaveLength(4);
+
+      const removeButtons = screen.getAllByTestId("button-note-remove");
+      fireEvent.click(removeButtons[3]);
+      expect(screen.getAllByTestId("note-form-item")).toHaveLength(3);
+    });
+  });
+
+  /**
+   * Regression test for bug #5825: saving 3+ Note entries caused the error banner
+   * "An issue has occured within Note."
+   *
+   * Root cause: `useFieldArray` rebuilds the `fields` snapshot from current form values
+   * on every `append()`. A previously-filled row has `item.typeId` populated in the
+   * new snapshot, which switches it from the editable path to the hidden-input path.
+   * The hidden `typeId` input was written as `value={item.type ? item.type.id : ""}`.
+   * Because form-entered rows have only a `typeId` string (no `type` object), the
+   * value collapsed to `""`, erasing the selection and causing required validation to
+   * fail on submit.
+   *
+   * Fix: `value={item.type ? item.type.id : item.typeId}` — falls back to the string.
+   */
+  describe("regression: 3+ entries caused save failure (#5825)", () => {
+    it("saves without an error banner when 3 rows are added and filled sequentially", async () => {
+      const user = userEvent.setup();
+
+      // Use a real form so handleSubmit/validation runs end-to-end.
+      const TestForm = () => {
+        const methods = useForm();
+        return (
+          <FormProvider {...methods}>
+            <form
+              data-testid="test-form"
+              onSubmit={methods.handleSubmit(() => {})}
+            >
+              <UIFormNote {...props} />
+              <button type="submit" data-testid="submit-btn">
+                Save
+              </button>
+            </form>
+          </FormProvider>
+        );
+      };
+      render(<TestForm />);
+
+      // --- Row 1 ---
+      await user.click(screen.getByTestId("button-add-field-array-row"));
+      // Row 1 is new (typeId="") → editable path.
+      fireEvent.change(screen.getAllByTestId("note-input")[0], {
+        target: { value: "First note text" },
+      });
+      fireEvent.change(screen.getAllByTestId("note-select")[0], {
+        target: { value: "GENERAL_NOTE" },
+      });
+
+      // --- Row 2 ---
+      // append() rebuilds fields; row 1 now has typeId="GENERAL_NOTE" in the snapshot
+      // → switches to the hidden-input path. Row 2 is new → editable path.
+      await user.click(screen.getByTestId("button-add-field-array-row"));
+      // Only row 2's inputs are visible now (row 1 is in hidden-input path).
+      fireEvent.change(screen.getAllByTestId("note-input")[0], {
+        target: { value: "Second note text" },
+      });
+      fireEvent.change(screen.getAllByTestId("note-select")[0], {
+        target: { value: "BIOGRAPHICAL_HISTORICAL_NOTE" },
+      });
+
+      // --- Row 3 ---
+      // append() rebuilds again; rows 1 & 2 switch to hidden-input path.
+      // Before the fix, these hidden inputs wrote value="" for form-entered rows,
+      // silently erasing the selections and causing required validation to fail.
+      await user.click(screen.getByTestId("button-add-field-array-row"));
+      // Only row 3's inputs are visible now.
+      fireEvent.change(screen.getAllByTestId("note-input")[0], {
+        target: { value: "Third note text" },
+      });
+      fireEvent.change(screen.getAllByTestId("note-select")[0], {
+        target: { value: "GENERAL_NOTE" },
+      });
+
+      // Submit and confirm no error banner appears.
+      await user.click(screen.getByTestId("submit-btn"));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(/An issue has occured within/),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/app/assets/js/components/UI/Form/RelatedURL.jsx
+++ b/app/assets/js/components/UI/Form/RelatedURL.jsx
@@ -74,7 +74,7 @@ const UIFormRelatedURL = ({
                       type="hidden"
                       name={`${itemName}.labelId`}
                       {...register(`${itemName}.labelId`)}
-                      value={item.label ? item.label.id : ""}
+                      value={item.label ? item.label.id : item.labelId}
                     />
                   </div>
                 )}

--- a/app/assets/js/components/UI/Form/RelatedURL.test.jsx
+++ b/app/assets/js/components/UI/Form/RelatedURL.test.jsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { FormProvider, useForm } from "react-hook-form";
 import UIFormRelatedURL from "./RelatedURL";
 import { relatedUrlSchemeMock } from "../../Work/controlledVocabulary.gql.mock";
 import { renderWithReactHookForm } from "../../../services/testing-helpers";
@@ -92,6 +93,90 @@ describe("Related Url controlled metadata form component", () => {
       const removeButtons = screen.getAllByTestId("button-related-url-remove");
       fireEvent.click(removeButtons[3]);
       expect(screen.getAllByTestId("related-url-form-item")).toHaveLength(3);
+    });
+  });
+
+  /**
+   * Regression test for bug #5825: saving 3+ Related URL entries caused the error banner
+   * "An issue has occured within Related URL."
+   *
+   * Root cause: `useFieldArray` rebuilds the `fields` snapshot from current form values
+   * on every `append()`. A previously-filled row has `item.labelId` populated in the
+   * new snapshot, which switches it from the editable path to the hidden-input path.
+   * The hidden `labelId` input was written as `value={item.label ? item.label.id : ""}`.
+   * Because form-entered rows have only a `labelId` string (no `label` object), the
+   * value collapsed to `""`, erasing the selection and causing required validation to
+   * fail on submit.
+   *
+   * Fix: `value={item.label ? item.label.id : item.labelId}` — falls back to the string.
+   */
+  describe("regression: 3+ entries caused save failure (#5825)", () => {
+    it("saves without an error banner when 3 rows are added and filled sequentially", async () => {
+      const user = userEvent.setup();
+
+      // Use a real form so handleSubmit/validation runs end-to-end.
+      const TestForm = () => {
+        const methods = useForm();
+        return (
+          <FormProvider {...methods}>
+            <form
+              data-testid="test-form"
+              onSubmit={methods.handleSubmit(() => {})}
+            >
+              <UIFormRelatedURL {...props} />
+              <button type="submit" data-testid="submit-btn">
+                Save
+              </button>
+            </form>
+          </FormProvider>
+        );
+      };
+      render(<TestForm />);
+
+      // --- Row 1 ---
+      await user.click(screen.getByTestId("button-add-field-array-row"));
+      // After append, fields snapshot is rebuilt; row 1 is new (labelId=""), so it
+      // renders the editable form path.
+      fireEvent.change(screen.getAllByTestId("related-url-url-input")[0], {
+        target: { value: "http://example1.com" },
+      });
+      fireEvent.change(screen.getAllByTestId("related-url-select")[0], {
+        target: { value: "FINDING_AID" },
+      });
+
+      // --- Row 2 ---
+      // append() rebuilds fields; row 1 now has labelId="FINDING_AID" in the snapshot
+      // → switches to the hidden-input path. Row 2 is new → editable path.
+      await user.click(screen.getByTestId("button-add-field-array-row"));
+      // Only row 2's inputs are visible now (row 1 is in hidden-input path).
+      fireEvent.change(screen.getAllByTestId("related-url-url-input")[0], {
+        target: { value: "http://example2.com" },
+      });
+      fireEvent.change(screen.getAllByTestId("related-url-select")[0], {
+        target: { value: "HATHI_TRUST_DIGITAL_LIBRARY" },
+      });
+
+      // --- Row 3 ---
+      // append() rebuilds again; rows 1 & 2 switch to hidden-input path.
+      // Before the fix, these hidden inputs wrote value="" for form-entered rows,
+      // silently erasing the selections and causing required validation to fail.
+      await user.click(screen.getByTestId("button-add-field-array-row"));
+      // Only row 3's inputs are visible now.
+      fireEvent.change(screen.getAllByTestId("related-url-url-input")[0], {
+        target: { value: "http://example3.com" },
+      });
+      fireEvent.change(screen.getAllByTestId("related-url-select")[0], {
+        target: { value: "RELATED_INFORMATION" },
+      });
+
+      // Submit and confirm no error banner appears.
+      await user.click(screen.getByTestId("submit-btn"));
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(/An issue has occured within/),
+        ).not.toBeInTheDocument();
+      });
     });
   });
 });


### PR DESCRIPTION
# Summary 

Adding 3 or more Notes (or Related URLs) and saving produced the error banner "An issue has occurred within Note. Verify  entries for Note." One or two entries saved fine. Once the error appeared, removing entries back down to 2 did not clear it, the error was sticky until a full page refresh.

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5825

# Specific Changes in this PR
- Fall back to the `typeId/labelId` string when no full object is present. This preserves the user's selection in the hidden input when the row is promoted into the existing-value path, so validation passes on submit.
- Add tests for these cases
```
  // Note.jsx
  value={item.type ? item.type.id : item.typeId}

  // RelatedURL.jsx
  value={item.label ? item.label.id : item.labelId}
```

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Go to a work edit page
- Add 3 or more Notes or RelatedURL's at a time.
- Verify no error

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

