### PR TITLE
Use bun to build / pack pipeline lambdas

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-hex-v7-${{ hashFiles('app/mix.lock') }}
             ${{ runner.os }}-hex-v7-
+      - name: Install exiftool & ffmpeg
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y exiftool ffmpeg
+        env:
+          DEBIAN_FRONTEND: noninteractive
       - name: Install Elixir dependencies
         run: make app-compile
         env:

--- a/app/lib/meadow/config/runtime/test.ex
+++ b/app/lib/meadow/config/runtime/test.ex
@@ -28,19 +28,6 @@ defmodule Meadow.Config.Runtime.Test do
       mime_type: {:local, {Path.expand("../lambdas/mime-type/index.js"), "handler"}},
       tiff: {:local, {Path.expand("../lambdas/pyramid-tiff/index.js"), "handler"}}
 
-    config :ex_aws, :lambda,
-      scheme: "http",
-      host: "localhost",
-      port: 3006
-
-    config :meadow, :lambda,
-      digester: {:lambda, "digester"},
-      exif: {:lambda, "exif"},
-      frame_extractor: {:lambda, "frameExtractor"},
-      mediainfo: {:lambda, "mediainfo"},
-      mime_type: {:lambda, "mimeType"},
-      tiff: {:lambda, "pyramidTiff"}
-
     config :meadow,
       checksum_notification: %{
         arn: "arn:aws:lambda:us-east-1:000000000000:function:digest-tag",

--- a/app/priv/nodejs/lambda/index.js
+++ b/app/priv/nodejs/lambda/index.js
@@ -32,7 +32,14 @@ process.stdin.on("data", (data) => {
   const payload = JSON.parse(data);
   handler(payload, {})
     .then((result) => writeln("[return] " + JSON.stringify(result)))
-    .catch((err) => writeln("[fatal] " + err));
+    .catch((err) => {
+      if (err.stack) {
+        for (const line of err.stack.split("\n")) {
+          writeln("[warning] " + line);
+        }
+      }
+      writeln("[fatal] " + (err.message || err));
+    });
 });
 
 process.stdin.on("end", () => {

--- a/infrastructure/pipeline/Makefile
+++ b/infrastructure/pipeline/Makefile
@@ -39,14 +39,8 @@ env-check:
 layers:
 	cd layers/build && make all
 
-build-image:
-	docker build \
-		--build-arg BUN_VERSION=$(BUN_VERSION) \
-		-t $(SAM_BUILD_IMAGE) \
-		-f Dockerfile.sam-bun .
-
-build: layers build-image
-	sam build --use-container --build-image $(SAM_BUILD_IMAGE) --cached
+build: layers
+	sam build --build-in-source --cached
 
 start: deps layers
 	./start_multi.sh $(SAM_PORT) $(PIPELINE_THREADS)

--- a/infrastructure/pipeline/layers/build/Makefile
+++ b/infrastructure/pipeline/layers/build/Makefile
@@ -10,11 +10,19 @@ ifdef BUILD_LAYER
 	@make build-$*Layer
 else
 	@echo "Downloading prebuilt $* layer..."
-	curl -sLo $(LAYER_DIR)/$*Layer.zip https://nul-public.s3.amazonaws.com/lambda-layers/$*Layer.zip
+	curl -fsLo $(LAYER_DIR)/$*Layer.zip https://nul-public.s3.amazonaws.com/lambda-layers/$*Layer.zip || make build-$*Layer
 endif
 
 upload-%Layer: $(LAYER_DIR)/%Layer.zip
 	aws s3 cp $(LAYER_DIR)/$*Layer.zip s3://nul-public/lambda-layers/ --acl public-read
+
+build-claudeLayer:
+	@echo "Building claude layer..."
+	@TMP_DIR=$$(mktemp -d) ; \
+		cd $$TMP_DIR ; \
+		mkdir -p nodejs ; \
+		npm install --prefix ./nodejs --no-package-lock --no-save --os=linux --cpu=x64 --libc=glibc @anthropic-ai/claude-agent-sdk@0.2.38 ; \
+		zip -r "$(TARGET_DIR)/claudeLayer.zip" . >/dev/null
 
 build-exifToolLayer:
 	@echo "Building exifTool layer..."
@@ -62,7 +70,15 @@ else
 	aws s3 cp s3://nul-public/lambda-layers/perlLayer.zip
 endif
 
-all: $(LAYER_DIR)/exifToolLayer.zip $(LAYER_DIR)/ffmpegLayer.zip $(LAYER_DIR)/mediaInfoLayer.zip $(LAYER_DIR)/perlLayer.zip
+build-sharpLayer:
+	@echo "Building sharp layer..."
+	@TMP_DIR=$$(mktemp -d) ; \
+		cd $$TMP_DIR ; \
+		mkdir -p nodejs ; \
+		npm install --prefix ./nodejs --no-package-lock --no-save --os=linux --cpu=x64 --libc=glibc sharp@0.35.2 ; \
+		zip -r "$(TARGET_DIR)/sharpLayer.zip" . >/dev/null
+
+all: $(LAYER_DIR)/claudeLayer.zip $(LAYER_DIR)/exifToolLayer.zip $(LAYER_DIR)/ffmpegLayer.zip $(LAYER_DIR)/mediaInfoLayer.zip $(LAYER_DIR)/perlLayer.zip $(LAYER_DIR)/sharpLayer.zip
 upload: upload-exifToolLayer upload-ffmpegLayer upload-mediaInfoLayer upload-perlLayer
 clean: 
 	rm -f $(LAYER_DIR)/*.zip

--- a/infrastructure/pipeline/template.yaml
+++ b/infrastructure/pipeline/template.yaml
@@ -24,6 +24,11 @@ Parameters:
     Description: Custom S3 endpoint (for local development with LocalStack)
     Default: ""
 Resources:
+  claudeLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      CompatibleRuntimes: ["nodejs22.x"]
+      ContentUri: ./layers/claudeLayer.zip
   exifToolLayer:
     Type: AWS::Serverless::LayerVersion
     Properties:
@@ -44,6 +49,11 @@ Resources:
     Properties:
       CompatibleRuntimes: ["nodejs22.x"]
       ContentUri: ./layers/perlLayer.zip
+  sharpLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      CompatibleRuntimes: ["nodejs22.x"]
+      ContentUri: ./layers/sharpLayer.zip
   digester:
     Type: AWS::Serverless::Function
     Properties:
@@ -58,16 +68,16 @@ Resources:
           AWS_S3_ENDPOINT: !Ref S3Endpoint
           AWS_S3_FORCE_PATH_STYLE: !Ref S3PathStyle
       Policies:
-      - Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action: "s3:*"
-            Resource:
-              - !Sub "arn:aws:s3:::*"
-              - !Sub "arn:aws:s3:::*/*"
-            Condition:
-              StringEquals:
-                "aws:ResourceTag/Project": !Ref ProjectName
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action: "s3:*"
+              Resource:
+                - !Sub "arn:aws:s3:::*"
+                - !Sub "arn:aws:s3:::*/*"
+              Condition:
+                StringEquals:
+                  "aws:ResourceTag/Project": !Ref ProjectName
     Metadata:
       BuildMethod: makefile
   exif:
@@ -90,16 +100,16 @@ Resources:
           AWS_S3_FORCE_PATH_STYLE: !Ref S3PathStyle
           EXIFTOOL: "/opt/bin/exiftool"
       Policies:
-      - Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action: "s3:*"
-            Resource:
-              - !Sub "arn:aws:s3:::*"
-              - !Sub "arn:aws:s3:::*/*"
-            Condition:
-              StringEquals:
-                "aws:ResourceTag/Project": !Ref ProjectName
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action: "s3:*"
+              Resource:
+                - !Sub "arn:aws:s3:::*"
+                - !Sub "arn:aws:s3:::*/*"
+              Condition:
+                StringEquals:
+                  "aws:ResourceTag/Project": !Ref ProjectName
     Metadata:
       BuildMethod: makefile
   frameExtractor:
@@ -120,24 +130,24 @@ Resources:
           FFMPEG_PATH: "/opt/bin/ffmpeg"
           FFPROBE_PATH: "/opt/bin/ffprobe"
       Policies:
-      - Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action: "s3:*"
-            Resource:
-              - !Sub "arn:aws:s3:::*"
-              - !Sub "arn:aws:s3:::*/*"
-            Condition:
-              StringEquals:
-                "aws:ResourceTag/Project": !Ref ProjectName
-          - Effect: Allow
-            Action: "s3:*"
-            Resource:
-              - !Sub "arn:aws:s3:::*"
-              - !Sub "arn:aws:s3:::*/*"
-            Condition:
-              StringEquals:
-                "aws:ResourceTag/Project": "IIIF Server"
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action: "s3:*"
+              Resource:
+                - !Sub "arn:aws:s3:::*"
+                - !Sub "arn:aws:s3:::*/*"
+              Condition:
+                StringEquals:
+                  "aws:ResourceTag/Project": !Ref ProjectName
+            - Effect: Allow
+              Action: "s3:*"
+              Resource:
+                - !Sub "arn:aws:s3:::*"
+                - !Sub "arn:aws:s3:::*/*"
+              Condition:
+                StringEquals:
+                  "aws:ResourceTag/Project": "IIIF Server"
     Metadata:
       BuildMethod: makefile
   mediainfo:
@@ -157,16 +167,16 @@ Resources:
           AWS_S3_FORCE_PATH_STYLE: !Ref S3PathStyle
           MEDIAINFO_PATH: "/opt/bin/mediainfo"
       Policies:
-      - Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action: "s3:*"
-            Resource:
-              - !Sub "arn:aws:s3:::*"
-              - !Sub "arn:aws:s3:::*/*"
-            Condition:
-              StringEquals:
-                "aws:ResourceTag/Project": !Ref ProjectName
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action: "s3:*"
+              Resource:
+                - !Sub "arn:aws:s3:::*"
+                - !Sub "arn:aws:s3:::*/*"
+              Condition:
+                StringEquals:
+                  "aws:ResourceTag/Project": !Ref ProjectName
     Metadata:
       BuildMethod: makefile
   metadataAgent:
@@ -176,6 +186,8 @@ Resources:
       CodeUri: ../../lambdas/metadata-agent
       Handler: index.handler
       Runtime: nodejs22.x
+      Layers:
+        - !Ref claudeLayer
       MemorySize: 512
       Timeout: 300
       Environment:
@@ -184,16 +196,16 @@ Resources:
           CLAUDE_CONFIG_DIR: /tmp
           DEBUG: metadata-agent:execute
       Policies:
-      - Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action:
-              - "bedrock:InvokeModel"
-              - "bedrock:InvokeModelWithResponseStream"
-            Resource: 
-              - "arn:aws:bedrock:*::foundation-model/*"
-              - "arn:aws:bedrock:*:*:inference-profile/*"
-              - "arn:aws:bedrock:*:*:application-inference-profile/*"
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - "bedrock:InvokeModel"
+                - "bedrock:InvokeModelWithResponseStream"
+              Resource:
+                - "arn:aws:bedrock:*::foundation-model/*"
+                - "arn:aws:bedrock:*:*:inference-profile/*"
+                - "arn:aws:bedrock:*:*:application-inference-profile/*"
     Metadata:
       BuildMethod: makefile
   mimeType:
@@ -210,16 +222,16 @@ Resources:
           AWS_S3_ENDPOINT: !Ref S3Endpoint
           AWS_S3_FORCE_PATH_STYLE: !Ref S3PathStyle
       Policies:
-      - Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action: "s3:*"
-            Resource:
-              - !Sub "arn:aws:s3:::*"
-              - !Sub "arn:aws:s3:::*/*"
-            Condition:
-              StringEquals:
-                "aws:ResourceTag/Project": !Ref ProjectName
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action: "s3:*"
+              Resource:
+                - !Sub "arn:aws:s3:::*"
+                - !Sub "arn:aws:s3:::*/*"
+              Condition:
+                StringEquals:
+                  "aws:ResourceTag/Project": !Ref ProjectName
     Metadata:
       BuildMethod: makefile
   pyramidTiff:
@@ -231,6 +243,7 @@ Resources:
       Runtime: nodejs22.x
       Layers:
         - !Ref ffmpegLayer
+        - !Ref sharpLayer
       MemorySize: 8192
       Timeout: 240
       Environment:
@@ -240,24 +253,24 @@ Resources:
           NODE_OPTIONS: "--max-old-space-size=8192"
           VIPS_DISC_THRESHOLD: "3500m"
       Policies:
-      - Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action: "s3:*"
-            Resource:
-              - !Sub "arn:aws:s3:::*"
-              - !Sub "arn:aws:s3:::*/*"
-            Condition:
-              StringEquals:
-                "aws:ResourceTag/Project": !Ref ProjectName
-          - Effect: Allow
-            Action: "s3:*"
-            Resource:
-              - !Sub "arn:aws:s3:::*"
-              - !Sub "arn:aws:s3:::*/*"
-            Condition:
-              StringEquals:
-                "aws:ResourceTag/Project": "IIIF Server"
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action: "s3:*"
+              Resource:
+                - !Sub "arn:aws:s3:::*"
+                - !Sub "arn:aws:s3:::*/*"
+              Condition:
+                StringEquals:
+                  "aws:ResourceTag/Project": !Ref ProjectName
+            - Effect: Allow
+              Action: "s3:*"
+              Resource:
+                - !Sub "arn:aws:s3:::*"
+                - !Sub "arn:aws:s3:::*/*"
+              Condition:
+                StringEquals:
+                  "aws:ResourceTag/Project": "IIIF Server"
     Metadata:
       BuildMethod: makefile
   streamAuthorizer:
@@ -279,14 +292,14 @@ Resources:
                 - edgelambda.amazonaws.com
                 - lambda.amazonaws.com
             Action:
-              - 'sts:AssumeRole'
+              - "sts:AssumeRole"
       Policies:
-      - Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Action: "es:ESHttpGet"
-            Resource:
-              - !Sub "arn:aws:es:*:${AWS::AccountId}:domain/*"
+        - Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action: "es:ESHttpGet"
+              Resource:
+                - !Sub "arn:aws:es:*:${AWS::AccountId}:domain/*"
     Metadata:
       BuildMethod: makefile
   pipelineConfiguration:
@@ -294,9 +307,9 @@ Resources:
     Properties:
       Name:
         Fn::Join:
-        - "/"
-        - - !Ref ConfigPrefix
-          - "config/meadow-pipeline"
+          - "/"
+          - - !Ref ConfigPrefix
+            - "config/meadow-pipeline"
       Description: Configuration secrets for Meadow Ingest Pipeline
       SecretString:
         Fn::ToJsonString:
@@ -313,11 +326,11 @@ Resources:
       Name: !Ref streamAuthorizer
       SecretString:
         Fn::ToJsonString:
-          dcApiEndpoint: !Sub '{{resolve:secretsmanager:${ConfigPrefix}/config/dcapi:SecretString:base_url}}'
+          dcApiEndpoint: !Sub "{{resolve:secretsmanager:${ConfigPrefix}/config/dcapi:SecretString:base_url}}"
           allowedFrom: !Ref TrustedReferers
   streamAuthorizerConfigurationAccess:
     Type: AWS::SecretsManager::ResourcePolicy
-    Properties: 
+    Properties:
       BlockPublicPolicy: true
       ResourcePolicy:
         Version: "2012-10-17"

--- a/lambdas/digester/Makefile
+++ b/lambdas/digester/Makefile
@@ -1,4 +1,1 @@
-build-digester:
-	find . -maxdepth 1 -type f ! -name 'Makefile' -exec cp {} "$(ARTIFACTS_DIR)/" \;
-	bun install --cwd $(ARTIFACTS_DIR) --production --frozen-lockfile || \
-	  bun install --cwd $(ARTIFACTS_DIR) --production
+include ../lambda.mk

--- a/lambdas/digester/bun.lock
+++ b/lambdas/digester/bun.lock
@@ -6,6 +6,7 @@
       "name": "digest-lambda",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
+        "source-map-support": "^0.5.21",
       },
     },
   },
