### PR TITLE
Fix broken thumbnails

### DIFF
--- a/app/assets/js/components/Collection/Collection.jsx
+++ b/app/assets/js/components/Collection/Collection.jsx
@@ -45,7 +45,7 @@ const Collection = ({ collection }) => {
               <Link to={`/work/${representativeWork.id}`} title="View work">
                 <img
                   className="hvr-shrink"
-                  src={`${representativeWork.representativeImage}/square/500,500/0/default.jpg`}
+                  src={`${representativeWork.representativeImage}/square/^500,500/0/default.jpg`}
                 />
               </Link>
             ) : (

--- a/app/assets/js/components/Collection/Image.jsx
+++ b/app/assets/js/components/Collection/Image.jsx
@@ -11,7 +11,7 @@ function CollectionImage({ collection, ...restProps }) {
       <img
         src={
           representativeWork
-            ? `${representativeWork.representativeImage}/square/500,500/0/default.jpg`
+            ? `${representativeWork.representativeImage}/square/^500,500/0/default.jpg`
             : "/images/placeholder.png"
         }
       />

--- a/app/assets/js/components/Plan/Plan.jsx
+++ b/app/assets/js/components/Plan/Plan.jsx
@@ -39,7 +39,7 @@ const Plan = ({ works }) => {
   // iterate works and get thumbnails
   const targetThumbnails = works.map((work) => {
     const thumbnail = new URL(work.representativeImage);
-    thumbnail.pathname += "/square/100,/0/default.jpg";
+    thumbnail.pathname += "/square/^100,/0/default.jpg";
     return thumbnail ? (
       <SquircleThumbnail
         key={work.id}

--- a/app/assets/js/components/Search/ResultItem.jsx
+++ b/app/assets/js/components/Search/ResultItem.jsx
@@ -24,7 +24,7 @@ const SearchResultItem = ({ res }) => {
           {file_sets.length > 0 && (
             <Link to={`/work/${_id}`}>
               <img
-                src={`${representative_file_set.url}/square/500,500/0/default.jpg`}
+                src={`${representative_file_set.url}/square/^500,500/0/default.jpg`}
                 alt="Placeholder image"
               />
             </Link>

--- a/app/assets/js/components/UI/PreviewItems.test.js
+++ b/app/assets/js/components/UI/PreviewItems.test.js
@@ -38,7 +38,7 @@ describe("Batch-edit preview items component", () => {
 
     // Renders correct image
     expect(imageEls[0].getAttribute("src")).toContain(
-      `${batchEditPreviewItems[0].representativeImage.url}/square/256,256/0/default.jpg`,
+      `${batchEditPreviewItems[0].representativeImage.url}/square/^256,256/0/default.jpg`,
     );
     expect(anchorEls[0].querySelector("svg")).toBeNull();
 

--- a/app/assets/js/components/UI/WorkImage.jsx
+++ b/app/assets/js/components/UI/WorkImage.jsx
@@ -5,7 +5,7 @@ import UIPlaceholder from "./Placeholder";
 function UIWorkImage({ imageUrl = "", size = 128, workTypeId }) {
   const figure = imageUrl ? (
     <img
-      src={`${imageUrl}/square/${size},${size}/0/default.jpg`}
+      src={`${imageUrl}/square/^${size},${size}/0/default.jpg`}
       data-testid="image-source"
     />
   ) : (

--- a/app/assets/js/components/UI/WorkImage.test.js
+++ b/app/assets/js/components/UI/WorkImage.test.js
@@ -18,7 +18,7 @@ describe("UIWorkImage component", () => {
     render(<UIWorkImage imageUrl={imageUrl} size={500} workType="Image" />);
     const imageEl = screen.getByTestId("image-source");
     expect(imageEl.getAttribute("src")).toContain(
-      `www.northwestern.edu/square/500,500/0/default.jpg`,
+      `www.northwestern.edu/square/^500,500/0/default.jpg`,
     );
     const figureEl = screen.getByTestId("work-image");
     expect(figureEl).toHaveClass(`is-square`);

--- a/app/assets/js/components/Work/Fileset/ActionButtons/GroupAdd.jsx
+++ b/app/assets/js/components/Work/Fileset/ActionButtons/GroupAdd.jsx
@@ -210,7 +210,7 @@ const WorkFilesetActionButtonsGroupAdd = ({
             >
               <figure>
                 <img
-                  src={`${iiifServerUrl}${candidate.id}/square/32,32/0/default.jpg`}
+                  src={`${iiifServerUrl}${candidate.id}/square/^32,32/0/default.jpg`}
                   placeholder="Fileset Image"
                   data-testid="fileset-image"
                 />

--- a/app/assets/js/components/Work/Fileset/ActionButtons/GroupAdd.test.jsx
+++ b/app/assets/js/components/Work/Fileset/ActionButtons/GroupAdd.test.jsx
@@ -77,7 +77,7 @@ describe("WorkFilesetActionButtonsGroupAdd component", () => {
     expect(filteredCandidate).toHaveTextContent("Voyager:2572813_FILE_0");
     expect(filteredCandidate.querySelector("img")).toHaveAttribute(
       "src",
-      "http://example.org/iiif/109b9a5c-3c6f-4a98-b98b-12402b871dc7/square/32,32/0/default.jpg",
+      "http://example.org/iiif/109b9a5c-3c6f-4a98-b98b-12402b871dc7/square/^32,32/0/default.jpg",
     );
 
     // click the candidate to add

--- a/app/assets/js/components/Work/Fileset/Draggable.jsx
+++ b/app/assets/js/components/Work/Fileset/Draggable.jsx
@@ -88,7 +88,7 @@ function WorkFilesetDraggable({
             <div css={content} className="is-flex">
               <figure css={figure}>
                 <img
-                  src={`${iiifServerUrl}${fileSet.id}/square/64,64/0/default.jpg`}
+                  src={`${iiifServerUrl}${fileSet.id}/square/^64,64/0/default.jpg`}
                   placeholder="Fileset Image"
                   data-testid="fileset-image"
                 />

--- a/app/assets/js/components/Work/Fileset/ListItem.jsx
+++ b/app/assets/js/components/Work/Fileset/ListItem.jsx
@@ -35,7 +35,7 @@ function WorkFilesetListItem({
     errored: false, // This prevents a potential infinite loop
     src: `${fileSet.representativeImageUrl}/${
       isMedia(fileSet) ? "full" : "square"
-    }/100,/0/default.jpg`,
+    }/^100,/0/default.jpg`,
   });
 
   const figure = css`

--- a/app/assets/js/components/Work/Tabs/Preservation/TransferFileSetsModal.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/TransferFileSetsModal.jsx
@@ -287,7 +287,7 @@ function WorkTabsPreservationTransferFileSetsModal({
                         {fs.representativeImageUrl && (
                           <figure css={previewFigure}>
                             <img
-                              src={`${fs.representativeImageUrl}/square/60,/0/default.jpg`}
+                              src={`${fs.representativeImageUrl}/square/^60,/0/default.jpg`}
                               alt={
                                 fs.coreMetadata?.originalFilename || "Fileset"
                               }

--- a/app/assets/js/services/global-vars.js
+++ b/app/assets/js/services/global-vars.js
@@ -29,7 +29,7 @@ export const REACTIVESEARCH_SORT_OPTIONS = [
 ];
 
 export const IIIF_SIZES = {
-  IIIF_SQUARE: "/square/500,500/0/default.jpg",
+  IIIF_SQUARE: "/square/^500,500/0/default.jpg",
   IIIF_FULL: "/full/max/0/default.jpg",
   IIIF_FULL_TIFF: "/full/max/0/default.tif",
 };


### PR DESCRIPTION
# Summary

Fixes broken search result thumbnails caused by IIIF Image API v3's upscaling restriction. The IIIF image server was upgraded to v3, which requires an explicit `^` opt-in before it will enlarge an image beyond its source dimensions. Fixed-size thumbnail requests (e.g. `/square/500,500/...`) without that flag now return a "Requested size requires upscaling" error instead of an image whenever a work's source image is smaller than the requested size, which renders as a broken `<img>` in the UI.

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5828

# Specific Changes in this PR
- Added the IIIF v3 `^` upscaling prefix to every fixed-size thumbnail URL built in the frontend, so the server enlarges small source images instead of erroring:
  - `app/assets/js/components/UI/WorkImage.jsx` — search result card/list thumbnails (the reported bug)
  - `app/assets/js/components/Search/ResultItem.jsx`
  - `app/assets/js/services/global-vars.js` (`IIIF_SIZES.IIIF_SQUARE` constant)
  - `app/assets/js/components/Collection/Collection.jsx`, `app/assets/js/components/Collection/Image.jsx`
  - `app/assets/js/components/Work/Fileset/Draggable.jsx`, `app/assets/js/components/Work/Fileset/ListItem.jsx`
  - `app/assets/js/components/Work/Fileset/ActionButtons/GroupAdd.jsx`
  - `app/assets/js/components/Work/Tabs/Preservation/TransferFileSetsModal.jsx`
  - `app/assets/js/components/Plan/Plan.jsx`
- Updated the two tests asserting these URL strings: `WorkImage.test.js`, `GroupAdd.test.jsx`

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- Confirm search results and other thumbnails are not broken
- Confirm the IIIF request does not fail with the "Requested size requires upscaling" error. (This was easy to see on the AV placeholder image, for example)

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks




