### PR TITLE
Fix MetadataAgent result handling and header construction

### DIFF
--- a/app/lib/meadow_ai/metadata_agent.ex
+++ b/app/lib/meadow_ai/metadata_agent.ex
@@ -167,21 +167,10 @@ defmodule MeadowAI.MetadataAgent do
       Keyword.get(opts, :context, %{})
       |> Map.put_new(:simple, simple)
 
-    auth_header =
-      case opts[:auth_token] do
-        nil -> {}
-        token -> {"Authorization", "Bearer #{token}"}
-      end
-
-    firewall_secrurity_header =
-      case opts[:firewall_security_header] do
-        [] -> {}
-        header -> {header[:name], header[:value]}
-      end
-
     headers =
-      [auth_header, firewall_secrurity_header]
-      |> Enum.into(%{})
+      %{}
+      |> put_auth_header(opts[:auth_token])
+      |> put_firewall_security_header(opts[:firewall_security_header])
 
     Config.lambda_config(:metadataAgent)
     |> Lambda.invoke(
@@ -198,11 +187,28 @@ defmodule MeadowAI.MetadataAgent do
     |> process_execution_result(opts)
   rescue
     error ->
-      Logger.error("Error executing Claude query: #{Exception.message(error)}")
+      Logger.error(
+        "Error executing Claude query: #{Exception.format(:error, error, __STACKTRACE__)}"
+      )
+
       {:error, {:query_execution_error, error}}
   end
 
-  defp process_execution_result({:ok, %{status_code: 200, body: body}}, opts) do
+  defp put_auth_header(headers, nil), do: headers
+  defp put_auth_header(headers, token), do: Map.put(headers, "Authorization", "Bearer #{token}")
+
+  defp put_firewall_security_header(headers, header) when is_list(header) do
+    case {header[:name], header[:value]} do
+      {name, value} when is_binary(name) and is_binary(value) -> Map.put(headers, name, value)
+      _ -> headers
+    end
+  end
+
+  defp put_firewall_security_header(headers, _), do: headers
+
+  # The metadataAgent lambda returns an API Gateway style `{statusCode, body}` map, which
+  # `Meadow.Utils.Lambda.invoke/3` hands back JSON-decoded with its wire (string) keys.
+  defp process_execution_result({:ok, %{"statusCode" => 200, "body" => body}}, opts) do
     case Jason.decode(body) do
       {:ok, decoded} ->
         log_metrics(decoded, Keyword.get(opts, :metadata, %{}))
@@ -213,14 +219,19 @@ defmodule MeadowAI.MetadataAgent do
     end
   end
 
-  defp process_execution_result({:ok, %{status_code: status_code, body: body}}, _opts) do
+  defp process_execution_result({:ok, %{"statusCode" => status_code, "body" => body}}, _opts) do
     Logger.error("Lambda execution error: Status #{status_code}, Body: #{body}")
     {:error, {:lambda_invocation_failed, status_code, body}}
   end
 
-  defp process_execution_result({:ok, %{error_message: error_message}}, _opts) do
+  defp process_execution_result({:ok, %{"errorMessage" => error_message}}, _opts) do
     Logger.error("Lambda execution error: #{error_message}")
     {:error, {:lambda_invocation_failed, error_message}}
+  end
+
+  defp process_execution_result({:error, reason}, _opts) do
+    Logger.error("Lambda invocation failed: #{inspect(reason)}")
+    {:error, {:lambda_invocation_failed, reason}}
   end
 
   defp process_execution_result(result, _opts) do

--- a/app/test/fixtures/lambda/index.js
+++ b/app/test/fixtures/lambda/index.js
@@ -46,4 +46,35 @@ const testHandler = async (event, _context, _callback) => {
   }
 }
 
-module.exports = {testHandler}
+// Mimics the response contract of lambdas/metadata-agent/index.js: an API Gateway style
+// `{statusCode, body}` map on completion, or a bare `errorMessage` when the runtime
+// reports a failure. The scenario is chosen via `event.context.test`.
+const metadataAgentHandler = async (event, _context, _callback) => {
+  switch (event.context && event.context.test) {
+    case "error_status":
+      return { statusCode: 500, body: "Something went wrong" };
+    case "error_message":
+      return { errorMessage: "Task timed out after 900.00 seconds" };
+    case "invalid_json":
+      return { statusCode: 200, body: "this is not json" };
+    case "echo_headers":
+      return {
+        statusCode: 200,
+        body: JSON.stringify({ result: event.additional_headers, total_cost_usd: 0 })
+      };
+    default:
+      return {
+        statusCode: 200,
+        body: JSON.stringify({
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          result: `Processed: ${event.prompt}`,
+          total_cost_usd: 0.25,
+          usage: { input_tokens: 10, output_tokens: 20 }
+        })
+      };
+  }
+}
+
+module.exports = {testHandler, metadataAgentHandler}

