### PR TITLE
Make sure all remote URL resolution goes through MeadowWeb.RemoteAccess

### DIFF
--- a/app/lib/meadow/evals/runner.ex
+++ b/app/lib/meadow/evals/runner.ex
@@ -6,7 +6,6 @@ defmodule Meadow.Evals.Runner do
   import Ecto.Query
   alias Meadow.{Evals, Repo}
   alias Meadow.Evals.{Judge, Schemas.EvalRun, Schemas.EvalTrial}
-  alias MeadowWeb.Router.Helpers, as: Routes
 
   @registry Meadow.HordeRegistry
 
@@ -119,8 +118,6 @@ defmodule Meadow.Evals.Runner do
   defp execute_trial(run, trial, member, prompt_version) do
     trial |> EvalTrial.mark_running() |> Repo.update!()
 
-    mcp_url = Routes.page_url(MeadowWeb.Endpoint, :index, ["api", "mcp", "eval"])
-
     prompt =
       prompt_version.user_prompt_template
       |> render_prompt(%{
@@ -141,7 +138,7 @@ defmodule Meadow.Evals.Runner do
 
     started_at = System.monotonic_time(:millisecond)
 
-    result = MeadowAI.query(prompt, mcp_url: mcp_url, context: context)
+    result = MeadowAI.query(prompt, mcp_path: "api/mcp/eval", context: context)
 
     duration_ms = System.monotonic_time(:millisecond) - started_at
 

--- a/app/lib/meadow_ai/metadata_agent.ex
+++ b/app/lib/meadow_ai/metadata_agent.ex
@@ -95,18 +95,19 @@ defmodule MeadowAI.MetadataAgent do
         is_superuser: true
       )
 
+    {mcp_path, opts} = Keyword.pop(opts, :mcp_path, "api/mcp")
+
     opts =
       opts
       |> Keyword.put_new(
         :mcp_url,
-        MeadowWeb.RemoteAccess.url("api/mcp")
+        MeadowWeb.RemoteAccess.url(mcp_path)
       )
       |> Keyword.put_new(:auth_token, token)
       |> Keyword.put_new(
         :firewall_security_header,
         Application.get_env(:meadow, :firewall_security_header)
       )
-      |> Keyword.update!(:mcp_url, &docker_reachable_mcp_url/1)
 
     Task.Supervisor.start_child(MeadowAI.MetadataAgent.TaskSupervisor, fn ->
       result =
@@ -199,38 +200,6 @@ defmodule MeadowAI.MetadataAgent do
     error ->
       Logger.error("Error executing Claude query: #{Exception.message(error)}")
       {:error, {:query_execution_error, error}}
-  end
-
-  defp docker_reachable_mcp_url(nil), do: nil
-
-  defp docker_reachable_mcp_url(url) do
-    if System.get_env("USE_SAM_LAMBDAS") do
-      rewrite_url_base(url, System.get_env("MEADOW_SAM_HOST_URL", "http://172.17.0.1:4000"))
-    else
-      url
-    end
-  end
-
-  defp rewrite_url_base(url, replacement_base) do
-    with %URI{} = uri <- URI.parse(url),
-         %URI{} = replacement <- URI.parse(replacement_base) do
-      %{
-        uri
-        | scheme: replacement.scheme || uri.scheme,
-          host: replacement.host,
-          port: explicit_port(replacement_base) || uri.port
-      }
-      |> URI.to_string()
-    else
-      _ -> url
-    end
-  end
-
-  defp explicit_port(url) do
-    case Regex.run(~r/^[a-z][a-z0-9+.-]*:\/\/(?:\[[^\]]+\]|[^\/:]+):(\d+)/i, url) do
-      [_, port] -> String.to_integer(port)
-      _ -> nil
-    end
   end
 
   defp process_execution_result({:ok, %{"statusCode" => 200, "body" => body}}, opts) do

--- a/app/lib/meadow_web/remote_access.ex
+++ b/app/lib/meadow_web/remote_access.ex
@@ -9,16 +9,19 @@ defmodule MeadowWeb.RemoteAccess do
   Returns the funnel URL if a funnel is active, otherwise the local server URL.
   """
   def url(path \\ nil) do
-    case detect_funnel() do
-      {:ok, funnel_url} ->
-        case path do
-          nil -> URI.to_string(funnel_url)
-          _ -> URI.merge(funnel_url, path) |> URI.to_string()
-        end
-        |> String.trim_trailing("/")
+    base_url = base_url()
 
-      {:error, _} ->
-        Path.join(default_url(), path || "")
+    case path do
+      nil -> URI.to_string(base_url)
+      _ -> URI.merge(base_url, path) |> URI.to_string()
+    end
+  end
+
+  defp base_url do
+    case {System.get_env("USE_SAM_LAMBDAS"), detect_funnel()} do
+      {"true", _} -> URI.parse(System.get_env("MEADOW_SAM_HOST_URL", "http://172.17.0.1:4000"))
+      {_, {:ok, funnel_url}} -> funnel_url
+      _ -> URI.parse(default_url())
     end
   end
 

--- a/app/test/meadow_ai/metadata_agent_test.exs
+++ b/app/test/meadow_ai/metadata_agent_test.exs
@@ -34,47 +34,5 @@ defmodule MeadowAI.MetadataAgentTest do
       assert {:ok, %{request_count: 2, failure_count: 1, last_failure: %DateTime{}}} =
                MetadataAgent.status()
     end
-
-    test "test queries rewrite localhost MCP URLs for SAM lambdas" do
-      System.put_env("USE_SAM_LAMBDAS", "true")
-      System.put_env("MEADOW_SAM_HOST_URL", "http://host.docker.internal")
-
-      on_exit(fn ->
-        System.delete_env("USE_SAM_LAMBDAS")
-        System.delete_env("MEADOW_SAM_HOST_URL")
-      end)
-
-      prompt = "Test prompt"
-
-      assert {:ok, {%{"result" => "test"}, ^prompt, opts}} =
-               MetadataAgent.query(prompt,
-                 test: true,
-                 timeout: 1_000,
-                 mcp_url: "http://localhost:4000/api/mcp/eval"
-               )
-
-      assert opts[:mcp_url] == "http://host.docker.internal:4000/api/mcp/eval"
-    end
-
-    test "test queries rewrite generated external MCP URLs for SAM lambdas" do
-      System.put_env("USE_SAM_LAMBDAS", "true")
-      System.delete_env("MEADOW_SAM_HOST_URL")
-
-      on_exit(fn ->
-        System.delete_env("USE_SAM_LAMBDAS")
-        System.delete_env("MEADOW_SAM_HOST_URL")
-      end)
-
-      prompt = "Test prompt"
-
-      assert {:ok, {%{"result" => "test"}, ^prompt, opts}} =
-               MetadataAgent.query(prompt,
-                 test: true,
-                 timeout: 1_000,
-                 mcp_url: "https://bmq.dev.rdc.library.northwestern.edu:3001/api/mcp/eval"
-               )
-
-      assert opts[:mcp_url] == "http://172.17.0.1:4000/api/mcp/eval"
-    end
   end
 end

--- a/app/test/meadow_web/remote_access_test.exs
+++ b/app/test/meadow_web/remote_access_test.exs
@@ -39,25 +39,43 @@ defmodule MeadowWeb.RemoteAccessTest do
         caller = self()
         Task.start(fn -> serve(listen_sock, reply, caller) end)
         System.put_env("TS_SOCKET", socket_path)
+
         on_exit(fn ->
           :gen_tcp.close(listen_sock)
-          System.delete_env("TS_SOCKET")
         end)
       end
+
+      if tags[:use_sam_lambdas] do
+        System.put_env("USE_SAM_LAMBDAS", "true")
+      else
+        System.delete_env("USE_SAM_LAMBDAS")
+      end
+
+      if tags[:sam_host_url] do
+        System.put_env("MEADOW_SAM_HOST_URL", tags[:sam_host_url])
+      else
+        System.delete_env("MEADOW_SAM_HOST_URL")
+      end
+
+      on_exit(fn ->
+        System.delete_env("TS_SOCKET")
+        System.delete_env("USE_SAM_LAMBDAS")
+        System.delete_env("MEADOW_SAM_HOST_URL")
+      end)
 
       :ok
     end
 
     @tag socket_response: File.read!("test/fixtures/remote_access/complex_funnel.json")
     test "returns the funnel URL if a funnel is active" do
-      assert RemoteAccess.url() == "https://my.tailnet:3333"
+      assert RemoteAccess.url() == "https://my.tailnet:3333/"
       assert RemoteAccess.url("api/mcp") == "https://my.tailnet:3333/api/mcp"
       assert_receive {:socket_request, "GET /localapi/v0/serve-config" <> _}
     end
 
     @tag socket_response: File.read!("test/fixtures/remote_access/funnel_with_path.json")
     test "returns the funnel URL if the funnel is mounted on a path" do
-      assert RemoteAccess.url() == "https://my.tailnet/meadow"
+      assert RemoteAccess.url() == "https://my.tailnet/meadow/"
       assert RemoteAccess.url("api/mcp") == "https://my.tailnet/meadow/api/mcp"
       assert_receive {:socket_request, "GET /localapi/v0/serve-config" <> _}
     end
@@ -69,10 +87,23 @@ defmodule MeadowWeb.RemoteAccessTest do
       assert_receive {:socket_request, "GET /localapi/v0/serve-config" <> _}
     end
 
-    test "returns the local server URL if the CLI command fails" do
+    test "returns the local server URL if tailscale is unreachable" do
       assert RemoteAccess.url() == "http://localhost:4002"
       assert RemoteAccess.url("api/mcp") == "http://localhost:4002/api/mcp"
       refute_receive {:socket_request, "GET /localapi/v0/serve-config" <> _}
+    end
+
+    @tag use_sam_lambdas: true,
+         sam_host_url: "http://host.docker.internal:4000"
+    test "returns the configured Docker-reachable host URL if using SAM Lambdas" do
+      assert RemoteAccess.url() == "http://host.docker.internal:4000"
+      assert RemoteAccess.url("api/mcp") == "http://host.docker.internal:4000/api/mcp"
+    end
+
+    @tag socket_response: "{}", use_sam_lambdas: true
+    test "returns the default Docker-reachable host URL if using SAM Lambdas" do
+      assert RemoteAccess.url() == "http://172.17.0.1:4000"
+      assert RemoteAccess.url("api/mcp") == "http://172.17.0.1:4000/api/mcp"
     end
   end
 end


### PR DESCRIPTION
# Summary 
Overriding `mcp_url` in `Meadow.Evals.Runner` broke dev mode when not using SAM lambdas, and the docker override in `MeadowAI.MetadataAgent` complicated the issue further. This PR consolidates all remote access logic through `Meadow.RemoteAccess`. Since the module is currently only used for MCP URL resolution, there's no need at this time to differentiate between lambda access and non-lambda access, so the docker override will always be used if `USE_SAM_LAMBDAS` is true.

# Specific Changes in this PR
- Consolidate all remote access URL logic under `Meadow.RemoteAccess`
- Add SAM Lambda docker override to `Meadow.RemoteAccess`
- Add `mcp_path` option to `MetadataAgent`
- Update tests

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

