### PR TITLE
Update bucket lifecycle rules and fixity stack name

### DIFF
--- a/infrastructure/deploy/digest_event.tf
+++ b/infrastructure/deploy/digest_event.tf
@@ -1,5 +1,5 @@
 data "aws_cloudformation_stack" "fixity" {
-  name = "fixity"
+  name = "stack-${var.environment}-fixity"
 }
 
 locals {

--- a/infrastructure/deploy/main.tf
+++ b/infrastructure/deploy/main.tf
@@ -86,6 +86,19 @@ resource "aws_s3_bucket_lifecycle_configuration" "meadow_ingest" {
       days = 30
     }
   }
+
+  rule {
+    id     = "AbortIncompleteMultipartUpload"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = local.is_staging ? 5 : 7
+    }
+
+    expiration {
+      expired_object_delete_marker = false
+    }
+  }
 }
 
 resource "aws_s3_bucket" "meadow_uploads" {
@@ -176,6 +189,19 @@ resource "aws_s3_bucket_lifecycle_configuration" "meadow_preservation_staging" {
       expired_object_delete_marker = true
     }
   }
+
+  rule {
+    id        = "AbortIncompleteMultipartUpload"
+    status    = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation   = 7
+    }
+
+    expiration {
+      expired_object_delete_marker = false
+    }
+  }
 }
 
 resource "aws_s3_bucket_intelligent_tiering_configuration" "meadow_preservation_production" {
@@ -218,6 +244,29 @@ resource "aws_s3_bucket_lifecycle_configuration" "meadow_preservation_production
     }
     expiration {
       expired_object_delete_marker = true
+    }
+  }
+
+  rule {
+    id     = "noncurrent-versions-direct-to-glacier-ir"
+    status = "Enabled"
+
+    noncurrent_version_transition {
+      noncurrent_days = 0
+      storage_class   = "GLACIER_IR"
+    }
+  }
+
+  rule {
+    id     = "AbortIncompleteMultipartUpload"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+
+    expiration {
+      days    = 0
     }
   }
 }
@@ -352,6 +401,35 @@ resource "aws_s3_bucket_lifecycle_configuration" "meadow_pyramids" {
     }
 
     status = "Enabled"
+  }
+
+  rule {
+    id     = "AbortIncompleteMultipartUpload"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+
+    expiration {
+      days    = 0
+    }
+  }
+
+  rule {
+    id     = "Transition_to_Intelligent_Tiering"
+    status = "Enabled"
+
+    noncurrent_version_transition {
+      newer_noncurrent_versions = 1
+      noncurrent_days           = 1
+      storage_class             = "INTELLIGENT_TIERING"
+    }
+
+    transition {
+      days          = 0
+      storage_class = "INTELLIGENT_TIERING"
+    }
   }
 }
 

--- a/infrastructure/deploy/replication.tf
+++ b/infrastructure/deploy/replication.tf
@@ -20,31 +20,33 @@ resource "aws_iam_role" "replication_role" {
       },
     ]
   })
+}
 
-  inline_policy {
-    name = "${var.stack_name}-replication-policy"
+resource "aws_iam_role_policy" "replication_role_policy" {
+  count = local.is_production ? 1 : 0
+  name  = "${var.stack_name}-replication-role-policy"
+  role  = aws_iam_role.replication_role[count.index].id
 
-    policy = jsonencode({
-      Version = "2012-10-17"
-      Statement = [
-        {
-          Effect   = "Allow"
-          Action   = ["s3:GetReplicationConfiguration", "s3:ListBucket"]
-          Resource = ["${aws_s3_bucket.meadow_preservation.arn}"]
-        },
-        {
-          Effect   = "Allow"
-          Action   = ["s3:GetObjectVersionForReplication", "s3:GetObjectVersionAcl", "s3:GetObjectVersionTagging"]
-          Resource = ["${aws_s3_bucket.meadow_preservation.arn}/*"]
-        },
-        {
-          Effect   = "Allow"
-          Action   = ["s3:ReplicateObject", "s3:ReplicateDelete", "s3:ReplicateTags"]
-          Resource = ["${aws_s3_bucket.meadow_preservation_replica[count.index].arn}/*"]
-        }
-      ]
-    })
-  }
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetReplicationConfiguration", "s3:ListBucket"]
+        Resource = ["${aws_s3_bucket.meadow_preservation.arn}"]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObjectVersionForReplication", "s3:GetObjectVersionAcl", "s3:GetObjectVersionTagging"]
+        Resource = ["${aws_s3_bucket.meadow_preservation.arn}/*"]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ReplicateObject", "s3:ReplicateDelete", "s3:ReplicateTags"]
+        Resource = ["${aws_s3_bucket.meadow_preservation_replica[count.index].arn}/*"]
+      }
+    ]
+  })
 }
 
 resource "aws_s3_bucket" "meadow_preservation_replica" {


### PR DESCRIPTION
# Summary 

Update bucket notifications to use the new namespaced fixity stack

# Specific Changes in this PR
- Change stack name for lookup from `fixity` to `stack-${environment}-fixity`
- Update bucket lifecycle rules to match deployed reality

Terraform-only change

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

