### PR TITLE
Allow querying works by controlled term

### DIFF
--- a/app/lib/meadow/data/works.ex
+++ b/app/lib/meadow/data/works.ex
@@ -647,4 +647,43 @@ defmodule Meadow.Data.Works do
       {:error, _} -> false
     end
   end
+
+  def works_by_term(term_id, field_name \\ nil) do
+    base_condition = dynamic([_, t], t.term == ^term_id)
+
+    condition =
+      if field_name do
+        dynamic([_, t], ^base_condition and t.field_name == ^to_string(field_name))
+      else
+        base_condition
+      end
+
+    from(w in Work,
+      join: t in "work_terms",
+      on: w.id == t.work_id,
+      where: ^condition
+    )
+  end
+
+  @doc """
+  Fetches all works that include a Metadata term, optionally limiting
+  the results to terms appearing in a specific field.
+  """
+  def get_works_by_term(term_id, field_name \\ nil) do
+    works_by_term(term_id, field_name)
+    |> distinct(true)
+    |> select([w], w)
+    |> Repo.all()
+    |> add_representative_image()
+  end
+
+  @doc """
+  Fetches all works that include a Metadata term, returning a list of maps
+  containing the work ID and the field name in which the term appears.
+  """
+  def get_term_placements(term_id) do
+    works_by_term(term_id)
+    |> select([w, t], %{work_id: w.id, field_name: t.field_name})
+    |> Repo.all()
+  end
 end

--- a/app/priv/repo/migrations/20260715183513_create_work_terms_table_and_triggers.exs
+++ b/app/priv/repo/migrations/20260715183513_create_work_terms_table_and_triggers.exs
@@ -1,0 +1,131 @@
+defmodule Meadow.Repo.Migrations.CreateWorkTermsTableAndTriggers do
+  use Ecto.Migration
+
+  require Logger
+
+  def up do
+    create table(:work_terms, primary_key: false) do
+      add(:work_id, :uuid, null: false)
+      add(:field_name, :text, null: false)
+      add(:term, :text)
+    end
+    create index(:work_terms, [:term])
+    create index(:work_terms, [:work_id])
+
+    # Create triggers to keep the work_terms table in sync with the works table
+    execute("""
+      CREATE OR REPLACE FUNCTION refresh_work_terms_ins() RETURNS trigger AS $$
+      BEGIN
+        DELETE FROM work_terms wt
+        USING new_table n
+        WHERE wt.work_id = n.id;
+
+        INSERT INTO work_terms (work_id, field_name, term)
+        SELECT
+          n.id,
+          f.key,
+          CASE
+            WHEN jsonb_typeof(elem->'term') = 'object' THEN elem->'term'->>'id'
+            ELSE elem->>'term'
+          END
+        FROM new_table n
+        CROSS JOIN LATERAL jsonb_each(n.descriptive_metadata) AS f(key, value)
+        CROSS JOIN LATERAL jsonb_array_elements(
+          CASE WHEN jsonb_typeof(f.value) = 'array' THEN f.value ELSE '[]'::jsonb END
+        ) AS elem
+        WHERE elem ? 'term';
+
+        RETURN NULL;
+      END;
+      $$ LANGUAGE plpgsql;
+    """)
+
+    execute("""
+      CREATE TRIGGER trg_work_terms_ins
+      AFTER INSERT ON works
+      REFERENCING NEW TABLE AS new_table
+      FOR EACH STATEMENT EXECUTE FUNCTION refresh_work_terms_ins();
+    """)
+
+    execute("""
+      CREATE OR REPLACE FUNCTION refresh_work_terms_upd() RETURNS trigger AS $$
+      BEGIN
+        DELETE FROM work_terms wt
+        USING new_table n
+        WHERE wt.work_id = n.id;
+
+        INSERT INTO work_terms (work_id, field_name, term)
+        SELECT
+          n.id,
+          f.key,
+          CASE
+            WHEN jsonb_typeof(elem->'term') = 'object' THEN elem->'term'->>'id'
+            ELSE elem->>'term'
+          END
+        FROM new_table n
+        CROSS JOIN LATERAL jsonb_each(n.descriptive_metadata) AS f(key, value)
+        CROSS JOIN LATERAL jsonb_array_elements(
+          CASE WHEN jsonb_typeof(f.value) = 'array' THEN f.value ELSE '[]'::jsonb END
+        ) AS elem
+        WHERE elem ? 'term';
+
+        RETURN NULL;
+      END;
+      $$ LANGUAGE plpgsql;
+    """)
+
+    execute("""
+      CREATE TRIGGER trg_work_terms_upd
+      AFTER UPDATE ON works
+      REFERENCING NEW TABLE AS new_table
+      FOR EACH STATEMENT EXECUTE FUNCTION refresh_work_terms_upd();
+    """)
+
+    execute("""
+      CREATE OR REPLACE FUNCTION refresh_work_terms_del() RETURNS trigger AS $$
+      BEGIN
+        DELETE FROM work_terms wt
+        USING old_table o
+        WHERE wt.work_id = o.id;
+
+        RETURN NULL;
+      END;
+      $$ LANGUAGE plpgsql;
+    """)
+
+    execute("""
+      CREATE TRIGGER trg_work_terms_del
+      AFTER DELETE ON works
+      REFERENCING OLD TABLE AS old_table
+      FOR EACH STATEMENT EXECUTE FUNCTION refresh_work_terms_del();
+    """)
+
+  Logger.info("Populating work_terms table with existing data...")
+  execute("""
+    INSERT INTO work_terms (work_id, field_name, term)
+    SELECT
+      w.id,
+      f.key,
+      CASE
+        WHEN jsonb_typeof(elem->'term') = 'object' THEN elem->'term'->>'id'
+        ELSE elem->>'term'
+      END
+    FROM works w
+    CROSS JOIN LATERAL jsonb_each(w.descriptive_metadata) AS f(key, value)
+    CROSS JOIN LATERAL jsonb_array_elements(
+      CASE WHEN jsonb_typeof(f.value) = 'array' THEN f.value ELSE '[]'::jsonb END
+    ) AS elem
+    WHERE elem ? 'term';
+    """)
+  end
+
+  def down do
+    execute("DROP TRIGGER IF EXISTS trg_work_terms_ins ON works;")
+    execute("DROP TRIGGER IF EXISTS trg_work_terms_upd ON works;")
+    execute("DROP TRIGGER IF EXISTS trg_work_terms_del ON works;")
+    execute("DROP FUNCTION IF EXISTS refresh_work_terms_ins();")
+    execute("DROP FUNCTION IF EXISTS refresh_work_terms_upd();")
+    execute("DROP FUNCTION IF EXISTS refresh_work_terms_del();")
+    drop table(:work_terms)
+  end
+end

