### PR TITLE
Update to new DCAPI canvas id format

### DIFF
--- a/app/assets/js/components/UI/IIIF/PosterSelector.jsx
+++ b/app/assets/js/components/UI/IIIF/PosterSelector.jsx
@@ -59,7 +59,7 @@ function IIIFViewerPosterSelector() {
     return null;
   }
 
-  const label = workState.activeMediaFileSet.coreMetadata.label;
+  const label = workState.activeMediaFileSet?.coreMetadata?.label;
 
   return (
     <div

--- a/app/assets/js/components/UI/IIIF/Viewer.jsx
+++ b/app/assets/js/components/UI/IIIF/Viewer.jsx
@@ -39,16 +39,18 @@ const IIIFViewer = ({ fileSets, iiifContent, workTypeId }) => {
    * When the Canvas changed in Clover, update the active media file set in Context.
    */
   const handleCanvasIdCallback = (canvasId) => {
-    if (canvasId) {
-      const canvasIndex = canvasId.split("/").pop();
-      if (fileSets[canvasIndex]?.id === activeMediaFileSet?.id) return;
+    if (!canvasId) return;
 
-      dispatch({
-        type: "updateActiveMediaFileSet",
-        fileSet: fileSets[canvasIndex],
-      });
-    }
-    return;
+    const fileSetId = canvasId.split("?")[0].split("/").pop();
+    const nextFileSet = fileSets.find((fs) => fs.id === fileSetId);
+
+    if (!nextFileSet) return;
+    if (nextFileSet.id === activeMediaFileSet?.id) return;
+
+    dispatch({
+      type: "updateActiveMediaFileSet",
+      fileSet: nextFileSet,
+    });
   };
 
   const customTheme = {

--- a/app/assets/js/components/UI/IIIF/Viewer.test.js
+++ b/app/assets/js/components/UI/IIIF/Viewer.test.js
@@ -27,14 +27,16 @@ const initialState = {
 
 const mocks = [dcApiTokenMock];
 
+let mockCanvasFileSetId = mockFileSets[0].id;
+
 jest.mock("@samvera/clover-iiif/viewer", () => {
   return {
     __esModule: true,
     default: (props) => {
-      // Call the canvasCallback with a string when the component is rendered
-      if (props.canvasCallback) {
-        props.canvasCallback(
-          "https://mat.dev.rdc.library.northwestern.edu:3002/works/a1239c42-6e26-4a95-8cde-0fa4dbf0af6a?as=iiif/canvas/access/0",
+      // Call the canvasIdCallback with a string when the component is rendered
+      if (props.canvasIdCallback) {
+        props.canvasIdCallback(
+          `https://mat.dev.rdc.library.northwestern.edu:3002/file-sets/${mockCanvasFileSetId}?as=iiif`,
         );
       }
       return <div></div>;
@@ -71,6 +73,54 @@ describe("IIIFViewer component", () => {
       { mocks },
     );
     expect(await screen.findByTestId("set-poster-image-button"));
+  });
+
+  it("keeps the poster selector button visible when the canvas callback can't resolve a file set", async () => {
+    mockCanvasFileSetId = "does-not-exist"; // no matching mock file set id
+
+    renderWithRouterApollo(
+      <WorkProvider initialState={initialState}>
+        <IIIFViewer
+          fileSet={mockFileSets[0]}
+          fileSets={[...mockFileSets]}
+          iiifContent="ABC123"
+          workTypeId="VIDEO"
+        />
+      </WorkProvider>,
+      { mocks },
+    );
+
+    expect(
+      await screen.findByTestId("set-poster-image-button"),
+    ).toBeInTheDocument();
+
+    mockCanvasFileSetId = mockFileSets[0].id;
+  });
+
+  it("updates the active file set when the canvas callback resolves a matching file set id", async () => {
+    mockCanvasFileSetId = mockFileSets[2].id;
+
+    renderWithRouterApollo(
+      <WorkProvider
+        initialState={{ ...initialState, activeMediaFileSet: mockFileSets[0] }}
+      >
+        <IIIFViewer
+          fileSet={mockFileSets[0]}
+          fileSets={[...mockFileSets]}
+          iiifContent="ABC123"
+          workTypeId="VIDEO"
+        />
+      </WorkProvider>,
+      { mocks },
+    );
+
+    // The poster button's label reflects the *active* file set, so seeing
+    // file set 2's label confirms the callback re-resolved by id.
+    expect(
+      await screen.findByText(mockFileSets[2].coreMetadata.label),
+    ).toBeInTheDocument();
+
+    mockCanvasFileSetId = mockFileSets[0].id;
   });
 
   it("does not render the poster selector button for an Audio work type", async () => {

--- a/app/assets/js/components/Work/Work.test.js
+++ b/app/assets/js/components/Work/Work.test.js
@@ -37,10 +37,10 @@ jest.mock("@samvera/clover-iiif/viewer", () => {
   return {
     __esModule: true,
     default: (props) => {
-      // Call the canvasCallback with a string when the component is rendered
-      if (props.canvasCallback) {
-        props.canvasCallback(
-          "https://mat.dev.rdc.library.northwestern.edu:3002/works/a1239c42-6e26-4a95-8cde-0fa4dbf0af6a?as=iiif/canvas/access/0",
+      // Call the canvasIdCallback with a string when the component is rendered
+      if (props.canvasIdCallback) {
+        props.canvasIdCallback(
+          "https://mat.dev.rdc.library.northwestern.edu:3002/file-sets/01E08T3EXBJX3PWDG22NSRE0BS?as=iiif",
         );
       }
       return <div></div>;

--- a/app/assets/js/context/work-context.jsx
+++ b/app/assets/js/context/work-context.jsx
@@ -40,10 +40,9 @@ function workReducer(state, action) {
       };
     }
     case "updateActiveMediaFileSet": {
-      const workTypeId = action.workTypeId || state.workTypeId;
       return {
         ...state,
-        activeMediaFileSet: { ...action.fileSet },
+        activeMediaFileSet: action.fileSet ? { ...action.fileSet } : null,
       };
     }
     case "updateWorkType": {

--- a/app/assets/js/screens/Work/Work.test.jsx
+++ b/app/assets/js/screens/Work/Work.test.jsx
@@ -31,10 +31,10 @@ jest.mock("@samvera/clover-iiif/viewer", () => {
   return {
     __esModule: true,
     default: (props) => {
-      // Call the canvasCallback with a string when the component is rendered
-      if (props.canvasCallback) {
-        props.canvasCallback(
-          "https://mat.dev.rdc.library.northwestern.edu:3002/works/a1239c42-6e26-4a95-8cde-0fa4dbf0af6a?as=iiif/canvas/access/0",
+      // Call the canvasIdCallback with a string when the component is rendered
+      if (props.canvasIdCallback) {
+        props.canvasIdCallback(
+          "https://mat.dev.rdc.library.northwestern.edu:3002/file-sets/0afa26f5-78e0-4ccb-b96f-052034dbbe27?as=iiif",
         );
       }
       return <div></div>;

--- a/app/assets/test/setup.ts
+++ b/app/assets/test/setup.ts
@@ -231,9 +231,9 @@ mock.module("@js/services/get-api-response-headers", () => ({
 
 mock.module("@samvera/clover-iiif/viewer", () => ({
   __esModule: true,
-  default: (props: { canvasCallback?: (canvasId: string) => void }) => {
-    props.canvasCallback?.(
-      "https://mat.dev.rdc.library.northwestern.edu:3002/works/a1239c42-6e26-4a95-8cde-0fa4dbf0af6a?as=iiif/canvas/access/0",
+  default: (props: { canvasIdCallback?: (canvasId: string) => void }) => {
+    props.canvasIdCallback?.(
+      "https://mat.dev.rdc.library.northwestern.edu:3002/file-sets/45226a50-87ca-443e-bc05-f47884e14505?as=iiif",
     );
     return React.createElement("div");
   },


### PR DESCRIPTION
# Summary

The "Set poster image for …" button was disappearing on VIDEO work pages shortly after the Clover viewer loaded. Root cause: the DC API's IIIF manifest canvas ids changed format (`/canvas/access/{n}` → `/file-sets/{fileSetId}?as=iiif`), but Meadow's canvas-change handler still assumed the old positional format and used the parsed value as an array index. When it failed to resolve, it wiped out the active file set in context, which also broke the "active" highlight in the file set list and canvas-switch syncing on multi-canvas works. This PR updates Meadow to resolve the active file set by matching the file set UUID embedded in the new canvas id, and hardens the reducer so a failed lookup can no longer wipe existing state.

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5831

# Specific Changes in this PR
- `Viewer.jsx`: `handleCanvasIdCallback` now parses the file set UUID out of the canvas id (`.../file-sets/{fileSetId}?as=iiif`) and resolves it via `fileSets.find(fs => fs.id === fileSetId)`, instead of indexing into `fileSets` by a positional segment. Bails out (leaving the current active file set in place) if the id doesn't resolve.
- `work-context.jsx`: `updateActiveMediaFileSet` reducer now sets `activeMediaFileSet` to `null` when no file set is provided, instead of spreading `undefined` into `{}` (a truthy object with no `id` that silently broke every consumer's guard checks).
- `PosterSelector.jsx`: defensive optional chaining on `activeMediaFileSet?.coreMetadata?.label`.
- Fixed a test-mock bug across 4 test files where the Clover mock invoked a `canvasCallback` prop that doesn't exist on the real component (the real prop is `canvasIdCallback`) — this is why the broken code path had no test coverage. Mocks now also use the current DC API canvas-id format.
- Added regression tests in `Viewer.test.js` covering: the poster button survives an unresolvable canvas id, and the active file set/poster button correctly updates when the canvas id resolves to a different file set.

# Version bump required by the PR

- [x] Patch

# Steps to Test

open any VIDEO work and confirm the "Set poster image for …" button stays visible after the viewer finishes loading (previously it be seen while the viewer is loading and then disappear). For a multi-canvas video work, confirm switching canvases in the viewer keeps the poster button and the file-set list's "active" highlight in sync with the displayed canvas.


# :rocket: Deployment Notes

- no special deployment tasks

