### PR TITLE
Fix flakey S3ObjectProvider test

### DIFF
--- a/app/assets/js/components/Work/Tabs/Preservation/S3ObjectProvider.jsx
+++ b/app/assets/js/components/Work/Tabs/Preservation/S3ObjectProvider.jsx
@@ -80,7 +80,12 @@ const S3ObjectProvider = forwardRef(
       setFiles(newFiles);
     }, [data, setFiles]);
 
+    const isInitialMount = useRef(true);
     useEffect(() => {
+      if (isInitialMount.current) {
+        isInitialMount.current = false;
+        return;
+      }
       refetch();
     }, [prefix]);
 


### PR DESCRIPTION
# Summary 

JS test suite is intermittently failing with:
```bash
1 tests failed:
(fail) S3ObjectProvider component > provides file and folderChain props [227.83ms]
```

The cause is that `S3ObjectProvider.jsx` has two effects that both fire a network request for the same ` { prefix: "" }`, but the mock tests are single use causing a race condition and intermittent failures. 

# Specific Changes in this PR
- In `S3ObjectProvider.jsx` skip refetch on initial mount since that is done by the `useQuery`

# Version bump required by the PR

- [x] Patch