@@ -196,11 +197,17 @@
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
     "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
 
     "fast-xml-parser": ["fast-xml-parser@5.5.8", "", { "dependencies": { "fast-xml-builder": "^1.1.4", "path-expression-matcher": "^1.2.0", "strnum": "^2.2.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ=="],
 
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "strnum": ["strnum@2.2.3", "", {}, "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg=="],
 

--- a/lambdas/digester/index.js
+++ b/lambdas/digester/index.js
@@ -1,5 +1,6 @@
-const { S3Client, GetObjectCommand } = require("@aws-sdk/client-s3");
-const crypto = require("crypto");
+import "source-map-support/register.js";
+import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+import crypto from "crypto";
 
 const handler = async (event, _context, _callback) => {
   return await generateDigest(event.bucket, event.key);
@@ -35,4 +36,4 @@ const s3ClientOpts = () => {
   return { endpoint, forcePathStyle, httpOptions: { timeout: 600000 } };
 };
 
-module.exports = { handler };
+export { handler };

--- a/lambdas/digester/package.json
+++ b/lambdas/digester/package.json
@@ -2,10 +2,12 @@
   "name": "digest-lambda",
   "version": "0.1.0",
   "description": "Generate a checksum from an S3 object",
+  "type": "module",
   "main": "index.js",
   "author": "mbklein",
   "license": "Apache2",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.995.0"
+    "@aws-sdk/client-s3": "^3.995.0",
+    "source-map-support": "^0.5.21"
   }
 }

--- a/lambdas/execute-fixity/bun.lock
+++ b/lambdas/execute-fixity/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "execute-fixity",
+      "dependencies": {
+        "source-map-support": "^0.5.21",
+      },
       "devDependencies": {
         "@aws-sdk/client-sfn": "^3.421.0",
       },
@@ -152,11 +155,17 @@
 
     "bowser": ["bowser@2.13.1", "", {}, "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw=="],
 
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
     "fast-xml-builder": ["fast-xml-builder@1.1.5", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA=="],
 
     "fast-xml-parser": ["fast-xml-parser@5.7.2", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.5", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w=="],
 
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "strnum": ["strnum@2.2.3", "", {}, "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg=="],
 

--- a/lambdas/execute-fixity/index.js
+++ b/lambdas/execute-fixity/index.js
@@ -1,37 +1,39 @@
-const { SFNClient, StartExecutionCommand } = require("@aws-sdk/client-sfn");
+import "source-map-support/register.js";
+import { SFNClient, StartExecutionCommand } from "@aws-sdk/client-sfn";
 const stateMachineArn = process.env.stateMachineArn;
 
 const fullyDecode = (str) => decodeURIComponent(str.replace(/\+/g, " "));
 
-exports.handler = (event, context, callback) => {
+export const handler = (event, context, callback) => {
   var params = {
     stateMachineArn: stateMachineArn,
     input: JSON.stringify({
       Bucket: fullyDecode(event.Records[0].s3.bucket.name),
-      Key: fullyDecode(event.Records[0].s3.object.key),
-    }),
+      Key: fullyDecode(event.Records[0].s3.object.key)
+    })
   };
   var stepfunctions = new SFNClient();
   const cmd = new StartExecutionCommand(params);
   return new Promise((resolve, _reject) => {
-    stepfunctions.send(cmd)
-    .then((data) => {
-      console.log(data);
-      resolve({
-        statusCode: 200,
-        body: JSON.stringify({
-          message: "Step function worked",
-        }),
+    stepfunctions
+      .send(cmd)
+      .then((data) => {
+        console.log(data);
+        resolve({
+          statusCode: 200,
+          body: JSON.stringify({
+            message: "Step function worked"
+          })
+        });
+      })
+      .catch((err) => {
+        console.log(err);
+        resolve({
+          statusCode: 500,
+          body: JSON.stringify({
+            message: "There was an error"
+          })
+        });
       });
-    })
-    .catch((err) => {
-      console.log(err);
-      resolve({
-        statusCode: 500,
-        body: JSON.stringify({
-          message: "There was an error",
-        }),
-      });
-    });
   });
 };

--- a/lambdas/execute-fixity/package.json
+++ b/lambdas/execute-fixity/package.json
@@ -2,10 +2,14 @@
   "name": "execute-fixity",
   "version": "0.1.0",
   "description": "Receives S3 upload notification and triggers fixity step function execution",
+  "type": "module",
   "main": "index.js",
   "author": "nulib",
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-sdk/client-sfn": "^3.421.0"
+  },
+  "dependencies": {
+    "source-map-support": "^0.5.21"
   }
 }

--- a/lambdas/exif/Makefile
+++ b/lambdas/exif/Makefile
@@ -1,4 +1,1 @@
-build-exif:
-	find . -maxdepth 1 -type f ! -name 'Makefile' -exec cp {} "$(ARTIFACTS_DIR)/" \;
-	bun install --cwd $(ARTIFACTS_DIR) --production --frozen-lockfile || \
-	  bun install --cwd $(ARTIFACTS_DIR) --production
+include ../lambda.mk

--- a/lambdas/exif/bun.lock
+++ b/lambdas/exif/bun.lock
@@ -6,6 +6,7 @@
       "name": "exif",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.985.0",
+        "source-map-support": "^0.5.21",
         "tmp-promise": "^3.0.3",
         "uri-js": "^4.4.1",
       },
