### PR TITLE
Evals add delete button, image thumbnail and ability to create run with accession

### DIFF
--- a/app/assets/js/components/Dashboards/Evals/StartRunModal.jsx
+++ b/app/assets/js/components/Dashboards/Evals/StartRunModal.jsx
@@ -135,7 +135,9 @@ export default function StartRunModal({ onClose, onStarted }) {
                 <select value={mode} onChange={(e) => setMode(e.target.value)}>
                   <option value="existing">Use existing set</option>
                   <option value="new">Create new set from query</option>
-                  <option value="ids">Paste work IDs</option>
+                  <option value="ids">
+                    Paste work IDs or accession numbers
+                  </option>
                 </select>
               </div>
             </div>
@@ -202,7 +204,9 @@ export default function StartRunModal({ onClose, onStarted }) {
                   <textarea
                     className={`textarea is-family-monospace is-size-7${tooManyIds ? " is-danger" : ""}`}
                     rows={6}
-                    placeholder={"One work ID per line — up to 20"}
+                    placeholder={
+                      "One work ID or accession number per line — up to 20"
+                    }
                     value={workIdsText}
                     onChange={(e) => setWorkIdsText(e.target.value)}
                   />

--- a/app/assets/js/components/Dashboards/Evals/TrialComparison.jsx
+++ b/app/assets/js/components/Dashboards/Evals/TrialComparison.jsx
@@ -1,7 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
+import CloverImage from "@samvera/clover-iiif/image";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faScaleBalanced } from "@fortawesome/free-solid-svg-icons";
+import { IIIF_SIZES } from "@js/services/global-vars";
 
 function SubjectList({ subjects }) {
   if (!subjects || subjects.length === 0) {
@@ -71,6 +73,7 @@ export default function TrialComparison({
   groundTruth,
   agentOutput,
   judgeRationale,
+  imageUrl,
 }) {
   const gt = groundTruth || {};
   const ai = agentOutput || {};
@@ -78,6 +81,31 @@ export default function TrialComparison({
   return (
     <div style={{ padding: "1rem 0" }}>
       <div className="columns">
+        <div className="column">
+          <div
+            className="box"
+            style={{
+              height: "320px",
+              padding: 0,
+              position: "relative",
+              zIndex: 0,
+            }}
+          >
+            {imageUrl ? (
+              <CloverImage
+                src={`${imageUrl}${IIIF_SIZES.IIIF_FULL}`}
+                openSeadragonConfig={{ showNavigator: false }}
+              />
+            ) : (
+              <p
+                className="has-text-grey is-size-7"
+                style={{ padding: "1rem" }}
+              >
+                No image available
+              </p>
+            )}
+          </div>
+        </div>
         <div className="column">
           <div className="box" style={{ height: "100%" }}>
             <p className="heading has-text-grey">Ground Truth</p>
@@ -130,4 +158,5 @@ TrialComparison.propTypes = {
     ),
   }),
   judgeRationale: PropTypes.string,
+  imageUrl: PropTypes.string,
 };

--- a/app/assets/js/components/Dashboards/Evals/evals.gql.ts
+++ b/app/assets/js/components/Dashboards/Evals/evals.gql.ts
@@ -110,6 +110,7 @@ export const GET_EVAL_RUN = gql`
           workId
           accessionNumber
           groundTruth
+          representativeImageUrl
         }
       }
       promptVersion {
@@ -292,6 +293,14 @@ export const CANCEL_EVAL_RUN = gql`
     cancelEvalRun(id: $id) {
       id
       status
+    }
+  }
+`;
+
+export const DELETE_EVAL_RUN = gql`
+  mutation DeleteEvalRun($id: ID!) {
+    deleteEvalRun(id: $id) {
+      id
     }
   }
 `;

--- a/app/assets/js/screens/Dashboards/Evals/Details.jsx
+++ b/app/assets/js/screens/Dashboards/Evals/Details.jsx
@@ -1,13 +1,16 @@
 import React, { useState } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams, Link, useHistory } from "react-router-dom";
 import { useQuery, useMutation } from "@apollo/client";
 import Layout from "@js/screens/Layout";
 import { Breadcrumbs } from "@js/components/UI/UI";
+import AuthDisplayAuthorized from "@js/components/Auth/DisplayAuthorized";
+import UIModalDelete from "@js/components/UI/Modal/Delete";
 import ScoreButtons from "@js/components/Dashboards/Evals/ScoreButtons";
 import TrialComparison from "@js/components/Dashboards/Evals/TrialComparison";
 import {
   GET_EVAL_RUN,
   CANCEL_EVAL_RUN,
+  DELETE_EVAL_RUN,
 } from "@js/components/Dashboards/Evals/evals.gql";
 
 const STATUS_COLORS = {
@@ -18,6 +21,8 @@ const STATUS_COLORS = {
   CANCELLED: "is-light",
   SKIPPED: "is-light",
 };
+
+const DELETABLE_STATUSES = ["COMPLETE", "ERRORED", "CANCELLED"];
 
 function percent(n) {
   if (n == null) return "—";
@@ -38,8 +43,10 @@ function enumLabel(value) {
 
 export default function EvalsDetailsScreen() {
   const { id } = useParams();
+  const history = useHistory();
   const [expandedTrialId, setExpandedTrialId] = useState(null);
   const [showPrompt, setShowPrompt] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   const { data, loading } = useQuery(GET_EVAL_RUN, {
     variables: { id },
@@ -49,6 +56,13 @@ export default function EvalsDetailsScreen() {
   const [cancelRun, { loading: cancelling }] = useMutation(CANCEL_EVAL_RUN, {
     refetchQueries: [{ query: GET_EVAL_RUN, variables: { id } }],
   });
+
+  const [deleteRun] = useMutation(DELETE_EVAL_RUN);
+
+  const handleDeleteConfirm = async () => {
+    await deleteRun({ variables: { id } });
+    history.push("/dashboards/evals");
+  };
 
   const run = data?.evalRun;
   const s = run?.summary || {};
@@ -142,6 +156,16 @@ export default function EvalsDetailsScreen() {
                 <button className="button is-light" onClick={handleDownloadCsv}>
                   Download CSV
                 </button>
+                {DELETABLE_STATUSES.includes(runStatus) && (
+                  <AuthDisplayAuthorized level="EDITOR">
+                    <button
+                      className="button is-danger is-outlined"
+                      onClick={() => setShowDeleteModal(true)}
+                    >
+                      Delete Run
+                    </button>
+                  </AuthDisplayAuthorized>
+                )}
               </div>
             </div>
           </div>
@@ -241,6 +265,7 @@ export default function EvalsDetailsScreen() {
               <thead>
                 <tr>
                   <th style={{ width: "1.5rem" }}></th>
+                  <th style={{ width: "5.5rem" }}></th>
                   <th>Work / Accession</th>
                   <th>#</th>
                   <th>Status</th>
@@ -260,10 +285,30 @@ export default function EvalsDetailsScreen() {
                   return (
                     <React.Fragment key={trial.id}>
                       <tr style={{ cursor: "pointer" }} onClick={toggleExpand}>
-                        <td style={{ verticalAlign: "middle" }}>
+                        <td style={{ verticalAlign: "top" }}>
                           <span style={{ fontSize: "0.75rem" }}>
                             {isExpanded ? "▾" : "▸"}
                           </span>
+                        </td>
+                        <td style={{ verticalAlign: "top" }}>
+                          {member.representativeImageUrl ? (
+                            <img
+                              src={`${member.representativeImageUrl}/square/^80,80/0/default.jpg`}
+                              alt=""
+                              style={{ borderRadius: "4px" }}
+                              width={80}
+                              height={80}
+                            />
+                          ) : (
+                            <div
+                              className="has-background-light"
+                              style={{
+                                width: 80,
+                                height: 80,
+                                borderRadius: "4px",
+                              }}
+                            />
+                          )}
                         </td>
                         <td>
                           <div>
@@ -297,7 +342,7 @@ export default function EvalsDetailsScreen() {
                       {isExpanded && (
                         <tr>
                           <td
-                            colSpan={8}
+                            colSpan={9}
                             style={{ background: "#fafafa", borderTop: "none" }}
                           >
                             {trialStatus === "COMPLETE" ? (
@@ -305,6 +350,7 @@ export default function EvalsDetailsScreen() {
                                 groundTruth={member.groundTruth}
                                 agentOutput={trial.agentOutput}
                                 judgeRationale={trial.judgeRationale}
+                                imageUrl={member.representativeImageUrl}
                               />
                             ) : (
                               <p
@@ -325,6 +371,13 @@ export default function EvalsDetailsScreen() {
           </div>
         </div>
       </section>
+
+      <UIModalDelete
+        isOpen={showDeleteModal}
+        handleClose={() => setShowDeleteModal(false)}
+        handleConfirm={handleDeleteConfirm}
+        thingToDeleteLabel={run.name || run.evalSet?.name || "this eval run"}
+      />
     </Layout>
   );
 }

--- a/app/assets/js/screens/Dashboards/Evals/List.jsx
+++ b/app/assets/js/screens/Dashboards/Evals/List.jsx
@@ -1,11 +1,15 @@
 import React, { useState } from "react";
 import { Link, useHistory } from "react-router-dom";
-import { useQuery } from "@apollo/client";
+import { useQuery, useMutation } from "@apollo/client";
 import Layout from "@js/screens/Layout";
 import { Breadcrumbs } from "@js/components/UI/UI";
 import AuthDisplayAuthorized from "@js/components/Auth/DisplayAuthorized";
+import UIModalDelete from "@js/components/UI/Modal/Delete";
 import StartRunModal from "@js/components/Dashboards/Evals/StartRunModal";
-import { GET_EVAL_RUNS } from "@js/components/Dashboards/Evals/evals.gql";
+import {
+  GET_EVAL_RUNS,
+  DELETE_EVAL_RUN,
+} from "@js/components/Dashboards/Evals/evals.gql";
 
 const STATUS_COLORS = {
   PENDING: "is-warning",
@@ -14,6 +18,8 @@ const STATUS_COLORS = {
   ERRORED: "is-danger",
   CANCELLED: "is-light",
 };
+
+const DELETABLE_STATUSES = ["COMPLETE", "ERRORED", "CANCELLED"];
 
 function enumKey(value) {
   return value?.toString().toUpperCase();
@@ -26,9 +32,16 @@ function enumLabel(value) {
 export default function EvalsListScreen() {
   const history = useHistory();
   const [showModal, setShowModal] = useState(false);
+  const [runToDelete, setRunToDelete] = useState(null);
   const { data, loading } = useQuery(GET_EVAL_RUNS, {
     variables: { limit: 50, offset: 0 },
     pollInterval: 5000,
+  });
+
+  const [deleteRun] = useMutation(DELETE_EVAL_RUN, {
+    refetchQueries: [
+      { query: GET_EVAL_RUNS, variables: { limit: 50, offset: 0 } },
+    ],
   });
 
   const runs = data?.evalRuns || [];
@@ -36,6 +49,11 @@ export default function EvalsListScreen() {
   const handleStarted = (runId) => {
     setShowModal(false);
     history.push(`/dashboards/evals/runs/${runId}`);
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (runToDelete) await deleteRun({ variables: { id: runToDelete.id } });
+    setRunToDelete(null);
   };
 
   return (
@@ -165,12 +183,24 @@ export default function EvalsListScreen() {
                             : "—"}
                         </td>
                         <td>
-                          <Link
-                            to={`/dashboards/evals/runs/${run.id}`}
-                            className="button is-small is-light"
-                          >
-                            View
-                          </Link>
+                          <div className="buttons are-small">
+                            <Link
+                              to={`/dashboards/evals/runs/${run.id}`}
+                              className="button is-small is-light"
+                            >
+                              View
+                            </Link>
+                            {DELETABLE_STATUSES.includes(status) && (
+                              <AuthDisplayAuthorized level="EDITOR">
+                                <button
+                                  className="button is-small is-danger is-light"
+                                  onClick={() => setRunToDelete(run)}
+                                >
+                                  Delete
+                                </button>
+                              </AuthDisplayAuthorized>
+                            )}
+                          </div>
                         </td>
                       </tr>
                     );
@@ -188,6 +218,15 @@ export default function EvalsListScreen() {
           onStarted={handleStarted}
         />
       )}
+
+      <UIModalDelete
+        isOpen={!!runToDelete}
+        handleClose={() => setRunToDelete(null)}
+        handleConfirm={handleDeleteConfirm}
+        thingToDeleteLabel={
+          runToDelete?.name || runToDelete?.evalSet?.name || "this eval run"
+        }
+      />
     </Layout>
   );
 }

--- a/app/lib/meadow/evals.ex
+++ b/app/lib/meadow/evals.ex
@@ -219,10 +219,29 @@ defmodule Meadow.Evals do
   Works with no description AND fewer than 3 subjects are skipped.
   Returns {:ok, eval_set, skipped_count} or {:error, reason}.
   """
-  def create_eval_set_from_work_ids(work_ids, attrs) when is_list(work_ids) do
+  def create_eval_set_from_work_ids(identifiers, attrs) when is_list(identifiers) do
+    work_ids = resolve_identifiers(identifiers)
     query_json = %{"query" => %{"ids" => %{"values" => work_ids}}}
     transient = %EvalQuery{id: nil, query_json: query_json}
     create_eval_set_from_query(transient, attrs)
+  end
+
+  @doc """
+  Resolve a mixed list of work UUIDs and/or accession numbers to work UUIDs.
+
+  Each identifier is auto-detected: a valid UUID is used as-is, anything else
+  is looked up by accession_number. Identifiers that don't resolve to a work
+  are silently dropped (consistent with how an unknown work UUID already
+  drops out downstream in build_member_attrs/1).
+  """
+  def resolve_identifiers(identifiers) do
+    {uuids, accessions} =
+      Enum.split_with(identifiers, fn id -> match?({:ok, _}, Ecto.UUID.cast(id)) end)
+
+    accession_work_ids =
+      Repo.all(from(w in Work, where: w.accession_number in ^accessions, select: w.id))
+
+    (uuids ++ accession_work_ids) |> Enum.uniq()
   end
 
   def create_eval_set_from_query(%EvalQuery{} = eval_query, attrs) do
@@ -432,6 +451,13 @@ defmodule Meadow.Evals do
     from(t in EvalTrial, where: t.eval_run_id == ^run_id and t.status in [:pending, :running])
     |> Repo.update_all(set: [status: :skipped, updated_at: DateTime.utc_now()])
   end
+
+  @doc """
+  Delete an eval run. Trials and their scores cascade via FK (on_delete: :delete_all).
+  Callers are responsible for guarding against deleting pending/running runs.
+  """
+  def delete_run(%EvalRun{} = run), do: Repo.delete(run)
+  def delete_run(id) when is_binary(id), do: get_run!(id) |> delete_run()
 
   # ---------------------------------------------------------------------------
   # Eval Trials

--- a/app/lib/meadow_web/resolvers/evals.ex
+++ b/app/lib/meadow_web/resolvers/evals.ex
@@ -1,6 +1,7 @@
 defmodule MeadowWeb.Resolvers.Evals do
   @moduledoc "Absinthe resolvers for the evals feature."
 
+  alias Meadow.Data.FileSets
   alias Meadow.Evals
   alias Meadow.Evals.Runner
 
@@ -81,6 +82,25 @@ defmodule MeadowWeb.Resolvers.Evals do
     end
   end
 
+  def eval_set_member_representative_image_url(
+        %{representative_file_set_id: nil},
+        _args,
+        _info
+      ) do
+    {:ok, nil}
+  end
+
+  def eval_set_member_representative_image_url(
+        %{representative_file_set_id: file_set_id},
+        _args,
+        _info
+      ) do
+    case FileSets.get_file_set(file_set_id) do
+      nil -> {:ok, nil}
+      file_set -> {:ok, FileSets.representative_image_url_for(file_set)}
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # Run resolvers
   # ---------------------------------------------------------------------------
@@ -117,6 +137,25 @@ defmodule MeadowWeb.Resolvers.Evals do
     case Evals.cancel_run(id) do
       {:ok, run} -> {:ok, run}
       {:error, reason} -> {:error, inspect(reason)}
+    end
+  end
+
+  @undeletable_run_statuses [:pending, :running]
+
+  def delete_run(_root, %{id: id}, _info) do
+    Evals.get_run!(id) |> delete_guarded_run()
+  rescue
+    Ecto.NoResultsError -> {:error, "Eval run not found"}
+  end
+
+  defp delete_guarded_run(%{status: status}) when status in @undeletable_run_statuses do
+    {:error, "Can't delete eval run with status: #{status}"}
+  end
+
+  defp delete_guarded_run(run) do
+    case Evals.delete_run(run) do
+      {:ok, run} -> {:ok, run}
+      {:error, changeset} -> {:error, format_errors(changeset)}
     end
   end
 

--- a/app/lib/meadow_web/schema/types/eval_types.ex
+++ b/app/lib/meadow_web/schema/types/eval_types.ex
@@ -76,6 +76,10 @@ defmodule MeadowWeb.Schema.EvalTypes do
     field(:accession_number, :string)
     field(:representative_file_set_id, :id)
     field(:ground_truth, :json)
+
+    field :representative_image_url, :string do
+      resolve(&Evals.eval_set_member_representative_image_url/3)
+    end
   end
 
   object :eval_set do
@@ -315,6 +319,14 @@ defmodule MeadowWeb.Schema.EvalTypes do
       middleware(Middleware.Authenticate)
       middleware(Middleware.Authorize, "Editor")
       resolve(&Evals.cancel_run/3)
+    end
+
+    @desc "Delete an eval run (only when not pending/running)"
+    field :delete_eval_run, :eval_run do
+      arg(:id, non_null(:id))
+      middleware(Middleware.Authenticate)
+      middleware(Middleware.Authorize, "Editor")
+      resolve(&Evals.delete_run/3)
     end
 
     @desc "Set manual score for an eval trial"

--- a/app/mix.exs
+++ b/app/mix.exs
@@ -1,7 +1,7 @@
 defmodule Meadow.MixProject do
   use Mix.Project
 
-  @app_version "10.5.4"
+  @app_version "10.6.0"
 
   def project do
     [

--- a/app/test/meadow/evals_test.exs
+++ b/app/test/meadow/evals_test.exs
@@ -1,0 +1,153 @@
+defmodule Meadow.EvalsTest do
+  use Meadow.DataCase
+
+  alias Meadow.Evals
+  alias Meadow.Evals.Schemas.{EvalRun, EvalSet, EvalSetMember, EvalTrial, EvalTrialScore}
+  alias Meadow.Repo
+
+  import Meadow.TestHelpers
+
+  describe "resolve_identifiers/1" do
+    test "resolves work UUIDs as-is" do
+      work_id = Ecto.UUID.generate()
+      assert Evals.resolve_identifiers([work_id]) == [work_id]
+    end
+
+    test "resolves accession numbers to work ids" do
+      work = work_fixture(%{accession_number: "TEST.ACC.001"})
+      assert Evals.resolve_identifiers(["TEST.ACC.001"]) == [work.id]
+    end
+
+    test "resolves a mix of work UUIDs and accession numbers, dropping unknowns" do
+      work = work_fixture(%{accession_number: "TEST.ACC.002"})
+      other_work_id = Ecto.UUID.generate()
+
+      result =
+        Evals.resolve_identifiers([
+          other_work_id,
+          "TEST.ACC.002",
+          "no-such-accession"
+        ])
+
+      assert Enum.sort(result) == Enum.sort([other_work_id, work.id])
+    end
+
+    test "deduplicates resolved ids" do
+      work = work_fixture(%{accession_number: "TEST.ACC.003"})
+      assert Evals.resolve_identifiers([work.id, "TEST.ACC.003"]) == [work.id]
+    end
+  end
+
+  describe "delete_run/1" do
+    test "deletes a run and cascades trials and scores" do
+      {run, trials} = setup_run_with_trial()
+      [trial] = trials
+
+      {:ok, _score} =
+        %EvalTrialScore{}
+        |> EvalTrialScore.changeset(%{
+          eval_trial_id: trial.id,
+          scored_by: "test@example.com",
+          score: :good
+        })
+        |> Repo.insert()
+
+      assert {:ok, _} = Evals.delete_run(run.id)
+
+      assert Repo.get(EvalRun, run.id) == nil
+      assert Repo.get(EvalTrial, trial.id) == nil
+      assert Repo.all(from(s in EvalTrialScore, where: s.eval_trial_id == ^trial.id)) == []
+    end
+  end
+
+  describe "MeadowWeb.Resolvers.Evals.delete_run/3" do
+    alias MeadowWeb.Resolvers.Evals, as: EvalsResolver
+
+    test "refuses to delete a pending run" do
+      {run, _trials} = setup_run_with_trial()
+      assert {:error, message} = EvalsResolver.delete_run(nil, %{id: run.id}, %{})
+      assert message =~ "pending"
+      assert Repo.get(EvalRun, run.id)
+    end
+
+    test "refuses to delete a running run" do
+      {run, _trials} = setup_run_with_trial()
+      {:ok, run} = run |> EvalRun.mark_running() |> Repo.update()
+
+      assert {:error, message} = EvalsResolver.delete_run(nil, %{id: run.id}, %{})
+      assert message =~ "running"
+      assert Repo.get(EvalRun, run.id)
+    end
+
+    test "allows deleting a complete run" do
+      {run, _trials} = setup_run_with_trial()
+      {:ok, run} = run |> EvalRun.mark_complete() |> Repo.update()
+
+      assert {:ok, deleted} = EvalsResolver.delete_run(nil, %{id: run.id}, %{})
+      assert deleted.id == run.id
+      assert Repo.get(EvalRun, run.id) == nil
+    end
+
+    test "allows deleting an errored run" do
+      {run, _trials} = setup_run_with_trial()
+      {:ok, run} = run |> EvalRun.mark_errored("boom") |> Repo.update()
+
+      assert {:ok, deleted} = EvalsResolver.delete_run(nil, %{id: run.id}, %{})
+      assert deleted.id == run.id
+      assert Repo.get(EvalRun, run.id) == nil
+    end
+
+    test "allows deleting a cancelled run" do
+      {run, _trials} = setup_run_with_trial()
+      {:ok, run} = run |> EvalRun.mark_cancelled() |> Repo.update()
+
+      assert {:ok, deleted} = EvalsResolver.delete_run(nil, %{id: run.id}, %{})
+      assert deleted.id == run.id
+      assert Repo.get(EvalRun, run.id) == nil
+    end
+  end
+
+  defp setup_run_with_trial do
+    {:ok, eval_query} =
+      Evals.create_eval_query(%{
+        name: "test-query-#{System.unique_integer()}",
+        query_json: %{"query" => %{"match_all" => %{}}},
+        author: "test"
+      })
+
+    {:ok, prompt_version} =
+      Evals.create_prompt_version(%{
+        name: "test-prompt-#{System.unique_integer()}",
+        system_prompt: "You are a test agent.",
+        user_prompt_template: "Analyze work {work_id}, trial {trial_id}.",
+        author: "test"
+      })
+
+    work_id = Ecto.UUID.generate()
+
+    eval_set =
+      Repo.insert!(%EvalSet{
+        name: "test-set-#{System.unique_integer()}",
+        query_id: eval_query.id,
+        work_count: 1
+      })
+
+    Repo.insert!(%EvalSetMember{
+      eval_set_id: eval_set.id,
+      work_id: work_id,
+      accession_number: "TEST.001",
+      ground_truth: %{description: ["test description"], subjects: [%{id: "http://id.worldcat.org/fast/1"}]}
+    })
+
+    {:ok, run} =
+      Evals.create_run(%{
+        eval_set_id: eval_set.id,
+        prompt_version_id: prompt_version.id,
+        trials_per_work: 1,
+        author: "test"
+      })
+
+    trials = Evals.list_trials_for_run(run.id)
+    {run, trials}
+  end
+end


### PR DESCRIPTION
# Summary
Three enhancements to the AI Metadata Eval dashboard: the ability to delete settled eval runs, support for pasting accession numbers (not just work UUIDs) when building an eval set, and thumbnail/zoomable image views so reviewers can compare AI output against the source image.

# Specific Changes in this PR
- Add "Delete Run" action (list + detail screens), gated to runs with status `complete`, `errored`, or `cancelled` — blocked for `pending`/`running` to avoid deleting in-flight work. Guard enforced server-side in the resolver, not just the UI.
- Trials and trial scores cascade-delete automatically via existing FK constraints (`on_delete: :delete_all`) — no migration required.
- Extend "paste IDs" set-builder (Start Run modal) to accept a mix of work UUIDs and accession numbers, one per line — each line is auto-detected and resolved server-side (`Evals.resolve_identifiers/1`); unmatched entries are dropped silently, same as an unresolvable work ID today.
- Add an 80x80 thumbnail per work in the run detail trial table.
- Add a zoomable IIIF image viewer (`CloverImage`, same component used in the Transcription modal) alongside the Ground Truth / AI Output comparison in each expanded trial row, so reviewers can pan/zoom the source image while checking AI-generated metadata.
- New GraphQL: `deleteEvalRun` mutation; `representativeImageUrl` field on `EvalSetMember` (resolved via the existing `FileSets.representative_image_url_for/1` helper — no new storage).
- Added unit tests (`test/meadow/evals_test.exs`) for identifier resolution and the delete-status guard.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Minor

# Steps to Test
- go to **Dashboards → AI Metadata Evals**:
- Start a run, let it complete (or cancel it), then confirm a "Delete" button appears on both the runs list and the run detail page, but only once the run is out of `pending`/`running` status. Confirm deleting removes the run (and its trials/scores) and you're redirected to the list if deleted from the detail page.
- Click "Start New Run" → "Paste work IDs or accession numbers" → paste a mix of work UUIDs and accession numbers (one per line) → confirm the resulting eval set contains the expected works.
- Open a completed run and expand a trial row → confirm a thumbnail appears in the trial table, and the expanded row shows a pannable/zoomable image next to the Ground Truth / AI Output comparison.
<hr />
<img width="1208" height="571" alt="Screenshot 2026-07-06 at 8 38 58 AM" src="https://github.com/user-attachments/assets/5515b4b5-38e6-4d40-9af3-1ecf94984790" />
<hr />
<img width="1204" height="571" alt="Screenshot 2026-07-06 at 8 40 07 AM" src="https://github.com/user-attachments/assets/551cf4f1-9779-4d7e-9465-a90ccb6a66c4" />

<hr />

<img width="1206" height="390" alt="Screenshot 2026-07-06 at 8 37 21 AM" src="https://github.com/user-attachments/assets/33d7cfe4-5095-4cf8-a76e-8aa704605eff" />





# :rocket: Deployment Notes

  - [x] GraphQL API
