### PR TITLE
Preserve file set order during work transfer

### DIFF
--- a/app/lib/meadow/data/works/transfer_file_sets.ex
+++ b/app/lib/meadow/data/works/transfer_file_sets.ex
@@ -384,10 +384,22 @@ defmodule Meadow.Data.Works.TransferFileSets do
 
     with {:ok, :valid} <- validate_filesets_exist(filesets, fileset_ids),
          {:ok, transferred_ids} <-
-           perform_fileset_transfer(filesets, target_work_id, max_rank_in_target_work) do
+           filesets
+           |> order_filesets_by_rank(fileset_ids)
+           |> perform_fileset_transfer(target_work_id, max_rank_in_target_work) do
       Logger.info("Transferred #{Enum.count(transferred_ids)} file sets to work #{target_work_id}")
       {:ok, transferred_ids}
     end
+  end
+
+  defp order_filesets_by_rank(filesets, fileset_ids) do
+    selected_ids = MapSet.new(fileset_ids)
+
+    filesets
+    |> Enum.map(& &1.work_id)
+    |> Enum.uniq()
+    |> Enum.flat_map(&Data.ranked_file_sets_for_work/1)
+    |> Enum.filter(&MapSet.member?(selected_ids, &1.id))
   end
 
   defp validate_filesets_exist(filesets, fileset_ids) do

--- a/app/test/meadow/data/works/transfer_file_sets_test.exs
+++ b/app/test/meadow/data/works/transfer_file_sets_test.exs
@@ -6,6 +6,7 @@ defmodule Meadow.Data.Works.TransferFileSetsTest do
 
   import ExUnit.CaptureLog
 
+  alias Meadow.Data
   alias Meadow.Data.Schemas.Work
   alias Meadow.Data.Works
   alias Meadow.Data.Works.TransferFileSets
@@ -223,6 +224,89 @@ defmodule Meadow.Data.Works.TransferFileSetsTest do
 
       assert {:error, "Accession number is required when transferring to existing work"} =
                TransferFileSets.transfer_subset(args)
+    end
+
+    test "ignores the order of the fileset_ids argument and preserves the source rank order, appended after the target work's existing filesets" do
+      source_work =
+        work_with_file_sets_fixture(4, %{work_type: %{id: "IMAGE", scheme: "work_type"}}, %{
+          role: %{id: "P", scheme: "FILE_SET_ROLE"}
+        })
+
+      target_work =
+        work_with_file_sets_fixture(2, %{work_type: %{id: "IMAGE", scheme: "work_type"}}, %{
+          role: %{id: "P", scheme: "FILE_SET_ROLE"}
+        })
+
+      target_fileset_ids_before = Enum.map(target_work.file_sets, & &1.id) |> Enum.sort()
+
+      source_ids_in_rank_order =
+        Data.ranked_file_sets_for_work(source_work.id, "P") |> Enum.map(& &1.id)
+
+      # Request the transfer with the fileset_ids deliberately scrambled —
+      # this must have no bearing on the final order.
+      shuffled_ids = Enum.reverse(source_ids_in_rank_order)
+
+      args = %{
+        fileset_ids: shuffled_ids,
+        create_work: false,
+        accession_number: target_work.accession_number
+      }
+
+      assert {:ok, %{transferred_fileset_ids: transferred_ids}} =
+               TransferFileSets.transfer_subset(args)
+
+      assert length(transferred_ids) == 4
+
+      updated_target_file_sets =
+        Data.ranked_file_sets_for_work(target_work.id, "P")
+
+      # The target work's pre-existing filesets keep their original relative
+      # order and rank ahead of the transferred ones.
+      {existing, transferred} =
+        Enum.split_with(updated_target_file_sets, &(&1.id in target_fileset_ids_before))
+
+      assert Enum.map(existing, & &1.id) |> Enum.sort() == target_fileset_ids_before
+
+      # The transferred filesets land in the source work's true rank order,
+      # not the (shuffled) fileset_ids argument order.
+      assert Enum.map(transferred, & &1.id) == source_ids_in_rank_order
+    end
+
+    test "preserves a manually reordered rank when transferring to a newly created work" do
+      source_work =
+        work_with_file_sets_fixture(4, %{work_type: %{id: "IMAGE", scheme: "work_type"}}, %{
+          role: %{id: "P", scheme: "FILE_SET_ROLE"}
+        })
+
+      insertion_order_ids = Enum.map(source_work.file_sets, & &1.id)
+
+      # Simulate a user manually dragging the filesets into a custom order
+      # (e.g. via the reorder UI) before transferring them. This order no
+      # longer matches insertion order.
+      custom_order_ids = Enum.reverse(insertion_order_ids)
+      assert {:ok, _result} = Works.update_file_set_order(source_work.id, "P", custom_order_ids)
+
+      # Request the transfer with yet another (insertion-order) argument —
+      # this must not override the file sets' actual rank.
+      args = %{
+        fileset_ids: insertion_order_ids,
+        create_work: true,
+        work_attributes: %{
+          accession_number: "REORDERED_TRANSFER_WORK",
+          work_type: "IMAGE",
+          descriptive_metadata: %{title: "Reordered Transfer Work"}
+        }
+      }
+
+      assert {:ok, %{transferred_fileset_ids: transferred_ids, created_work_id: work_id}} =
+               TransferFileSets.transfer_subset(args)
+
+      assert length(transferred_ids) == 4
+
+      new_work_ids_in_rank_order =
+        Data.ranked_file_sets_for_work(work_id, "P") |> Enum.map(& &1.id)
+
+      assert new_work_ids_in_rank_order == custom_order_ids
     end
 
     test "fails when filesets do not exist" do


### PR DESCRIPTION

# Summary
Users report that transferring a subset of file sets to another work (existing or newly created) scrambles their order. This fixes `Meadow.Data.Works.TransferFileSets` to preserve the file sets' actual saved order (rank) across the transfer, so a manually reordered Access/Auxiliary sequence survives moving to a new or existing work.

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5829


# Specific Changes in this PR
- `transfer_fileset_subset/2` now re-derives file set order from the persisted `rank` field (grouped by role: Access/Preservation/Supplemental/Auxiliary), instead of relying on unordered `Repo.all()` results or the order file set IDs happened to be passed in.
- Added tests verifying order is preserved regardless of the order of the `fileset_ids` argument, and that a manually reordered set of file sets keeps that order when transferred into a newly created work.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch


# Steps to Test

Reorder a work's Access (or Auxiliary) file sets via the Structure tab drag-and-drop, then use "Transfer File Sets" on the Preservation tab to move a subset of them to a new work (and separately, to an existing work). Confirm the destination work's Structure tab shows the file sets in the same order they had in the source work.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- no special deployment steps needed



