### PR TITLE
Add download transcription functionality

### DIFF
--- a/app/assets/bun.lock
+++ b/app/assets/bun.lock
@@ -33,6 +33,7 @@
         "downshift": "^9.3.6",
         "edtf": "^4.11.0",
         "faker": "^5.5.3",
+        "fflate": "^0.8.3",
         "file-saver": "^2.0.5",
         "graphql": "^17.0.1",
         "graphql-ws": "^6.0.8",
@@ -1572,6 +1573,8 @@
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
     "figgy-pudding": ["figgy-pudding@3.5.2", "", {}, "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="],
 

--- a/app/assets/js/components/UI/Modal/DownloadAll.jsx
+++ b/app/assets/js/components/UI/Modal/DownloadAll.jsx
@@ -5,9 +5,10 @@ import { IconDownload } from "@js/components/Icon";
 import classNames from "classnames";
 import UIFormField from "@js/components/UI/Form/Field";
 import useIsAuthorized from "@js/hooks/useIsAuthorized";
-import { WORK_ARCHIVER_ENDPOINT } from "@js/components/Work/work.gql";
+import { WORK_ARCHIVER_ENDPOINT, GET_WORK } from "@js/components/Work/work.gql";
 import { useQuery } from "@apollo/client/react";
-import { toastWrapper } from "@js/services/helpers";
+import { toastWrapper, downloadBlob } from "@js/services/helpers";
+import { zipSync, strToU8 } from "fflate";
 
 /** @jsx jsx */
 import { jsx } from "@emotion/react";
