### PR TITLE
Record provenance events during CSV batch updates

### DIFF
--- a/app/lib/meadow/ai/provenance.ex
+++ b/app/lib/meadow/ai/provenance.ex
@@ -576,8 +576,34 @@ defmodule Meadow.AI.Provenance do
   being recorded through the explicit human-attestation path instead, so they
   don't also pick up a spurious `human_edited`/`ai_assisted_human_modified`
   event.
+
+  Recording failures are rescued and logged, never raised: this runs after the
+  work is already saved, so a provenance failure must not fail the caller's
+  save. Callers that instead want provenance atomic with their own transaction
+  should use `record_work_manual_edit!/4`.
   """
   def record_work_manual_edit(work_before, work_after, actor, opts \\ []) do
+    each_changed_ai_field(work_before, work_after, opts, fn target, before_value, after_value ->
+      record_manual_edit_for_target(target, before_value, after_value, actor)
+    end)
+  end
+
+  @doc """
+  Strict variant of `record_work_manual_edit/4` for callers recording
+  provenance inside their own transaction (e.g. the CSV bulk import's
+  `Ecto.Multi`). Records the same transitions, but failures raise instead of
+  being rescued and logged, so the caller's transaction rolls back rather than
+  committing a work update with silently missing provenance. Opens no
+  transaction of its own: nested `Repo.transaction` calls join the caller's
+  transaction without a savepoint, so atomicity must come from the caller.
+  """
+  def record_work_manual_edit!(work_before, work_after, actor, opts \\ []) do
+    each_changed_ai_field(work_before, work_after, opts, fn target, before_value, after_value ->
+      apply_manual_edit!(target, before_value, after_value, actor)
+    end)
+  end
+
+  defp each_changed_ai_field(work_before, work_after, opts, fun) do
     except = Keyword.get(opts, :except, [])
 
     work_before.id
@@ -588,7 +614,7 @@ defmodule Meadow.AI.Provenance do
       after_value = field_value(work_after, target.field_path)
 
       if before_value != after_value do
-        record_manual_edit_for_target(target, before_value, after_value, actor)
+        fun.(target, before_value, after_value)
       end
     end)
 
@@ -917,6 +943,29 @@ defmodule Meadow.AI.Provenance do
 
   def record_annotation_human_attestation(_annotation, _actor, _opts),
     do: {:error, :no_ai_provenance}
+
+  @doc """
+  Filter a list of work ids down to those that currently have at least one
+  applied, AI-involved provenance target. A cheap candidate filter for batch
+  callers (e.g. CSV metadata updates) that need to know which works are worth
+  snapshotting before an edit — it may over-select a work whose newest applied
+  target per field is no longer AI-involved, but `record_work_manual_edit/4`
+  re-checks precisely per work and no-ops in that case.
+  """
+  def work_ids_with_applied_ai_targets(work_ids, repo \\ Repo)
+  def work_ids_with_applied_ai_targets([], _repo), do: []
+
+  def work_ids_with_applied_ai_targets(work_ids, repo) do
+    from(t in Target,
+      where: t.target_type == "Work",
+      where: t.target_id in ^Enum.map(work_ids, &to_string/1),
+      where: t.status == "applied",
+      where: t.origin in @ai_involved_origins,
+      select: t.target_id,
+      distinct: true
+    )
+    |> repo.all()
+  end
 
   defp applied_ai_targets(work_id) do
     from(t in Target,

--- a/app/lib/meadow/data/csv/bulk_import.ex
+++ b/app/lib/meadow/data/csv/bulk_import.ex
@@ -4,41 +4,89 @@ defmodule Meadow.Data.CSV.BulkImport do
   COPY/UPDATE
   """
 
+  import Ecto.Query, only: [from: 2]
+
   alias Ecto.Adapters.SQL
+  alias Ecto.Multi
+  alias Meadow.AI.Provenance
   alias Meadow.Data.CSV.Import
+  alias Meadow.Data.Schemas.Work
   alias Meadow.Utils.Stream, as: StreamUtil
   alias NimbleCSV.RFC4180, as: CSV
 
