### PR TITLE
Fix bug in multipart uploads over 20MiB threshold

### DIFF
--- a/app/lib/meadow/aws/http_client.ex
+++ b/app/lib/meadow/aws/http_client.ex
@@ -25,8 +25,9 @@ defmodule Meadow.AWS.HTTPClient do
 
   @behaviour AWS.HTTPClient
 
-  # Timeout options aws-elixir may pass through from a caller's request options.
-  @request_options [:pool_timeout, :receive_timeout, :connect_options]
+  # Options aws-elixir may pass through from a caller's request options: timeouts, and
+  # `:plug` so tests can route a request through `Req.Test`.
+  @request_options [:pool_timeout, :receive_timeout, :connect_options, :plug]
 
   @impl AWS.HTTPClient
   def request(method, url, body, headers, options) do

--- a/app/lib/meadow/aws/s3.ex
+++ b/app/lib/meadow/aws/s3.ex
@@ -134,7 +134,10 @@ defmodule Meadow.AWS.S3 do
     Meadow.AWS.client(:s3)
     |> AWS.S3.copy_object(dest_bucket, object_key(dest_key), input)
     |> Response.unwrap(fn body ->
-      %{etag: body |> get_in([:copy_object_result, :e_tag]) |> unquote_etag()}
+      %{
+        etag:
+          body |> Response.normalize() |> get_in([:copy_object_result, :e_tag]) |> unquote_etag()
+      }
     end)
   end
 