--- a/app/test/meadow/data/works_test.exs
+++ b/app/test/meadow/data/works_test.exs
@@ -110,6 +110,55 @@ defmodule Meadow.Data.WorksTest do
     end
   end
 
+  describe "query works by terms" do
+    setup do
+      work1 = work_fixture(%{
+        descriptive_metadata: %{
+          title: "Work #1",
+          contributor: [%{term: "mock1:result1", role: %{id: "aut", scheme: "marc_relator"}}],
+          subject: [%{term: "mock1:result2", role: %{id: "TOPICAL", scheme: "subject_role"}}],
+          genre: [%{term: "mock2:result3"}]
+        }
+      })
+
+      work2 = work_fixture(%{
+        descriptive_metadata: %{
+          title: "Work #2",
+          creator: [%{term: "mock1:result1"}],
+          subject: [%{term: "mock1:result2", role: %{id: "TOPICAL", scheme: "subject_role"}}],
+          genre: [%{term: "mock2:result3"}]
+        }
+      })
+
+      work3 = work_fixture(%{descriptive_metadata: %{title: "Work #3"}})
+      {:ok, %{works: [work1, work2, work3]}}
+    end
+
+    test "get_works_by_term/1 returns works with matching term" do
+      results = Works.get_works_by_term("mock1:result1")
+      assert length(results) == 2
+      assert Enum.find(results, &(&1.descriptive_metadata.title == "Work #1"))
+      assert Enum.find(results, &(&1.descriptive_metadata.title == "Work #2"))
+      refute Enum.find(results, &(&1.descriptive_metadata.title == "Work #3"))
+    end
+
+    test "get_works_by_term/2 returns works with matching term and field" do
+      results = Works.get_works_by_term("mock1:result1", "contributor")
+      assert length(results) == 1
+      assert Enum.find(results, &(&1.descriptive_metadata.title == "Work #1"))
+      refute Enum.find(results, &(&1.descriptive_metadata.title == "Work #2"))
+      refute Enum.find(results, &(&1.descriptive_metadata.title == "Work #3"))
+    end
+
+    test "get_term_placements/1 returns work ids and field names for matching term" do
+      results = Works.get_term_placements("mock1:result1")
+      assert length(results) == 2
+      assert Enum.find(results, &(&1.work_id == List.first(results).work_id))
+      assert Enum.find(results, &(&1.field_name == "contributor"))
+      assert Enum.find(results, &(&1.field_name == "creator"))
+    end
+  end
+
   describe "representative images for image type works" do
     setup do
       work =


### PR DESCRIPTION
# Summary 
Allow querying works by controlled term, optionally limiting by a specific field. Also makes it easier to quickly identify which fields a given term appears in across many works.

This is largely for use in Livebook or IEx when it's useful to find where, across all works and descriptive fields, a specific controlled vocabulary term exists.

# Specific Changes in this PR
- Create `work_terms` table, populate it with existing data, and create the trigger that maintains it.
- Add three functions to `Meadow.Data.Works` schema: `get_works_by_term/2`, `get_term_placements/1`, and `works_by_term/2`, which creates a composable query used by the other two.
- Tests for the above

I experimented with creating a view instead of a table, but querying it was slow. A materialized view with an index on the `term` field was faster (as fast as the standalone table), but requires a lengthy manual refresh when the data changes. The table + trigger approach is fast and atomic.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test

- `mix ecto.migrate`
- Add and edit controlled metadata on multiple works. Use a term that's not present on other works to make querying easier.
- Use `Works.get_works_by_term(term)` and `Works.get_works_by_term(term, field)` from iex to query those
- Use `Works.get_term_placements(term)` to get a list of work IDs and field names where that term is present
- Make more updates. Repeat the queries to make sure the results immediately reflect those changes.

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