+  require Logger
+
   @chunk_size 500
 
-  def import_stream(stream, job_id, repo \\ Meadow.Repo) do
-    with temp_table <- "works_" <> String.replace(job_id, "-", "") do
-      repo.transaction(
-        fn ->
-          repo.query("CREATE TEMP TABLE #{temp_table} (LIKE works)")
+  @doc """
+  Bulk-update works from a CSV stream. Returns `{:ok, before_works}`, where
+  `before_works` are pre-update snapshots of the works that carried applied AI
+  provenance, ready for `record_ai_provenance/3`.
 
-          try do
-            stream
-            |> stream_rows()
-            |> Stream.map(fn chunk ->
-              update_chunk(temp_table, job_id, chunk, repo)
-            end)
-            |> Stream.run()
-          after
-            repo.query("DROP TABLE #{temp_table}")
-          end
-        end,
-        timeout: :infinity
-      )
+  Opens no transaction of its own: it is designed to run as an `Ecto.Multi`
+  step inside the caller's transaction. Each chunk's work rows are locked
+  `FOR UPDATE` before the AI provenance check, and those locks must be held
+  until the caller commits.
+  """
+  def import_stream(stream, job_id, repo \\ Meadow.Repo) do
+    temp_table = "works_" <> String.replace(job_id, "-", "")
+    repo.query("CREATE TEMP TABLE #{temp_table} (LIKE works)")
+
+    try do
+      before_works =
+        stream
+        |> stream_rows()
+        |> Enum.flat_map(fn chunk ->
+          update_chunk(temp_table, job_id, chunk, repo)
+        end)
+        |> Enum.uniq_by(& &1.id)
+
+      {:ok, before_works}
+    after
+      repo.query("DROP TABLE #{temp_table}")
     end
   end
 
   def import_job(job) do
-    job.source
-    |> StreamUtil.stream_from()
-    |> Import.read_csv()
-    |> Import.stream()
-    |> import_stream(job.id)
+    stream =
+      job.source
+      |> StreamUtil.stream_from()
+      |> Import.read_csv()
+      |> Import.stream()
+
+    Multi.new()
+    |> Multi.run(:import, fn repo, _ -> import_stream(stream, job.id, repo) end)
+    |> Multi.run(:provenance, fn repo, %{import: before_works} ->
+      record_ai_provenance(before_works, job.user, repo)
+    end)
+    |> Meadow.Repo.transaction(timeout: :infinity)
+    |> case do
+      {:ok, %{import: before_works}} -> {:ok, before_works}
+      {:error, _step, reason, _changes} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Record human mediation of AI-provenanced fields changed by a bulk import.
+  Takes the before-update work snapshots returned by `import_stream/3` and,
+  for each, compares against the updated work. Designed to run inside the same
+  transaction as the import (the `Ecto.Multi` step after `import_stream/3`):
+  recording is strict, so a failure returns `{:error, reason}` and rolls the
+  whole import back instead of committing works with missing provenance.
+  """
+  def record_ai_provenance(before_works, actor, repo \\ Meadow.Repo) do
+    Enum.each(before_works, fn before_work ->
+      case repo.get(Work, before_work.id) do
+        nil -> :ok
+        after_work -> Provenance.record_work_manual_edit!(before_work, after_work, actor)
+      end
+    end)
+
+    {:ok, before_works}
+  rescue
+    error ->
+      Logger.warning("Failed to record bulk import provenance: #{Exception.message(error)}")
+      {:error, error}
   end
 
   defp update_chunk(temp_table, job_id, stream, repo) do
@@ -53,6 +101,8 @@ defmodule Meadow.Data.CSV.BulkImport do
       rows |> Enum.into(SQL.stream(repo, sql))
       # credo:disable-for-previous-line Credo.Check.Warning.UnusedEnumOperation
 
+      before_works = snapshot_ai_provenanced_works(temp_table, repo)
+
       repo.query(
         "UPDATE #{temp_table} SET inserted_at = works.inserted_at FROM works WHERE #{temp_table}.id = works.id"
       )
@@ -66,6 +116,24 @@ defmodule Meadow.Data.CSV.BulkImport do
       )
 
       repo.query("TRUNCATE TABLE #{temp_table}")
+
+      before_works
+    end
+  end
+
+  # Lock the chunk's work rows (ids only) before reading provenance: without
+  # the lock, a plan apply could add an applied AI target between the candidate
+  # check and the bulk update, and that field's change would go unrecorded. The
+  # locks are held until the import transaction commits.
+  defp snapshot_ai_provenanced_works(temp_table, repo) do
+    {:ok, %{rows: rows}} =
+      repo.query(
+        "SELECT works.id::text FROM works JOIN #{temp_table} ON works.id = #{temp_table}.id FOR UPDATE OF works"
+      )
+
+    case Provenance.work_ids_with_applied_ai_targets(List.flatten(rows), repo) do
+      [] -> []
+      ai_ids -> from(w in Work, where: w.id in ^ai_ids) |> repo.all()
     end
   end
 

--- a/app/lib/meadow/data/csv/metadata_update_jobs.ex
+++ b/app/lib/meadow/data/csv/metadata_update_jobs.ex
@@ -120,39 +120,53 @@ defmodule Meadow.Data.CSV.MetadataUpdateJobs do
       |> Multi.run("import", fn repo, _ ->
         BulkImport.import_stream(stream, job.id, repo)
       end)
+      |> Multi.run("provenance", fn repo, %{"import" => before_works} ->
+        BulkImport.record_ai_provenance(before_works, job.user, repo)
+      end)
       |> Multi.update(job.id, MetadataUpdateJob.changeset(job, %{status: "complete"}))
 
     case with_locked_job(job, multi) do
       {:ok, result} ->
         {:ok, result |> Map.get(job.id)}
 
-      {:error, id, changeset, _} ->
+      {:error, id, %Changeset{} = changeset, _} ->
         update_job(job, %{status: "error"})
 
         {:error, id,
          ChangesetErrors.humanize_errors(changeset,
            flatten: [:administrative_metadata, :descriptive_metadata]
          )}
+
+      {:error, id, error, _} ->
+        update_job(job, %{status: "error"})
+        {:error, id, error}
     end
   end
 
   def apply_job(%MetadataUpdateJob{status: status}),
     do: {:error, "Update Job cannot be applied: status is #{status}."}
 
-  defp get_and_lock_job(%{id: job_id}) do
+  defp get_and_lock_job(%{id: job_id}, repo \\ Repo) do
     from(j in MetadataUpdateJob, where: j.id == ^job_id, lock: "FOR UPDATE NOWAIT")
-    |> Repo.one()
+    |> repo.one()
   end
 
-  defp with_locked_job(job, func_or_multi) do
+  # The job lock and the work share one flat transaction: nested
+  # `Repo.transaction` calls join the outer transaction rather than creating
+  # savepoints, so wrapping the multi in a second transaction adds no isolation
+  # and hides the multi's `{:error, step, value, changes}` result from callers.
+  defp with_locked_job(job, %Multi{} = multi) do
+    Multi.new()
+    |> Multi.run("lock_job", fn repo, _ -> {:ok, get_and_lock_job(job, repo)} end)
+    |> Multi.append(multi)
+    |> Repo.transaction(timeout: :infinity)
+  end
+
+  defp with_locked_job(job, func) when is_function(func, 0) do
     Repo.transaction(
       fn ->
         get_and_lock_job(job)
-
-        case Repo.transaction(func_or_multi, timeout: :infinity) do
-          {:ok, result} -> result
-          {:error, error} -> raise error
-        end
+        func.()
       end,
       timeout: :infinity
     )

--- a/app/test/meadow/ai/provenance_test.exs
+++ b/app/test/meadow/ai/provenance_test.exs
@@ -884,6 +884,35 @@ defmodule Meadow.AI.ProvenanceTest do
       assert %{"descriptive_metadata.description" => %{origin: "ai_generated"}} =
                Provenance.target_summary_map("Work", work.id)
     end
+
+    test "record_work_manual_edit!/4 records the same transitions as the lax variant",
+         %{work: work} do
+      edited = put_in(work.descriptive_metadata.description, ["Human-edited description"])
+
+      assert :ok = Provenance.record_work_manual_edit!(work, edited, "bmq449")
+
+      entry =
+        Provenance.work_summary(work.id)
+        |> Enum.find(&(&1.field_path == "descriptive_metadata.description"))
+
+      assert entry.origin == "ai_assisted_human_modified"
+      assert entry.latest_event_type == "human_edited"
+      assert entry.human_oversight_level == "human_modified"
+    end
+
+    test "record_work_manual_edit!/4 raises where the lax variant rescues and logs",
+         %{work: work} do
+      # A tuple can't be JSON-encoded, so recording the event's value_after
+      # fails. The lax variant swallows the failure; the strict variant raises
+      # so a caller's enclosing transaction rolls back.
+      edited = put_in(work.descriptive_metadata.description, {:not, :encodable})
+
+      assert :ok = Provenance.record_work_manual_edit(work, edited, "bmq449")
+
+      assert_raise Protocol.UndefinedError, fn ->
+        Provenance.record_work_manual_edit!(work, edited, "bmq449")
+      end
+    end
   end
 
   describe "explicit human attestation" do
@@ -1535,6 +1564,55 @@ defmodule Meadow.AI.ProvenanceTest do
 
       target = Repo.preload(target, :events, force: true)
       assert Enum.count(target.events, &(&1.event_type == "transferred")) == 1
+    end
+  end
+
+  describe "work_ids_with_applied_ai_targets/2" do
+    defp seed_lookup_target(work, origin, status) do
+      {:ok, activity} =
+        Provenance.create_activity(%{
+          activity_type: "metadata_plan",
+          work_id: work.id,
+          status: "completed"
+        })
+
+      {:ok, _target} =
+        Provenance.record_target(
+          activity,
+          %{
+            target_type: "Work",
+            target_id: work.id,
+            field_path: "descriptive_metadata.description",
+            operation: "replace",
+            proposed_value: ["value"],
+            origin: origin,
+            status: status
+          },
+          "proposed"
+        )
+
+      :ok
+    end
+
+    test "returns only works with applied, AI-involved targets" do
+      ai_work = work_fixture()
+      proposed_work = work_fixture()
+      rejected_work = work_fixture()
+      human_work = work_fixture()
+      untouched_work = work_fixture()
+
+      seed_lookup_target(ai_work, "ai_generated", "applied")
+      seed_lookup_target(proposed_work, "ai_generated", "proposed")
+      seed_lookup_target(rejected_work, "ai_generated", "rejected")
+      seed_lookup_target(human_work, "human_generated", "applied")
+
+      ids = [ai_work.id, proposed_work.id, rejected_work.id, human_work.id, untouched_work.id]
+
+      assert Provenance.work_ids_with_applied_ai_targets(ids) == [ai_work.id]
+    end
+
+    test "returns an empty list for empty input" do
+      assert Provenance.work_ids_with_applied_ai_targets([]) == []
     end
   end
 end

--- a/app/test/meadow/data/csv/metadata_update_jobs_test.exs
+++ b/app/test/meadow/data/csv/metadata_update_jobs_test.exs
@@ -3,10 +3,15 @@ defmodule Meadow.Data.CSV.MetadataUpdateJobsTest do
   use Meadow.CSVMetadataUpdateCase
   use Meadow.IndexCase
   use Meadow.GeoNamesCase
-  alias Meadow.Data.{CSV.MetadataUpdateJobs, Works}
+  alias Ecto.Multi
+  alias Meadow.AI.Provenance
+  alias Meadow.AI.Provenance.Schemas.Target, as: ProvenanceTarget
+  alias Meadow.Data.CSV.{BulkImport, Import, MetadataUpdateJobs}
   alias Meadow.Data.Schemas.{CSV.MetadataUpdateJob, Work}
+  alias Meadow.Data.Works
   alias Meadow.Repo
   alias Meadow.Search.Document
+  alias Meadow.Utils.Stream, as: StreamUtil
 
   setup %{source_url: source_url} do
     with filename <- Path.basename(source_url) do
@@ -139,6 +144,173 @@ defmodule Meadow.Data.CSV.MetadataUpdateJobsTest do
           assert result.active == active
         end
       end)
+    end
+  end
+
+  describe "AI provenance" do
+    @describetag source: "test/fixtures/csv/sheets/valid.csv"
+
+    # Title the first CSV data row writes to the first fixture work
+    @csv_title "Est qui ut quibusdam iure laudantium praesentium harum cumque repellendus!"
+
+    defp seed_ai_target(work, field_path, proposed_value) do
+      {:ok, activity} =
+        Provenance.create_activity(%{
+          activity_type: "metadata_plan",
+          work_id: work.id,
+          status: "completed"
+        })
+
+      {:ok, _target} =
+        Provenance.record_target(
+          activity,
+          %{
+            target_type: "Work",
+            target_id: work.id,
+            field_path: field_path,
+            operation: "replace",
+            proposed_value: proposed_value,
+            origin: "ai_generated",
+            status: "applied"
+          },
+          "applied"
+        )
+
+      :ok
+    end
+
+    test "records human mediation when the CSV changes an AI-provenanced field",
+         %{create_result: {:ok, job}, works: works} do
+      work = Enum.at(works, 0)
+      seed_ai_target(work, "descriptive_metadata.title", "Test title")
+
+      assert {:ok, %{status: "complete"}} = MetadataUpdateJobs.apply_job(job)
+
+      entry =
+        Provenance.work_summary(work.id)
+        |> Enum.find(&(&1.field_path == "descriptive_metadata.title"))
+
+      assert entry.origin == "ai_assisted_human_modified"
+      assert entry.latest_event_type == "human_edited"
+
+      [target] = Provenance.list_activities(work_id: work.id) |> hd() |> Map.fetch!(:targets)
+      event = Enum.find(target.events, &(&1.event_type == "human_edited"))
+
+      assert event.actor == "validUser"
+      assert event.value_before == %{"value" => "Test title"}
+      assert event.value_after == %{"value" => @csv_title}
+    end
+
+    test "records a deletion when the CSV clears an AI-provenanced field",
+         %{create_result: {:ok, job}, works: works} do
+      {:ok, work} =
+        works
+        |> Enum.at(0)
+        |> Works.update_work(%{descriptive_metadata: %{description: ["AI description"]}})
+
+      seed_ai_target(work, "descriptive_metadata.description", ["AI description"])
+
+      assert {:ok, %{status: "complete"}} = MetadataUpdateJobs.apply_job(job)
+
+      assert %{
+               "descriptive_metadata.description" => %{
+                 origin: "human_replacement_after_ai_suggestion",
+                 status: "deleted",
+                 latest_event_type: "deleted"
+               }
+             } = Provenance.target_summary_map("Work", work.id)
+    end
+
+    test "leaves fields without AI provenance untouched",
+         %{create_result: {:ok, job}, works: works} do
+      work = Enum.at(works, 0)
+      seed_ai_target(work, "descriptive_metadata.title", "Test title")
+
+      assert {:ok, %{status: "complete"}} = MetadataUpdateJobs.apply_job(job)
+
+      # The CSV also changes published, visibility, contributor, etc. on this
+      # work, but only the AI-provenanced title may have a target.
+      assert Provenance.target_summary_map("Work", work.id) |> Map.keys() ==
+               ["descriptive_metadata.title"]
+    end
+
+    test "records nothing when no work has AI provenance", %{create_result: {:ok, job}} do
+      assert {:ok, %{status: "complete"}} = MetadataUpdateJobs.apply_job(job)
+      assert Repo.aggregate(ProvenanceTarget, :count) == 0
+    end
+
+    test "snapshots only works with applied AI provenance",
+         %{create_result: {:ok, job}, works: works} do
+      work = Enum.at(works, 0)
+      seed_ai_target(work, "descriptive_metadata.title", "Test title")
+
+      stream =
+        StreamUtil.stream_from(job.source)
+        |> Import.read_csv()
+        |> Import.stream()
+
+      # import_stream must run inside the caller's transaction.
+      {:ok, {:ok, before_works}} =
+        Repo.transaction(fn -> BulkImport.import_stream(stream, job.id) end)
+
+      assert [before_work] = before_works
+      assert before_work.id == work.id
+      assert before_work.descriptive_metadata.title == "Test title"
+    end
+
+    test "rolls back work updates when a later transaction step fails",
+         %{create_result: {:ok, job}, works: works} do
+      work = Enum.at(works, 0)
+      original_title = work.descriptive_metadata.title
+
+      stream =
+        StreamUtil.stream_from(job.source)
+        |> Import.read_csv()
+        |> Import.stream()
+
+      multi =
+        Multi.new()
+        |> Multi.run("import", fn repo, _ ->
+          BulkImport.import_stream(stream, job.id, repo)
+        end)
+        |> Multi.run("provenance", fn _repo, _ -> {:error, :provenance_failed} end)
+
+      assert {:error, "provenance", :provenance_failed, _} = Repo.transaction(multi)
+      assert Repo.get!(Work, work.id).descriptive_metadata.title == original_title
+    end
+
+    test "record_ai_provenance converts recording failures into an error tuple",
+         %{works: works} do
+      work = Enum.at(works, 0)
+      seed_ai_target(work, "descriptive_metadata.title", "Test title")
+
+      # A tuple can't be JSON-encoded, so recording the human_edited event's
+      # value_before raises inside the strict provenance path.
+      bad_before = %{
+        work
+        | descriptive_metadata: %{work.descriptive_metadata | title: {:not, :encodable}}
+      }
+
+      assert {:error, %Protocol.UndefinedError{}} =
+               BulkImport.record_ai_provenance([bad_before], "validUser")
+    end
+
+    test "does not record events when the CSV value matches the AI value",
+         %{create_result: {:ok, job}, works: works} do
+      {:ok, work} =
+        works
+        |> Enum.at(0)
+        |> Works.update_work(%{descriptive_metadata: %{title: @csv_title}})
+
+      seed_ai_target(work, "descriptive_metadata.title", @csv_title)
+
+      assert {:ok, %{status: "complete"}} = MetadataUpdateJobs.apply_job(job)
+
+      assert %{"descriptive_metadata.title" => %{origin: "ai_generated"}} =
+               Provenance.target_summary_map("Work", work.id)
+
+      [target] = Provenance.list_activities(work_id: work.id) |> hd() |> Map.fetch!(:targets)
+      refute Enum.any?(target.events, &(&1.event_type == "human_edited"))
     end
   end
 


### PR DESCRIPTION
# Summary 
Fixes https://github.com/nulib/repodev_planning_and_docs/issues/5849 

Records AI provenance events when a CSV metadata update changes fields that carry applied AI provenance. Each batch update now snapshots the affected works before the bulk `UPDATE`, then compares them against the updated rows and records human mediation the same way a direct edit in the work form does: an edited AI field flips to `ai_assisted_human_modified` with a `human_edited` event, and a cleared field is recorded as a deletion. Works with no AI provenance are untouched, and a CSV value identical to the AI value records nothing. A new `work_ids_with_applied_ai_targets/2` query keeps this cheap for large imports by prefiltering each 500-row chunk down to the works actually worth snapshotting.

Provenance recording is atomic with the import: it runs as an `Ecto.Multi` step inside a single flat transaction, so a recording failure rolls the whole import back and marks the job error rather than committing works with silently missing provenance. To close the race where a plan apply could land between the candidate check and the bulk update, each chunk's work rows are locked `FOR UPDATE` before the prefilter runs. This required a strict `Provenance.record_work_manual_edit!/4` (the existing function rescues and logs, which is right for after-commit callers but we don't want that in the transaction) and flattening the previously nested transactions in `with_locked_job/2`, which as a side effect fixes multi failures crashing with a `CaseClauseError` instead of reaching the error branch.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
- Make sure you've got AI generated values in your data
- Export metadata to CSV
- Edit/Delete AI generated fields
- Import edited CSV, double-check the UI badges and the provenance in the activity log (`Human edited` or `deleted`)

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

