### PR TITLE
Transcription saved toast message after generation

### DIFF
--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Workflow.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Workflow.jsx
@@ -56,6 +56,8 @@ function WorkTabsStructureTranscriptionWorkflow({
   onContentChange,
 }) {
   const flashedAnnotationErrorIdRef = useRef(null);
+  const flashedAnnotationCompletedIdRef = useRef(null);
+  const generationInFlightRef = useRef(false);
   const [manualEntry, setManualEntry] = useState(false);
   const { data: { fileSetAnnotation } = {} } = useFileSetAnnotation(fileSetId);
   const {
@@ -111,12 +113,25 @@ function WorkTabsStructureTranscriptionWorkflow({
     fileSetAnnotation?.error,
   ]);
 
+  useEffect(() => {
+    if (
+      generationInFlightRef.current &&
+      fileSetAnnotation?.status === "completed" &&
+      flashedAnnotationCompletedIdRef.current !== fileSetAnnotation.id
+    ) {
+      toastWrapper("is-success", "Transcription generated and saved");
+      flashedAnnotationCompletedIdRef.current = fileSetAnnotation.id;
+      generationInFlightRef.current = false;
+    }
+  }, [fileSetAnnotation?.id, fileSetAnnotation?.status]);
+
   const runTranscribeMutation = () => {
     transcribeFileSet({
       variables: {
         fileSetId,
       },
       onError: (error) => {
+        generationInFlightRef.current = false;
         flashTranscriptionError(error);
       },
       refetchQueries: [
@@ -133,6 +148,7 @@ function WorkTabsStructureTranscriptionWorkflow({
     if (!fileSetId) return;
 
     toastWrapper("is-success", "Generating transcription");
+    generationInFlightRef.current = true;
 
     if (failedAnnotationId) {
       try {
@@ -142,6 +158,7 @@ function WorkTabsStructureTranscriptionWorkflow({
           awaitRefetchQueries: true,
         });
       } catch (error) {
+        generationInFlightRef.current = false;
         flashTranscriptionError(error);
         return;
       }

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Workflow.test.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Workflow.test.jsx
@@ -172,6 +172,130 @@ describe("WorkTabsStructureTranscriptionWorkflow", () => {
     expect(screen.queryByTestId("transcription-pane")).not.toBeInTheDocument();
   });
 
+  it("shows a saved toast once a generated transcription completes", async () => {
+    const workMocks = [
+      {
+        request: { query: GET_WORK, variables: { id: workId } },
+        result: { data: { work: baseWork } },
+      },
+      {
+        request: { query: GET_WORK, variables: { id: workId } },
+        result: { data: { work: baseWork } },
+      },
+      {
+        request: {
+          query: TRANSCRIBE_FILE_SET,
+          variables: { fileSetId },
+        },
+        result: {
+          data: {
+            transcribeFileSet: { id: fileSetId },
+          },
+        },
+      },
+    ];
+
+    useFileSetAnnotation.mockReturnValue({
+      data: { fileSetAnnotation: null },
+    });
+
+    const { rerender } = render(
+      <MockedProvider mocks={workMocks}>
+        <WorkTabsStructureTranscriptionWorkflow
+          fileSetId={fileSetId}
+          workId={workId}
+          isActive={true}
+          hasTranscriptionCallback={jest.fn()}
+        />
+      </MockedProvider>,
+    );
+
+    const button = await screen.findByRole("button", {
+      name: /generate transcription/i,
+    });
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(toastWrapper).toHaveBeenCalledWith(
+        "is-success",
+        "Generating transcription",
+      );
+    });
+
+    // Subscription now reports the generated annotation as completed
+    useFileSetAnnotation.mockReturnValue({
+      data: {
+        fileSetAnnotation: {
+          id: "ann-generated-1",
+          status: "completed",
+          type: "transcription",
+          content: "Generated text",
+        },
+      },
+    });
+
+    rerender(
+      <MockedProvider mocks={workMocks}>
+        <WorkTabsStructureTranscriptionWorkflow
+          fileSetId={fileSetId}
+          workId={workId}
+          isActive={true}
+          hasTranscriptionCallback={jest.fn()}
+        />
+      </MockedProvider>,
+    );
+
+    await waitFor(() => {
+      expect(toastWrapper).toHaveBeenCalledWith(
+        "is-success",
+        "Transcription generated and saved",
+      );
+    });
+  });
+
+  it("does not show a saved toast for a pre-existing completed annotation", async () => {
+    const completedAnnotation = {
+      id: "ann-existing-1",
+      status: "completed",
+      type: "transcription",
+      content: "Hello world",
+      __typename: "Annotation",
+    };
+
+    const workMocks = [
+      {
+        request: { query: GET_WORK, variables: { id: workId } },
+        result: {
+          data: {
+            work: {
+              ...baseWork,
+              fileSets: [
+                {
+                  id: fileSetId,
+                  annotations: [completedAnnotation],
+                  __typename: "FileSet",
+                },
+              ],
+            },
+          },
+        },
+      },
+    ];
+
+    renderWorkflow({
+      mocks: workMocks,
+      hookData: { data: { fileSetAnnotation: completedAnnotation } },
+    });
+
+    await screen.findByTestId("transcription-pane");
+
+    expect(toastWrapper).not.toHaveBeenCalledWith(
+      "is-success",
+      "Transcription generated and saved",
+    );
+  });
+
   it("renders GraphQL errors from TRANSCRIBE_FILE_SET when transcription fails", async () => {
     const details = { model: "is invalid" };
     const workMocks = [


### PR DESCRIPTION
# Summary 

When a user clicks Generate Transcription, `Workflow.jsx` already fires a "Generating transcription" toast immediately, but there was no confirmation once the async job actually finished and got saved, leaving users unsure if it had persisted or they needed to subsequently click "Save".

Added a one-time success toast ("Transcription generated and saved") that fires only when the file-set-annotation subscription reports `status: "completed"`, and that completion followed a generation the user just triggered. This deliberately excludes:
- Manual entry saves: those already get their own "Transcription successfully saved" toast in `Modal.jsx.`
- Pre-existing completed transcriptions loaded when the modal opens (no generation was in flight).

# Specific Changes in this PR
-  Edited `app/assets/js/components/Work/Tabs/Structure/Transcription/Workflow.jsx` to add notification to the workflow
- Added two tests to `Workflow.test.jsx` covering the new toast and its guard against firing for pre-existing transcriptions. 

# Version bump required by the PR

- [x] Patch

# Steps to Test

- Generate a transcription
- Verify that you see a toast notification that it has been saved. 

# :rocket: Deployment Notes

- No specific deployment tasks or instructions


<img width="1563" height="847" alt="Screenshot 2026-07-07 at 1 13 13 PM" src="https://github.com/user-attachments/assets/f93dc934-2393-4d81-a8d1-68dfe77f0510" />


