### PR TITLE
Allow user to manually enter transcription and cleanup button behavior

### DIFF
--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Modal.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Modal.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import CloverImage from "@samvera/clover-iiif/image";
 import { Button, Notification } from "@nulib/design-system";
@@ -11,12 +11,15 @@ import { useMutation } from "@apollo/client/react";
 import {
   UPDATE_FILE_SET_ANNOTATION,
   DELETE_FILE_SET_ANNOTATION,
+  UPSERT_FILE_SET_ANNOTATION,
 } from "@js/components/Work/Tabs/Structure/Transcription/transcription.gql";
 import WorkTabsStructureTranscriptionWorkflow from "@js/components/Work/Tabs/Structure/Transcription/Workflow";
 
 function WorkTabsStructureTranscriptionModal({ isActive }) {
   const [textArea, setTextArea] = useState();
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+  const initialValueRef = useRef("");
 
   const dispatch = useWorkDispatch();
   const iiifServerUrl = useContext(IIIFContext);
@@ -28,9 +31,15 @@ function WorkTabsStructureTranscriptionModal({ isActive }) {
   const iiifImageUrl = `${iiifServerUrl}${fileSetId}${IIIF_SIZES.IIIF_FULL}`;
 
   const [updateFileSetAnnotation] = useMutation(UPDATE_FILE_SET_ANNOTATION);
+  const [upsertFileSetAnnotation] = useMutation(UPSERT_FILE_SET_ANNOTATION);
   const [deleteFileSetAnnotation] = useMutation(DELETE_FILE_SET_ANNOTATION);
 
   useEffect(() => {
+    if (!isActive) {
+      setTextArea(null);
+      setIsDirty(false);
+      return;
+    }
     const textAreaElement = document.getElementById(
       "file-set-transcription-textarea",
     );
@@ -49,22 +58,31 @@ function WorkTabsStructureTranscriptionModal({ isActive }) {
     const annotationContent = textArea?.value || "";
     const annotationId = textArea?.getAttribute("data-annotation-id");
 
-    updateFileSetAnnotation({
-      variables: {
-        annotationId: annotationId,
-        content: annotationContent,
-      },
-      onCompleted: () => {
-        handleClose();
-        toastWrapper("is-success", "Transcription successfully saved");
-      },
-      onError: (error) => {
-        toastWrapper(
-          "is-danger",
-          "Error saving transcription: " + error.message,
-        );
-      },
-    });
+    const onCompleted = () => {
+      handleClose();
+      toastWrapper("is-success", "Transcription successfully saved");
+    };
+    const onError = (error) => {
+      toastWrapper("is-danger", "Error saving transcription: " + error.message);
+    };
+
+    if (annotationId) {
+      updateFileSetAnnotation({
+        variables: { annotationId, content: annotationContent },
+        onCompleted,
+        onError,
+      });
+    } else {
+      upsertFileSetAnnotation({
+        variables: {
+          fileSetId,
+          type: "transcription",
+          content: annotationContent,
+        },
+        onCompleted,
+        onError,
+      });
+    }
   };
 
   const handleDeleteTranscription = () => {
@@ -102,10 +120,16 @@ function WorkTabsStructureTranscriptionModal({ isActive }) {
     const textAreaElement = document.getElementById(
       "file-set-transcription-textarea",
     );
+    initialValueRef.current = textAreaElement?.value ?? "";
+    setIsDirty(false);
     setTextArea(textAreaElement);
   };
 
-  const hasTextArea = Boolean(textArea);
+  const handleContentChange = (value) => {
+    setIsDirty(value !== initialValueRef.current);
+  };
+
+  const hasAnnotationId = Boolean(textArea?.getAttribute("data-annotation-id"));
 
   return (
     <div className={classNames(["modal"], { "is-active": isActive })}>
@@ -157,12 +181,13 @@ function WorkTabsStructureTranscriptionModal({ isActive }) {
               workId={workId}
               hasTranscriptionCallback={handleHasTranscriptionCallback}
               isActive={isActive}
+              onContentChange={handleContentChange}
             />
           </div>
         </section>
 
         <footer className="modal-card-foot buttons is-justify-content-space-between">
-          {!confirmDelete && hasTextArea && (
+          {!confirmDelete && hasAnnotationId && (
             <div>
               <Button isDanger onClick={handleDeleteTranscription}>
                 Delete Transcription
@@ -178,7 +203,7 @@ function WorkTabsStructureTranscriptionModal({ isActive }) {
             ) : (
               <Button
                 isPrimary
-                disabled={!hasTextArea}
+                disabled={!isDirty}
                 onClick={handleSaveTranscription}
               >
                 Save

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Modal.test.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Modal.test.jsx
@@ -41,18 +41,30 @@ jest.mock("@js/services/helpers", () => ({
   toastWrapper: jest.fn(),
 }));
 
-// Mock Workflow so it renders the textarea the modal is looking for
+// Mock Workflow so it renders the textarea the modal is looking for,
+// wiring hasTranscriptionCallback and onContentChange the same way the real
+// Workflow/Pane pair does so dirty-state tracking works in tests.
 jest.mock("@js/components/Work/Tabs/Structure/Transcription/Workflow", () => {
   const React = require("react");
+  const { useEffect } = React;
   return {
     __esModule: true,
-    default: function MockWorkflow() {
+    default: function MockWorkflow({
+      hasTranscriptionCallback,
+      onContentChange,
+    }) {
+      useEffect(() => {
+        hasTranscriptionCallback?.();
+      }, []);
       return (
         <textarea
           id="file-set-transcription-textarea"
           data-annotation-id="ann-1"
           data-annotation-type="transcription"
           defaultValue="Existing transcription"
+          onChange={
+            onContentChange ? (e) => onContentChange(e.target.value) : undefined
+          }
         />
       );
     },
@@ -99,14 +111,18 @@ describe("WorkTabsStructureTranscriptionModal", () => {
     expect(image.getAttribute("src")).toContain("fs-123");
   });
 
-  it("disables Save when textarea is not yet found", async () => {
-    // The effect that finds the textarea runs after mount, so on first paint
-    // Save may be disabled. We can at least assert it's a button and becomes
-    // enabled once the textarea exists.
+  it("Save is disabled until the user edits the textarea", async () => {
     renderModal();
 
     const saveButton = await screen.findByRole("button", { name: /save/i });
-    // After the effect + mock Workflow render, it should be enabled:
+
+    // Save stays disabled even after the textarea is found — no changes yet.
+    await waitFor(() => expect(saveButton).toBeDisabled());
+
+    // Simulate the user typing a change.
+    const textarea = document.getElementById("file-set-transcription-textarea");
+    fireEvent.change(textarea, { target: { value: "Edited transcription" } });
+
     await waitFor(() => expect(saveButton).not.toBeDisabled());
   });
 
@@ -117,14 +133,14 @@ describe("WorkTabsStructureTranscriptionModal", () => {
           query: UPDATE_FILE_SET_ANNOTATION,
           variables: {
             annotationId: "ann-1",
-            content: "Existing transcription",
+            content: "Edited transcription",
           },
         },
         result: {
           data: {
             updateFileSetAnnotation: {
               id: "ann-1",
-              content: "Existing transcription",
+              content: "Edited transcription",
             },
           },
         },
@@ -135,7 +151,9 @@ describe("WorkTabsStructureTranscriptionModal", () => {
 
     const saveButton = await screen.findByRole("button", { name: /save/i });
 
-    // Wait until textarea is found and Save enabled
+    // Edit the textarea to make Save active.
+    const textarea = document.getElementById("file-set-transcription-textarea");
+    fireEvent.change(textarea, { target: { value: "Edited transcription" } });
     await waitFor(() => expect(saveButton).not.toBeDisabled());
 
     fireEvent.click(saveButton);
@@ -161,7 +179,7 @@ describe("WorkTabsStructureTranscriptionModal", () => {
           query: UPDATE_FILE_SET_ANNOTATION,
           variables: {
             annotationId: "ann-1",
-            content: "Existing transcription",
+            content: "Edited transcription",
           },
         },
         error: new Error("Boom"),
@@ -171,6 +189,9 @@ describe("WorkTabsStructureTranscriptionModal", () => {
     renderModal({ mocks: mutationMocks });
 
     const saveButton = await screen.findByRole("button", { name: /save/i });
+
+    const textarea = document.getElementById("file-set-transcription-textarea");
+    fireEvent.change(textarea, { target: { value: "Edited transcription" } });
     await waitFor(() => expect(saveButton).not.toBeDisabled());
 
     fireEvent.click(saveButton);

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Pane.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Pane.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef } from "react";
 function WorkTabsStructureTranscriptionPane({
   annotation,
   hasTranscriptionCallback,
+  onContentChange,
 }) {
   const textAreaRef = useRef(null);
   const { content, id, status, type } = annotation;
@@ -10,8 +11,8 @@ function WorkTabsStructureTranscriptionPane({
   useEffect(() => {
     if (!textAreaRef.current) return;
     if (typeof content === "string") {
-      hasTranscriptionCallback(true);
       textAreaRef.current.value = content;
+      hasTranscriptionCallback(true);
       return;
     }
   }, [content]);
@@ -52,6 +53,9 @@ function WorkTabsStructureTranscriptionPane({
         data-annotation-status={status}
         data-annotation-type={type}
         id="file-set-transcription-textarea"
+        onChange={
+          onContentChange ? (e) => onContentChange(e.target.value) : undefined
+        }
         ref={textAreaRef}
         style={{
           height: "100%",

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Workflow.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Workflow.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Button } from "@nulib/design-system";
 import WorkTabsStructureTranscriptionPane from "@js/components/Work/Tabs/Structure/Transcription/Pane";
 import {
@@ -53,8 +53,10 @@ function WorkTabsStructureTranscriptionWorkflow({
   isActive,
   workId,
   hasTranscriptionCallback,
+  onContentChange,
 }) {
   const flashedAnnotationErrorIdRef = useRef(null);
+  const [manualEntry, setManualEntry] = useState(false);
   const { data: { fileSetAnnotation } = {} } = useFileSetAnnotation(fileSetId);
   const {
     data: { work } = {},
@@ -163,20 +165,44 @@ function WorkTabsStructureTranscriptionWorkflow({
       }}
     >
       {!annotation || annotationFailed ? (
-        <div>
-          <Button
-            isPrimary
-            isLowercase
-            onClick={handleStartTranscription}
-            style={{ gap: "0.5rem" }}
+        manualEntry ? (
+          <WorkTabsStructureTranscriptionPane
+            annotation={{
+              content: "",
+              id: null,
+              status: "completed",
+              type: "transcription",
+            }}
+            hasTranscriptionCallback={hasTranscriptionCallback}
+            onContentChange={onContentChange}
+          />
+        ) : (
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: "0.75rem",
+            }}
           >
-            Generate Transcription
-          </Button>
-        </div>
+            <Button
+              isPrimary
+              isLowercase
+              onClick={handleStartTranscription}
+              style={{ gap: "0.5rem" }}
+            >
+              Generate Transcription
+            </Button>
+            <Button isLowercase onClick={() => setManualEntry(true)}>
+              Enter Manually
+            </Button>
+          </div>
+        )
       ) : (
         <WorkTabsStructureTranscriptionPane
           annotation={annotation}
           hasTranscriptionCallback={hasTranscriptionCallback}
+          onContentChange={onContentChange}
         />
       )}
     </div>

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/transcription.gql.ts
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/transcription.gql.ts
@@ -61,6 +61,33 @@ export const UPDATE_FILE_SET_ANNOTATION = gql`
   }
 `;
 
+export const UPSERT_FILE_SET_ANNOTATION = gql`
+  mutation upsertFileSetAnnotation(
+    $fileSetId: ID!
+    $type: String!
+    $content: String!
+    $language: [String]
+  ) {
+    upsertFileSetAnnotation(
+      fileSetId: $fileSetId
+      type: $type
+      content: $content
+      language: $language
+    ) {
+      content
+      fileSetId
+      id
+      insertedAt
+      language
+      model
+      s3Location
+      status
+      type
+      updatedAt
+    }
+  }
+`;
+
 export const DELETE_FILE_SET_ANNOTATION = gql`
   mutation deleteFileSetAnnotation($annotationId: ID!) {
     deleteFileSetAnnotation(annotationId: $annotationId) {


### PR DESCRIPTION
# Summary

Adds manual transcription entry to the transcription modal and improves Save button UX. Previously, the only option when no transcription existed was to generate one via AI. Users also saw an always-enabled Save button after a transcription was generated, which was confusing since the AI result was already saved. Also now only shows delete button when appropriate.

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5746

# Specific Changes in this PR

- Added "Enter Manually" button alongside "Generate Transcription" when no transcription exists, allowing users to type or paste a transcription directly
- Wired "Enter Manually" to the existing `upsertFileSetAnnotation` GraphQL mutation (already present on the backend) to save the manually-entered text
- Added `UPSERT_FILE_SET_ANNOTATION` GraphQL mutation to the frontend GQL definitions
- Save button is now disabled until the user has made changes to the textarea (dirty-state tracking via `initialValueRef` + `onChange`), so it's clear that closing without saving does not discard an AI-generated transcription
- Delete button now only appears when an existing saved annotation is present (not during manual entry before first save)

# Version bump required by the PR
- [x] Patch

# Steps to Test
1. Open a work with no transcription → "Access Files" tab → click "Transcription" on a file set
2. Confirm both "Generate Transcription" and "Enter Manually" buttons appear
3. Click "Enter Manually" → confirm an empty editable textarea appears with Save grayed out
4. Type or paste text → confirm Save becomes enabled → save and confirm success toast
5. Reopen the modal → confirm the text is shown, Save is grayed out until edited
6. Open a work that already has an AI-generated transcription → confirm Save is grayed out on open and only enables after editing

<img width="1469" height="930" alt="Screenshot 2026-06-24 at 8 55 35 AM" src="https://github.com/user-attachments/assets/80a7989c-0b94-44f7-ac03-9a82a0870471" />


# Deployment Notes
- Backward compatible API changes
  - [x] GraphQL API — `upsertFileSetAnnotation` mutation was already defined on the backend; this PR only adds it to the frontend GQL definitions

# Tested/Verified
- [ ] End users/stakeholders