@@ -19,13 +20,41 @@ const Radio = styled.input`
 
 const UIDownloadAll = ({ workId }) => {
   const [isModalVisible, setIsModalVisible] = React.useState(false);
+  const [downloadType, setDownloadType] = React.useState("images");
   const [width, setWidth] = React.useState("1500");
+  const [transcriptionFormat, setTranscriptionFormat] =
+    React.useState("combined");
   const { user } = useIsAuthorized();
 
   const { loading, error, data } = useQuery(WORK_ARCHIVER_ENDPOINT);
+  const { data: workData } = useQuery(GET_WORK, {
+    variables: { id: workId },
+    skip: !workId,
+  });
 
   if (loading) return <p>Loading...</p>;
   if (error) return <p>{error}</p>;
+
+  const work = workData?.work;
+
+  const transcriptionFileSets = (work?.fileSets || [])
+    .map((fs) => ({
+      accessionNumber: fs.accessionNumber,
+      id: fs.id,
+      content: fs.annotations?.find(
+        (a) => a.type === "transcription" && a.status === "completed",
+      )?.content,
+    }))
+    .filter((fs) => fs.content);
+
+  const hasTranscriptions = transcriptionFileSets.length > 0;
+
+  function handleOpenModal() {
+    // Default to images; only switch if the work has transcriptions and user had selected
+    // transcriptions before — keep last selection unless it's no longer valid.
+    if (!hasTranscriptions) setDownloadType("images");
+    setIsModalVisible(true);
+  }
 
   function handleCancelClick() {
     setIsModalVisible(false);
@@ -33,6 +62,10 @@ const UIDownloadAll = ({ workId }) => {
 
   function handleRadioChange(e) {
     setWidth(e.target.value);
+  }
+
+  function handleTranscriptionFormatChange(e) {
+    setTranscriptionFormat(e.target.value);
   }
 
   function handleSubmit() {
@@ -63,20 +96,50 @@ const UIDownloadAll = ({ workId }) => {
       .catch((error) => console.error(`Error: ${error}`));
   }
 
+  function handleDownloadTranscriptions() {
+    if (transcriptionFileSets.length === 0) {
+      toastWrapper("is-danger", "No transcriptions to download");
+      return;
+    }
+
+    const workLabel = work?.accessionNumber || work?.id || workId;
+
+    if (transcriptionFormat === "combined") {
+      const text = transcriptionFileSets
+        .map(
+          (fs) => `===== ${fs.accessionNumber || fs.id} =====\n\n${fs.content}`,
+        )
+        .join("\n\n");
+      const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
+      downloadBlob(blob, `transcriptions-${workLabel}.txt`);
+    } else {
+      const seenNames = {};
+      const files = {};
+      transcriptionFileSets.forEach((fs) => {
+        const baseName = fs.accessionNumber || fs.id;
+        const count = seenNames[baseName] || 0;
+        seenNames[baseName] = count + 1;
+        const filename =
+          count === 0
+            ? `transcription-${baseName}.txt`
+            : `transcription-${baseName}-${count}.txt`;
+        files[filename] = strToU8(fs.content);
+      });
+      const zipped = zipSync(files);
+      const blob = new Blob([zipped], { type: "application/zip" });
+      downloadBlob(blob, `transcriptions-${workLabel}.zip`);
+    }
+  }
+
   return (
     <>
-      <Button
-        data-testid="download-all-button"
-        onClick={() => setIsModalVisible(true)}
-      >
+      <Button data-testid="download-all-button" onClick={handleOpenModal}>
         <IconDownload />
         <span>Download all</span>
       </Button>
 
       <div
-        className={classNames("modal", {
-          "is-active": isModalVisible,
-        })}
+        className={classNames("modal", { "is-active": isModalVisible })}
         data-testid="download-all-modal"
       >
         <div className="modal-background"></div>
@@ -89,46 +152,115 @@ const UIDownloadAll = ({ workId }) => {
               onClick={handleCancelClick}
             ></button>
           </div>
-          <section className="modal-card-body">
-            <UIFormField label="Email">
-              <p data-testid="email">{user.email}</p>
-            </UIFormField>
 
-            <UIFormField label="Select image width">
-              <div className="control" data-testid="radio-image-size">
-                <label className="radio">
-                  <Radio
-                    type="radio"
-                    name="width"
-                    value="1500"
-                    checked={width === "1500"}
-                    onChange={handleRadioChange}
-                  />
-                  1500
-                </label>
-                <label className="radio">
-                  <Radio
-                    type="radio"
-                    name="width"
-                    value="3000"
-                    checked={width === "3000"}
-                    onChange={handleRadioChange}
-                  />
-                  3000
-                </label>
-                <label className="radio">
-                  <Radio
-                    type="radio"
-                    name="width"
-                    value="full"
-                    checked={width === "full"}
-                    onChange={handleRadioChange}
-                  />
-                  full
-                </label>
-              </div>
-            </UIFormField>
+          <section className="modal-card-body">
+            {/* Step 1: choose what to download (only shown when transcriptions exist) */}
+            {hasTranscriptions && (
+              <UIFormField label="What would you like to download?">
+                <div
+                  className="control"
+                  data-testid="radio-download-type"
+                  style={{ display: "flex", gap: "1.5rem" }}
+                >
+                  <label className="radio">
+                    <Radio
+                      type="radio"
+                      name="downloadType"
+                      value="images"
+                      checked={downloadType === "images"}
+                      onChange={(e) => setDownloadType(e.target.value)}
+                    />
+                    Images
+                  </label>
+                  <label className="radio">
+                    <Radio
+                      type="radio"
+                      name="downloadType"
+                      value="transcriptions"
+                      checked={downloadType === "transcriptions"}
+                      onChange={(e) => setDownloadType(e.target.value)}
+                    />
+                    Transcriptions
+                  </label>
+                </div>
+              </UIFormField>
+            )}
+
+            {/* Step 2: options for the chosen type */}
+            {downloadType === "images" && (
+              <>
+                <UIFormField label="Email">
+                  <p data-testid="email">{user.email}</p>
+                </UIFormField>
+
+                <UIFormField label="Select image width">
+                  <div className="control" data-testid="radio-image-size">
+                    <label className="radio">
+                      <Radio
+                        type="radio"
+                        name="width"
+                        value="1500"
+                        checked={width === "1500"}
+                        onChange={handleRadioChange}
+                      />
+                      1500
+                    </label>
+                    <label className="radio">
+                      <Radio
+                        type="radio"
+                        name="width"
+                        value="3000"
+                        checked={width === "3000"}
+                        onChange={handleRadioChange}
+                      />
+                      3000
+                    </label>
+                    <label className="radio">
+                      <Radio
+                        type="radio"
+                        name="width"
+                        value="full"
+                        checked={width === "full"}
+                        onChange={handleRadioChange}
+                      />
+                      full
+                    </label>
+                  </div>
+                </UIFormField>
+              </>
+            )}
+
+            {downloadType === "transcriptions" && (
+              <UIFormField label="Select format">
+                <div
+                  className="control"
+                  data-testid="radio-transcription-format"
+                >
+                  <label className="radio">
+                    <Radio
+                      type="radio"
+                      name="transcriptionFormat"
+                      value="combined"
+                      checked={transcriptionFormat === "combined"}
+                      onChange={handleTranscriptionFormatChange}
+                    />
+                    Combined text file (.txt)
+                  </label>
+                  <label className="radio">
+                    <Radio
+                      type="radio"
+                      name="transcriptionFormat"
+                      value="zip"
+                      checked={transcriptionFormat === "zip"}
+                      onChange={handleTranscriptionFormatChange}
+                    />
+                    Separate files (.zip)
+                  </label>
+                </div>
+              </UIFormField>
+            )}
           </section>
+
           <footer className="modal-card-foot buttons is-right">
             <Button
               isText
@@ -138,13 +270,25 @@ const UIDownloadAll = ({ workId }) => {
             >
               Cancel
             </Button>
-            <Button
-              isPrimary
-              onClick={handleSubmit}
-              data-testid="submit-button"
-            >
-              Start download job
-            </Button>
+
+            {downloadType === "images" ? (
+              <Button
+                isPrimary
+                onClick={handleSubmit}
+                data-testid="submit-button"
+              >
+                Start download job
+              </Button>
+            ) : (
+              <Button
+                isPrimary
+                onClick={handleDownloadTranscriptions}
+                data-testid="download-transcriptions-button"
+              >
+                <IconDownload />
+                <span>Download transcriptions</span>
+              </Button>
+            )}
           </footer>
         </div>
       </div>

--- a/app/assets/js/components/UI/Modal/DownloadAll.test.js
+++ b/app/assets/js/components/UI/Modal/DownloadAll.test.js
@@ -1,8 +1,9 @@
-import { screen, render } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
 import React from "react";
 import UIDownloadAll from "@js/components/UI/Modal/DownloadAll";
 import userEvent from "@testing-library/user-event";
 import { workArchiverEndpointMock } from "@js/components/Work/work.gql.mock";
+import { GET_WORK } from "@js/components/Work/work.gql";
 import { renderWithApollo } from "@js/services/testing-helpers";
 import useIsAuthorized from "@js/hooks/useIsAuthorized";
 import { mockUser } from "@js/components/Auth/auth.gql.mock";
@@ -12,10 +13,76 @@ useIsAuthorized.mockReturnValue({
   isAuthorized: () => true,
 });
 
-describe("UIDownloadAll component", () => {
+// Minimal GET_WORK mock — no transcriptions — for the images-only flow
+const getWorkNoTranscriptionsMock = {
+  request: { query: GET_WORK, variables: { id: "asdf" } },
+  result: {
+    data: {
+      work: {
+        id: "asdf",
+        accessionNumber: "WORK-ASDF",
+        fileSets: [],
+      },
+    },
+  },
+};
+
+// GET_WORK mock with two transcribed file sets
+const getWorkWithTranscriptionsMock = {
+  request: { query: GET_WORK, variables: { id: "work-789" } },
+  result: {
+    data: {
+      work: {
+        id: "work-789",
+        accessionNumber: "WORK-ACC-001",
+        fileSets: [
+          {
+            id: "fs-1",
+            accessionNumber: "FS-ACC-001",
+            annotations: [
+              {
+                type: "transcription",
+                status: "completed",
+                content: "Page one text.",
+              },
+            ],
+          },
+          {
+            id: "fs-2",
+            accessionNumber: "FS-ACC-002",
+            annotations: [
+              {
+                type: "transcription",
+                status: "completed",
+                content: "Page two text.",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
+};
+
+// Helper: spy on document.createElement to capture the <a> tag and mock .click()
+function spyOnCreateElement() {
+  const originalCreateElement = document.createElement.bind(document);
+  let capturedLink = null;
+  jest.spyOn(document, "createElement").mockImplementation((tag) => {
+    const el = originalCreateElement(tag);
+    if (tag === "a") {
+      capturedLink = el;
+      jest.spyOn(el, "click").mockImplementation(() => {});
+    }
+    return el;
+  });
+  return { getCapturedLink: () => capturedLink };
+}
+
+describe("UIDownloadAll component — images flow", () => {
   beforeEach(() => {
     renderWithApollo(<UIDownloadAll workId="asdf" />, {
-      mocks: [workArchiverEndpointMock],
+      mocks: [workArchiverEndpointMock, getWorkNoTranscriptionsMock],
     });
   });
 
@@ -51,5 +118,134 @@ describe("UIDownloadAll component", () => {
   it("renders the submit and cancel buttons", async () => {
     expect(await screen.findByTestId("cancel-button"));
     expect(await screen.findByTestId("submit-button"));
+  });
+
+  it("does not show the download-type choice when no transcriptions exist", async () => {
+    // Wait for work data to load
+    await screen.findByTestId("email");
+    expect(screen.queryByTestId("radio-download-type")).not.toBeInTheDocument();
+  });
+});
+
+describe("UIDownloadAll — transcription flow", () => {
+  beforeEach(() => {
+    window.URL.createObjectURL = jest.fn(() => "blob:mock-url");
+    window.URL.revokeObjectURL = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("shows the download-type choice when transcriptions exist", async () => {
+    renderWithApollo(<UIDownloadAll workId="work-789" />, {
+      mocks: [workArchiverEndpointMock, getWorkWithTranscriptionsMock],
+    });
+
+    expect(
+      await screen.findByTestId("radio-download-type"),
+    ).toBeInTheDocument();
+  });
+
+  it("defaults to images when transcriptions exist", async () => {
+    renderWithApollo(<UIDownloadAll workId="work-789" />, {
+      mocks: [workArchiverEndpointMock, getWorkWithTranscriptionsMock],
+    });
+
+    await screen.findByTestId("radio-download-type");
+
+    // Images radios and submit button visible by default
+    expect(screen.getByTestId("radio-image-size")).toBeInTheDocument();
+    expect(screen.getByTestId("submit-button")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("radio-transcription-format"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("download-transcriptions-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("switches to transcriptions view when transcriptions radio is selected", async () => {
+    renderWithApollo(<UIDownloadAll workId="work-789" />, {
+      mocks: [workArchiverEndpointMock, getWorkWithTranscriptionsMock],
+    });
+
+    await screen.findByTestId("radio-download-type");
+
+    const transcriptionsRadio = screen.getByDisplayValue("transcriptions");
+    fireEvent.click(transcriptionsRadio);
+
+    expect(
+      screen.getByTestId("radio-transcription-format"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("download-transcriptions-button"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("radio-image-size")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("submit-button")).not.toBeInTheDocument();
+  });
+
+  it("downloads a combined .txt when the default format is used", async () => {
+    const { getCapturedLink } = spyOnCreateElement();
+
+    renderWithApollo(<UIDownloadAll workId="work-789" />, {
+      mocks: [workArchiverEndpointMock, getWorkWithTranscriptionsMock],
+    });
+
+    await screen.findByTestId("radio-download-type");
+    fireEvent.click(screen.getByDisplayValue("transcriptions"));
+
+    const downloadButton = await screen.findByTestId(
+      "download-transcriptions-button",
+    );
+    fireEvent.click(downloadButton);
+
+    expect(window.URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    expect(getCapturedLink()).not.toBeNull();
+    expect(getCapturedLink().download).toBe("transcriptions-WORK-ACC-001.txt");
+    expect(window.URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+  });
+
+  it("downloads a .zip when the zip format is selected", async () => {
+    const { getCapturedLink } = spyOnCreateElement();
+
+    renderWithApollo(<UIDownloadAll workId="work-789" />, {
+      mocks: [workArchiverEndpointMock, getWorkWithTranscriptionsMock],
+    });
+
+    await screen.findByTestId("radio-download-type");
+    fireEvent.click(screen.getByDisplayValue("transcriptions"));
+
+    const zipRadio = await screen.findByDisplayValue("zip");
+    fireEvent.click(zipRadio);
+
+    fireEvent.click(screen.getByTestId("download-transcriptions-button"));
+
+    expect(getCapturedLink()).not.toBeNull();
+    expect(getCapturedLink().download).toBe("transcriptions-WORK-ACC-001.zip");
+  });
+
+  it("combined .txt content includes headers and both transcriptions", async () => {
+    let capturedBlob = null;
+    window.URL.createObjectURL = jest.fn((blob) => {
+      capturedBlob = blob;
+      return "blob:mock-url";
+    });
+    spyOnCreateElement();
+
+    renderWithApollo(<UIDownloadAll workId="work-789" />, {
+      mocks: [workArchiverEndpointMock, getWorkWithTranscriptionsMock],
+    });
+
+    await screen.findByTestId("radio-download-type");
+    fireEvent.click(screen.getByDisplayValue("transcriptions"));
+    fireEvent.click(screen.getByTestId("download-transcriptions-button"));
+
+    expect(capturedBlob).not.toBeNull();
+    const text = await capturedBlob.text();
+    expect(text).toContain("===== FS-ACC-001 =====");
+    expect(text).toContain("Page one text.");
+    expect(text).toContain("===== FS-ACC-002 =====");
+    expect(text).toContain("Page two text.");
   });
 });

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Modal.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Modal.jsx
@@ -6,13 +6,15 @@ import classNames from "classnames";
 import { useWorkDispatch, useWorkState } from "@js/context/work-context";
 import { IIIFContext } from "@js/components/IIIF/IIIFProvider";
 import { IIIF_SIZES } from "@js/services/global-vars";
-import { toastWrapper } from "@js/services/helpers";
-import { useMutation } from "@apollo/client/react";
+import { toastWrapper, downloadBlob } from "@js/services/helpers";
+import { useMutation, useQuery } from "@apollo/client/react";
 import {
   UPDATE_FILE_SET_ANNOTATION,
   DELETE_FILE_SET_ANNOTATION,
   UPSERT_FILE_SET_ANNOTATION,
 } from "@js/components/Work/Tabs/Structure/Transcription/transcription.gql";
+import { GET_WORK } from "@js/components/Work/work.gql";
+import { IconDownload } from "@js/components/Icon";
 import WorkTabsStructureTranscriptionWorkflow from "@js/components/Work/Tabs/Structure/Transcription/Workflow";
 
 function WorkTabsStructureTranscriptionModal({ isActive }) {
@@ -29,6 +31,14 @@ function WorkTabsStructureTranscriptionModal({ isActive }) {
   } = useWorkState();
 
   const iiifImageUrl = `${iiifServerUrl}${fileSetId}${IIIF_SIZES.IIIF_FULL}`;
+
+  const { data: { work } = {} } = useQuery(GET_WORK, {
+    variables: { id: workId },
+    skip: !workId,
+  });
+  const accessionNumber = work?.fileSets?.find(
+    (fs) => fs.id === fileSetId,
+  )?.accessionNumber;
 
   const [updateFileSetAnnotation] = useMutation(UPDATE_FILE_SET_ANNOTATION);
   const [upsertFileSetAnnotation] = useMutation(UPSERT_FILE_SET_ANNOTATION);
@@ -96,6 +106,16 @@ function WorkTabsStructureTranscriptionModal({ isActive }) {
     setConfirmDelete(true);
   };
 
+  const handleDownloadTranscription = () => {
+    const content = textArea?.value || "";
+    if (!content) {
+      toastWrapper("is-danger", "No transcription to download");
+      return;
+    }
+    const blob = new Blob([content], { type: "text/plain;charset=utf-8" });
+    downloadBlob(blob, `transcription-${accessionNumber || fileSetId}.txt`);
+  };
+
   const handleConfirmDelete = () => {
     const annotationId = textArea?.getAttribute("data-annotation-id");
 
@@ -103,6 +123,7 @@ function WorkTabsStructureTranscriptionModal({ isActive }) {
       variables: {
         annotationId: annotationId,
       },
+      refetchQueries: [{ query: GET_WORK, variables: { id: workId } }],
       onCompleted: () => {
         handleClose();
         toastWrapper("is-success", "Transcription successfully deleted");
@@ -187,11 +208,17 @@ function WorkTabsStructureTranscriptionModal({ isActive }) {
         </section>
 
         <footer className="modal-card-foot buttons is-justify-content-space-between">
-          {!confirmDelete && hasAnnotationId && (
-            <div>
-              <Button isDanger onClick={handleDeleteTranscription}>
-                Delete Transcription
+          {!confirmDelete && (hasAnnotationId || isDirty) && (
+            <div style={{ display: "flex", gap: "0.5rem" }}>
+              <Button onClick={handleDownloadTranscription}>
+                <IconDownload />
+                <span>Download Transcription</span>
               </Button>
+              {hasAnnotationId && (
+                <Button isDanger onClick={handleDeleteTranscription}>
+                  Delete Transcription
+                </Button>
+              )}
             </div>
           )}
           <div className="is-flex is-justify-content-flex-end is-flex-grow-1">

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Modal.test.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Modal.test.jsx
@@ -7,6 +7,7 @@ import {
   UPDATE_FILE_SET_ANNOTATION,
   DELETE_FILE_SET_ANNOTATION,
 } from "./transcription.gql";
+import { GET_WORK } from "@js/components/Work/work.gql";
 
 // --- Mocks ---
 
@@ -36,9 +37,10 @@ jest.mock("@js/context/work-context", () => ({
   useWorkState: jest.fn(),
 }));
 
-// toast wrapper
+// toast wrapper and download helper
 jest.mock("@js/services/helpers", () => ({
   toastWrapper: jest.fn(),
+  downloadBlob: jest.fn(),
 }));
 
 // Mock Workflow so it renders the textarea the modal is looking for,
@@ -283,6 +285,26 @@ describe("WorkTabsStructureTranscriptionModal", () => {
       type: "toggleTranscriptionModal",
       fileSetId: null,
     });
+  });
+
+  it("downloads transcription text when Download button is clicked", async () => {
+    // downloadBlob is mocked via jest.mock("@js/services/helpers", …) above.
+    // Assert it is called with a Blob and a filename derived from the file set.
+    // We don't provide a GET_WORK mock here so the accession number is unavailable
+    // and the filename falls back to the fileSetId ("fs-123").
+    const { downloadBlob } = await import("@js/services/helpers");
+
+    renderModal();
+
+    const downloadButton = await screen.findByRole("button", {
+      name: /download transcription/i,
+    });
+    fireEvent.click(downloadButton);
+
+    expect(downloadBlob).toHaveBeenCalledWith(
+      expect.any(Blob),
+      "transcription-fs-123.txt",
+    );
   });
 
   it("shows error toast when delete mutation fails", async () => {

--- a/app/assets/js/services/helpers.ts
+++ b/app/assets/js/services/helpers.ts
@@ -217,3 +217,14 @@ export function getFileNameFromS3Uri(s3Uri: string) {
   const segments = s3Uri.split("/");
   return segments[segments.length - 1];
 }
+
+export function downloadBlob(blob: Blob, filename: string) {
+  const url = window.URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  window.URL.revokeObjectURL(url);
+}

--- a/app/assets/package.json
+++ b/app/assets/package.json
@@ -45,6 +45,7 @@
     "downshift": "^9.3.6",
     "edtf": "^4.11.0",
     "faker": "^5.5.3",
+    "fflate": "^0.8.3",
     "file-saver": "^2.0.5",
     "graphql": "^17.0.1",
     "graphql-ws": "^6.0.8",


### PR DESCRIPTION
# Summary

Adds the ability to download transcriptions from the Work Structure tab - both individually (per file set) and all at once for a work. This is a fully client-side feature, separate from the existing archiver-based image download service.

# Specific Changes in this PR

- **Single transcription download** — added a "Download Transcription" button (with download icon) to the individual Transcription modal. Downloads the current textarea content as `transcription-<fileSetAccessionNumber>.txt`.
- **Bulk transcription download** — extended the existing "Download all" modal (Structure tab, IMAGE works only) with a two-step UI: users first choose whether they want to download **Images** or **Transcriptions**, then see the relevant options.
  - Transcription download supports two formats via a toggle: **Combined text file (.txt)** (default) or **Separate files (.zip)**
  - Combined file uses `===== <accessionNumber> =====` section headers to separate pages
  - ZIP file contains one `transcription-<accessionNumber>.txt` per file set
  - Filenames use the work/file set accession number; falls back to the ID if unavailable
- **Shared download helper** — extracted `downloadBlob(blob, filename)` utility into `js/services/helpers.ts` to deduplicate the Blob+anchor download pattern
- **Dependency** — added `fflate ^0.8.3` (8KB, zero deps, MIT) for ZIP generation

<img width="1381" height="640" alt="Screenshot 2026-06-30 at 9 44 35 AM" src="https://github.com/user-attachments/assets/b1de5e6d-009d-4ba3-a467-5c32a3cc24e2" />
<img width="683" height="389" alt="Screenshot 2026-06-30 at 10 03 56 AM" src="https://github.com/user-attachments/assets/24cf666a-19f1-490b-934a-3656d2d312e0" />



# Version bump required by the PR

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

**Single transcription download:**
1. Open a work with at least one transcription → Structure tab → click the transcription icon for a file set
2. In the Transcription modal, click **Download Transcription**
3. Confirm a `transcription-<accessionNumber>.txt` file downloads containing the transcription text

**Bulk transcription download:**
1. Open an IMAGE work with two or more transcribed file sets → Structure tab
2. Click **Download all** → confirm the modal now shows **"What would you like to download?"** with Images and Transcriptions options
3. Select **Transcriptions** → confirm the image width options disappear and format options appear
4. With **Combined text file (.txt)** selected, click **Download transcriptions** → confirm a single `.txt` file downloads containing all transcriptions separated by headers
5. Switch to **Separate files (.zip)** and download → confirm a `.zip` containing one file per transcription
6. Open the same modal on a work with *no* transcriptions → confirm the Images/Transcriptions choice is not shown and the modal behaves as before


# :rocket: Deployment Notes

No deployment steps required. This is a purely client-side change with no schema, API, or infrastructure impact.
