### PR TITLE
Provenance fixups

### DIFF
--- a/app/assets/js/components/AIProvenance/AnnotationAttestationControl.jsx
+++ b/app/assets/js/components/AIProvenance/AnnotationAttestationControl.jsx
@@ -20,11 +20,22 @@ import { toastWrapper } from "@js/services/helpers";
  * Renders nothing unless provenance badges are visible, the annotation's AI
  * provenance is still attestable (AI-involved, not already attested), and the
  * viewer is an Editor.
+ *
+ * When the surrounding editor reports unsaved changes (`hasUnsavedChanges`),
+ * confirming first awaits `onBeforeAttest` so those edits are saved before the
+ * attestation is recorded; a note below the controls tells the reviewer this
+ * will happen. A failed save aborts the attestation.
  */
-function AnnotationAttestationControl({ annotation, workId }) {
+function AnnotationAttestationControl({
+  annotation,
+  workId,
+  hasUnsavedChanges,
+  onBeforeAttest,
+}) {
   const { visible } = useAIProvenanceBadges();
   const [open, setOpen] = React.useState(false);
   const [reason, setReason] = React.useState("");
+  const [saving, setSaving] = React.useState(false);
 
   const [attest, { loading }] = useMutation(ATTEST_HUMAN_AUTHORED_ANNOTATION, {
     refetchQueries: workId
@@ -48,7 +59,23 @@ function AnnotationAttestationControl({ annotation, workId }) {
   if (!visible || !annotationId) return null;
   if (!isAttestable(annotation.aiProvenance)) return null;
 
-  const handleConfirm = () => {
+  const busy = loading || saving;
+
+  const handleConfirm = async () => {
+    if (hasUnsavedChanges && onBeforeAttest) {
+      setSaving(true);
+      try {
+        await onBeforeAttest();
+      } catch (error) {
+        toastWrapper(
+          "is-danger",
+          `Could not save transcription edits: ${error.message}`,
+        );
+        return;
+      } finally {
+        setSaving(false);
+      }
+    }
     attest({
       variables: {
         annotationId,
@@ -59,43 +86,59 @@ function AnnotationAttestationControl({ annotation, workId }) {
 
   return (
     <AuthDisplayAuthorized level="EDITOR">
-      <span data-testid="annotation-attestation">
+      {/* When open, take a full row of the wrapping header so the input,
+          buttons, and autosave note sit on their own lines instead of
+          crowding the badge and the controls below. */}
+      <span
+        data-testid="annotation-attestation"
+        style={open ? { flexBasis: "100%" } : undefined}
+      >
         {open ? (
-          <span className="field has-addons is-inline-flex mb-0">
-            <span className="control">
-              <input
-                className="input is-small"
-                type="text"
-                placeholder="Reason (optional)"
-                data-testid="annotation-attestation-reason"
-                value={reason}
-                onChange={(e) => setReason(e.target.value)}
-              />
+          <span className="is-block">
+            <span className="field has-addons is-inline-flex mb-0">
+              <span className="control">
+                <input
+                  className="input is-small"
+                  type="text"
+                  placeholder="Reason (optional)"
+                  data-testid="annotation-attestation-reason"
+                  value={reason}
+                  onChange={(e) => setReason(e.target.value)}
+                />
+              </span>
+              <span className="control">
+                <button
+                  type="button"
+                  className={`button is-small is-primary ${
+                    busy ? "is-loading" : ""
+                  }`}
+                  data-testid="annotation-attestation-confirm"
+                  disabled={busy}
+                  onClick={handleConfirm}
+                >
+                  Mark human-authored
+                </button>
+              </span>
+              <span className="control">
+                <button
+                  type="button"
+                  className="button is-small"
+                  data-testid="annotation-attestation-cancel"
+                  disabled={busy}
+                  onClick={() => setOpen(false)}
+                >
+                  Cancel
+                </button>
+              </span>
             </span>
-            <span className="control">
-              <button
-                type="button"
-                className={`button is-small is-primary ${
-                  loading ? "is-loading" : ""
-                }`}
-                data-testid="annotation-attestation-confirm"
-                disabled={loading}
-                onClick={handleConfirm}
+            {hasUnsavedChanges && (
+              <span
+                className="help is-block has-text-grey mt-1 mb-0"
+                data-testid="annotation-attestation-autosave-note"
               >
-                Mark human-authored
-              </button>
-            </span>
-            <span className="control">
-              <button
-                type="button"
-                className="button is-small"
-                data-testid="annotation-attestation-cancel"
-                disabled={loading}
-                onClick={() => setOpen(false)}
-              >
-                Cancel
-              </button>
-            </span>
+                Your unsaved edits will be saved automatically.
+              </span>
+            )}
           </span>
         ) : (
           <button
@@ -123,6 +166,8 @@ AnnotationAttestationControl.propTypes = {
     }),
   }),
   workId: PropTypes.string,
+  hasUnsavedChanges: PropTypes.bool,
+  onBeforeAttest: PropTypes.func,
 };
 
 export default AnnotationAttestationControl;

--- a/app/assets/js/components/AIProvenance/AnnotationAttestationControl.test.jsx
+++ b/app/assets/js/components/AIProvenance/AnnotationAttestationControl.test.jsx
@@ -85,4 +85,120 @@ describe("AnnotationAttestationControl", () => {
 
     await waitFor(() => expect(attestedWith).not.toBeNull());
   });
+
+  it("does not show the autosave note when there are no unsaved changes", () => {
+    const { getByTestId, queryByTestId } = renderWithRouterApollo(
+      <AnnotationAttestationControl
+        annotation={aiAnnotation}
+        workId="work-1"
+        hasUnsavedChanges={false}
+        onBeforeAttest={jest.fn()}
+      />,
+      { mocks: [] },
+    );
+
+    fireEvent.click(getByTestId("annotation-attestation-trigger"));
+    expect(
+      queryByTestId("annotation-attestation-autosave-note"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("saves unsaved edits before attesting and shows the autosave note", async () => {
+    let attested = false;
+    let savedBeforeAttest = null;
+    const onBeforeAttest = jest.fn(() => {
+      savedBeforeAttest = !attested;
+      return Promise.resolve();
+    });
+
+    const attestMock = {
+      request: {
+        query: ATTEST_HUMAN_AUTHORED_ANNOTATION,
+        variables: { annotationId: "annotation-1" },
+      },
+      result: () => {
+        attested = true;
+        return {
+          data: {
+            attestHumanAuthoredAnnotation: {
+              id: "annotation-1",
+              fileSetId: "fs-1",
+              aiProvenance: {
+                origin: "human_attested_after_ai",
+                status: "applied",
+              },
+            },
+          },
+        };
+      },
+    };
+
+    const { getByTestId } = renderWithRouterApollo(
+      <AnnotationAttestationControl
+        annotation={aiAnnotation}
+        workId="work-1"
+        hasUnsavedChanges={true}
+        onBeforeAttest={onBeforeAttest}
+      />,
+      { mocks: [attestMock] },
+    );
+
+    fireEvent.click(getByTestId("annotation-attestation-trigger"));
+    expect(
+      getByTestId("annotation-attestation-autosave-note"),
+    ).toHaveTextContent(/unsaved edits will be saved automatically/i);
+
+    fireEvent.click(getByTestId("annotation-attestation-confirm"));
+
+    await waitFor(() => expect(attested).toBe(true));
+    expect(onBeforeAttest).toHaveBeenCalledTimes(1);
+    expect(savedBeforeAttest).toBe(true);
+  });
+
+  it("aborts the attestation when saving unsaved edits fails", async () => {
+    let attested = false;
+    const onBeforeAttest = jest.fn(() =>
+      Promise.reject(new Error("save failed")),
+    );
+
+    const attestMock = {
+      request: {
+        query: ATTEST_HUMAN_AUTHORED_ANNOTATION,
+        variables: { annotationId: "annotation-1" },
+      },
+      result: () => {
+        attested = true;
+        return {
+          data: {
+            attestHumanAuthoredAnnotation: {
+              id: "annotation-1",
+              fileSetId: "fs-1",
+              aiProvenance: {
+                origin: "human_attested_after_ai",
+                status: "applied",
+              },
+            },
+          },
+        };
+      },
+    };
+
+    const { getByTestId } = renderWithRouterApollo(
+      <AnnotationAttestationControl
+        annotation={aiAnnotation}
+        workId="work-1"
+        hasUnsavedChanges={true}
+        onBeforeAttest={onBeforeAttest}
+      />,
+      { mocks: [attestMock] },
+    );
+
+    fireEvent.click(getByTestId("annotation-attestation-trigger"));
+    fireEvent.click(getByTestId("annotation-attestation-confirm"));
+
+    await waitFor(() => expect(onBeforeAttest).toHaveBeenCalled());
+    // Give the (aborted) attest mutation a chance to fire if it was going to.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(attested).toBe(false);
+  });
 });

--- a/app/assets/js/components/Plan/Panel/Diff.jsx
+++ b/app/assets/js/components/Plan/Panel/Diff.jsx
@@ -63,14 +63,24 @@ function recordedOriginByPath(activities = []) {
  * value). Using the server-computed attribution keeps the plan diff and the
  * work About tab in lock-step rather than re-deriving it here. Like
  * recordedOriginByPath, activities are newest-first, so the first (newest)
- * activity to record a field keeps its attribution.
+ * activity to record a field keeps its attribution. Within that activity a
+ * field can have several targets (e.g. a swap recorded as delete + add on the
+ * same field), so their attributions are unioned, deduped by item id.
  */
 function itemProvenanceByPath(activities = []) {
   const map = {};
   activities.forEach((activity) => {
+    const wonByThisActivity = new Set();
     (activity.targets || []).forEach((target) => {
-      if (!(target.fieldPath in map)) {
-        map[target.fieldPath] = target.itemProvenance || [];
+      const path = target.fieldPath;
+      if (!(path in map)) {
+        map[path] = [...(target.itemProvenance || [])];
+        wonByThisActivity.add(path);
+      } else if (wonByThisActivity.has(path)) {
+        const seen = new Set(map[path].map((entry) => entry.id));
+        (target.itemProvenance || []).forEach((entry) => {
+          if (!seen.has(entry.id)) map[path].push(entry);
+        });
       }
     });
   });
@@ -287,9 +297,10 @@ const PlanPanelChangesDiff = ({
   planChangeId,
   currentWork,
 }) => {
-  // Editing/deleting a row records a manual edit on the backend (the target's
-  // origin becomes ai_assisted_human_modified / human_replacement_after_ai_suggestion),
-  // so refetch the provenance to keep the preview badges in sync.
+  // Editing a row records a manual edit on the backend (the target's origin
+  // becomes ai_assisted_human_modified); deleting a row records a rejection
+  // (status rejected, origin unchanged). Refetch the provenance to keep the
+  // preview badges in sync.
   const [updatePlanChange] = useMutation(UPDATE_PLAN_CHANGE, {
     awaitRefetchQueries: true,
     refetchQueries: planChangeId

--- a/app/assets/js/components/Plan/Panel/Diff.test.jsx
+++ b/app/assets/js/components/Plan/Panel/Diff.test.jsx
@@ -271,6 +271,58 @@ describe("PlanPanelChangesDiff", () => {
     expect(screen.queryByTestId("provenance-preview")).not.toBeInTheDocument();
   });
 
+  test("unions item provenance across same-field targets (delete + add swap)", () => {
+    // A swap proposal records two targets on one field: a delete of the
+    // existing human value (which carries no item attribution) and an add of
+    // the AI value. The add row's items must still badge even when the delete
+    // target is listed first for the field.
+    mockUseQuery.mockReturnValue({
+      data: {
+        aiActivities: [
+          {
+            id: "a1",
+            targets: [
+              {
+                fieldPath: "descriptive_metadata.alternate_title",
+                origin: "ai_modified_human_content",
+                itemProvenance: [],
+              },
+              {
+                fieldPath: "descriptive_metadata.alternate_title",
+                origin: "ai_generated",
+                itemProvenance: [{ id: "AI alt", origin: "ai_generated" }],
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    mockToRows
+      .mockReturnValueOnce([
+        {
+          id: "add-alt",
+          method: "add",
+          path: "descriptive_metadata.alternate_title",
+          label: "Alternate Title",
+          value: ["AI alt"],
+          controlled: false,
+        },
+      ])
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([]);
+
+    render(
+      <PlanPanelChangesDiff
+        proposedChanges={baseProposed}
+        planChangeId="pc-1"
+      />,
+    );
+
+    expect(screen.getAllByTestId("provenance-origin-badge")).toHaveLength(1);
+    expect(screen.queryByTestId("provenance-preview")).not.toBeInTheDocument();
+  });
+
   test("renders non-controlled primitive values directly", () => {
     mockToRows
       .mockReturnValueOnce([

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Modal.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Modal.jsx
@@ -75,41 +75,53 @@ function WorkTabsStructureTranscriptionModal({ isActive }) {
     });
   };
 
-  const handleSaveTranscription = () => {
+  // An existing annotation is edited in place (preserving its AI provenance,
+  // which is what flips an AI transcription to "AI + human edited"). A
+  // transcription typed from scratch has no annotation id yet, so upsert one
+  // by type — it is recorded as human-authored.
+  const persistTranscription = () => {
     const annotationContent = textArea?.value || "";
     const annotationId = textArea?.getAttribute("data-annotation-id");
 
-    const onCompleted = () => {
-      handleClose();
-      toastWrapper("is-success", "Transcription successfully saved");
-    };
-
-    const onError = (error) => {
-      toastWrapper("is-danger", "Error saving transcription: " + error.message);
-    };
-
-    // An existing annotation is edited in place (preserving its AI provenance,
-    // which is what flips an AI transcription to "AI + human edited"). A
-    // transcription typed from scratch has no annotation id yet, so upsert one
-    // by type — it is recorded as human-authored.
     if (annotationId) {
-      updateFileSetAnnotation({
+      return updateFileSetAnnotation({
         variables: { annotationId, content: annotationContent },
-        onCompleted,
-        onError,
-      });
-    } else {
-      upsertFileSetAnnotation({
-        variables: {
-          fileSetId,
-          type: TRANSCRIPTION_TYPE,
-          content: annotationContent,
-        },
-        refetchQueries: [{ query: GET_WORK, variables: { id: workId } }],
-        onCompleted,
-        onError,
       });
     }
+    return upsertFileSetAnnotation({
+      variables: {
+        fileSetId,
+        type: TRANSCRIPTION_TYPE,
+        content: annotationContent,
+      },
+      refetchQueries: [{ query: GET_WORK, variables: { id: workId } }],
+    });
+  };
+
+  const handleSaveTranscription = () => {
+    persistTranscription()
+      .then(() => {
+        handleClose();
+        toastWrapper("is-success", "Transcription successfully saved");
+      })
+      .catch((error) => {
+        toastWrapper(
+          "is-danger",
+          "Error saving transcription: " + error.message,
+        );
+      });
+  };
+
+  // Called by the attestation control before it records "human attested" so an
+  // edit-then-attest never loses the edits: the live textarea content is saved
+  // first, and the modal's dirty baseline resets so closing afterwards without
+  // touching Save doesn't discard anything. Errors propagate to the caller,
+  // which aborts the attestation.
+  const handleSaveBeforeAttest = async () => {
+    if (!isDirty) return;
+    await persistTranscription();
+    initialValueRef.current = textArea?.value ?? "";
+    setIsDirty(false);
   };
 
   const handleDeleteTranscription = () => {
@@ -225,6 +237,8 @@ function WorkTabsStructureTranscriptionModal({ isActive }) {
               hasTranscriptionCallback={handleHasTranscriptionCallback}
               isActive={isActive}
               onContentChange={handleContentChange}
+              hasUnsavedChanges={isDirty}
+              onBeforeAttest={handleSaveBeforeAttest}
             />
           </div>
         </section>

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Modal.test.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Modal.test.jsx
@@ -58,6 +58,10 @@ const workflowState = {
   // Set by the mock so tests can re-fire hasTranscriptionCallback the way the
   // real Pane does when a generation completes.
   trigger: null,
+  // Captured by the mock so tests can drive the attestation control's
+  // save-before-attest hook the way the real Workflow does.
+  onBeforeAttest: null,
+  hasUnsavedChanges: null,
 };
 
 // Mock Workflow so it renders the textarea the modal is looking for, wiring
@@ -71,11 +75,15 @@ jest.mock("@js/components/Work/Tabs/Structure/Transcription/Workflow", () => {
     default: function MockWorkflow({
       hasTranscriptionCallback,
       onContentChange,
+      hasUnsavedChanges,
+      onBeforeAttest,
     }) {
       const props = workflowState.annotationId
         ? { "data-annotation-id": workflowState.annotationId }
         : {};
       workflowState.trigger = hasTranscriptionCallback;
+      workflowState.onBeforeAttest = onBeforeAttest;
+      workflowState.hasUnsavedChanges = hasUnsavedChanges;
       useEffect(() => {
         hasTranscriptionCallback?.();
       }, []);
@@ -245,6 +253,55 @@ describe("WorkTabsStructureTranscriptionModal", () => {
     });
 
     expect(mockDispatch).toHaveBeenCalledWith({
+      type: "toggleTranscriptionModal",
+      fileSetId: null,
+    });
+  });
+
+  it("saves unsaved edits without closing the modal when attestation asks it to", async () => {
+    const mutationMocks = [
+      {
+        request: {
+          query: UPDATE_FILE_SET_ANNOTATION,
+          variables: {
+            annotationId: "ann-1",
+            content: "Edited before attesting",
+          },
+        },
+        result: {
+          data: {
+            updateFileSetAnnotation: {
+              id: "ann-1",
+              content: "Edited before attesting",
+            },
+          },
+        },
+      },
+    ];
+
+    renderModal({ mocks: mutationMocks });
+
+    const saveButton = await screen.findByRole("button", { name: /save/i });
+
+    const textarea = document.getElementById("file-set-transcription-textarea");
+    fireEvent.change(textarea, {
+      target: { value: "Edited before attesting" },
+    });
+    await waitFor(() => expect(saveButton).not.toBeDisabled());
+    expect(workflowState.hasUnsavedChanges).toBe(true);
+
+    // Drive the hook the attestation control awaits before recording the
+    // attestation.
+    await act(async () => {
+      await workflowState.onBeforeAttest();
+    });
+
+    // The edits are saved and the dirty baseline resets, but the modal stays
+    // open and shows no save toast (the attestation flow owns messaging).
+    await waitFor(() => expect(saveButton).toBeDisabled());
+    expect(workflowState.hasUnsavedChanges).toBe(false);
+    expect(toastWrapper).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalledWith({
       type: "toggleTranscriptionModal",
       fileSetId: null,
     });

--- a/app/assets/js/components/Work/Tabs/Structure/Transcription/Workflow.jsx
+++ b/app/assets/js/components/Work/Tabs/Structure/Transcription/Workflow.jsx
@@ -53,6 +53,8 @@ function WorkTabsStructureTranscriptionWorkflow({
   workId,
   hasTranscriptionCallback,
   onContentChange,
+  hasUnsavedChanges,
+  onBeforeAttest,
 }) {
   const flashedAnnotationErrorIdRef = useRef(null);
   const flashedAnnotationCompletedIdRef = useRef(null);
@@ -215,20 +217,25 @@ function WorkTabsStructureTranscriptionWorkflow({
         </div>
       ) : (
         <>
+          {/* flexShrink 0 on the control rows: the pane below asks for 100% of
+              the column, and without it these rows get squashed to their
+              min-height and their content overflows onto the row below. */}
           <div
             className="is-flex is-align-items-center is-flex-wrap-wrap mb-2"
-            style={{ gap: "0.5rem", minHeight: "2rem" }}
+            style={{ gap: "0.5rem", minHeight: "2rem", flexShrink: 0 }}
           >
             <AnnotationOriginBadge annotation={annotation} />
             <AnnotationAttestationControl
               annotation={annotation}
               workId={workId}
+              hasUnsavedChanges={hasUnsavedChanges}
+              onBeforeAttest={onBeforeAttest}
             />
           </div>
           {canGenerate && (
             <div
               className="is-flex is-align-items-center is-flex-wrap-wrap mb-2"
-              style={{ gap: "0.5rem 0.75rem" }}
+              style={{ gap: "0.5rem 0.75rem", flexShrink: 0 }}
             >
               <Button
                 isPrimary

--- a/app/lib/meadow/ai/provenance.ex
+++ b/app/lib/meadow/ai/provenance.ex
@@ -220,6 +220,7 @@ defmodule Meadow.AI.Provenance do
     event_type = Keyword.get(opts, :event_type, "proposed")
     actor = Keyword.get(opts, :actor)
     target_attrs = Keyword.get(opts, :target_attrs, %{})
+    prior_values = Keyword.get(opts, :prior_values, %{})
 
     operations
     |> operation_targets(target_type, target_id)
@@ -230,10 +231,30 @@ defmodule Meadow.AI.Provenance do
         |> Map.put(:origin, origin)
         |> Map.put(:status, status)
         |> Map.put(:actor, actor)
+        |> classify_proposed_modification(Map.get(prior_values, attrs.field_path))
 
       {:ok, target} = record_target(activity, attrs, event_type)
       target
     end)
+  end
+
+  # Proposal-time counterpart of finalize_apply_target!/4: an AI replace or
+  # delete over existing content modifies human content rather than generating
+  # fresh content, so classify it that way as soon as the target is recorded.
+  # Without this, a plan that never reaches apply (rejected, abandoned) leaves
+  # the human's existing value attributed to the AI. Callers opt in by passing
+  # `prior_values` (see prior_values_for_operations/2); the apply step re-runs
+  # the same rule and is a no-op for targets already classified here.
+  defp classify_proposed_modification(attrs, prior_value) do
+    if modification?(attrs.origin, attrs.operation, prior_value) do
+      Map.merge(attrs, %{
+        origin: "ai_modified_human_content",
+        source_value_snapshot: prior_value,
+        digital_source_type_uri: @enhanced_source_type
+      })
+    else
+      attrs
+    end
   end
 
   @doc """
@@ -302,22 +323,35 @@ defmodule Meadow.AI.Provenance do
     existing = find_target(activity.id, before_target)
     after_target = matching_operation_target(after_targets, before_target)
 
-    if existing do
-      event_type = if is_nil(after_target), do: "human_replaced", else: "human_edited"
+    cond do
+      is_nil(existing) ->
+        :ok
 
-      origin =
-        if is_nil(after_target),
-          do: "human_replacement_after_ai_suggestion",
-          else: "ai_assisted_human_modified"
+      # Row deleted from a not-yet-applied proposal: the human is rejecting the
+      # AI suggestion, not replacing content. Keep origin (authorship) intact
+      # and record the review outcome, matching review_target!/5's reject path.
+      # If the field is later re-added to the same plan change,
+      # record_manual_addition!/3 no-ops on this target and apply flips it to
+      # "applied", so the record self-heals.
+      is_nil(after_target) ->
+        update_target_status_origin!(existing, existing.origin, "rejected")
 
-      update_target_status_origin!(existing, origin, "reviewed")
+        add_event!(existing, %{
+          event_type: "rejected",
+          actor: actor,
+          value_before: before_target.proposed_value,
+          value_after: nil
+        })
 
-      add_event!(existing, %{
-        event_type: event_type,
-        actor: actor,
-        value_before: before_target.proposed_value,
-        value_after: after_target && after_target.proposed_value
-      })
+      true ->
+        update_target_status_origin!(existing, "ai_assisted_human_modified", "reviewed")
+
+        add_event!(existing, %{
+          event_type: "human_edited",
+          actor: actor,
+          value_before: before_target.proposed_value,
+          value_after: after_target.proposed_value
+        })
     end
   end
 
@@ -974,8 +1008,16 @@ defmodule Meadow.AI.Provenance do
   keyed by field_path. Captured before the work is mutated so the apply step can
   tell whether the AI overwrote pre-existing content.
   """
-  def prior_values_for_change(work, plan_change) do
-    plan_operation_map(plan_change)
+  def prior_values_for_change(work, plan_change),
+    do: prior_values_for_operations(work, plan_operation_map(plan_change))
+
+  @doc """
+  Same as prior_values_for_change/2 but for a bare operations map
+  (`%{add: ..., delete: ..., replace: ...}`), for callers recording proposal
+  targets before a plan change exists.
+  """
+  def prior_values_for_operations(work, operations) do
+    operations
     |> operation_targets("Work", work.id)
     |> Map.new(fn %{field_path: field_path} -> {field_path, field_value(work, field_path)} end)
   end
@@ -1296,22 +1338,38 @@ defmodule Meadow.AI.Provenance do
   applies to, but in-place edits (the common case) are attributed correctly.
   Shared by the work About tab (`item_provenance` on the provenance summary) and
   the plan diff, so both stages show identical per-item attribution.
+
+  A `delete` target's proposed_value is existing content the AI wants removed,
+  not content the AI authored, so it contributes no item attribution.
   """
   def item_provenance(%Target{} = target),
     do: ai_item_provenance(target, target.events || [])
+
+  # Targets whose proposal never touched the work: not yet applied (proposed,
+  # reviewed) or never will be (rejected, failed). Their items must not badge
+  # the field's live value, mirroring the frontend's INACTIVE_FIELD_STATUSES
+  # rule for field-level badges.
+  @unapplied_target_statuses ~w(proposed reviewed rejected failed)
 
   # A single field's value can be touched by several targets (e.g. one activity
   # replaces a note and a later one adds another), so per-item attribution is the
   # union of every target's items. Targets are merged oldest-first and deduped by
   # id, so when two targets touch the same item the most recent attribution wins.
+  # Only targets that were actually applied contribute: a rejected or still-
+  # pending proposal (e.g. a delete of a human-entered term) must not mark the
+  # field's live items as AI content.
   defp merge_item_provenance(targets) do
     targets
+    |> Enum.reject(&(&1.status in @unapplied_target_statuses))
     |> Enum.sort_by(&summary_sort_key/1)
     |> Enum.flat_map(&ai_item_provenance(&1, &1.events || []))
     |> Enum.reverse()
     |> Enum.uniq_by(& &1.id)
     |> Enum.reverse()
   end
+
+  # The AI proposed *removing* these items; it did not author them.
+  defp ai_item_provenance(%{operation: "delete"}, _events), do: []
 
   defp ai_item_provenance(target, events) do
     attested = attested_item_ids(events)

--- a/app/lib/meadow/ai/provenance.ex
+++ b/app/lib/meadow/ai/provenance.ex
@@ -447,6 +447,80 @@ defmodule Meadow.AI.Provenance do
     )
   end
 
+  @doc """
+  Re-point AI provenance after file sets are transferred to another work.
+  Activities whose `file_set_id` is among the transferred file sets get
+  `work_id` set to the destination (work-level activities with a nil
+  `file_set_id` are never touched); source citations for those file sets get
+  their resolvable pointer fields (`work_id`, `collection_id`,
+  `collection_title`, `access_link`) refreshed so citations stay resolvable
+  after the emptied source work is deleted; and a `transferred` event is
+  appended to each affected target so the move is recorded rather than
+  silently rewritten. File-set identity fields on sources (`item_id`, content
+  hashes, `source_snapshot`) describe the file set itself and are left alone.
+
+  Intended to be called inside the same transaction as the file set moves.
+  Idempotent: activities already pointing at the destination work are skipped.
+  """
+  def transfer_file_set_provenance(file_set_ids, to_work_id, opts \\ [])
+
+  def transfer_file_set_provenance([], _to_work_id, _opts),
+    do: {:ok, %{activities: 0, sources: 0, events: 0}}
+
+  def transfer_file_set_provenance(file_set_ids, to_work_id, opts) do
+    actor = Keyword.get(opts, :actor)
+    to_work = Repo.get!(Work, to_work_id) |> Repo.preload(:collection)
+
+    affected =
+      Repo.all(
+        from(a in Activity,
+          where: a.file_set_id in ^file_set_ids,
+          where: is_nil(a.work_id) or a.work_id != ^to_work_id,
+          select: %{id: a.id, old_work_id: a.work_id}
+        )
+      )
+
+    {activity_count, _} =
+      from(a in Activity, where: a.id in ^Enum.map(affected, & &1.id))
+      |> Repo.update_all(set: [work_id: to_work_id, updated_at: DateTime.utc_now()])
+
+    {source_count, _} =
+      from(s in Source, where: s.file_set_id in ^file_set_ids)
+      |> Repo.update_all(
+        set: [
+          work_id: to_work_id,
+          collection_id: to_work.collection_id,
+          collection_title: to_work.collection && to_work.collection.title,
+          access_link: work_access_link(to_work_id),
+          updated_at: DateTime.utc_now()
+        ]
+      )
+
+    event_count = record_transfer_events(affected, to_work_id, actor)
+
+    {:ok, %{activities: activity_count, sources: source_count, events: event_count}}
+  end
+
+  # `value_before`/`value_after` stay nil on transfer events: `current_value/2`
+  # treats the latest non-proposed event with a non-nil `value_after` as the
+  # field's live value, so a payload here would clobber the target's content.
+  defp record_transfer_events(affected, to_work_id, actor) do
+    affected
+    |> Enum.flat_map(fn %{id: activity_id, old_work_id: old_work_id} ->
+      activity_id
+      |> targets_for_activity()
+      |> Enum.map(fn target ->
+        add_event!(target, %{
+          event_type: "transferred",
+          actor: actor,
+          notes: "File set transferred from work #{old_work_id} to work #{to_work_id}",
+          outcome_detail: "from_work_id=#{old_work_id} to_work_id=#{to_work_id}"
+        })
+      end)
+    end)
+    |> length()
+  end
+
   # Origins that carry AI history, so a later human edit of the field should be
   # recorded as human mediation rather than silently keeping the AI label.
   @ai_involved_origins ~w(
@@ -1596,6 +1670,7 @@ defmodule Meadow.AI.Provenance do
   defp premis_event_type("applied"), do: "metadata update"
   defp premis_event_type("deleted"), do: "deletion"
   defp premis_event_type("failed"), do: "metadata update"
+  defp premis_event_type("transferred"), do: "transfer"
   defp premis_event_type(value), do: value
 
   defp event_outcome("rejected"), do: "failure"

--- a/app/lib/meadow/ai/provenance/schemas/event.ex
+++ b/app/lib/meadow/ai/provenance/schemas/event.ex
@@ -16,6 +16,7 @@ defmodule Meadow.AI.Provenance.Schemas.Event do
     applied
     deleted
     failed
+    transferred
   )
 
   @primary_key {:id, Ecto.UUID, autogenerate: false, read_after_writes: true}

--- a/app/lib/meadow/data/planner.ex
+++ b/app/lib/meadow/data/planner.ex
@@ -375,23 +375,32 @@ defmodule Meadow.Data.Planner do
   defp check_approvable(%Plan{}), do: {:error, "Only proposed plans can be approved"}
 
   @doc """
-  Rejects a plan.
+  Rejects a plan, cascading the rejection to its proposed and approved
+  changes and recording review provenance for each.
 
   ## Examples
 
-      iex> reject_plan(plan, "Changes not needed")
+      iex> reject_plan(plan, "Changes not needed", "user@example.com")
       {:ok, %Plan{status: :rejected, notes: "Changes not needed"}}
   """
-  def reject_plan(%Plan{} = plan, notes \\ nil) do
-    case plan
-         |> Plan.reject(notes)
-         |> Repo.update() do
-      {:ok, updated_plan} = result ->
-        broadcast_plan_update(updated_plan)
-        result
+  def reject_plan(%Plan{} = plan, notes \\ nil, user \\ nil) do
+    with {:ok, {updated_plan, changes}} <-
+           Repo.transaction(fn -> reject_plan_and_changes(plan, notes, user) end) do
+      Enum.each(changes, &broadcast_plan_change_update(&1, "updated"))
+      broadcast_plan_update(updated_plan)
+      {:ok, updated_plan}
+    end
+  end
 
-      error ->
-        error
+  # :proposed covers rejecting at the approval step; :approved covers
+  # rejecting at the apply step (changes were already bulk-approved).
+  defp reject_plan_and_changes(plan, notes, user) do
+    {changes, _count} =
+      reject_changes_with_statuses(plan.id, [:proposed, :approved], notes, user)
+
+    case plan |> Plan.reject(notes, user) |> Repo.update() do
+      {:ok, updated_plan} -> {updated_plan, changes}
+      {:error, changeset} -> Repo.rollback(changeset)
     end
   end
 
@@ -841,34 +850,43 @@ defmodule Meadow.Data.Planner do
   def reject_proposed_plan_changes(%Plan{} = plan, notes \\ nil, user \\ nil) do
     with {:ok, {changes, count}} <-
            Repo.transaction(fn ->
-             timestamp = DateTime.utc_now()
-             change_ids = proposed_change_ids(plan.id)
-
-             # Recheck status in the UPDATE so a change reviewed concurrently
-             # (between the select above and this update) is skipped rather
-             # than overwritten; only the ids actually updated get review
-             # provenance recorded below.
-             {count, updated_ids} =
-               from(c in PlanChange,
-                 where: c.id in ^change_ids and c.status == :proposed,
-                 select: c.id,
-                 update: [set: [status: :rejected, notes: ^notes, updated_at: ^timestamp]]
-               )
-               |> Repo.update_all([])
-
-             changes = list_plan_changes_by_ids(updated_ids, :rejected)
-
-             Enum.each(
-               changes,
-               &Provenance.record_review_for_plan_change(&1, "rejected", user, notes)
-             )
-
-             {changes, count}
+             reject_changes_with_statuses(plan.id, [:proposed], notes, user)
            end) do
       Enum.each(changes, &broadcast_plan_change_update(&1, "updated"))
 
       {:ok, maybe_reload_plan(plan), count}
     end
+  end
+
+  # Must be called inside a Repo.transaction. Returns {changes, count}.
+  defp reject_changes_with_statuses(plan_id, statuses, notes, user) do
+    timestamp = DateTime.utc_now()
+
+    change_ids =
+      from(c in PlanChange,
+        where: c.plan_id == ^plan_id and c.status in ^statuses,
+        where: ^change_fragment(:not_empty),
+        select: c.id
+      )
+      |> Repo.all()
+
+    # Recheck status in the UPDATE so a change reviewed concurrently
+    # (between the select above and this update) is skipped rather
+    # than overwritten; only the ids actually updated get review
+    # provenance recorded below.
+    {count, updated_ids} =
+      from(c in PlanChange,
+        where: c.id in ^change_ids and c.status in ^statuses,
+        select: c.id,
+        update: [set: [status: :rejected, notes: ^notes, user: ^user, updated_at: ^timestamp]]
+      )
+      |> Repo.update_all([])
+
+    changes = list_plan_changes_by_ids(updated_ids, :rejected)
+
+    Enum.each(changes, &Provenance.record_review_for_plan_change(&1, "rejected", user, notes))
+
+    {changes, count}
   end
 
   @doc """

--- a/app/lib/meadow/data/schemas/plan.ex
+++ b/app/lib/meadow/data/schemas/plan.ex
@@ -95,12 +95,12 @@ defmodule Meadow.Data.Schemas.Plan do
 
   ## Example
 
-      iex> plan |> Plan.reject("Changes not needed") |> Repo.update()
-      {:ok, %Plan{status: :rejected, notes: "Changes not needed"}}
+      iex> plan |> Plan.reject("Changes not needed", "user@example.com") |> Repo.update()
+      {:ok, %Plan{status: :rejected, notes: "Changes not needed", user: "user@example.com"}}
   """
-  def reject(plan, notes \\ nil) do
+  def reject(plan, notes \\ nil, user \\ nil) do
     plan
-    |> cast(%{status: :rejected, notes: notes}, [:status, :notes])
+    |> cast(%{status: :rejected, notes: notes, user: user}, [:status, :notes, :user])
     |> validate_inclusion(:status, @statuses)
   end
 

--- a/app/lib/meadow/data/works/transfer_file_sets.ex
+++ b/app/lib/meadow/data/works/transfer_file_sets.ex
@@ -5,6 +5,7 @@ defmodule Meadow.Data.Works.TransferFileSets do
 
   import Ecto.Query, warn: false
   alias Ecto.Multi
+  alias Meadow.AI.Provenance
   alias Meadow.Data
   alias Meadow.Data.IndexBatcher
   alias Meadow.Data.Schemas.FileSet
@@ -130,6 +131,13 @@ defmodule Meadow.Data.Works.TransferFileSets do
       |> Multi.run(:transfer_filesets, fn _repo, %{create_target_work: target_work_id} ->
         transfer_fileset_subset(fileset_ids, target_work_id)
       end)
+      |> Multi.run(:transfer_provenance, fn _repo,
+                                            %{
+                                              create_target_work: target_work_id,
+                                              transfer_filesets: transferred_ids
+                                            } ->
+        Provenance.transfer_file_set_provenance(transferred_ids, target_work_id)
+      end)
       |> maybe_add_delete_empty_works_step(delete_empty_works)
 
     case Repo.transaction(multi, timeout: :infinity) do
@@ -176,6 +184,13 @@ defmodule Meadow.Data.Works.TransferFileSets do
       end)
       |> Multi.run(:transfer_filesets, fn _repo, %{get_target_work: target_work_id} ->
         transfer_fileset_subset(fileset_ids, target_work_id)
+      end)
+      |> Multi.run(:transfer_provenance, fn _repo,
+                                            %{
+                                              get_target_work: target_work_id,
+                                              transfer_filesets: transferred_ids
+                                            } ->
+        Provenance.transfer_file_set_provenance(transferred_ids, target_work_id)
       end)
       |> maybe_add_delete_empty_works_step(delete_empty_works)
 
@@ -227,6 +242,9 @@ defmodule Meadow.Data.Works.TransferFileSets do
       end)
       |> Multi.run(:transfer_file_sets, fn _repo, _changes ->
         transfer_file_sets(from_work_id, to_work_id)
+      end)
+      |> Multi.run(:transfer_provenance, fn _repo, %{transfer_file_sets: transferred_ids} ->
+        Provenance.transfer_file_set_provenance(transferred_ids, to_work_id)
       end)
       |> Multi.run(:delete_empty_work, fn _repo, _changes -> delete_empty_work(from_work_id) end)
       |> Multi.run(:refetch_to_work, fn _repo, _changes -> fetch_work(to_work_id) end)
@@ -547,6 +565,7 @@ defmodule Meadow.Data.Works.TransferFileSets do
       :create_target_work,
       :get_target_work,
       :transfer_filesets,
+      :transfer_provenance,
       :get_source_work_ids,
       :delete_empty_works
     ]
@@ -591,17 +610,17 @@ defmodule Meadow.Data.Works.TransferFileSets do
         changeset = FileSet.changeset(file_set, %{work_id: to_work_id, rank: new_rank})
 
         case Repo.update(changeset) do
-          {:ok, _} -> {:ok, :transferred}
+          {:ok, updated} -> {:ok, updated.id}
           {:error, _} -> {:error, :transfer_failed}
         end
       end)
 
-    if Enum.all?(updates, fn {:ok, _} -> true end) do
+    if Enum.all?(updates, &match?({:ok, _}, &1)) do
       Logger.info(
         "Transferred #{Enum.count(updates)} file sets from #{from_work_id} to #{to_work_id}"
       )
 
-      {:ok, :transferred}
+      {:ok, Enum.map(updates, fn {:ok, id} -> id end)}
     else
       {:error, :transfer_failed}
     end
@@ -634,6 +653,7 @@ defmodule Meadow.Data.Works.TransferFileSets do
       :to_work -> "Fetching 'to' work"
       :check_work_types -> "Checking work types"
       :transfer_file_sets -> "Transferring file sets"
+      :transfer_provenance -> "Updating AI provenance"
       :delete_empty_work -> "Deleting empty work"
       :refetch_to_work -> "Refetching work"
       _ -> "Unknown operation"

--- a/app/lib/meadow_web/mcp/tools/apply_work_metadata.ex
+++ b/app/lib/meadow_web/mcp/tools/apply_work_metadata.ex
@@ -103,21 +103,26 @@ defmodule MeadowWeb.MCP.Tools.ApplyWorkMetadata do
         Provenance.add_source(activity, Provenance.work_source_attrs(work))
         |> unwrap_or_rollback()
 
+        operations = %{
+          replace: %{
+            descriptive_metadata: %{
+              description: [description],
+              subject: subject_attrs
+            }
+          }
+        }
+
         Provenance.record_targets_for_operations(
           activity,
           "Work",
           work_id,
-          %{
-            replace: %{
-              descriptive_metadata: %{
-                description: [description],
-                subject: subject_attrs
-              }
-            }
-          },
+          operations,
           origin: "ai_generated",
           status: "applied",
           event_type: "applied",
+          # `work` is the pre-update snapshot, so replacing existing content is
+          # recorded as modifying human content, not attributing it to the AI.
+          prior_values: Provenance.prior_values_for_operations(work, operations),
           target_attrs: %{
             premis_object_category: "intellectual_entity",
             object_identifier_type: "Meadow Work",

--- a/app/lib/meadow_web/mcp/tools/update_plan_change.ex
+++ b/app/lib/meadow_web/mcp/tools/update_plan_change.ex
@@ -226,6 +226,15 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChange do
     if has_metadata_changes?(attrs) do
       plan = Repo.preload(change, :plan).plan
 
+      # Current work values for the touched fields, so a replace/delete over
+      # existing content is recorded as modifying human content rather than
+      # attributing that content to the AI.
+      prior_values =
+        case Repo.get(Work, change.work_id) do
+          nil -> %{}
+          work -> Provenance.prior_values_for_operations(work, attrs)
+        end
+
       with {:ok, activity} <- activity_for_change(change, plan) do
         Provenance.record_targets_for_operations(
           activity,
@@ -235,6 +244,7 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChange do
           origin: "ai_generated",
           status: "proposed",
           event_type: "proposed",
+          prior_values: prior_values,
           target_attrs: %{
             premis_object_category: "intellectual_entity",
             object_identifier_type: "Meadow Work",

--- a/app/lib/meadow_web/resolvers/plans.ex
+++ b/app/lib/meadow_web/resolvers/plans.ex
@@ -22,7 +22,7 @@ defmodule MeadowWeb.Resolvers.Data.Plans do
         result =
           case status do
             :approved -> Planner.approve_plan(plan, user.username)
-            :rejected -> Planner.reject_plan(plan, Map.get(args, :notes))
+            :rejected -> Planner.reject_plan(plan, Map.get(args, :notes), user.username)
             _ -> {:error, "Invalid status transition"}
           end
 

--- a/app/test/meadow/ai/provenance_test.exs
+++ b/app/test/meadow/ai/provenance_test.exs
@@ -1212,4 +1212,180 @@ defmodule Meadow.AI.ProvenanceTest do
              ] = Provenance.work_summary(work.id)
     end
   end
+
+  describe "transfer_file_set_provenance/3" do
+    alias Meadow.AI.Provenance.Schemas.{Activity, Source}
+    alias Meadow.Repo
+
+    setup do
+      source_collection = collection_fixture(%{title: "Source Collection"})
+      destination_collection = collection_fixture(%{title: "Destination Collection"})
+
+      source_work = work_with_file_sets_fixture(2, %{collection_id: source_collection.id})
+      destination_work = work_fixture(%{collection_id: destination_collection.id})
+
+      [file_set, other_file_set] = source_work.file_sets
+
+      {:ok, activity} =
+        Provenance.create_activity(%{
+          activity_type: "transcription",
+          ai_use_type: "transcription",
+          model: "test-model",
+          work_id: source_work.id,
+          file_set_id: file_set.id,
+          status: "completed"
+        })
+
+      {:ok, _source} = Provenance.add_source(activity, Provenance.file_set_source_attrs(file_set))
+
+      annotation_id = Ecto.UUID.generate()
+
+      {:ok, target} =
+        Provenance.record_target(
+          activity,
+          %{
+            target_type: "FileSetAnnotation",
+            target_id: annotation_id,
+            field_path: "file_set_annotations.content",
+            operation: "add",
+            proposed_value: "Generated transcript",
+            origin: "ai_generated",
+            status: "applied"
+          },
+          "applied"
+        )
+
+      {:ok,
+       source_work: source_work,
+       destination_work: destination_work,
+       destination_collection: destination_collection,
+       file_set: file_set,
+       other_file_set: other_file_set,
+       activity: activity,
+       target: target,
+       annotation_id: annotation_id}
+    end
+
+    test "re-points activity and refreshes source citation fields", %{
+      source_work: source_work,
+      destination_work: destination_work,
+      destination_collection: destination_collection,
+      file_set: file_set,
+      activity: activity
+    } do
+      assert {:ok, %{activities: 1, sources: 1, events: 1}} =
+               Provenance.transfer_file_set_provenance([file_set.id], destination_work.id)
+
+      activity = Repo.get!(Activity, activity.id)
+      assert activity.work_id == destination_work.id
+
+      assert [source] = Repo.all(from(s in Source, where: s.file_set_id == ^file_set.id))
+      assert source.work_id == destination_work.id
+      assert source.collection_id == destination_collection.id
+      assert source.collection_title == "Destination Collection"
+      assert source.access_link =~ destination_work.id
+      refute source.access_link =~ source_work.id
+
+      # File set identity fields are snapshots of the file set itself, untouched
+      assert source.item_id == file_set.id
+      assert source.source_snapshot == %{"accession_number" => file_set.accession_number}
+    end
+
+    test "appends a transferred audit event with old and new work ids", %{
+      source_work: source_work,
+      destination_work: destination_work,
+      file_set: file_set,
+      target: target
+    } do
+      {:ok, _} = Provenance.transfer_file_set_provenance([file_set.id], destination_work.id)
+
+      target = Repo.preload(target, :events, force: true)
+      assert transfer_event = Enum.find(target.events, &(&1.event_type == "transferred"))
+
+      assert transfer_event.premis_event_type == "transfer"
+      assert transfer_event.outcome == "success"
+      assert transfer_event.notes =~ source_work.id
+      assert transfer_event.notes =~ destination_work.id
+      assert transfer_event.outcome_detail ==
+               "from_work_id=#{source_work.id} to_work_id=#{destination_work.id}"
+
+      assert is_nil(transfer_event.value_before)
+      assert is_nil(transfer_event.value_after)
+    end
+
+    test "work summaries follow the file set without losing the current value", %{
+      source_work: source_work,
+      destination_work: destination_work,
+      file_set: file_set,
+      annotation_id: annotation_id
+    } do
+      {:ok, _} = Provenance.transfer_file_set_provenance([file_set.id], destination_work.id)
+
+      assert Provenance.work_summary(source_work.id) == []
+
+      assert [
+               %{
+                 target_type: "FileSetAnnotation",
+                 target_id: ^annotation_id,
+                 current_value: %{"value" => "Generated transcript"},
+                 latest_event_type: "transferred"
+               }
+             ] = Provenance.work_summary(destination_work.id)
+
+      assert [_] = Provenance.list_activities(work_id: destination_work.id)
+      assert [] == Provenance.list_activities(work_id: source_work.id)
+    end
+
+    test "leaves work-level activities and other file sets' provenance untouched", %{
+      source_work: source_work,
+      destination_work: destination_work,
+      file_set: file_set,
+      other_file_set: other_file_set
+    } do
+      {:ok, work_level_activity} =
+        Provenance.create_activity(%{
+          activity_type: "metadata_plan",
+          work_id: source_work.id
+        })
+
+      {:ok, other_activity} =
+        Provenance.create_activity(%{
+          activity_type: "transcription",
+          work_id: source_work.id,
+          file_set_id: other_file_set.id
+        })
+
+      {:ok, _} =
+        Provenance.add_source(other_activity, Provenance.file_set_source_attrs(other_file_set))
+
+      assert {:ok, %{activities: 1, sources: 1, events: 1}} =
+               Provenance.transfer_file_set_provenance([file_set.id], destination_work.id)
+
+      assert Repo.get!(Activity, work_level_activity.id).work_id == source_work.id
+      assert Repo.get!(Activity, other_activity.id).work_id == source_work.id
+
+      assert [other_source] =
+               Repo.all(from(s in Source, where: s.file_set_id == ^other_file_set.id))
+
+      assert other_source.work_id == source_work.id
+    end
+
+    test "is idempotent and a no-op for empty input", %{
+      destination_work: destination_work,
+      file_set: file_set,
+      target: target
+    } do
+      assert {:ok, %{activities: 0, sources: 0, events: 0}} =
+               Provenance.transfer_file_set_provenance([], destination_work.id)
+
+      {:ok, %{activities: 1}} =
+        Provenance.transfer_file_set_provenance([file_set.id], destination_work.id)
+
+      assert {:ok, %{activities: 0, events: 0}} =
+               Provenance.transfer_file_set_provenance([file_set.id], destination_work.id)
+
+      target = Repo.preload(target, :events, force: true)
+      assert Enum.count(target.events, &(&1.event_type == "transferred")) == 1
+    end
+  end
 end

--- a/app/test/meadow/ai/provenance_test.exs
+++ b/app/test/meadow/ai/provenance_test.exs
@@ -453,6 +453,155 @@ defmodule Meadow.AI.ProvenanceTest do
     end
   end
 
+  describe "plan-change row rejection" do
+    test "records a rejection when a proposed row is removed, keeping origin" do
+      work = work_fixture()
+
+      {:ok, activity} =
+        Provenance.create_activity(%{
+          activity_type: "metadata_plan",
+          ai_use_type: "metadata_generation",
+          work_id: work.id,
+          status: "completed"
+        })
+
+      proposed_location = [%{term: %{id: "loc1", label: "Illinois--Evanston"}}]
+
+      Provenance.record_targets_for_operations(
+        activity,
+        "Work",
+        work.id,
+        %{
+          add: %{
+            descriptive_metadata: %{
+              location: proposed_location,
+              subject: ["AI subject"]
+            }
+          }
+        },
+        origin: "ai_generated",
+        status: "proposed",
+        event_type: "proposed"
+      )
+
+      location_before =
+        Provenance.get_activity!(activity.id).targets
+        |> Enum.find(&(&1.field_path == "descriptive_metadata.location"))
+
+      change_before = %{
+        ai_activity_id: activity.id,
+        work_id: work.id,
+        add: %{
+          descriptive_metadata: %{
+            location: proposed_location,
+            subject: ["AI subject"]
+          }
+        },
+        delete: %{},
+        replace: %{}
+      }
+
+      # Reviewer deletes the location row and edits the subject.
+      Provenance.record_plan_manual_edit(
+        change_before,
+        %{add: %{descriptive_metadata: %{subject: ["Reviewer subject"]}}},
+        "bmq449"
+      )
+
+      targets = Provenance.get_activity!(activity.id).targets
+      location = Enum.find(targets, &(&1.field_path == "descriptive_metadata.location"))
+      subject = Enum.find(targets, &(&1.field_path == "descriptive_metadata.subject"))
+
+      # Removing a never-applied proposal is a rejection of the AI suggestion,
+      # not a replacement: origin (authorship) stays intact.
+      assert location.origin == "ai_generated"
+      assert location.status == "rejected"
+      assert location.human_oversight_level == location_before.human_oversight_level
+
+      rejected = Enum.find(location.events, &(&1.event_type == "rejected"))
+      assert rejected.actor == "bmq449"
+      assert rejected.value_before == location_before.proposed_value
+      assert is_nil(rejected.value_after)
+      assert rejected.premis_event_type == "validation"
+      assert rejected.outcome == "failure"
+      assert is_nil(rejected.c2pa_action)
+
+      # Editing a surviving row still records an AI-assisted human edit.
+      assert subject.origin == "ai_assisted_human_modified"
+      assert subject.status == "reviewed"
+
+      human_edited = Enum.find(subject.events, &(&1.event_type == "human_edited"))
+      assert human_edited.actor == "bmq449"
+      assert human_edited.value_after == %{"value" => ["Reviewer subject"]}
+    end
+  end
+
+  describe "rejected plan over existing human content" do
+    test "keeps human content attributed to humans" do
+      work =
+        work_fixture(%{
+          descriptive_metadata: %{
+            title: "Test title",
+            description: ["Human description"]
+          }
+        })
+
+      {:ok, activity} =
+        Provenance.create_activity(%{
+          activity_type: "metadata_plan",
+          ai_use_type: "metadata_generation",
+          work_id: work.id,
+          status: "completed"
+        })
+
+      # The AI proposes swapping the human value for its own: delete + add on
+      # the same field, as the planner agent records via update_plan_change.
+      operations = %{
+        delete: %{descriptive_metadata: %{description: ["Human description"]}},
+        add: %{descriptive_metadata: %{description: ["AI description"]}}
+      }
+
+      Provenance.record_targets_for_operations(
+        activity,
+        "Work",
+        work.id,
+        operations,
+        origin: "ai_generated",
+        status: "proposed",
+        event_type: "proposed",
+        prior_values: Provenance.prior_values_for_operations(work, operations)
+      )
+
+      targets = Provenance.get_activity!(activity.id).targets
+      delete_target = Enum.find(targets, &(&1.operation == "delete"))
+      add_target = Enum.find(targets, &(&1.operation == "add"))
+
+      # A delete over existing content modifies human content; the AI did not
+      # author the value it proposes to remove.
+      assert delete_target.origin == "ai_modified_human_content"
+      assert delete_target.source_value_snapshot == %{"value" => ["Human description"]}
+      assert delete_target.digital_source_type_uri == Provenance.enhanced_source_type()
+      assert add_target.origin == "ai_generated"
+
+      # The delete target's items are content being removed, never AI items.
+      assert Provenance.item_provenance(delete_target) == []
+
+      change = %{ai_activity_id: activity.id, work_id: work.id}
+      Provenance.record_review_for_plan_change(change, "rejected", "bmq449", "Not needed")
+
+      summary =
+        work.id
+        |> Provenance.work_summary()
+        |> Enum.find(&(&1.field_path == "descriptive_metadata.description"))
+
+      assert summary.status == "rejected"
+
+      # Never-applied targets contribute no per-item attribution, so the
+      # human-entered value keeps no AI badge on the About tab.
+      assert summary.item_provenance == []
+    end
+  end
+
   describe "item_provenance reconciliation" do
     alias Meadow.AI.Provenance.Schemas.{Event, Target}
 

--- a/app/test/meadow/data/planner_test.exs
+++ b/app/test/meadow/data/planner_test.exs
@@ -321,7 +321,7 @@ defmodule Meadow.Data.PlannerTest do
     end
   end
 
-  describe "reject_plan/2" do
+  describe "reject_plan/3" do
     test "transitions plan to rejected status", %{plan: plan} do
       assert {:ok, %Plan{} = rejected_plan} = Planner.reject_plan(plan)
       assert rejected_plan.status == :rejected
@@ -331,6 +331,93 @@ defmodule Meadow.Data.PlannerTest do
       assert {:ok, %Plan{} = rejected_plan} = Planner.reject_plan(plan, "Not appropriate")
       assert rejected_plan.status == :rejected
       assert rejected_plan.notes == "Not appropriate"
+    end
+
+    test "cascades rejection to proposed changes with provenance", %{plan: plan, work: work} do
+      {activity, change} = plan_change_with_provenance(plan, work)
+
+      assert {:ok, %Plan{} = rejected_plan} =
+               Planner.reject_plan(plan, "Not needed", "curator@example.com")
+
+      assert rejected_plan.status == :rejected
+      assert rejected_plan.notes == "Not needed"
+      assert rejected_plan.user == "curator@example.com"
+
+      change = Planner.get_plan_change!(change.id)
+      assert change.status == :rejected
+      assert change.notes == "Not needed"
+      assert change.user == "curator@example.com"
+
+      [target] = Provenance.get_activity!(activity.id).targets
+      assert target.status == "rejected"
+      assert target.origin == "ai_generated"
+
+      rejected_event = Enum.find(target.events, &(&1.event_type == "rejected"))
+      assert rejected_event.actor == "curator@example.com"
+      assert rejected_event.premis_event_type == "validation"
+      assert rejected_event.outcome == "failure"
+    end
+
+    test "cascades rejection to approved changes at the apply step", %{plan: plan, work: work} do
+      {activity, change} = plan_change_with_provenance(plan, work)
+
+      assert {:ok, plan, 1} =
+               Planner.approve_proposed_plan_changes(plan, "curator@example.com")
+
+      assert {:ok, plan} = Planner.approve_plan(plan, "curator@example.com")
+      assert Planner.get_plan_change!(change.id).status == :approved
+
+      assert {:ok, %Plan{status: :rejected}} =
+               Planner.reject_plan(plan, "Changed my mind", "curator@example.com")
+
+      assert Planner.get_plan_change!(change.id).status == :rejected
+
+      [target] = Provenance.get_activity!(activity.id).targets
+      assert target.status == "rejected"
+
+      event_types = Enum.map(target.events, & &1.event_type)
+      assert "approved" in event_types
+      assert "rejected" in event_types
+    end
+
+    test "leaves terminal changes untouched", %{plan: plan, work: work} do
+      {:ok, completed_change} =
+        Planner.create_plan_change(%{
+          plan_id: plan.id,
+          work_id: work.id,
+          add: %{descriptive_metadata: %{title: "Applied title"}},
+          status: :completed
+        })
+
+      {:ok, proposed_change} =
+        Planner.create_plan_change(%{
+          plan_id: plan.id,
+          work_id: work_fixture().id,
+          add: %{descriptive_metadata: %{title: "Proposed title"}},
+          status: :proposed
+        })
+
+      assert {:ok, %Plan{status: :rejected}} = Planner.reject_plan(plan)
+
+      assert Planner.get_plan_change!(completed_change.id).status == :completed
+      assert Planner.get_plan_change!(proposed_change.id).status == :rejected
+    end
+  end
+
+  describe "reject_proposed_plan_changes/3" do
+    test "rejects all proposed changes and records the user", %{plan: plan, work: work} do
+      {activity, change} = plan_change_with_provenance(plan, work)
+
+      assert {:ok, _plan, 1} =
+               Planner.reject_proposed_plan_changes(plan, "No thanks", "curator@example.com")
+
+      change = Planner.get_plan_change!(change.id)
+      assert change.status == :rejected
+      assert change.notes == "No thanks"
+      assert change.user == "curator@example.com"
+
+      [target] = Provenance.get_activity!(activity.id).targets
+      assert target.status == "rejected"
     end
   end
 
@@ -599,7 +686,7 @@ defmodule Meadow.Data.PlannerTest do
       assert error_message == ~s'"#{invalid_plan_id}" is invalid'
     end
 
-    test "records human replacement provenance when reviewer replaces AI proposal", %{
+    test "records rejection provenance when reviewer removes AI proposal", %{
       plan: plan,
       work: work
     } do
@@ -641,7 +728,12 @@ defmodule Meadow.Data.PlannerTest do
                })
 
       summary = Provenance.work_summary(work.id)
-      assert Enum.any?(summary, &(&1.origin == "human_replacement_after_ai_suggestion"))
+
+      description_entry =
+        Enum.find(summary, &(&1.field_path == "descriptive_metadata.description"))
+
+      assert description_entry.origin == "ai_generated"
+      assert description_entry.status == "rejected"
       assert Enum.any?(summary, &(&1.origin == "human_generated"))
     end
   end
@@ -1143,5 +1235,36 @@ defmodule Meadow.Data.PlannerTest do
       # Verify all changes were completed
       assert Planner.list_plan_changes(plan.id, status: :completed) |> length() == 2
     end
+  end
+
+  defp plan_change_with_provenance(plan, work) do
+    {:ok, activity} =
+      Provenance.create_activity(%{
+        activity_type: "metadata_plan",
+        work_id: work.id,
+        plan_id: plan.id,
+        status: "completed"
+      })
+
+    Provenance.record_targets_for_operations(
+      activity,
+      "Work",
+      work.id,
+      %{add: %{descriptive_metadata: %{description: ["AI proposal"]}}},
+      origin: "ai_generated",
+      status: "proposed",
+      event_type: "proposed"
+    )
+
+    {:ok, change} =
+      Planner.create_plan_change(%{
+        plan_id: plan.id,
+        work_id: work.id,
+        add: %{descriptive_metadata: %{description: ["AI proposal"]}},
+        status: :proposed,
+        ai_activity_id: activity.id
+      })
+
+    {activity, change}
   end
 end

--- a/app/test/meadow/data/works/transfer_file_sets_test.exs
+++ b/app/test/meadow/data/works/transfer_file_sets_test.exs
@@ -651,6 +651,170 @@ defmodule Meadow.Data.Works.TransferFileSetsTest do
     end
   end
 
+  describe "AI provenance" do
+    alias Meadow.AI.Provenance
+    alias Meadow.AI.Provenance.Schemas.{Activity, Source}
+
+    test "transfer/2 re-points provenance to the destination work before deleting the source" do
+      from_work = work_with_file_sets_fixture(2)
+      to_work = work_with_file_sets_fixture(1)
+      file_set = hd(from_work.file_sets)
+      %{activity: activity, target: target} = attach_transcription_provenance(file_set)
+
+      assert {:ok, %Work{}} = TransferFileSets.transfer(from_work.id, to_work.id)
+      refute Works.get_work(from_work.id)
+
+      assert Repo.get!(Activity, activity.id).work_id == to_work.id
+
+      source = Repo.get_by!(Source, file_set_id: file_set.id)
+      assert source.work_id == to_work.id
+      assert source.access_link =~ to_work.id
+
+      events = Repo.preload(target, :events, force: true).events
+      assert Enum.any?(events, &(&1.event_type == "transferred"))
+    end
+
+    test "transfer_subset/1 re-points provenance to a newly created work" do
+      source_work = work_with_file_sets_fixture(2)
+      file_set = hd(source_work.file_sets)
+      %{activity: activity} = attach_transcription_provenance(file_set)
+
+      args = %{
+        fileset_ids: [file_set.id],
+        create_work: true,
+        work_attributes: %{accession_number: "PROVENANCE_NEW_WORK", work_type: "IMAGE"}
+      }
+
+      assert {:ok, %{created_work_id: created_work_id}} = TransferFileSets.transfer_subset(args)
+
+      assert Repo.get!(Activity, activity.id).work_id == created_work_id
+      assert Repo.get_by!(Source, file_set_id: file_set.id).work_id == created_work_id
+      assert [_] = Provenance.list_activities(work_id: created_work_id)
+    end
+
+    test "transfer_subset/1 refreshes source citation fields for the destination collection" do
+      source_collection = collection_fixture(%{title: "Source Collection"})
+      destination_collection = collection_fixture(%{title: "Destination Collection"})
+
+      source_work = work_with_file_sets_fixture(2, %{collection_id: source_collection.id})
+      target_work = work_with_file_sets_fixture(1, %{collection_id: destination_collection.id})
+      file_set = hd(source_work.file_sets)
+      attach_transcription_provenance(file_set)
+
+      args = %{
+        fileset_ids: [file_set.id],
+        create_work: false,
+        accession_number: target_work.accession_number
+      }
+
+      assert {:ok, _} = TransferFileSets.transfer_subset(args)
+
+      source = Repo.get_by!(Source, file_set_id: file_set.id)
+      assert source.work_id == target_work.id
+      assert source.collection_id == destination_collection.id
+      assert source.collection_title == "Destination Collection"
+      assert source.access_link =~ target_work.id
+    end
+
+    test "transfer_subset/1 leaves no provenance pointing at deleted source works" do
+      source_work = work_with_file_sets_fixture(2)
+      target_work = work_with_file_sets_fixture(1)
+      fileset_ids = Enum.map(source_work.file_sets, & &1.id)
+      Enum.each(source_work.file_sets, &attach_transcription_provenance/1)
+
+      args = %{
+        fileset_ids: fileset_ids,
+        create_work: false,
+        accession_number: target_work.accession_number
+      }
+
+      assert {:ok, _} = TransferFileSets.transfer_subset(args)
+      refute Works.get_work(source_work.id)
+
+      assert [] == Provenance.list_activities(work_id: source_work.id)
+      assert length(Provenance.list_activities(work_id: target_work.id)) == 2
+      assert [] == Repo.all(from(s in Source, where: s.work_id == ^source_work.id))
+    end
+
+    test "transfer_subset/1 leaves provenance of file sets that stay behind untouched" do
+      source_work = work_with_file_sets_fixture(2)
+      target_work = work_with_file_sets_fixture(1)
+      [moved, staying] = source_work.file_sets
+
+      attach_transcription_provenance(moved)
+
+      %{activity: staying_activity, target: staying_target} =
+        attach_transcription_provenance(staying)
+
+      args = %{
+        fileset_ids: [moved.id],
+        create_work: false,
+        accession_number: target_work.accession_number
+      }
+
+      assert {:ok, _} = TransferFileSets.transfer_subset(args)
+
+      assert Repo.get!(Activity, staying_activity.id).work_id == source_work.id
+      assert Repo.get_by!(Source, file_set_id: staying.id).work_id == source_work.id
+
+      events = Repo.preload(staying_target, :events, force: true).events
+      refute Enum.any?(events, &(&1.event_type == "transferred"))
+    end
+
+    test "failed transfers leave provenance unchanged" do
+      source_work = work_with_file_sets_fixture(1)
+      file_set = hd(source_work.file_sets)
+      %{activity: activity, target: target} = attach_transcription_provenance(file_set)
+
+      args = %{
+        fileset_ids: [file_set.id],
+        create_work: false,
+        accession_number: "NONEXISTENT_WORK"
+      }
+
+      assert {:error, _} = TransferFileSets.transfer_subset(args)
+
+      assert Repo.get!(Activity, activity.id).work_id == source_work.id
+      assert Repo.get_by!(Source, file_set_id: file_set.id).work_id == source_work.id
+
+      events = Repo.preload(target, :events, force: true).events
+      refute Enum.any?(events, &(&1.event_type == "transferred"))
+    end
+  end
+
+  defp attach_transcription_provenance(file_set) do
+    alias Meadow.AI.Provenance
+
+    {:ok, activity} =
+      Provenance.create_activity(%{
+        activity_type: "transcription",
+        ai_use_type: "transcription",
+        model: "test-model",
+        work_id: file_set.work_id,
+        file_set_id: file_set.id,
+        status: "completed"
+      })
+
+    {:ok, _source} = Provenance.add_source(activity, Provenance.file_set_source_attrs(file_set))
+
+    {:ok, target} =
+      Provenance.record_target(
+        activity,
+        %{
+          target_type: "FileSetAnnotation",
+          target_id: Ecto.UUID.generate(),
+          field_path: "file_set_annotations.content",
+          operation: "add",
+          proposed_value: "Generated transcript",
+          origin: "ai_generated",
+          status: "applied"
+        },
+        "applied"
+      )
+
+    %{activity: activity, target: target}
+  end
+
   defp assert_rank_ordering_valid(to_work_id) do
     Enum.each(["A", "P", "S", "X"], fn role ->
       file_sets = Works.with_file_sets(to_work_id, role).file_sets |> Enum.sort_by(& &1.rank)

--- a/app/test/meadow/indexing/v2/encoding_test.exs
+++ b/app/test/meadow/indexing/v2/encoding_test.exs
@@ -161,6 +161,7 @@ defmodule Meadow.Indexing.V2.EncodingTest do
 
       Indexer.synchronize_index()
       doc = subject |> Document.encode(2)
+
       assert doc |> get_in([:title]) == subject.descriptive_metadata.title
       assert doc |> get_in([:alternate_title]) == subject.descriptive_metadata.alternate_title
       assert doc |> get_in([:collection, :title]) == subject.collection.title

--- a/app/test/meadow_web/mcp/tools/update_plan_change_test.exs
+++ b/app/test/meadow_web/mcp/tools/update_plan_change_test.exs
@@ -42,10 +42,12 @@ defmodule MeadowWeb.MCP.Tools.UpdatePlanChangeTest do
       assert get_in(result, ["replace", "descriptive_metadata", "title"]) == "Updated Title"
       assert is_binary(result["ai_activity_id"])
 
+      # The work already has a human-entered title, so the AI's replacement is
+      # classified as modifying human content at proposal time.
       assert [
                %{
                  field_path: "descriptive_metadata.title",
-                 origin: "ai_generated"
+                 origin: "ai_modified_human_content"
                }
              ] = Provenance.work_summary(plan_change.work_id)
     end

--- a/app/test/meadow_web/schema/mutation/transfer_file_sets_test.exs
+++ b/app/test/meadow_web/schema/mutation/transfer_file_sets_test.exs
@@ -23,6 +23,29 @@ defmodule MeadowWeb.Schema.Mutation.TransferFileSetsTest do
       assert returned_id == work2.id
     end
 
+    test "moves AI provenance along with the file sets", %{work1: work1, work2: work2} do
+      alias Meadow.AI.Provenance
+
+      file_set = hd(work1.file_sets)
+
+      {:ok, _activity} =
+        Provenance.create_activity(%{
+          activity_type: "transcription",
+          work_id: work1.id,
+          file_set_id: file_set.id
+        })
+
+      result =
+        query_gql(
+          variables: %{"fromWorkId" => work1.id, "toWorkId" => work2.id},
+          context: gql_context()
+        )
+
+      assert {:ok, %{data: %{"transferFileSets" => %{"id" => _}}}} = result
+      assert [_] = Provenance.list_activities(work_id: work2.id)
+      assert [] == Provenance.list_activities(work_id: work1.id)
+    end
+
     test "returns error for non-existent from work", %{work2: work2} do
       fake_id = Ecto.UUID.generate()
 
@@ -149,6 +172,37 @@ defmodule MeadowWeb.Schema.Mutation.TransferFileSetsTest.Subset do
 
       assert length(transferred_ids) == 2
       assert work_id != nil
+    end
+
+    test "moves AI provenance along with the file sets", %{
+      work1: work1,
+      work2: work2,
+      fileset_ids: fileset_ids
+    } do
+      alias Meadow.AI.Provenance
+
+      {:ok, _activity} =
+        Provenance.create_activity(%{
+          activity_type: "transcription",
+          work_id: work1.id,
+          file_set_id: hd(fileset_ids)
+        })
+
+      result =
+        query_gql(
+          variables: %{
+            "filesetIds" => fileset_ids,
+            "createWork" => false,
+            "accessionNumber" => work2.accession_number
+          },
+          context: gql_context()
+        )
+
+      assert {:ok, %{data: %{"transfer_file_sets_subset" => %{"transferredFilesetIds" => _}}}} =
+               result
+
+      assert [_] = Provenance.list_activities(work_id: work2.id)
+      assert [] == Provenance.list_activities(work_id: work1.id)
     end
 
     test "returns error for empty fileset_ids" do

--- a/app/test/meadow_web/schema/mutation/update_plan_status_test.exs
+++ b/app/test/meadow_web/schema/mutation/update_plan_status_test.exs
@@ -3,6 +3,9 @@ defmodule MeadowWeb.Schema.Mutation.UpdatePlanStatusTest do
   use MeadowWeb.ConnCase, async: false
   use Wormwood.GQLCase
 
+  alias Meadow.AI.Provenance
+  alias Meadow.Data.Planner
+
   load_gql(MeadowWeb.Schema, "test/gql/UpdatePlanStatus.gql")
 
   test "should approve a plan" do
@@ -39,6 +42,58 @@ defmodule MeadowWeb.Schema.Mutation.UpdatePlanStatusTest do
 
     notes = get_in(query_data, [:data, "updatePlanStatus", "notes"])
     assert notes == "Not needed"
+
+    user = get_in(query_data, [:data, "updatePlanStatus", "user"])
+    assert user != nil
+  end
+
+  test "rejecting a plan cascades to its changes and records provenance" do
+    plan = plan_fixture()
+    work = work_fixture()
+
+    {:ok, activity} =
+      Provenance.create_activity(%{
+        activity_type: "metadata_plan",
+        work_id: work.id,
+        plan_id: plan.id,
+        status: "completed"
+      })
+
+    Provenance.record_targets_for_operations(
+      activity,
+      "Work",
+      work.id,
+      %{add: %{descriptive_metadata: %{description: ["AI proposal"]}}},
+      origin: "ai_generated",
+      status: "proposed",
+      event_type: "proposed"
+    )
+
+    {:ok, change} =
+      Planner.create_plan_change(%{
+        plan_id: plan.id,
+        work_id: work.id,
+        add: %{descriptive_metadata: %{description: ["AI proposal"]}},
+        status: :proposed,
+        ai_activity_id: activity.id
+      })
+
+    result =
+      query_gql(
+        variables: %{"id" => plan.id, "status" => "REJECTED", "notes" => "Not needed"},
+        context: gql_context()
+      )
+
+    assert {:ok, query_data} = result
+    assert get_in(query_data, [:data, "updatePlanStatus", "status"]) == "REJECTED"
+
+    change = Planner.get_plan_change!(change.id)
+    assert change.status == :rejected
+    assert change.user != nil
+
+    [target] = Provenance.get_activity!(activity.id).targets
+    assert target.status == "rejected"
+    assert Enum.any?(target.events, &(&1.event_type == "rejected"))
   end
 
   test "should return error for non-existent plan" do


### PR DESCRIPTION
# Summary 
Addresses several issues discovered in feedback from AI provenance user testing.

# Specific Changes in this PR
**1. Handle provenance data during file set transfers. Activity log screenshot:**
<img width="660" height="163" alt="file_settransferred_event" src="https://github.com/user-attachments/assets/11ae445c-8de1-4e8b-b6c4-d1de0804c9e2" />

---

**2. Automatically save transcription changes before human attestation:**
<img width="916" height="724" alt="SCR-20260728-knia" src="https://github.com/user-attachments/assets/0acfdb01-e623-4a06-a2ff-0ce0a7b4f5d1" />

---

**3. Make plan rejections clearer in the activity log:**
<img width="1394" height="233" alt="SCR-20260728-lmca" src="https://github.com/user-attachments/assets/4dcc57a6-85cd-4a94-8e36-417abd222b06" />

---

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

