### PR TITLE
Bugfix in fileset grouping functionality

### DIFF
--- a/app/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
+++ b/app/assets/js/components/Work/Fileset/ActionButtons/Access.jsx
@@ -50,7 +50,7 @@ export function MediaButtons({ fileSet }) {
 
   return (
     <div className="buttons is-grouped is-right">
-      {!fileSet.group_with && isAuthorized() && (
+      {!fileSet.groupWith && isAuthorized() && (
         <Button
           data-testid="edit-structure-button"
           onClick={() =>
@@ -84,7 +84,7 @@ export function ImageButtons({ iiifServerUrl, fileSet }) {
 
   return (
     <div className="buttons is-grouped is-right">
-      {!fileSet.group_with &&
+      {!fileSet.groupWith &&
         fileSet.representativeImageUrl &&
         isAuthorized() && (
           <a

--- a/app/assets/js/components/Work/Fileset/Draggable.jsx
+++ b/app/assets/js/components/Work/Fileset/Draggable.jsx
@@ -102,7 +102,7 @@ function WorkFilesetDraggable({
                 </p>
               </div>
               <div css={actions}>
-                {fileSet.group_with ? (
+                {fileSet.groupWith ? (
                   <WorkFilesetActionButtonsGroupRemove
                     fileSetId={fileSet.id}
                     handleUpdateFileSet={handleUpdateFileSet}

--- a/app/assets/js/components/Work/Fileset/List.jsx
+++ b/app/assets/js/components/Work/Fileset/List.jsx
@@ -25,8 +25,8 @@ function WorkFilesetList({
   const isWebVttModalActive = webVttModal?.isOpen;
 
   const uniqueGroupWithValues = fileSets.access
-    .filter((fs) => fs.group_with !== null)
-    .map((fs) => fs.group_with)
+    .filter((fs) => fs.groupWith !== null)
+    .map((fs) => fs.groupWith)
     .filter((value, index, self) => self.indexOf(value) === index);
 
   if (isReordering) {
@@ -36,16 +36,16 @@ function WorkFilesetList({
           <div ref={provided.innerRef} {...provided.droppableProps}>
             <div data-testid="fileset-draggable-list" className="mb-5">
               {fileSets.access
-                .filter((fileSet) => !fileSet.group_with)
+                .filter((fileSet) => !fileSet.groupWith)
                 .map((fileSet, index) => {
                   const groupedFileSets = fileSets.access.filter(
-                    (entry) => entry.group_with === fileSet.id,
+                    (entry) => entry.groupWith === fileSet.id,
                   );
 
                   const candidateFileSets = fileSets.access.filter((fs) => {
                     return (
                       fs.id !== fileSet.id &&
-                      fs.group_with === null &&
+                      fs.groupWith === null &&
                       !uniqueGroupWithValues.includes(fs.id)
                     );
                   });
@@ -75,11 +75,11 @@ function WorkFilesetList({
       <div data-testid="fileset-list" className="mb-5">
         <SubHead>Access files</SubHead>
         {fileSets.access
-          .filter((fileSet) => !fileSet.group_with)
+          .filter((fileSet) => !fileSet.groupWith)
           .map((fileSet) => {
-            // get all filesets that have a group_with value matching fileSet.id
+            // get all filesets that have a groupWith value matching fileSet.id
             const groupedFileSets = fileSets.access.filter(
-              (entry) => entry.group_with === fileSet.id,
+              (entry) => entry.groupWith === fileSet.id,
             );
 
             return (

--- a/app/assets/js/components/Work/Fileset/List.test.js
+++ b/app/assets/js/components/Work/Fileset/List.test.js
@@ -2,7 +2,7 @@ import {
   renderWithRouterApollo,
   withReactBeautifulDND,
 } from "@js/services/testing-helpers";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import { CodeListProvider } from "@js/context/code-list-context";
 import React from "react";
 import WorkFilesetList from "@js/components/Work/Fileset/List";
@@ -12,6 +12,7 @@ import { mockUser } from "@js/components/Auth/auth.gql.mock";
 import useIsAuthorized from "@js/hooks/useIsAuthorized";
 import { allCodeListMocks } from "@js/components/Work/controlledVocabulary.gql.mock";
 import { mockWork, mockWork2 } from "../work.gql.mock";
+import userEvent from "@testing-library/user-event";
 
 useIsAuthorized.mockReturnValue({
   user: mockUser,
@@ -72,5 +73,53 @@ describe("WorkFilesetList component", () => {
     await waitFor(() => {
       expect(screen.getAllByTestId("fileset-item")).toHaveLength(4);
     });
+  });
+
+  it("shows applicable candidates in the Attach filesets dropdown when reordering", async () => {
+    const reorderableFileSets = [
+      {
+        id: "fileset-a",
+        accessionNumber: "Acc_A",
+        role: { id: "A", label: "Access" },
+        groupWith: null,
+        coreMetadata: { label: "Fileset A" },
+      },
+      {
+        id: "fileset-b",
+        accessionNumber: "Acc_B",
+        role: { id: "A", label: "Access" },
+        groupWith: null,
+        coreMetadata: { label: "Fileset B" },
+      },
+    ];
+
+    renderWithRouterApollo(
+      <CodeListProvider>
+        <WorkProvider initialState={{ ...defaultState, work: mockWork }}>
+          {withReactBeautifulDND(WorkFilesetList, {
+            fileSets: { access: reorderableFileSets, auxiliary: [] },
+            isReordering: true,
+          })}
+        </WorkProvider>
+      </CodeListProvider>,
+      {
+        mocks: allCodeListMocks,
+      },
+    );
+
+    const user = userEvent.setup();
+    const [groupAdd] = await screen.findAllByTestId("fileset-group-add");
+    const input = within(groupAdd).getByPlaceholderText("Attach filesets...");
+    await user.click(input);
+
+    expect(
+      within(groupAdd).queryByText("Applicable fileset(s) not found."),
+    ).not.toBeInTheDocument();
+
+    const candidates = within(groupAdd).getAllByTestId(
+      "fileset-group-add-candidate",
+    );
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toHaveTextContent("Fileset B");
   });
 });

--- a/app/assets/js/components/Work/Fileset/ListItem.jsx
+++ b/app/assets/js/components/Work/Fileset/ListItem.jsx
@@ -21,7 +21,7 @@ function WorkFilesetListItem({
   workImageFilesetId,
   groupedFileSets,
 }) {
-  const { id, coreMetadata, group_with, accessionNumber } = fileSet;
+  const { id, coreMetadata, groupWith, accessionNumber } = fileSet;
   const { hasRepresentativeImage, isImage, isMedia, isPDF, isZip } =
     useFileSet();
   const workContextState = useWorkState();
@@ -96,7 +96,7 @@ function WorkFilesetListItem({
       className={`box is-relative`}
       data-testid="fileset-item"
       style={{
-        zIndex: group_with ? 0 : 1,
+        zIndex: groupWith ? 0 : 1,
       }}
     >
       <div css={flex}>
@@ -185,7 +185,7 @@ function WorkFilesetListItem({
         <div className="has-text-right is-clearfix">
           {!isEditing && (
             <>
-              {showWorkImageToggle() && !fileSet.group_with && (
+              {showWorkImageToggle() && !fileSet.groupWith && (
                 <AuthDisplayAuthorized>
                   <div className="field">
                     <input

--- a/app/assets/js/components/Work/Tabs/Structure/FilesetsDragAndDrop.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/FilesetsDragAndDrop.jsx
@@ -22,18 +22,18 @@ function FilesetsDragAndDrop({
 
   const indexArray = state.fileSets.map((fs) => ({
     id: fs.id,
-    group_with: fs.group_with,
-    droppableId: fs.group_with ? fs.group_with : "access",
+    groupWith: fs.groupWith,
+    droppableId: fs.groupWith ? fs.groupWith : "access",
   }));
 
   function handleSaveClick() {
     // Update order of all filesets
     handleSaveReorder(state.fileSets.map((fs) => fs.id));
 
-    // Update group_with values for applicable filesets
+    // Update groupWith values for applicable filesets
     const updateGroupWith = state.fileSets.filter((fs) =>
       fileSets.find(
-        (fs2) => fs2.id === fs.id && fs2.group_with !== fs.group_with,
+        (fs2) => fs2.id === fs.id && fs2.groupWith !== fs.groupWith,
       ),
     );
 
@@ -85,7 +85,7 @@ function FilesetsDragAndDrop({
   function handleUpdateFileSet(id, groupWith) {
     const updatedFileSets = state.fileSets.map((fs) => {
       if (fs.id === id) {
-        return { ...fs, group_with: groupWith };
+        return { ...fs, groupWith: groupWith };
       }
       return fs;
     });

--- a/app/assets/js/components/Work/Tabs/Structure/Structure.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Structure.jsx
@@ -138,7 +138,7 @@ const WorkTabsStructure = ({ work }) => {
   const handleGroupWithUpdate = (groupWithFileSets) => {
     groupWithFileSets.forEach((fs) => {
       groupWithFileSet({
-        variables: { id: fs.id, groupWith: fs.group_with },
+        variables: { id: fs.id, groupWith: fs.groupWith },
       });
     });
   };
@@ -211,11 +211,11 @@ const WorkTabsStructure = ({ work }) => {
     const { idMap, groupedMap } = fileSets.reduce(
       (acc, fileSet) => {
         acc.idMap.set(fileSet.id, fileSet);
-        if (fileSet.group_with) {
-          if (!acc.groupedMap.has(fileSet.group_with)) {
-            acc.groupedMap.set(fileSet.group_with, []);
+        if (fileSet.groupWith) {
+          if (!acc.groupedMap.has(fileSet.groupWith)) {
+            acc.groupedMap.set(fileSet.groupWith, []);
           }
-          acc.groupedMap.get(fileSet.group_with).push(fileSet);
+          acc.groupedMap.get(fileSet.groupWith).push(fileSet);
         }
         return acc;
       },
@@ -223,7 +223,7 @@ const WorkTabsStructure = ({ work }) => {
     );
 
     return fileSets.reduce((orderedList, fileSet) => {
-      if (!fileSet.group_with || !idMap.has(fileSet.group_with)) {
+      if (!fileSet.groupWith || !idMap.has(fileSet.groupWith)) {
         orderedList.push(fileSet);
         if (groupedMap.has(fileSet.id)) {
           orderedList.push(...groupedMap.get(fileSet.id));

--- a/app/assets/js/components/Work/work.gql.mock.js
+++ b/app/assets/js/components/Work/work.gql.mock.js
@@ -163,6 +163,7 @@ export const mockWork = {
       accessionNumber: "Donohue_001_04",
       id: "01E08T3EXBJX3PWDG22NSRE0BS",
       role: { id: "A", label: "Access" },
+      groupWith: null,
       coreMetadata: {
         description: "Letter, page 2, If these papers, verso, blank",
         location: "s3://bucket/foo/bar",
@@ -182,6 +183,7 @@ export const mockWork = {
       accessionNumber: "Donohue_001_01",
       id: "01E08T3EW3TQ9T0AXCR6X9QDJW",
       role: { id: "A", label: "Access" },
+      groupWith: null,
       coreMetadata: {
         description: "Letter, page 1, Dear Sir, recto",
         location: "s3://bucket/foo/bar",
@@ -202,6 +204,7 @@ export const mockWork = {
       accessionNumber: "Donohue_001_03",
       id: "01E08T3EWRPXMWW0B1NHZ56AW6",
       role: { id: "A", label: "Access" },
+      groupWith: null,
       coreMetadata: {
         description: "Letter, page 2, If these papers, recto",
         originalFilename: "coffee.jpg",
@@ -219,6 +222,7 @@ export const mockWork = {
       accessionNumber: "Donohue_001_02",
       id: "01E08T3EWFJB35RY3RVR65AXMK",
       role: { id: "A", label: "Access" },
+      groupWith: null,
       coreMetadata: {
         description: "Letter, page 1, Dear Sir, verso, blank",
         originalFilename: "coffee.jpg",
@@ -361,6 +365,7 @@ export const mockWork2 = {
         id: "A",
         label: "Access",
       },
+      groupWith: null,
       updatedAt: "2020-07-18T09:01:01",
     },
     {
@@ -381,6 +386,7 @@ export const mockWork2 = {
         id: "A",
         label: "Access",
       },
+      groupWith: null,
     },
     {
       accessionNumber: "Donohue_002_02b",
@@ -400,6 +406,7 @@ export const mockWork2 = {
         id: "A",
         label: "Access",
       },
+      groupWith: null,
     },
   ],
   id: MOCK_WORK_ID,

--- a/app/assets/js/mock-data/filesets.js
+++ b/app/assets/js/mock-data/filesets.js
@@ -16,7 +16,7 @@ export const mockFileSets = [
       originalFilename: "inu-dil-9d35d0ba-a84b-4e0a-99e6-9c6b548a46db.jpg",
     },
     id: "45226a50-87ca-443e-bc05-f47884e14505",
-    group_with: null,
+    groupWith: null,
     representativeImageUrl:
       "https://iiif.dev.rdc.library.northwestern.edu/iiif/2/wildcat-dev/posters/6d6bb649-2a5c-40d2-8d1b-23835de1c40a",
     role: {
@@ -43,7 +43,7 @@ export const mockFileSets = [
       originalFilename: "inu-dil-41913a91-037f-494b-9113-06004a8a98fb.jpg",
     },
     id: "109b9a5c-3c6f-4a98-b98b-12402b871dc7",
-    group_with: "45226a50-87ca-443e-bc05-f47884e14505",
+    groupWith: "45226a50-87ca-443e-bc05-f47884e14505",
     representativeImageUrl:
       "https://iiif.dev.rdc.library.northwestern.edu/iiif/2/wildcat-dev/posters/6d6bb649-2a5c-40d2-8d1b-23835de1c40a",
     role: {
@@ -70,7 +70,7 @@ export const mockFileSets = [
       originalFilename: "inu-dil-96e6d167-5022-42e7-9de7-7f851a866f44.jpg",
     },
     id: "d414d3d4-b72c-49cc-b7cc-faa9bc0f256e",
-    group_with: null,
+    groupWith: null,
     representativeImageUrl:
       "https://iiif.dev.rdc.library.northwestern.edu/iiif/2/wildcat-dev/posters/6d6bb649-2a5c-40d2-8d1b-23835de1c40a",
     role: {


### PR DESCRIPTION
# Summary

Fixes a regression on the Work page's Access/Structure tab where clicking "Attach filesets..." while re-ordering/grouping always showed "Applicable fileset(s) not found." A prior graphql-codegen migration ([`f3edb426`](https://github.com/nulib/meadow/commit/f3edb426) renamed the `GET_WORK` query's fileset field selection from `group_with` to `groupWith`, but every JS consumer (List, Draggable, Structure, ListItem, Access, FilesetsDragAndDrop) still reads `fileSet.group_with`, which silently became `undefined`. The strict `fs.group_with === null` candidate filter then matched nothing.

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5838

# Specific Changes in this PR

- `List.jsx`, `Draggable.jsx`, `ListItem.jsx`, `ActionButtons/Access.jsx`, `Tabs/Structure/Structure.jsx`, `Tabs/Structure/FilesetsDragAndDrop.jsx`: renamed every `fileSet.group_with` reference to `fileSet.groupWith` so the frontend reads the field the API actually returns. This is the root fix, the mismatch (query returning `groupWith` while components read `group_with`) is why the "Attach filesets..." candidate list came back empty.
- `mock-data/filesets.js`, `work.gql.mock.js`: renamed fixture fields to `groupWith` to match the real response shape.
- `Fileset/List.test.js`: added a regression test that renders the re-ordering branch and asserts the "Attach filesets..." dropdown lists candidates instead of showing "Applicable fileset(s) not found."

# Version bump required by the PR

- [x] Patch


# Steps to Test

1. Open any work with 2+ access file sets.
2. Go to the Access/Structure tab.
3. Click "Re-order & Group".
4. Click "Attach filesets..." on any ungrouped file set.
5. Confirm the dropdown lists the other ungrouped file sets (not "Applicable fileset(s) not found.").
6. Attach one, click Save, reload the page, and confirm the group persists and renders correctly.

# :rocket: Deployment Notes

 - No special deployment tasks