--- a/app/test/meadow_ai/metadata_agent_test.exs
+++ b/app/test/meadow_ai/metadata_agent_test.exs
@@ -1,6 +1,7 @@
 defmodule MeadowAI.MetadataAgentTest do
   use ExUnit.Case, async: false
 
+  alias Meadow.Utils.Lambda
   alias MeadowAI.MetadataAgent
 
   describe "query/2" do
@@ -33,6 +34,75 @@ defmodule MeadowAI.MetadataAgentTest do
 
       assert {:ok, %{request_count: 2, failure_count: 1, last_failure: %DateTime{}}} =
                MetadataAgent.status()
+    end
+  end
+
+  describe "query/2 against the metadataAgent lambda" do
+    setup do
+      start_supervised!(MetadataAgent)
+      start_supervised!({Task.Supervisor, name: MeadowAI.MetadataAgent.TaskSupervisor})
+
+      script = Path.expand("./test/fixtures/lambda/index")
+      lambda_config = {:local, {script, "metadataAgentHandler"}}
+      original = Application.get_env(:meadow, :lambda, [])
+
+      Application.put_env(
+        :meadow,
+        :lambda,
+        Keyword.put(original, :metadataAgent, lambda_config)
+      )
+
+      on_exit(fn ->
+        Lambda.close(lambda_config)
+        Application.put_env(:meadow, :lambda, original)
+      end)
+
+      :ok
+    end
+
+    test "unwraps the result from a successful {statusCode, body} response" do
+      assert {:ok, response} =
+               MetadataAgent.query("Improve the title", context: %{test: "success"})
+
+      assert %{"result" => "Processed: Improve the title", "total_cost_usd" => 0.25} = response
+      refute Map.has_key?(response, "usage")
+
+      assert {:ok, %{request_count: 1, failure_count: 0}} = MetadataAgent.status()
+    end
+
+    test "sends the auth token and firewall security header to the lambda" do
+      assert {:ok, %{"result" => %{"Authorization" => "Bearer " <> _} = headers}} =
+               MetadataAgent.query("Improve the title", context: %{test: "echo_headers"})
+
+      assert map_size(headers) == 1
+
+      assert {:ok, %{"result" => %{"Authorization" => "Bearer " <> _, "X-Firewall" => "secret"}}} =
+               MetadataAgent.query("Improve the title",
+                 context: %{test: "echo_headers"},
+                 firewall_security_header: [value: "secret", name: "X-Firewall"]
+               )
+    end
+
+    test "returns an error for a non-200 statusCode" do
+      assert {:error, {:lambda_invocation_failed, 500, "Something went wrong"}} =
+               MetadataAgent.query("Improve the title", context: %{test: "error_status"})
+
+      assert {:ok, %{failure_count: 1}} = MetadataAgent.status()
+    end
+
+    test "returns an error when the lambda reports an errorMessage" do
+      assert {:error, {:lambda_invocation_failed, "Task timed out after 900.00 seconds"}} =
+               MetadataAgent.query("Improve the title", context: %{test: "error_message"})
+    end
+
+    test "returns an error when the body is not valid JSON" do
+      assert {:error, {:invalid_response, {:error, %Jason.DecodeError{}}}} =
+               MetadataAgent.query("Improve the title", context: %{test: "invalid_json"})
+    end
+
+    test "rejects prompts over 10,000 characters" do
+      assert {:error, {:input_too_large, _}} =
+               MetadataAgent.query(String.duplicate("x", 10_001), context: %{test: "success"})
     end
   end
 end


### PR DESCRIPTION
# Summary 
Meadow is currently erroring when Auto-Edits get to the plan UI when we swapped the `ex_aws` dependency:

<img width="1514" height="913" alt="SCR-20260826-oojz" src="https://github.com/user-attachments/assets/9565a13d-e517-43c2-8a01-ed4f8082465b" />


The cause was `process_execution_result/2` matched on atom keys (status_code, error_message) but `Lambda.invoke/3` returns string keys ("statusCode", "errorMessage"), so every response, including successes, fell through to the "unknown result" clause. Separately, absent headers were built as empty tuples and piped through `Enum.into(%{})`, which raises whenever the auth token or firewall header is missing; the rescue made the "argument error" log line hard to interpret.

This fixes the key matching, adds an explicit `{:error, reason} `clause, replaces header construction with `put_auth_header/2` / `put_firewall_security_header/2`, and logs the full stacktrace on rescue. Adds a `metadataAgentHandler` lambda fixture and tests covering success, header forwarding, non-200, errorMessage, invalid JSON, and the prompt size limit.

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
- Run an Auto-Edit on a work and make sure the plan UI doesn't error out:

<img width="1433" height="982" alt="SCR-20260826-ojwm" src="https://github.com/user-attachments/assets/5fdb1353-decd-46ec-9ee6-47815641dd6f" />


Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