@@ -200,6 +201,8 @@
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
     "fast-xml-builder": ["fast-xml-builder@1.2.0", "", { "dependencies": { "path-expression-matcher": "^1.5.0", "xml-naming": "^0.1.0" } }, "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q=="],
 
     "fast-xml-parser": ["fast-xml-parser@5.7.2", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.5", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w=="],
@@ -207,6 +210,10 @@
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "strnum": ["strnum@2.2.3", "", {}, "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg=="],
 

--- a/lambdas/exif/exif.js
+++ b/lambdas/exif/exif.js
@@ -1,9 +1,9 @@
-const { S3Client, GetObjectCommand } = require("@aws-sdk/client-s3");
-const URI = require("uri-js");
-const fs = require("fs");
-const path = require("path");
-const tmp = require("tmp-promise");
-const { spawn } = require("child_process");
+import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+import URI from "uri-js";
+import fs from "fs";
+import path from "path";
+import tmp from "tmp-promise";
+import { spawn } from "child_process";
 
 const includeTags = [
   "Artist",
@@ -127,4 +127,4 @@ const s3ClientOpts = () => {
   return { endpoint, forcePathStyle, httpOptions: { timeout: 600000 } };
 };
 
-module.exports = { extract, version };
+export { extract, version };

--- a/lambdas/exif/index.js
+++ b/lambdas/exif/index.js
@@ -1,25 +1,26 @@
-const exif = require("./exif");
-const fs = require('fs');
+import "source-map-support/register.js";
+import * as exif from "./exif.js";
+import fs from "fs";
 
 const cleanTmpFiles = () => {
-  fs.readdirSync('/tmp')
-    .filter(fn => fn.startsWith('exif-'))
-    .map(fn => {
+  fs.readdirSync("/tmp")
+    .filter((fn) => fn.startsWith("exif-"))
+    .map((fn) => {
       const path = `/tmp/${fn}`;
       console.log(`Cleaning up ${path}`);
       fs.unlinkSync(path);
     });
-}
+};
 
 const handler = async (event, _context, _callback) => {
   cleanTmpFiles();
-  const source = event.source || event.headers['x-source-location'];
+  const source = event.source || event.headers["x-source-location"];
   const result = await exif.extract(source);
   if (result === null || result === undefined) {
     return null;
   }
   delete result.SourceFile;
-  
+
   return {
     tool: "exiftool",
     tool_version: await exif.version(),
@@ -27,4 +28,4 @@ const handler = async (event, _context, _callback) => {
   };
 };
 
-module.exports = { handler };
+export { handler };

--- a/lambdas/exif/package.json
+++ b/lambdas/exif/package.json
@@ -2,11 +2,13 @@
   "name": "exif",
   "version": "0.1.0",
   "description": "Extract image exif data.",
+  "type": "module",
   "main": "index.js",
   "author": "bmquinn",
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.985.0",
+    "source-map-support": "^0.5.21",
     "tmp-promise": "^3.0.3",
     "uri-js": "^4.4.1"
   }

--- a/lambdas/frame-extractor/Makefile
+++ b/lambdas/frame-extractor/Makefile
@@ -1,4 +1,1 @@
-build-frameExtractor:
-	find . -maxdepth 1 -type f ! -name 'Makefile' -exec cp {} "$(ARTIFACTS_DIR)/" \;
-	bun install --cwd $(ARTIFACTS_DIR) --production --frozen-lockfile || \
-	  bun install --cwd $(ARTIFACTS_DIR) --production
+include ../lambda.mk

--- a/lambdas/frame-extractor/bun.lock
+++ b/lambdas/frame-extractor/bun.lock
@@ -10,6 +10,7 @@
         "fluent-ffmpeg": "^2.1.2",
         "fs": "^0.0.1-security",
         "m3u8-file-parser": "^0.2.4",
+        "source-map-support": "^0.5.21",
         "tempy": "^3.2.0",
         "uri-js": "^4.4.1",
       },
@@ -233,6 +234,10 @@
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 

--- a/lambdas/frame-extractor/index.js
+++ b/lambdas/frame-extractor/index.js
@@ -1,9 +1,14 @@
-const { S3Client, GetObjectCommand, PutObjectCommand } = require("@aws-sdk/client-s3");
-const ffmpeg = require("fluent-ffmpeg");
-const concat = require("concat-stream");
-const URI = require("uri-js");
-const M3U8FileParser = require("m3u8-file-parser");
-const path = require("path");
+import "source-map-support/register.js";
+import {
+  S3Client,
+  GetObjectCommand,
+  PutObjectCommand
+} from "@aws-sdk/client-s3";
+import ffmpeg from "fluent-ffmpeg";
+import concat from "concat-stream";
+import URI from "uri-js";
+import M3U8FileParser from "m3u8-file-parser";
+import path from "path";
 
 const handler = async (event, _context, _callback) => {
   if (event.source.endsWith(".m3u8")) {
@@ -53,14 +58,20 @@ const extractFrameFromPlaylist = async (source, destination, offset) => {
               if (err) {
                 reject("Error running ffprobe: " + err.message);
               } else {
-                const videoStream = data.streams.find((s) => s.codec_type === "video");
+                const videoStream = data.streams.find(
+                  (s) => s.codec_type === "video"
+                );
                 dimensions.width = videoStream.width;
                 dimensions.height = videoStream.height;
 
                 s3Client
-                  .send(new GetObjectCommand({ Bucket: uri.host, Key: location }))
+                  .send(
+                    new GetObjectCommand({ Bucket: uri.host, Key: location })
+                  )
                   .then(({ Body: secondReadStream }) => {
-                    secondReadStream.on("error", (error) => console.error(error));
+                    secondReadStream.on("error", (error) =>
+                      console.error(error)
+                    );
 
                     ffmpegProcess = ffmpeg(secondReadStream)
                       .seek(segOffInSeconds)
@@ -96,7 +107,9 @@ const extractFrameFromVideo = async (source, destination, offset) => {
   let key = getS3Key(uri);
 
   const s3Client = new S3Client(s3ClientOpts());
-  const { Body: readStream } = await s3Client.send(new GetObjectCommand({ Bucket: uri.host, Key: key }));
+  const { Body: readStream } = await s3Client.send(
+    new GetObjectCommand({ Bucket: uri.host, Key: key })
+  );
   readStream.on("error", (error) => console.error(error));
 
   return new Promise((resolve, reject) => {
@@ -110,7 +123,12 @@ const extractFrameFromVideo = async (source, destination, offset) => {
         } else {
           dimensions.width = data.streams[0].width;
           dimensions.height = data.streams[0].height;
-          console.log("Video dimensions: ", dimensions.width, "x", dimensions.height);
+          console.log(
+            "Video dimensions: ",
+            dimensions.width,
+            "x",
+            dimensions.height
+          );
 
           s3Client
             .send(new GetObjectCommand({ Bucket: uri.host, Key: key }))
@@ -149,7 +167,9 @@ const loadHighestQuality = async (bucket, key) => {
   const reader = new M3U8FileParser();
   try {
     const s3Client = new S3Client(s3ClientOpts());
-    const { Body } = await s3Client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+    const { Body } = await s3Client.send(
+      new GetObjectCommand({ Bucket: bucket, Key: key })
+    );
     const m3u8 = await streamToString(Body);
     reader.read(m3u8);
     const playlist = reader.getResult();
@@ -171,7 +191,8 @@ const parsePlaylist = async (bucket, key, offset) => {
 
   let elapsed = 0.0;
   let segmentOffset = "";
-  for (segment of source.playlist.segments) {
+  let location = "";
+  for (const segment of source.playlist.segments) {
     const duration = segment.inf.duration * 1000;
 
     if (elapsed + duration > offset) {
@@ -221,4 +242,4 @@ const s3ClientOpts = () => {
   return { endpoint, forcePathStyle, httpOptions: { timeout: 600000 } };
 };
 
-module.exports = { handler };
+export { handler };

--- a/lambdas/frame-extractor/package.json
+++ b/lambdas/frame-extractor/package.json
@@ -1,6 +1,7 @@
 {
   "name": "frame-extractor",
   "version": "1.0.0",
+  "type": "module",
   "main": "index.js",
   "license": "Apache-2.0",
   "private": true,
@@ -10,6 +11,7 @@
     "fluent-ffmpeg": "^2.1.2",
     "fs": "^0.0.1-security",
     "m3u8-file-parser": "^0.2.4",
+    "source-map-support": "^0.5.21",
     "tempy": "^3.2.0",
     "uri-js": "^4.4.1"
   }

--- a/lambdas/lambda.mk
+++ b/lambdas/lambda.mk
@@ -1,0 +1,22 @@
+EXTERNAL ?=
+
+BUNDLE := $(ARTIFACTS_DIR)/index.mjs
+NM     := $(ARTIFACTS_DIR)/node_modules
+
+.PHONY: bundle build-%
+
+bundle: $(BUNDLE) $(STAMPS)
+
+$(BUNDLE): $(wildcard **/*.js) package.json bun.lock
+	@mkdir -p $(ARTIFACTS_DIR)
+	bun install --frozen-lockfile
+	bun build index.js \
+		--format=esm \
+		--target=node \
+		--sourcemap=linked \
+		--outdir=$(ARTIFACTS_DIR) \
+		--entry-naming=index.mjs \
+		$(foreach pkg,$(EXTERNAL),--external=$(pkg))
+
+build-%: bundle
+	@:

--- a/lambdas/mediainfo/Makefile
+++ b/lambdas/mediainfo/Makefile
@@ -1,4 +1,1 @@
-build-mediainfo:
-	find . -maxdepth 1 -type f ! -name 'Makefile' -exec cp {} "$(ARTIFACTS_DIR)/" \;
-	bun install --cwd $(ARTIFACTS_DIR) --production --frozen-lockfile || \
-	  bun install --cwd $(ARTIFACTS_DIR) --production
+include ../lambda.mk

--- a/lambdas/mediainfo/bun.lock
+++ b/lambdas/mediainfo/bun.lock
@@ -8,6 +8,7 @@
         "@aws-sdk/client-s3": "^3.975.0",
         "@aws-sdk/s3-request-presigner": "^3.981.0",
         "mediainfo.js": "^0.1.5",
+        "source-map-support": "^0.5.21",
         "uri-js": "^4.4.1",
       },
     },
@@ -209,6 +210,8 @@
 
     "bowser": ["bowser@2.13.1", "", {}, "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw=="],
 
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, ""],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, ""],
@@ -234,6 +237,10 @@
     "punycode": ["punycode@2.3.1", "", {}, ""],
 
     "require-directory": ["require-directory@2.1.1", "", {}, ""],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, ""],
 

--- a/lambdas/mediainfo/index.js
+++ b/lambdas/mediainfo/index.js
@@ -1,9 +1,16 @@
-const { getSignedUrl } = require("@aws-sdk/s3-request-presigner");
-const { S3Client, GetObjectCommand, HeadBucketCommand } = require("@aws-sdk/client-s3");
-const URI = require("uri-js");
+import "source-map-support/register.js";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import {
+  S3Client,
+  GetObjectCommand,
+  HeadBucketCommand
+} from "@aws-sdk/client-s3";
+import URI from "uri-js";
+import { promisify } from "util";
+import { exec as execCallback } from "child_process";
+
 const mediainfoPath = process.env.MEDIAINFO_PATH || "mediainfo";
-const util = require("util");
-const exec = util.promisify(require("child_process").exec);
+const exec = promisify(execCallback);
 
 async function mediainfoVersion() {
   const { stdout, _stderr } = await exec(`${mediainfoPath} --Version`);
@@ -18,7 +25,7 @@ async function extractMediainfoMetadata(url) {
   const { stdout, _stderr } = await exec(
     `${mediainfoPath} --Full --Output=JSON "${url}"`
   );
-  result = JSON.parse(stdout);
+  const result = JSON.parse(stdout);
 
   if (result.media == null) {
     throw "404 Not Found";
@@ -43,9 +50,15 @@ const handler = async (event, _context) => {
   // Interact with S3 to resolve credentials before trying to generate signed URL
   const s3Client = new S3Client(s3ClientOpts());
   await s3Client.send(new HeadBucketCommand({ Bucket: uri.host }));
-  const url = await getSignedUrl( s3Client, new GetObjectCommand({ Bucket: uri.host, Key: uri.path.replace(/^\/+/, "") }) );
+  const url = await getSignedUrl(
+    s3Client,
+    new GetObjectCommand({
+      Bucket: uri.host,
+      Key: uri.path.replace(/^\/+/, "")
+    })
+  );
 
   return await extractMediainfoMetadata(url);
 };
 
-module.exports = { handler };
+export { handler };

--- a/lambdas/mediainfo/package.json
+++ b/lambdas/mediainfo/package.json
@@ -2,13 +2,15 @@
   "name": "exif",
   "version": "0.1.0",
   "description": "Extract image exif data.",
+  "type": "module",
   "main": "index.js",
   "author": "bmquinn",
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/s3-request-presigner": "^3.981.0",
     "@aws-sdk/client-s3": "^3.975.0",
+    "@aws-sdk/s3-request-presigner": "^3.981.0",
     "mediainfo.js": "^0.1.5",
+    "source-map-support": "^0.5.21",
     "uri-js": "^4.4.1"
   }
 }

--- a/lambdas/metadata-agent/Makefile
+++ b/lambdas/metadata-agent/Makefile
@@ -1,4 +1,2 @@
-build-metadataAgent:
-	find . -maxdepth 1 -type f ! -name 'Makefile' -exec cp {} "$(ARTIFACTS_DIR)/" \;
-	bun install --cwd $(ARTIFACTS_DIR) --production --frozen-lockfile || \
-	  bun install --cwd $(ARTIFACTS_DIR) --production
+EXTERNAL := @anthropic-ai/claude-agent-sdk sharp
+include ../lambda.mk

--- a/lambdas/metadata-agent/bun.lock
+++ b/lambdas/metadata-agent/bun.lock
@@ -7,46 +7,227 @@
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.38",
         "debug": "^4.4.3",
+        "source-map-support": "^0.5.21",
       },
     },
   },
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.38", "", { "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.33.5", "@img/sharp-darwin-x64": "^0.33.5", "@img/sharp-linux-arm": "^0.33.5", "@img/sharp-linux-arm64": "^0.33.5", "@img/sharp-linux-x64": "^0.33.5", "@img/sharp-linuxmusl-arm64": "^0.33.5", "@img/sharp-linuxmusl-x64": "^0.33.5", "@img/sharp-win32-x64": "^0.33.5" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-U1vpf3rlSkw1qUlzC6CBibBA30ouQnla9JnuqYFLQ2zBb1U2NUCXIElrnV7RwWrI5e9ZKCHgR+1uaCwROONo7w=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.141", "", { "dependencies": { "@anthropic-ai/sdk": "^0.93.0", "@modelcontextprotocol/sdk": "^1.29.0" }, "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.141", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.141", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.141", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.141" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-AIBacMWGcZIUcXlUoObqjwJ6pmJI3BayAqPAFXuvSq3DHJXdiuZVs7l/zTB5l3nRhRv5cqSrI2XbiDeHgZWizw=="],
 
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.141", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9HZ0ot6+FwOfQ1aeMqQLH4IJGMm/DcP08SysDxscVjBm6l2JjqleHohxi3zid0DurfGweqT+4x9GScJffwg55g=="],
 
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.0.4" }, "os": "darwin", "cpu": "x64" }, "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.141", "", { "os": "darwin", "cpu": "x64" }, "sha512-4iAdarJaQ+2R58s6QJswZCzUdz2WQmL5lYG7Y+FLzWbRSROFfcH0QYpmOqSaPXd2KRQhIJwEacqecDZd/Q1XKQ=="],
 
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.141", "", { "os": "linux", "cpu": "arm64" }, "sha512-Jdf0ZEwJzOP8sE6rPqdJN+SxMb0/L8sxJg4twCv/7S+Qzk0hJtls+wxSi+0Tjh6EEMaNxJqEGc7S3fx99Wi99Q=="],
 
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.141", "", { "os": "linux", "cpu": "arm64" }, "sha512-6H1AJ/AVaWNnV22kubUPkOTRzZFH0+qP9k7WlhriHMN9gtgZcVAsITMddDeGjQsQJMCAdhXFd6sgi7TM1LdeOQ=="],
 
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.0.5", "", { "os": "linux", "cpu": "arm" }, "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.2.141", "", { "os": "linux", "cpu": "x64" }, "sha512-DVjp72f3HmrRYpbneWZZWIqkUht5kTZXS7wXGFiwzLz6eNYEgjjh+GcsnhIi8UOwZUtNiKUrjZnoP38ovFqV8A=="],
 
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.141", "", { "os": "linux", "cpu": "x64" }, "sha512-fTI1YuM4cxOa4nSgsyMAdB5ELizkWp+w5Ispo4JnnYtcczMAL4D9GBNjWPW0sUzKvjsJOUVim68SmWLWhUOpXQ=="],
 
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw=="],
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.141", "", { "os": "win32", "cpu": "arm64" }, "sha512-Wm10J6kfbufbPGFELokiJ/7Y5Oqug4Uag3HXFsV8g7TWCpaItx/oqVaJoiGptuAtXQB7xGLQVTuk082wER+Y5w=="],
 
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA=="],
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.2.141", "", { "os": "win32", "cpu": "x64" }, "sha512-IXuP29YJuWbR5Q6xOHrjFVGG54V2s1FC61UVNwEN5fpxL09MwPnbwtQL6fqgzt/U1MP7vWAwpXZriYAklkH/mg=="],
 
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw=="],
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.93.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA=="],
 
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.0.5" }, "os": "linux", "cpu": "arm" }, "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ=="],
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA=="],
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA=="],
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g=="],
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw=="],
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
   }
 }

--- a/lambdas/metadata-agent/index.js
+++ b/lambdas/metadata-agent/index.js
@@ -1,3 +1,4 @@
+import "source-map-support/register.js";
 import { queryClaude } from "./execute.js";
 import debug from "debug";
 

--- a/lambdas/metadata-agent/package.json
+++ b/lambdas/metadata-agent/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.38",
-    "debug": "^4.4.3"
+    "debug": "^4.4.3",
+    "source-map-support": "^0.5.21"
   }
 }

--- a/lambdas/mime-type/Makefile
+++ b/lambdas/mime-type/Makefile
@@ -1,4 +1,1 @@
-build-mimeType:
-	find . -maxdepth 1 -type f ! -name 'Makefile' -exec cp {} "$(ARTIFACTS_DIR)/" \;
-	bun install --cwd $(ARTIFACTS_DIR) --production --frozen-lockfile || \
-	  bun install --cwd $(ARTIFACTS_DIR) --production
+include ../lambda.mk

--- a/lambdas/mime-type/bun.lock
+++ b/lambdas/mime-type/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.987.0",
         "file-type": "^16.0",
+        "source-map-support": "^0.5.21",
       },
     },
   },
@@ -207,6 +208,8 @@
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
@@ -230,6 +233,10 @@
     "readable-web-to-node-stream": ["readable-web-to-node-stream@3.0.4", "", { "dependencies": { "readable-stream": "^4.7.0" } }, "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 

--- a/lambdas/mime-type/index.js
+++ b/lambdas/mime-type/index.js
@@ -1,7 +1,7 @@
-const { S3Client, GetObjectCommand } = require("@aws-sdk/client-s3");
-const FileType = require("file-type");
-const path = require("path");
-
+import "source-map-support/register.js";
+import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+import FileType from "file-type";
+import path from "path";
 
 const handler = async (event, _context, _callback) => {
   return await extractMimeType(event);
@@ -29,8 +29,8 @@ const extractMimeType = async (event) => {
     // response: {"ext":"jpg","mime":"image/jpeg"}
     const fileType = await FileType.fromBuffer(firstK);
     if (fileType) {
-      console.log('identified file as', JSON.stringify(fileType));
-      return { ...fileType, verified: true };  
+      console.log("identified file as", JSON.stringify(fileType));
+      return { ...fileType, verified: true };
     } else {
       return fallback(event);
     }
@@ -44,11 +44,13 @@ const fallback = (event) => {
   const ext = path.extname(event.key).replace(/^\./, "");
   const mime = event.fallback;
 
-  if (mime === undefined) 
-    return { ext, mime: "application/octet-stream", verified: false }
+  if (mime === undefined)
+    return { ext, mime: "application/octet-stream", verified: false };
 
-  if (mime && (! mime.match(/xml$/)) && FileType.mimeTypes.has(mime)) {
-    console.warn(`${path.basename(event.key)} attempting to fall back to ${mime} but magic number doesn't match.`);
+  if (mime && !mime.match(/xml$/) && FileType.mimeTypes.has(mime)) {
+    console.warn(
+      `${path.basename(event.key)} attempting to fall back to ${mime} but magic number doesn't match.`
+    );
     return undefined;
   }
 
@@ -56,8 +58,8 @@ const fallback = (event) => {
     ext: path.extname(event.key).replace(/^\./, ""),
     mime: mime,
     verified: false
-  }
-}
+  };
+};
 
 const s3ClientOpts = () => {
   const forcePathStyle = process.env.AWS_S3_FORCE_PATH_STYLE === "true";
@@ -65,4 +67,4 @@ const s3ClientOpts = () => {
   return { endpoint, forcePathStyle, httpOptions: { timeout: 600000 } };
 };
 
-module.exports = { handler };
+export { handler };

--- a/lambdas/mime-type/package.json
+++ b/lambdas/mime-type/package.json
@@ -2,6 +2,7 @@
   "name": "mime-type",
   "version": "0.1.0",
   "description": "Extract mime-type.",
+  "type": "module",
   "main": "index.js",
   "author": "kdid",
   "license": "Apache-2.0",
@@ -10,6 +11,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.987.0",
-    "file-type": "^16.0"
+    "file-type": "^16.0",
+    "source-map-support": "^0.5.21"
   }
 }

--- a/lambdas/pyramid-tiff/Makefile
+++ b/lambdas/pyramid-tiff/Makefile
@@ -1,3 +1,2 @@
-build-pyramidTiff:
-	find . -maxdepth 1 -type f ! -name 'Makefile' -exec cp {} "$(ARTIFACTS_DIR)/" \;
-	cd "$(ARTIFACTS_DIR)" && SHARP_IGNORE_GLOBAL_LIBVIPS=1 bun install --production --frozen-lockfile || bun install --production
+EXTERNAL := sharp
+include ../lambda.mk

--- a/lambdas/pyramid-tiff/bun.lock
+++ b/lambdas/pyramid-tiff/bun.lock
@@ -7,7 +7,8 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.987.0",
         "concat-stream": "^2.0.0",
-        "sharp": "^0.34.4",
+        "sharp": "^0.35.2",
+        "source-map-support": "^0.5.21",
       },
     },
   },
@@ -94,57 +95,61 @@
 
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.3", "", {}, "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
-    "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.1" }, "os": "darwin", "cpu": "arm64" }, "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg=="],
 
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.1" }, "os": "darwin", "cpu": "x64" }, "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw=="],
 
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+    "@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.2", "", { "dependencies": { "@img/sharp-wasm32": "0.35.2" }, "os": "freebsd" }, "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw=="],
 
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g=="],
 
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ=="],
 
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.1", "", { "os": "linux", "cpu": "arm" }, "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg=="],
 
-    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw=="],
 
-    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng=="],
 
-    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.1", "", { "os": "linux", "cpu": "none" }, "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw=="],
 
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew=="],
 
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A=="],
 
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw=="],
 
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg=="],
 
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.1" }, "os": "linux", "cpu": "arm" }, "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A=="],
 
-    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA=="],
 
-    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.1" }, "os": "linux", "cpu": "ppc64" }, "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg=="],
 
-    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.1" }, "os": "linux", "cpu": "none" }, "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA=="],
 
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.1" }, "os": "linux", "cpu": "s390x" }, "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA=="],
 
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA=="],
 
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg=="],
 
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg=="],
 
-    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.2", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw=="],
 
-    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+    "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.2", "", { "dependencies": { "@img/sharp-wasm32": "0.35.2" }, "cpu": "none" }, "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g=="],
 
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.2", "", { "os": "win32", "cpu": "x64" }, "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ=="],
 
     "@smithy/abort-controller": ["@smithy/abort-controller@4.2.8", "", { "dependencies": { "@smithy/types": "^4.12.0", "tslib": "^2.6.2" } }, "sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw=="],
 
@@ -268,9 +273,13 @@
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
-    "semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
-    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+    "sharp": ["sharp@0.35.2", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.4" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.2", "@img/sharp-darwin-x64": "0.35.2", "@img/sharp-freebsd-wasm32": "0.35.2", "@img/sharp-libvips-darwin-arm64": "1.3.1", "@img/sharp-libvips-darwin-x64": "1.3.1", "@img/sharp-libvips-linux-arm": "1.3.1", "@img/sharp-libvips-linux-arm64": "1.3.1", "@img/sharp-libvips-linux-ppc64": "1.3.1", "@img/sharp-libvips-linux-riscv64": "1.3.1", "@img/sharp-libvips-linux-s390x": "1.3.1", "@img/sharp-libvips-linux-x64": "1.3.1", "@img/sharp-libvips-linuxmusl-arm64": "1.3.1", "@img/sharp-libvips-linuxmusl-x64": "1.3.1", "@img/sharp-linux-arm": "0.35.2", "@img/sharp-linux-arm64": "0.35.2", "@img/sharp-linux-ppc64": "0.35.2", "@img/sharp-linux-riscv64": "0.35.2", "@img/sharp-linux-s390x": "0.35.2", "@img/sharp-linux-x64": "0.35.2", "@img/sharp-linuxmusl-arm64": "0.35.2", "@img/sharp-linuxmusl-x64": "0.35.2", "@img/sharp-webcontainers-wasm32": "0.35.2", "@img/sharp-win32-arm64": "0.35.2", "@img/sharp-win32-ia32": "0.35.2", "@img/sharp-win32-x64": "0.35.2" } }, "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 

--- a/lambdas/pyramid-tiff/index.js
+++ b/lambdas/pyramid-tiff/index.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
-const pyramid = require("./pyramid");
+import "source-map-support/register.js";
+import * as pyramid from "./pyramid.js";
 
 const handler = async (event, _context, _callback) => {
   return await pyramid.createPyramidTiff(event.source, event.target);
 }
 
-module.exports = {handler};
+export { handler };

--- a/lambdas/pyramid-tiff/package.json
+++ b/lambdas/pyramid-tiff/package.json
@@ -2,12 +2,14 @@
   "name": "node-pyramid",
   "version": "0.1.0",
   "description": "Create pyramid TIFFs in nodejs/sharp",
+  "type": "module",
   "main": "index.js",
   "author": "mbklein",
   "license": "Apache2",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.987.0",
     "concat-stream": "^2.0.0",
-    "sharp": "^0.34.4"
+    "sharp": "^0.35.2",
+    "source-map-support": "^0.5.21"
   }
 }

--- a/lambdas/pyramid-tiff/pyramid.js
+++ b/lambdas/pyramid-tiff/pyramid.js
@@ -1,6 +1,6 @@
-const { S3Client, GetObjectCommand, PutObjectCommand } = require("@aws-sdk/client-s3");
-const concat = require("concat-stream");
-const sharp = require("sharp");
+import { S3Client, GetObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import concat from "concat-stream";
+import sharp from "sharp";
 
 const MAX_DIMENSION = 15000;
 const TILE_SIZE = 256;
@@ -91,4 +91,4 @@ const s3ClientOpts = () => {
   return { endpoint, forcePathStyle, httpOptions: { timeout: 600000 } };
 };
 
-module.exports = { createPyramidTiff };
+export { createPyramidTiff };

--- a/lambdas/stream-authorizer/Makefile
+++ b/lambdas/stream-authorizer/Makefile
@@ -1,4 +1,1 @@
-build-streamAuthorizer:
-	find . -maxdepth 1 -type f ! -name 'Makefile' -exec cp {} "$(ARTIFACTS_DIR)/" \;
-	bun install --cwd $(ARTIFACTS_DIR) --production --frozen-lockfile || \
-	  bun install --cwd $(ARTIFACTS_DIR) --production
+include ../lambda.mk

--- a/lambdas/stream-authorizer/bun.lock
+++ b/lambdas/stream-authorizer/bun.lock
@@ -8,6 +8,7 @@
         "@aws-sdk/client-secrets-manager": "^3.984",
         "@middy/core": "^5.0",
         "@middy/secrets-manager": "^5.0",
+        "source-map-support": "^0.5.21",
       },
     },
   },
@@ -166,6 +167,8 @@
 
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
     "cloneable-readable": ["cloneable-readable@3.0.0", "", { "dependencies": { "readable-stream": "^4.0.0" } }, "sha512-Lkfd9IRx1nfiBr7UHNxJSl/x7DOeUfYmxzCkxYJC2tyc/9vKgV75msgLGurGQsak/NvJDHMWcshzEXRlxfvhqg=="],
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
@@ -185,6 +188,10 @@
     "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 

--- a/lambdas/stream-authorizer/index.js
+++ b/lambdas/stream-authorizer/index.js
@@ -1,3 +1,4 @@
+import "source-map-support/register.js";
 import authorize from "./authorize.js";
 import middy from "@middy/core";
 import secretsManager from "@middy/secrets-manager";
@@ -10,13 +11,13 @@ function addAccessControlHeaders(request, response) {
   const origin = getEventHeader(request, "origin") || "*";
   if (!response.headers) response.headers = {};
   response.headers["access-control-allow-origin"] = [
-    { key: "Access-Control-Allow-Origin", value: origin },
+    { key: "Access-Control-Allow-Origin", value: origin }
   ];
   response.headers["access-control-allow-headers"] = [
-    { key: "Access-Control-Allow-Headers", value: "authorization, cookie" },
+    { key: "Access-Control-Allow-Headers", value: "authorization, cookie" }
   ];
   response.headers["access-control-allow-credentials"] = [
-    { key: "Access-Control-Allow-Credentials", value: "true" },
+    { key: "Access-Control-Allow-Credentials", value: "true" }
   ];
   return response;
 }
@@ -40,7 +41,7 @@ async function viewerRequestHandler(event, { config }) {
   const response = {
     status: "403",
     statusDescription: "Forbidden",
-    body: "Forbidden",
+    body: "Forbidden"
   };
   return response;
 }
@@ -65,26 +66,28 @@ async function requestHandler(event, context) {
 
 function functionNameAndRegion() {
   let nameVar = process.env.AWS_LAMBDA_FUNCTION_NAME;
-  const match = /^(?<functionRegion>[a-z]{2}-[a-z]+-\d+)\.(?<functionName>.+)$/.exec(nameVar);
+  const match =
+    /^(?<functionRegion>[a-z]{2}-[a-z]+-\d+)\.(?<functionName>.+)$/.exec(
+      nameVar
+    );
   if (match) {
-    return { ...match.groups }
+    return { ...match.groups };
   } else {
     return {
       functionName: nameVar,
       functionRegion: process.env.AWS_REGION
-    }
+    };
   }
 }
 
 const { functionName, functionRegion } = functionNameAndRegion();
 
-export const handler = 
-  middy()
-    .use(
-      secretsManager({
-        fetchData: { config: functionName },
-        awsClientOptions: { region: functionRegion },
-        setToContext: true
-      })
-    )
-    .handler(requestHandler);
+export const handler = middy()
+  .use(
+    secretsManager({
+      fetchData: { config: functionName },
+      awsClientOptions: { region: functionRegion },
+      setToContext: true
+    })
+  )
+  .handler(requestHandler);

--- a/lambdas/stream-authorizer/package.json
+++ b/lambdas/stream-authorizer/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.984",
     "@middy/core": "^5.0",
-    "@middy/secrets-manager": "^5.0"
+    "@middy/secrets-manager": "^5.0",
+    "source-map-support": "^0.5.21"
   }
 }


### PR DESCRIPTION
# Summary 
Use bun to build / pack pipeline lambdas

# Specific Changes in this PR
- Build pipeline using `bun build`
- Use `--build-in-source` when building pipeline to allow `Makefile`s to include a common `lambda.mk` file
- Add new layers for claude and sharp
- Convert CJS lambdas to ESM

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Test ingest and Metadata Agent using `make pipeline-start` and `USE_SAM_LAMBDAS=true`
- Test `make pipeline-build`
- Test `make pipeline-deploy ENV=dev-environment`
- Test ingest and Metadata Agent with deployed pipeline

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