@@ -275,6 +278,7 @@ defmodule Meadow.AWS.S3 do
     |> AWS.S3.list_buckets()
     |> Response.unwrap(fn body ->
       body
+      |> Response.normalize()
       |> get_in([:list_all_my_buckets_result, :buckets, :bucket])
       |> Response.list()
       |> Enum.map(& &1.name)
@@ -311,9 +315,22 @@ defmodule Meadow.AWS.S3 do
 
   ## Multipart
 
+  # CopyObject-only options. CreateMultipartUpload has no header for them, so
+  # aws-elixir would XML-encode them into the POST body, and S3 rejects that request
+  # with `InvalidRequest: The request included a body`. (LocalStack ignores the body,
+  # which is why only real S3 fails.) A multipart copy always writes the metadata and
+  # tags given at initiation, so REPLACE is the only behavior anyway.
+  @copy_only_keys [:metadata_directive, :tagging_directive]
+
+  @doc """
+  Start a multipart upload and return its upload id. `opts` accepts the same keys as
+  `copy_object/5`; the copy directives are dropped, since they only apply to CopyObject.
+  """
   def create_multipart_upload(bucket, key, opts \\ []) do
+    input = opts |> Keyword.drop(@copy_only_keys) |> copy_object_input()
+
     Meadow.AWS.client(:s3)
-    |> AWS.S3.create_multipart_upload(bucket, object_key(key), copy_object_input(opts))
+    |> AWS.S3.create_multipart_upload(bucket, object_key(key), input, request_opts(opts))
     |> Response.unwrap(fn body ->
       get_in(body, ["InitiateMultipartUploadResult", "UploadId"])
     end)
@@ -355,7 +372,7 @@ defmodule Meadow.AWS.S3 do
     Meadow.AWS.client(:s3)
     |> AWS.S3.upload_part_copy(bucket, object_key(key), input, request_opts(opts))
     |> Response.unwrap(fn body ->
-      body |> get_in([:copy_part_result, :e_tag]) |> unquote_etag()
+      body |> Response.normalize() |> get_in([:copy_part_result, :e_tag]) |> unquote_etag()
     end)
   end
 
@@ -373,7 +390,9 @@ defmodule Meadow.AWS.S3 do
 
     Meadow.AWS.client(:s3)
     |> AWS.S3.complete_multipart_upload(bucket, object_key(key), input)
-    |> Response.unwrap(fn body -> Map.get(body, :complete_multipart_upload_result, %{}) end)
+    |> Response.unwrap(fn body ->
+      body |> Response.normalize() |> Map.get(:complete_multipart_upload_result, %{})
+    end)
   end
 
   def abort_multipart_upload(bucket, key, upload_id) do
@@ -396,27 +415,29 @@ defmodule Meadow.AWS.S3 do
     case client do
       %{access_key_id: access_key_id, secret_access_key: secret} when is_binary(access_key_id) ->
         url =
-        [
-          Meadow.AWS.endpoint_url(client, Meadow.AWS.host(client, "s3")),
-          AWS.Util.encode_uri(bucket),
-          object_key(key)
-        ]
-        |> Enum.join("/")
+          [
+            Meadow.AWS.endpoint_url(client, Meadow.AWS.host(client, "s3")),
+            AWS.Util.encode_uri(bucket),
+            object_key(key)
+          ]
+          |> Enum.join("/")
 
-      signed =
-        :aws_signature.sign_v4_query_params(
-          access_key_id,
-          secret,
-          client.region,
-          "s3",
-          NaiveDateTime.utc_now() |> NaiveDateTime.to_erl(),
-          method |> to_string() |> String.upcase(),
-          url,
-          presign_options(client, opts)
-        )
+        signed =
+          :aws_signature.sign_v4_query_params(
+            access_key_id,
+            secret,
+            client.region,
+            "s3",
+            NaiveDateTime.utc_now() |> NaiveDateTime.to_erl(),
+            method |> to_string() |> String.upcase(),
+            url,
+            presign_options(client, opts)
+          )
 
-      {:ok, signed}
-      _ -> {:error, :no_credentials}
+        {:ok, signed}
+
+      _ ->
+        {:error, :no_credentials}
     end
   end
 
@@ -537,6 +558,10 @@ defmodule Meadow.AWS.S3 do
     |> Map.put("Body", content)
   end
 
+  # Options forwarded to the HTTP client rather than encoded into the request. `:plug`
+  # lets tests route a request through `Req.Test` and inspect what goes over the wire.
+  @request_option_keys [:receive_timeout, :request_timeout, :pool_timeout, :plug]
+
   @input_keys %{
     acl: "ACL",
     cache_control: "CacheControl",
@@ -549,8 +574,7 @@ defmodule Meadow.AWS.S3 do
   }
 
   # Options consumed by Meadow rather than sent to S3.
-  @passthrough_keys [:chunk_size, :max_concurrency, :expires_in] ++
-                      [:receive_timeout, :request_timeout, :pool_timeout]
+  @passthrough_keys [:chunk_size, :max_concurrency, :expires_in] ++ @request_option_keys
 
   defp copy_object_input(opts) do
     Enum.reduce(opts, %{}, fn {key, value}, input ->
@@ -575,8 +599,7 @@ defmodule Meadow.AWS.S3 do
 
   # Only options aws-elixir passes through to the HTTP client, so callers can set
   # per-request timeouts on slow multipart operations.
-  defp request_opts(opts),
-    do: Keyword.take(opts, [:receive_timeout, :request_timeout, :pool_timeout])
+  defp request_opts(opts), do: Keyword.take(opts, @request_option_keys)
 
   defp presign_options(client, opts) do
     [

--- a/app/test/meadow/aws/s3_test.exs
+++ b/app/test/meadow/aws/s3_test.exs
@@ -1,0 +1,69 @@
+defmodule Meadow.AWS.S3Test do
+  use Meadow.S3Case
+
+  @upload_id "example-upload-id"
+  @key "s3_test/source.txt"
+  @fixture %{bucket: @ingest_bucket, key: @key, content: "s3 test content"}
+
+  describe "list_buckets/0" do
+    test "returns bucket names" do
+      assert {:ok, buckets} = S3.list_buckets()
+      assert @ingest_bucket in buckets
+    end
+  end
+
+  describe "copy_object/5" do
+    @describetag s3: [@fixture]
+
+    setup do
+      on_exit(fn -> delete_object(@ingest_bucket, "s3_test/copy.txt") end)
+    end
+
+    test "returns the new object's etag" do
+      assert {:ok, %{etag: etag}} =
+               S3.copy_object(@ingest_bucket, "s3_test/copy.txt", @ingest_bucket, @key)
+
+      assert {:ok, %{etag: ^etag}} = S3.head_object(@ingest_bucket, "s3_test/copy.txt")
+    end
+  end
+
+  describe "create_multipart_upload/3" do
+    test "sends CopyObject directives as nothing at all, and metadata and tags as headers" do
+      test_pid = self()
+
+      Req.Test.stub(__MODULE__, fn conn ->
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        send(test_pid, {:request, conn, body})
+
+        Plug.Conn.send_resp(conn, 200, """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <InitiateMultipartUploadResult>
+          <Bucket>bucket</Bucket>
+          <Key>path/to/key</Key>
+          <UploadId>#{@upload_id}</UploadId>
+        </InitiateMultipartUploadResult>
+        """)
+      end)
+
+      assert {:ok, @upload_id} =
+               S3.create_multipart_upload("bucket", "path/to/key",
+                 content_type: "image/tiff",
+                 metadata_directive: "REPLACE",
+                 meta: [md5: "abc123"],
+                 tagging: "computed-md5=abc123",
+                 tagging_directive: "REPLACE",
+                 plug: {Req.Test, __MODULE__}
+               )
+
+      assert_received {:request, conn, body}
+      assert conn.method == "POST"
+      assert conn.request_path == "/bucket/path/to/key"
+      assert conn.query_string == "uploads"
+      # S3 rejects a CreateMultipartUpload request that carries a body
+      assert body == ""
+      assert Plug.Conn.get_req_header(conn, "content-type") == ["image/tiff"]
+      assert Plug.Conn.get_req_header(conn, "x-amz-meta-md5") == ["abc123"]
+      assert Plug.Conn.get_req_header(conn, "x-amz-tagging") == ["computed-md5=abc123"]
+    end
+  end
+end

--- a/app/test/meadow/utils/aws/multipart_copy_test.exs
+++ b/app/test/meadow/utils/aws/multipart_copy_test.exs
@@ -1,0 +1,47 @@
+defmodule Meadow.Utils.AWS.MultipartCopyTest do
+  use Meadow.S3Case
+
+  alias Meadow.Utils.AWS.MultipartCopy
+
+  # Just over MultipartCopy's 20 MiB single-request threshold, copied in S3's
+  # minimum 5 MiB parts so the copy takes several UploadPartCopy requests.
+  @size 21 * 1024 * 1024
+  @chunk_size 5 * 1024 * 1024
+  @src_key "multipart_copy_test/source.bin"
+  @dest_key "multipart_copy_test/destination.bin"
+  @fixture %{
+    bucket: @ingest_bucket,
+    key: @src_key,
+    content: :binary.copy(<<0>>, @size)
+  }
+
+  describe "copy_object/5 above the multipart threshold" do
+    @describetag s3: [@fixture]
+
+    setup do
+      on_exit(fn -> delete_object(@preservation_bucket, @dest_key) end)
+    end
+
+    test "copies the object with the options CopyFileToPreservation passes" do
+      assert {:ok, %{content_length: @size}} =
+               MultipartCopy.copy_object(
+                 @preservation_bucket,
+                 @dest_key,
+                 @ingest_bucket,
+                 @src_key,
+                 chunk_size: @chunk_size,
+                 content_type: "application/octet-stream",
+                 metadata_directive: "REPLACE",
+                 meta: [sha256: "abc123"],
+                 tagging: "computed-sha256=abc123",
+                 tagging_directive: "REPLACE"
+               )
+
+      assert object_size(@preservation_bucket, @dest_key) == @size
+      assert object_metadata(@preservation_bucket, @dest_key) == %{sha256: "abc123"}
+
+      assert {:ok, [%{key: "computed-sha256", value: "abc123"}]} =
+               S3.get_object_tagging(@preservation_bucket, @dest_key)
+    end
+  end
+end


### PR DESCRIPTION
# Summary 

Fixes https://github.com/nulib/repodev_planning_and_docs/issues/5856 

Multipart S3 copies, which have failed for every file set over the 20 MiB threshold since the move from ExAws to aws-elixir. `CopyFileToPreservation` passes `metadata_directive` and `tagging_directive`, which only apply to `CopyObject`; `aws-elixir` has no header mapping for them on `CreateMultipartUpload`, so it XML-encoded them into the POST body and S3 rejected the request with `InvalidRequest: The request included  a body`. LocalStack ignores the body, which is why the test suite never caught it. A second, latent bug would have failed right after: several response lookups (the part-copy and copy-object ETags, the complete result, and the bucket listing) used atom keys on bodies that still carry the wire's string keys, so `CompleteMultipartUpload` would have crashed on a nil ETag. Both are fixed in `Meadow.AWS.S3`.

New tests assert at the wire level (via a Req.Test stub, routed through a new :plug request option) that `CreateMultipartUpload` sends no body, and run an end-to-end 21 MiB multipart copy against LocalStack with the same options the preservation action uses.

<img width="758" height="999" alt="SCR-20260902-jhbp" src="https://github.com/user-attachments/assets/5505ce93-94df-450d-b01e-a9f3cba5f05a" />


# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# Steps to Test
- Run an ingest with video files over the 20MiB threshhold

Should see logs like:
```
module=Meadow.Utils.AWS.MultipartCopy id=82616a38-0db2-4abe-bae7-f09e3f8a44b7 [info] File size 40333432 > 20971520; using MultipartUpload
module=Meadow.Pipeline.Action id=7111942c-7ad3-4039-b3ac-b8eeffef52ef [info] Beginning Elixir.Meadow.Pipeline.Actions.ExtractExifMetadata for file set: 7111942c-7ad3-4039-b3ac-b8eeffef52ef
module=Meadow.Utils.AWS.MultipartCopy id=82616a38-0db2-4abe-bae7-f09e3f8a44b7 [info] Completing multipart upload.
```

Also please let developers know if there are any special instructions to test this in the development environment. 

# :rocket: Deployment Notes

**Note** - __if you check any of these boxes go to the [(always open) `main` <- `staging` PR](https://github.com/nulib/meadow/pulls) and add detailed notes and instructions to help out others who may end up deploying your changes to production__

- Backward compatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- Backwards-incompatible API changes
  - [ ] Database Schema changes
  - [ ] GraphQL API
  - [ ] Elasticsearch API
  - [ ] Ingest Sheet
  - [ ] CSV metadata export/update API
  - [ ] Shared Links export API
- [ ] Requires data migration
- [ ] Requires database triggers disabled during deployment/migration
- [ ] Requires reindex
- [ ] Requires `terraform apply`
  - [ ] Adds/requires new or changed `ENVIRONMENT.tfvars` variables
- [ ] Requires `sam deploy`
  - [ ] Adds/requires new or changed `samconfig.yaml` variables
- [ ] Other specific instructions/tasks


# Tested/Verified
- [ ] End users/stakeholders

